### PR TITLE
CI: Split up some builds to a new job

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -6845,7 +6845,7 @@ jobs:
         name: _internal-flowey-bootstrap-x86_64-windows-uid-15
         path: ${{ runner.temp }}/bootstrapped-flowey
   job6:
-    name: build artifacts [aarch64-linux] (shared)
+    name: build artifacts (shared VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7155,7 +7155,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
         include-hidden-files: true
   job7:
-    name: build artifacts [aarch64-linux] (for VMM tests)
+    name: build artifacts (for VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7433,7 +7433,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
         include-hidden-files: true
   job8:
-    name: build artifacts [x64-linux] (shared)
+    name: build artifacts (shared VMM tests) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7743,7 +7743,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
         include-hidden-files: true
   job9:
-    name: build artifacts [x64-linux] (for VMM tests)
+    name: build artifacts (for VMM tests) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7910,7 +7910,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7923,7 +7923,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 5
         flowey e 9 flowey_lib_hvlite::build_openvmm 0
         flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7936,7 +7936,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -7949,7 +7949,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 10
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
@@ -7962,7 +7962,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 9 flowey_core::pipeline::artifact::publish 3
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -7975,7 +7975,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -8029,14 +8029,7 @@ jobs:
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
         flowey e 9 flowey_core::pipeline::artifact::publish 6
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+        flowey e 9 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -784,7 +784,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 2
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -797,7 +797,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_build 5
         flowey e 11 flowey_lib_hvlite::build_openvmm 0
         flowey e 11 flowey_core::pipeline::artifact::publish 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 4
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -810,7 +810,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_build 9
         flowey e 11 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 11 flowey_core::pipeline::artifact::publish 1
-        flowey e 11 flowey_lib_hvlite::init_cross_build 6
+        flowey e 11 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -823,7 +823,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_build 14
         flowey e 11 flowey_lib_hvlite::build_vmgstool 0
         flowey e 11 flowey_core::pipeline::artifact::publish 2
-        flowey e 11 flowey_lib_hvlite::init_cross_build 5
+        flowey e 11 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
@@ -836,7 +836,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 11 flowey_core::pipeline::artifact::publish 3
-        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+        flowey e 11 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -849,7 +849,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 11 flowey_core::pipeline::artifact::publish 4
-        flowey e 11 flowey_lib_hvlite::init_cross_build 7
+        flowey e 11 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -936,7 +936,7 @@ jobs:
         flowey e 11 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 0
         flowey e 11 flowey_core::pipeline::artifact::publish 8
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+        flowey e 11 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -6924,10 +6924,6 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 6 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
@@ -7010,7 +7006,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 6
+        flowey e 6 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -7022,10 +7018,23 @@ jobs:
         flowey e 6 flowey_lib_hvlite::build_guest_test_uefi 0
         flowey e 6 flowey_core::pipeline::artifact::publish 0
         flowey e 6 flowey_lib_hvlite::init_cross_build 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: cargo build simple_tmk
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 2
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 5
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 6 flowey_lib_hvlite::build_tmks 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 1
+        flowey e 6 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tpm_guest_tests
       run: |-
         flowey e 6 flowey_lib_common::run_cargo_build 4
         flowey e 6 flowey_lib_hvlite::run_cargo_build 9
@@ -7034,19 +7043,6 @@ jobs:
       run: |-
         flowey e 6 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 6 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 6 flowey_lib_hvlite::build_tmks 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 1
-        flowey e 6 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 6
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 14
         flowey e 6 flowey_lib_hvlite::build_tpm_guest_tests 0
         flowey e 6 flowey_core::pipeline::artifact::publish 2
       shell: bash
@@ -7060,54 +7056,28 @@ jobs:
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 6 flowey_lib_hvlite::build_pipette 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 3
-        flowey e 6 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 5
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 11
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 6 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 4
-        flowey e 6 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
         flowey e 6 flowey_lib_common::run_cargo_build 1
         flowey e 6 flowey_lib_hvlite::run_cargo_build 1
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 6 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::build_openvmm 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 5
+        flowey e 6 flowey_lib_hvlite::build_pipette 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 3
         flowey e 6 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: cargo build openvmm_vhost
+    - name: cargo build tmk_vmm
       run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 6 flowey_lib_common::run_cargo_build 3
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 7
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 4
-        flowey e 6 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 6
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 6 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 6 flowey_lib_common::cache 3
@@ -7117,18 +7087,6 @@ jobs:
       with:
         name: aarch64-guest_test_uefi
         path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v7
@@ -7234,6 +7192,10 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 7 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 7 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
@@ -7331,42 +7293,42 @@ jobs:
         flowey e 7 flowey_lib_hvlite::run_cargo_build 5
         flowey e 7 flowey_lib_hvlite::build_openvmm 0
         flowey e 7 flowey_core::pipeline::artifact::publish 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 1
+        flowey e 7 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 7 flowey_lib_common::run_cargo_build 4
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 9
         flowey e 7 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 7 flowey_core::pipeline::artifact::publish 1
         flowey e 7 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 5
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 7 flowey_lib_common::run_cargo_build 7
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 14
         flowey e 7 flowey_lib_hvlite::build_vmgstool 0
         flowey e 7 flowey_core::pipeline::artifact::publish 2
         flowey e 7 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 4
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 7 flowey_lib_common::run_cargo_build 6
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 12
         flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
         flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 7 flowey_core::pipeline::artifact::publish 3
-        flowey e 7 flowey_lib_hvlite::init_cross_build 2
+        flowey e 7 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -7375,7 +7337,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 7 flowey_lib_hvlite::run_cargo_build 1
         flowey e 7 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 7 flowey_core::pipeline::artifact::publish 4
@@ -7393,6 +7355,39 @@ jobs:
         flowey e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey e 7 flowey_core::pipeline::artifact::publish 5
       shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 7 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 7 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 7 flowey_lib_hvlite::init_cross_build 6
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 7 flowey_lib_common::run_cargo_build 3
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 7 flowey_lib_hvlite::build_openvmm 1
+        flowey e 7 flowey_core::pipeline::artifact::publish 6
+        flowey e 7 flowey_lib_hvlite::init_cross_build 7
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 7 flowey_lib_common::run_cargo_build 5
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 10
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 7 flowey_lib_hvlite::build_openvmm_vhost 1
+        flowey e 7 flowey_core::pipeline::artifact::publish 7
+      shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 7 flowey_lib_common::cache 3
       shell: bash
@@ -7401,6 +7396,18 @@ jobs:
       with:
         name: aarch64-linux-igvmfilegen
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v7
@@ -7512,10 +7519,6 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 8 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 8 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 8 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
@@ -7598,7 +7601,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 6
+        flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -7610,10 +7613,23 @@ jobs:
         flowey e 8 flowey_lib_hvlite::build_guest_test_uefi 0
         flowey e 8 flowey_core::pipeline::artifact::publish 0
         flowey e 8 flowey_lib_hvlite::init_cross_build 0
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: cargo build simple_tmk
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::build_tmks 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 1
+        flowey e 8 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tpm_guest_tests
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 4
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
@@ -7622,19 +7638,6 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 8 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 8 flowey_lib_hvlite::build_tmks 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 1
-        flowey e 8 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
         flowey e 8 flowey_lib_hvlite::build_tpm_guest_tests 0
         flowey e 8 flowey_core::pipeline::artifact::publish 2
       shell: bash
@@ -7648,54 +7651,28 @@ jobs:
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::build_pipette 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 3
-        flowey e 8 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 5
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 11
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 4
-        flowey e 8 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 1
         flowey e 8 flowey_lib_hvlite::run_cargo_build 1
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 8 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::build_openvmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 5
+        flowey e 8 flowey_lib_hvlite::build_pipette 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 3
         flowey e 8 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: cargo build openvmm_vhost
+    - name: cargo build tmk_vmm
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 8 flowey_lib_common::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
-        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 6
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
@@ -7705,18 +7682,6 @@ jobs:
       with:
         name: x64-guest_test_uefi
         path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v7
@@ -7822,6 +7787,10 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
@@ -7923,38 +7892,38 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 5
         flowey e 9 flowey_lib_hvlite::build_openvmm 0
         flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 9 flowey_lib_common::run_cargo_build 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
         flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 9 flowey_lib_common::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
         flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 4
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 9 flowey_lib_common::run_cargo_build 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       shell: bash
     - name: test vmgs_lib
@@ -7962,7 +7931,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 9 flowey_core::pipeline::artifact::publish 3
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -7971,7 +7940,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
@@ -7988,6 +7957,39 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 3
         flowey e 9 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey e 9 flowey_core::pipeline::artifact::publish 5
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::build_openvmm 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 7
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -8028,14 +8030,14 @@ jobs:
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 6
+        flowey e 9 flowey_core::pipeline::artifact::publish 8
         flowey e 9 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 1
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
-        flowey e 9 flowey_core::pipeline::artifact::publish 7
+        flowey e 9 flowey_core::pipeline::artifact::publish 9
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 9 flowey_lib_common::cache 3
@@ -8048,6 +8050,18 @@ jobs:
       with:
         name: x64-linux-igvmfilegen
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
       uses: actions/upload-artifact@v7

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -345,7 +345,7 @@ jobs:
       run: flowey e 1 flowey_lib_common::cache 3
       shell: bash
   job10:
-    name: build openhcl [aarch64-linux]
+    name: build artifacts (shared VMM tests) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -422,44 +422,16 @@ jobs:
         cat <<'EOF' | flowey v 10 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline" | flowey v 10 'artifact_publish_from_aarch64-openhcl-baseline' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 10 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 10 flowey_lib_common::cache 2
-        flowey e 10 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (aarch64)
-      run: flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 10 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 10 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 10 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 10 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 10 'artifact_publish_from_x64-tmks' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 10 flowey_lib_common::install_rust 0
@@ -475,7 +447,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
         flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -483,7 +455,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -497,6 +469,35 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 10 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 10 flowey_lib_common::cache 0
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 10 flowey_lib_common::cache 2
+        flowey e 10 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 10 flowey_lib_common::resolve_protoc 0
@@ -505,153 +506,114 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 0
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 10 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 1
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 3
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 10 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build guest_test_uefi
       run: |-
         flowey e 10 flowey_lib_common::run_cargo_build 0
         flowey e 10 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
-    - name: split debug symbols
+    - name: build guest_test_uefi.img
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 10 flowey_lib_hvlite::build_guest_test_uefi 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
-    - name: building igvm file
+    - name: cargo build simple_tmk
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: |-
-        flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::build_tmks 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 1
         flowey e 10 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build openvmm_hcl
+    - name: cargo build tpm_guest_tests
       run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 10 flowey_lib_common::run_cargo_build 4
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 10 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 2
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::build_pipette 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 3
+        flowey e 10 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: copying openhcl build to publish dir
-      run: flowey e 10 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 10 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-openhcl-baseline
+    - name: 🌼📦 Publish x64-guest_test_uefi
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-baseline
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-baseline/
+        name: x64-guest_test_uefi
+        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm
+    - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        name: x64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
+    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
+        name: x64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-tmks
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
         include-hidden-files: true
   job11:
-    name: build openhcl [x64-linux]
+    name: build artifacts (for VMM tests) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -728,44 +690,26 @@ jobs:
         cat <<'EOF' | flowey v 11 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline" | flowey v 11 'artifact_publish_from_x64-openhcl-baseline' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 11 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 11 flowey_lib_common::cache 2
-        flowey e 11 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 11 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 11 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 11 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 11 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 11 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 11 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 11 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 11 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 11 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 11 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 11 flowey_lib_common::install_rust 0
@@ -778,10 +722,16 @@ jobs:
         flowey e 11 flowey_lib_common::install_rust 2
         flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
         flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -789,7 +739,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -803,6 +753,29 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 11 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 11 flowey_lib_common::cache 4
+        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 11 flowey_lib_common::cache 6
+        flowey e 11 flowey_lib_common::download_gh_release 1
+      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 11 flowey_lib_common::resolve_protoc 0
@@ -811,67 +784,59 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 0
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 11 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: cargo build sidecar
+    - name: cargo build openvmm
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 4
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 11
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 7
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 11 flowey_lib_hvlite::build_sidecar 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 1
+        flowey e 11 flowey_lib_common::run_cargo_build 2
         flowey e 11 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 11 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 11 flowey_lib_hvlite::build_openvmm 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 0
         flowey e 11 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: cargo build openvmm_hcl
+    - name: cargo build openvmm_vhost
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 3
+        flowey e 11 flowey_lib_common::run_cargo_build 4
         flowey e 11 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 11 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 1
+        flowey e 11 flowey_lib_hvlite::init_cross_build 6
       shell: bash
-    - name: building openhcl initrd
+    - name: cargo build vmgstool
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 11 flowey_lib_hvlite::init_cross_build 2
+        flowey e 11 flowey_lib_common::run_cargo_build 7
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 11 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 2
+        flowey e 11 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 6
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      shell: bash
+    - name: test vmgs_lib
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey e 11 flowey_core::pipeline::artifact::publish 3
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -880,180 +845,185 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 8
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 11 flowey_core::pipeline::artifact::publish 4
+        flowey e 11 flowey_lib_hvlite::init_cross_build 7
       shell: bash
-    - name: building igvm file
+    - name: cargo build ohcldiag-dev
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 11 flowey_lib_common::run_cargo_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 11 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 5
       shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+    - name: unpack openvmm-deps archive
+      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: building openhcl initrd
+    - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 8
       shell: bash
-    - name: building igvm file
+    - name: cargo build openvmm
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 3
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 11 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: |-
-        flowey e 11 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 2
+        flowey e 11 flowey_lib_common::run_cargo_build 3
         flowey e 11 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 11 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 11 flowey_lib_hvlite::build_openvmm 1
+        flowey e 11 flowey_core::pipeline::artifact::publish 6
+        flowey e 11 flowey_lib_hvlite::init_cross_build 9
       shell: bash
-    - name: copying openhcl build to publish dir
-      run: flowey e 11 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 5
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 11 flowey_lib_hvlite::build_openvmm_vhost 1
+        flowey e 11 flowey_core::pipeline::artifact::publish 7
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 11 flowey_lib_common::download_cargo_nextest 0
+        flowey e 11 flowey_lib_common::download_cargo_nextest 1
+        flowey e 11 flowey_lib_common::download_cargo_nextest 2
+        flowey e 11 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 11 flowey_lib_common::cache 0
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 11 flowey_lib_common::cache 2
+        flowey e 11 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 11 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 11 flowey_lib_common::install_cargo_nextest 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 8
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_nextest_archive 1
+        flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 1
+        flowey e 11 flowey_core::pipeline::artifact::publish 9
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey e 11 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-openhcl-baseline
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 11 flowey_lib_common::cache 7
+      shell: bash
+    - name: 🌼📦 Publish x64-linux-igvmfilegen
       uses: actions/upload-artifact@v7
       with:
-        name: x64-openhcl-baseline
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-baseline/
+        name: x64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-extras
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: x64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
         include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgs_lib
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
+        include-hidden-files: true
+    - name: 🌼🧼 Redact bootstrap var db
+      run: rm $AgentTempDirNormal/bootstrapped-flowey/job11.json
+      shell: bash
+    - name: 🌼🥾 Publish bootstrapped flowey
+      uses: actions/upload-artifact@v7
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-11
+        path: ${{ runner.temp }}/bootstrapped-flowey
   job12:
-    name: clippy [x64-windows], unit tests [x64-windows]
+    name: build openhcl [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1093,11 +1063,11 @@ jobs:
     - name: Build flowey
       run: |
         set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
         OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         mkdir -p "$OutDirNormal"
         mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
       working-directory: flowey_bootstrap
       shell: bash
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
@@ -1110,7 +1080,7 @@ jobs:
         ${{ runner.temp }}
         EOF
         )
-        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
       shell: bash
     - name: 🌼🛫 Initialize job
       run: |
@@ -1118,205 +1088,244 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey.exe v 12 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 12 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 12 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 12 'verbose' update
+        cat <<'EOF' | flowey v 12 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline" | flowey v 12 'artifact_publish_from_aarch64-openhcl-baseline' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 12 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 12 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 12 flowey_lib_common::cache 0
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 12 flowey_lib_common::cache 2
+        flowey e 12 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (aarch64)
+      run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 12 flowey_lib_common::install_rust 0
+      run: flowey e 12 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 12 flowey_lib_common::install_rust 1
+      run: flowey e 12 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 12 flowey_lib_common::install_rust 2
-        flowey.exe e 12 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 12 flowey_lib_common::install_rust 2
+        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 12 flowey_lib_common::git_checkout 0
-        flowey.exe v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 12 flowey_lib_common::git_checkout 0
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar7 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 12 flowey_lib_common::git_checkout 3
-        flowey.exe e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 12 flowey_lib_common::git_checkout 3
+        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 12 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 12 flowey_lib_common::cache 4
-        flowey.exe v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 12 flowey_lib_common::cache 6
-        flowey.exe e 12 flowey_lib_common::download_gh_release 1
+      run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 12 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 12 flowey_lib_common::resolve_protoc 0
+        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 2
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 0
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
-    - name: cargo build xtask
+    - name: cargo build openhcl_boot
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 12 flowey_lib_hvlite::build_xtask 0
+        flowey e 12 flowey_lib_common::run_cargo_build 1
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
-    - name: determine clippy exclusions
-      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: create cargo-nextest cache dir
+    - name: split debug symbols
       run: |-
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 3
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
-    - name: Pre-processing cache vars
+    - name: extract and resolve kernel package
       run: |-
-        flowey.exe e 12 flowey_lib_common::cache 0
-        flowey.exe v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
+    - name: unpack openvmm-deps archive
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
       run: |-
-        flowey.exe v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 12 flowey_lib_common::cache 2
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 4
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: report $CARGO_HOME
-      run: flowey.exe e 12 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
+    - name: cargo build openvmm_hcl
       run: |-
-        flowey.exe e 12 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey e 12 flowey_lib_common::run_cargo_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
-    - name: cargo build xtask
+    - name: split debug symbols
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 12 flowey_lib_hvlite::build_xtask 1
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
-    - name: determine unit test exclusions
+    - name: building openhcl initrd
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests' nextest tests
+    - name: cargo build igvmfilegen
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 12 flowey_lib_common::publish_test_results 5
-        flowey.exe e 12 flowey_lib_common::publish_test_results 6
-        flowey.exe e 12 flowey_lib_common::publish_test_results 4
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 12 flowey_lib_common::run_cargo_build 0
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: split debug symbols
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 12 flowey_lib_common::publish_test_results 0
-        flowey.exe e 12 flowey_lib_common::publish_test_results 1
-        flowey.exe e 12 flowey_lib_common::publish_test_results 2
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: building igvm file
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: run doctests for x86_64-pc-windows-msvc
-      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 12 flowey_lib_common::cache 3
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: |-
+        flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+      shell: bash
+    - name: copying openhcl build to publish dir
+      run: flowey e 12 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 12 flowey_lib_common::cache 7
+      run: flowey e 12 flowey_lib_common::cache 3
       shell: bash
+    - name: 🌼📦 Publish aarch64-openhcl-baseline
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-baseline
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-baseline/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
+        include-hidden-files: true
   job13:
-    name: clippy [x64-linux, macos], unit tests [x64-linux]
+    name: build openhcl [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -1393,6 +1402,44 @@ jobs:
         cat <<'EOF' | flowey v 13 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline" | flowey v 13 'artifact_publish_from_x64-openhcl-baseline' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 13 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 13 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 13 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 13 flowey_lib_common::cache 0
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 13 flowey_lib_common::cache 2
+        flowey e 13 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 13 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 13 flowey_lib_common::install_rust 0
@@ -1408,7 +1455,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 13 flowey_lib_common::git_checkout 0
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
         flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1416,7 +1463,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1430,35 +1477,6 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 13 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 13 flowey_lib_common::cache 4
-        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 13 flowey_lib_common::cache 6
-        flowey e 13 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 13 flowey_lib_common::resolve_protoc 0
@@ -1467,214 +1485,517 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 3
+        flowey e 13 flowey_lib_hvlite::init_cross_build 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 10
       shell: bash
-    - name: cargo build xtask
+    - name: cargo build sidecar
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 4
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 13 flowey_lib_hvlite::build_sidecar 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
       run: |-
         flowey e 13 flowey_lib_common::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: |-
-        flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 1
-        flowey e 13 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_clippy 1
-        flowey e 13 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_build 2
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 13 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 5
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 13 flowey_lib_common::download_cargo_nextest 0
-        flowey e 13 flowey_lib_common::download_cargo_nextest 1
-        flowey e 13 flowey_lib_common::download_cargo_nextest 2
-        flowey e 13 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 13 flowey_lib_common::cache 2
-        flowey e 13 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 13 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 13 flowey_lib_common::install_cargo_nextest 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 13 flowey_lib_common::publish_test_results 5
-        flowey e 13 flowey_lib_common::publish_test_results 6
-        flowey e 13 flowey_lib_common::publish_test_results 4
-        flowey v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 13 flowey_lib_common::publish_test_results 8
-        flowey e 13 flowey_lib_common::publish_test_results 9
-        flowey e 13 flowey_lib_common::publish_test_results 10
-        flowey v 13 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 13 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: cargo build xtask
-      run: |-
-        flowey e 13 flowey_lib_hvlite::init_cross_build 2
-        flowey e 13 flowey_lib_common::run_cargo_build 0
         flowey e 13 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 13 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 13 flowey_lib_hvlite::build_xtask 2
+        flowey e 13 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 13 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 3
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 13 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 8
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 4
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 13 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: |-
+        flowey e 13 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 2
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 0
+      shell: bash
+    - name: copying openhcl build to publish dir
+      run: flowey e 13 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 13 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish x64-openhcl-baseline
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-baseline
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-baseline/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
+        include-hidden-files: true
+  job14:
+    name: clippy [x64-windows], unit tests [x64-windows]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+
+        echo '"debug"' | flowey.exe v 14 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 14 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 14 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey.exe e 14 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 14 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey.exe e 14 flowey_lib_common::install_rust 2
+        flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 14 flowey_lib_common::git_checkout 0
+        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar7 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 14 flowey_lib_common::git_checkout 3
+        flowey.exe e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey.exe e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 14 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 14 flowey_lib_common::cache 4
+        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 14 flowey_lib_common::cache 6
+        flowey.exe e 14 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey.exe e 14 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey.exe e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey.exe e 14 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 14 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 14 flowey_lib_common::cache 0
+        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 14 flowey_lib_common::cache 2
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 14 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey.exe e 14 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey.exe e 14 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 14 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 13 flowey_lib_common::publish_test_results 12
-        flowey e 13 flowey_lib_common::publish_test_results 13
-        flowey e 13 flowey_lib_common::publish_test_results 14
-        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 14 flowey_lib_common::publish_test_results 5
+        flowey.exe e 14 flowey_lib_common::publish_test_results 6
+        flowey.exe e 14 flowey_lib_common::publish_test_results 4
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__15
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+        name: x64-windows-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 13 flowey_lib_common::publish_test_results 0
-        flowey e 13 flowey_lib_common::publish_test_results 1
-        flowey e 13 flowey_lib_common::publish_test_results 2
-        flowey v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 14 flowey_lib_common::publish_test_results 0
+        flowey.exe e 14 flowey_lib_common::publish_test_results 1
+        flowey.exe e 14 flowey_lib_common::publish_test_results 2
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
-    - name: run doctests for x86_64-unknown-linux-gnu
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+    - name: run doctests for x86_64-pc-windows-msvc
+      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 13 flowey_lib_common::cache 3
+      run: flowey.exe e 14 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 13 flowey_lib_common::cache 7
+      run: flowey.exe e 14 flowey_lib_common::cache 7
       shell: bash
-  job14:
-    name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
+  job15:
+    name: clippy [x64-linux, macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1740,29 +2061,382 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 14 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 14 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 15 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 14 'verbose' update
+        cat <<'EOF' | flowey v 15 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 14 flowey_lib_common::install_rust 0
+      run: flowey e 15 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 14 flowey_lib_common::install_rust 1
+      run: flowey e 15 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 14 flowey_lib_common::install_rust 2
-        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 15 flowey_lib_common::install_rust 2
+        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::git_checkout 0
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar9 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 15 flowey_lib_common::git_checkout 3
+        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 15 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 15 flowey_lib_common::cache 4
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 15 flowey_lib_common::cache 6
+        flowey e 15 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 15 flowey_lib_common::resolve_protoc 0
+        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: |-
+        flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 1
+        flowey e 15 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_clippy 1
+        flowey e 15 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_build 2
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 15 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 5
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 15 flowey_lib_common::download_cargo_nextest 0
+        flowey e 15 flowey_lib_common::download_cargo_nextest 1
+        flowey e 15 flowey_lib_common::download_cargo_nextest 2
+        flowey e 15 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 15 flowey_lib_common::cache 0
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 15 flowey_lib_common::cache 2
+        flowey e 15 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 15 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 15 flowey_lib_common::install_cargo_nextest 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 15 flowey_lib_common::publish_test_results 5
+        flowey e 15 flowey_lib_common::publish_test_results 6
+        flowey e 15 flowey_lib_common::publish_test_results 4
+        flowey v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__7
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 15 flowey_lib_common::publish_test_results 8
+        flowey e 15 flowey_lib_common::publish_test_results 9
+        flowey e 15 flowey_lib_common::publish_test_results 10
+        flowey v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey e 15 flowey_lib_hvlite::init_cross_build 2
+        flowey e 15 flowey_lib_common::run_cargo_build 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 15 flowey_lib_hvlite::build_xtask 2
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 15 flowey_lib_common::publish_test_results 12
+        flowey e 15 flowey_lib_common::publish_test_results 13
+        flowey e 15 flowey_lib_common::publish_test_results 14
+        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 15 flowey_lib_common::publish_test_results 0
+        flowey e 15 flowey_lib_common::publish_test_results 1
+        flowey e 15 flowey_lib_common::publish_test_results 2
+        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: |-
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for x86_64-unknown-linux-gnu
+      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 15 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 15 flowey_lib_common::cache 7
+      shell: bash
+  job16:
+    name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
+        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 16 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 16 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 16 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 16 flowey_lib_common::install_rust 2
+        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 16 flowey_lib_common::git_checkout 0
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1774,27 +2448,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 14 flowey_lib_common::git_checkout 3
-        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 16 flowey_lib_common::git_checkout 3
+        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 14 flowey_lib_common::download_gh_release 0
+      run: flowey e 16 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 16 flowey_lib_common::cache 4
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1804,78 +2478,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 14 flowey_lib_common::cache 6
-        flowey e 14 flowey_lib_common::download_gh_release 1
+        flowey e 16 flowey_lib_common::cache 6
+        flowey e 16 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 14 flowey_lib_common::resolve_protoc 0
+      run: flowey e 16 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 2
+        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_clippy 5
-        flowey e 14 flowey_lib_hvlite::init_cross_build 0
+        flowey e 16 flowey_lib_common::run_cargo_clippy 5
+        flowey e 16 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_build 0
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 16 flowey_lib_common::run_cargo_build 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 14 flowey_lib_hvlite::build_xtask 0
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 14 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 14 flowey_lib_common::download_cargo_nextest 0
-        flowey e 14 flowey_lib_common::download_cargo_nextest 1
-        flowey e 14 flowey_lib_common::download_cargo_nextest 2
-        flowey e 14 flowey_lib_common::download_cargo_nextest 3
+        flowey e 16 flowey_lib_common::download_cargo_nextest 0
+        flowey e 16 flowey_lib_common::download_cargo_nextest 1
+        flowey e 16 flowey_lib_common::download_cargo_nextest 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 16 flowey_lib_common::cache 0
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1885,34 +2559,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 14 flowey_lib_common::cache 2
-        flowey e 14 flowey_lib_common::download_cargo_nextest 4
+        flowey e 16 flowey_lib_common::cache 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 14 flowey_lib_common::install_rust 3
+      run: flowey e 16 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 14 flowey_lib_common::install_cargo_nextest 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 3
-        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::install_cargo_nextest 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 3
+        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 14 flowey_lib_common::publish_test_results 5
-        flowey e 14 flowey_lib_common::publish_test_results 6
-        flowey e 14 flowey_lib_common::publish_test_results 4
-        flowey v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 16 flowey_lib_common::publish_test_results 5
+        flowey e 16 flowey_lib_common::publish_test_results 6
+        flowey e 16 flowey_lib_common::publish_test_results 4
+        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1922,18 +2596,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 14 flowey_lib_common::publish_test_results 8
-        flowey e 14 flowey_lib_common::publish_test_results 9
-        flowey e 14 flowey_lib_common::publish_test_results 10
-        flowey v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 16 flowey_lib_common::publish_test_results 8
+        flowey e 16 flowey_lib_common::publish_test_results 9
+        flowey e 16 flowey_lib_common::publish_test_results 10
+        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -1943,18 +2617,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 14 flowey_lib_common::publish_test_results 12
-        flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey e 14 flowey_lib_common::publish_test_results 14
-        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey e 16 flowey_lib_common::publish_test_results 13
+        flowey e 16 flowey_lib_common::publish_test_results 14
+        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -1964,18 +2638,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 14 flowey_lib_common::publish_test_results 16
-        flowey e 14 flowey_lib_common::publish_test_results 17
-        flowey e 14 flowey_lib_common::publish_test_results 18
-        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 16 flowey_lib_common::publish_test_results 16
+        flowey e 16 flowey_lib_common::publish_test_results 17
+        flowey e 16 flowey_lib_common::publish_test_results 18
+        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -1986,32 +2660,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_hvlite::init_cross_build 1
-        flowey e 14 flowey_lib_common::run_cargo_build 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 16 flowey_lib_hvlite::init_cross_build 1
+        flowey e 16 flowey_lib_common::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 14 flowey_lib_hvlite::build_xtask 1
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 16 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 14 flowey_lib_common::publish_test_results 0
-        flowey e 14 flowey_lib_common::publish_test_results 1
-        flowey e 14 flowey_lib_common::publish_test_results 2
-        flowey v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 16 flowey_lib_common::publish_test_results 0
+        flowey e 16 flowey_lib_common::publish_test_results 1
+        flowey e 16 flowey_lib_common::publish_test_results 2
+        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2022,25 +2696,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
-      run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 14 flowey_lib_common::cache 3
+      run: flowey e 16 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 14 flowey_lib_common::cache 7
+      run: flowey e 16 flowey_lib_common::cache 7
       shell: bash
-  job15:
+  job17:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=win-arm64
-    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2106,29 +2780,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 15 'verbose' update
+        cat <<'EOF' | flowey.exe v 17 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 15 flowey_lib_common::install_rust 0
+      run: flowey.exe e 17 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 15 flowey_lib_common::install_rust 1
+      run: flowey.exe e 17 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 15 flowey_lib_common::install_rust 2
-        flowey.exe e 15 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 17 flowey_lib_common::install_rust 2
+        flowey.exe e 17 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 15 flowey_lib_common::git_checkout 0
-        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 17 flowey_lib_common::git_checkout 0
+        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2140,23 +2814,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 15 flowey_lib_common::git_checkout 3
-        flowey.exe e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 17 flowey_lib_common::git_checkout 3
+        flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 15 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 17 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 15 flowey_lib_common::cache 4
-        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 17 flowey_lib_common::cache 4
+        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2166,50 +2840,50 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 15 flowey_lib_common::cache 6
-        flowey.exe e 15 flowey_lib_common::download_gh_release 1
+        flowey.exe e 17 flowey_lib_common::cache 6
+        flowey.exe e 17 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 15 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 17 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 15 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 17 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 17 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 15 flowey_lib_common::cache 0
-        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe e 17 flowey_lib_common::cache 0
+        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2219,45 +2893,45 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 15 flowey_lib_common::cache 2
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 17 flowey_lib_common::cache 2
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 15 flowey_lib_common::install_rust 3
+      run: flowey.exe e 17 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 15 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 17 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 17 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 17 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 15 flowey_lib_common::publish_test_results 5
-        flowey.exe e 15 flowey_lib_common::publish_test_results 6
-        flowey.exe e 15 flowey_lib_common::publish_test_results 4
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 17 flowey_lib_common::publish_test_results 5
+        flowey.exe e 17 flowey_lib_common::publish_test_results 6
+        flowey.exe e 17 flowey_lib_common::publish_test_results 4
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2267,18 +2941,18 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 15 flowey_lib_common::publish_test_results 0
-        flowey.exe e 15 flowey_lib_common::publish_test_results 1
-        flowey.exe e 15 flowey_lib_common::publish_test_results 2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 17 flowey_lib_common::publish_test_results 0
+        flowey.exe e 17 flowey_lib_common::publish_test_results 1
+        flowey.exe e 17 flowey_lib_common::publish_test_results 2
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2289,25 +2963,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
-      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 15 flowey_lib_common::cache 3
+      run: flowey.exe e 17 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 15 flowey_lib_common::cache 7
+      run: flowey.exe e 17 flowey_lib_common::cache 7
       shell: bash
-  job16:
+  job18:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2373,35 +3047,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 18 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 16 'verbose' update
+        cat <<'EOF' | flowey v 18 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 16 flowey_lib_common::install_rust 0
+      run: flowey e 18 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 16 flowey_lib_common::install_rust 1
+      run: flowey e 18 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 16 flowey_lib_common::install_rust 2
-        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 18 flowey_lib_common::install_rust 2
+        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::git_checkout 0
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2413,23 +3087,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 16 flowey_lib_common::git_checkout 3
-        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 18 flowey_lib_common::git_checkout 3
+        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 16 flowey_lib_common::download_gh_release 0
+      run: flowey e 18 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey e 18 flowey_lib_common::cache 4
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2439,61 +3113,61 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 16 flowey_lib_common::cache 6
-        flowey e 16 flowey_lib_common::download_gh_release 1
+        flowey e 18 flowey_lib_common::cache 6
+        flowey e 18 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 16 flowey_lib_common::resolve_protoc 0
-        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 18 flowey_lib_common::resolve_protoc 0
+        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 2
+        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_build 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 18 flowey_lib_common::run_cargo_build 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::build_xtask 0
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 16 flowey_lib_common::download_cargo_nextest 0
-        flowey e 16 flowey_lib_common::download_cargo_nextest 1
-        flowey e 16 flowey_lib_common::download_cargo_nextest 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 3
+        flowey e 18 flowey_lib_common::download_cargo_nextest 0
+        flowey e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey e 18 flowey_lib_common::download_cargo_nextest 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey e 18 flowey_lib_common::cache 0
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2503,34 +3177,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 16 flowey_lib_common::cache 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 4
+        flowey e 18 flowey_lib_common::cache 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 16 flowey_lib_common::install_rust 3
+      run: flowey e 18 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 16 flowey_lib_common::install_cargo_nextest 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::install_cargo_nextest 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 16 flowey_lib_common::publish_test_results 5
-        flowey e 16 flowey_lib_common::publish_test_results 6
-        flowey e 16 flowey_lib_common::publish_test_results 4
-        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 18 flowey_lib_common::publish_test_results 5
+        flowey e 18 flowey_lib_common::publish_test_results 6
+        flowey e 18 flowey_lib_common::publish_test_results 4
+        flowey v 18 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2540,18 +3214,18 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 16 flowey_lib_common::publish_test_results 8
-        flowey e 16 flowey_lib_common::publish_test_results 9
-        flowey e 16 flowey_lib_common::publish_test_results 10
-        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 18 flowey_lib_common::publish_test_results 8
+        flowey e 18 flowey_lib_common::publish_test_results 9
+        flowey e 18 flowey_lib_common::publish_test_results 10
+        flowey v 18 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2562,32 +3236,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_cross_build 3
-        flowey e 16 flowey_lib_common::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 18 flowey_lib_hvlite::init_cross_build 3
+        flowey e 18 flowey_lib_common::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 16 flowey_lib_hvlite::build_xtask 1
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 18 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 18 flowey_lib_common::publish_test_results 12
+        flowey e 18 flowey_lib_common::publish_test_results 13
+        flowey e 18 flowey_lib_common::publish_test_results 14
+        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 18 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -2597,18 +3271,18 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 16 flowey_lib_common::publish_test_results 0
-        flowey e 16 flowey_lib_common::publish_test_results 1
-        flowey e 16 flowey_lib_common::publish_test_results 2
-        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 18 flowey_lib_common::publish_test_results 0
+        flowey e 18 flowey_lib_common::publish_test_results 1
+        flowey e 18 flowey_lib_common::publish_test_results 2
+        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2619,25 +3293,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 16 flowey_lib_common::cache 3
+      run: flowey e 18 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 16 flowey_lib_common::cache 7
+      run: flowey e 18 flowey_lib_common::cache 7
       shell: bash
-  job17:
+  job19:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2703,29 +3377,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 17 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 17 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 19 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 19 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 17 'verbose' update
+        cat <<'EOF' | flowey v 19 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 17 flowey_lib_common::install_rust 0
+      run: flowey e 19 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 17 flowey_lib_common::install_rust 1
+      run: flowey e 19 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 17 flowey_lib_common::install_rust 2
-        flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 19 flowey_lib_common::install_rust 2
+        flowey e 19 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::git_checkout 0
+        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2737,27 +3411,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 17 flowey_lib_common::git_checkout 3
-        flowey e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 19 flowey_lib_common::git_checkout 3
+        flowey e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 19 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 19 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 17 flowey_lib_common::download_gh_release 0
+      run: flowey e 19 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 19 flowey_lib_common::cache 4
+        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2767,78 +3441,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 17 flowey_lib_common::cache 6
-        flowey e 17 flowey_lib_common::download_gh_release 1
+        flowey e 19 flowey_lib_common::cache 6
+        flowey e 19 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 19 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 17 flowey_lib_common::resolve_protoc 0
+      run: flowey e 19 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 17 flowey_lib_hvlite::init_cross_build 2
+        flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 19 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_clippy 5
-        flowey e 17 flowey_lib_hvlite::init_cross_build 0
+        flowey e 19 flowey_lib_common::run_cargo_clippy 5
+        flowey e 19 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_build 0
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 19 flowey_lib_common::run_cargo_build 0
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 17 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 17 flowey_lib_hvlite::build_xtask 0
+        flowey e 19 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 19 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 17 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 19 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 17 flowey_lib_common::download_cargo_nextest 0
-        flowey e 17 flowey_lib_common::download_cargo_nextest 1
-        flowey e 17 flowey_lib_common::download_cargo_nextest 2
-        flowey e 17 flowey_lib_common::download_cargo_nextest 3
+        flowey e 19 flowey_lib_common::download_cargo_nextest 0
+        flowey e 19 flowey_lib_common::download_cargo_nextest 1
+        flowey e 19 flowey_lib_common::download_cargo_nextest 2
+        flowey e 19 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 19 flowey_lib_common::cache 0
+        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2848,34 +3522,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 17 flowey_lib_common::cache 2
-        flowey e 17 flowey_lib_common::download_cargo_nextest 4
+        flowey e 19 flowey_lib_common::cache 2
+        flowey e 19 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 17 flowey_lib_common::install_rust 3
+      run: flowey e 19 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 17 flowey_lib_common::install_cargo_nextest 0
-        flowey e 17 flowey_lib_hvlite::init_cross_build 3
-        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 19 flowey_lib_common::install_cargo_nextest 0
+        flowey e 19 flowey_lib_hvlite::init_cross_build 3
+        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 17 flowey_lib_common::publish_test_results 5
-        flowey e 17 flowey_lib_common::publish_test_results 6
-        flowey e 17 flowey_lib_common::publish_test_results 4
-        flowey v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 19 flowey_lib_common::publish_test_results 5
+        flowey e 19 flowey_lib_common::publish_test_results 6
+        flowey e 19 flowey_lib_common::publish_test_results 4
+        flowey v 19 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2885,18 +3559,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 17 flowey_lib_common::publish_test_results 8
-        flowey e 17 flowey_lib_common::publish_test_results 9
-        flowey e 17 flowey_lib_common::publish_test_results 10
-        flowey v 17 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 17 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 19 flowey_lib_common::publish_test_results 8
+        flowey e 19 flowey_lib_common::publish_test_results 9
+        flowey e 19 flowey_lib_common::publish_test_results 10
+        flowey v 19 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 19 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2906,18 +3580,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 17 flowey_lib_common::publish_test_results 12
-        flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey e 17 flowey_lib_common::publish_test_results 14
-        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 19 flowey_lib_common::publish_test_results 12
+        flowey e 19 flowey_lib_common::publish_test_results 13
+        flowey e 19 flowey_lib_common::publish_test_results 14
+        flowey v 19 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 19 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -2927,18 +3601,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 17 flowey_lib_common::publish_test_results 16
-        flowey e 17 flowey_lib_common::publish_test_results 17
-        flowey e 17 flowey_lib_common::publish_test_results 18
-        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 19 flowey_lib_common::publish_test_results 16
+        flowey e 19 flowey_lib_common::publish_test_results 17
+        flowey e 19 flowey_lib_common::publish_test_results 18
+        flowey v 19 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 19 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -2949,32 +3623,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 17 flowey_lib_hvlite::init_cross_build 1
-        flowey e 17 flowey_lib_common::run_cargo_build 1
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 19 flowey_lib_hvlite::init_cross_build 1
+        flowey e 19 flowey_lib_common::run_cargo_build 1
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 17 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 17 flowey_lib_hvlite::build_xtask 1
+        flowey e 19 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 19 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 17 flowey_lib_common::publish_test_results 0
-        flowey e 17 flowey_lib_common::publish_test_results 1
-        flowey e 17 flowey_lib_common::publish_test_results 2
-        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 19 flowey_lib_common::publish_test_results 0
+        flowey e 19 flowey_lib_common::publish_test_results 1
+        flowey e 19 flowey_lib_common::publish_test_results 2
+        flowey v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2985,551 +3659,17 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
-      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 17 flowey_lib_common::cache 3
+      run: flowey e 19 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 17 flowey_lib_common::cache 7
-      shell: bash
-  job18:
-    name: run vmm-tests [x64-windows-intel]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job11
-    - job5
-    - job8
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-15,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15/flowey.exe
-
-        echo '"debug"' | flowey.exe v 18 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 18 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 18 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 18 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 18 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 18 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 18 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 18 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 18 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 18 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 18 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 18 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 18 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 18 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 18 flowey_lib_common::cache 0
-        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::cache 2
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 18 flowey_lib_common::git_checkout 0
-        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::git_checkout 3
-        flowey.exe e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 18 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 18 flowey_lib_common::cache 8
-        flowey.exe v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::cache 10
-        flowey.exe e 18 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 18 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 18 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 18 flowey_lib_common::cache 4
-        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::cache 6
-        flowey.exe e 18 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 18 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 18 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 18 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 18 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 18 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 18 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 18 flowey_lib_common::publish_test_results 4
-        flowey.exe e 18 flowey_lib_common::publish_test_results 5
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 18 flowey_lib_common::publish_test_results 0
-        flowey.exe e 18 flowey_lib_common::publish_test_results 1
-        flowey.exe e 18 flowey_lib_common::publish_test_results 2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 18 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 18 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 18 flowey_lib_common::cache 11
-      shell: bash
-  job19:
-    name: run vmm-tests [x64-windows-intel-tdx]
-    runs-on:
-    - self-hosted
-    - Windows
-    - X64
-    - TDX
-    - Baremetal
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job11
-    - job5
-    - job8
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-15,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15/flowey.exe
-
-        echo '"debug"' | flowey.exe v 19 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 19 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 19 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 19 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 19 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 19 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 19 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 19 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 19 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 19 flowey_lib_common::cache 0
-        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 19 flowey_lib_common::cache 2
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 19 flowey_lib_common::git_checkout 0
-        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 19 flowey_lib_common::git_checkout 3
-        flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 19 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 19 flowey_lib_common::cache 8
-        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 19 flowey_lib_common::cache 10
-        flowey.exe e 19 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 19 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 19 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 19 flowey_lib_common::cache 4
-        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 19 flowey_lib_common::cache 6
-        flowey.exe e 19 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 19 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 19 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 19 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 19 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 19 flowey_lib_common::publish_test_results 4
-        flowey.exe e 19 flowey_lib_common::publish_test_results 5
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-tdx-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 19 flowey_lib_common::publish_test_results 0
-        flowey.exe e 19 flowey_lib_common::publish_test_results 1
-        flowey.exe e 19 flowey_lib_common::publish_test_results 2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-tdx-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 19 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 19 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 19 flowey_lib_common::cache 11
+      run: flowey e 19 flowey_lib_common::cache 7
       shell: bash
   job2:
     name: build artifacts (not for VMM tests) [aarch64-windows]
@@ -3747,19 +3887,20 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-windows-amd]
+    name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
-    - job11
-    - job5
-    - job8
+    - job10
+    - job13
+    - job6
+    - job7
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -3978,9 +4119,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-logs
+        name: x64-windows-intel-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3994,9 +4135,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-junit-xml
+        name: x64-windows-intel-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4011,20 +4152,21 @@ jobs:
       run: flowey.exe e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [x64-windows-amd-snp]
+    name: run vmm-tests [x64-windows-intel-tdx]
     runs-on:
     - self-hosted
     - Windows
     - X64
-    - SNP
+    - TDX
     - Baremetal
     permissions:
       contents: read
       id-token: write
     needs:
-    - job11
-    - job5
-    - job8
+    - job10
+    - job13
+    - job6
+    - job7
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -4113,10 +4255,6 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
@@ -4124,6 +4262,10 @@ jobs:
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4248,9 +4390,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-snp-vmm-tests-logs
+        name: x64-windows-intel-tdx-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4264,9 +4406,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-snp-vmm-tests-junit-xml
+        name: x64-windows-intel-tdx-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4281,19 +4423,555 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
-    name: run vmm-tests [x64-linux-amd-kvm]
+    name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=win-amd64
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
-    - job5
-    - job8
-    - job9
+    - job10
+    - job13
+    - job6
+    - job7
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-15,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15/flowey.exe
+
+        echo '"debug"' | flowey.exe v 22 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 22 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 22 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 22 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 22 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 22 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 22 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 0
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 22 flowey_lib_common::git_checkout 0
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::git_checkout 3
+        flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 8
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 10
+        flowey.exe e 22 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 22 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 22 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 4
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 6
+        flowey.exe e 22 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 22 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 22 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 22 flowey_lib_common::publish_test_results 4
+        flowey.exe e 22 flowey_lib_common::publish_test_results 5
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 22 flowey_lib_common::publish_test_results 0
+        flowey.exe e 22 flowey_lib_common::publish_test_results 1
+        flowey.exe e 22 flowey_lib_common::publish_test_results 2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 22 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 22 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 22 flowey_lib_common::cache 11
+      shell: bash
+  job23:
+    name: run vmm-tests [x64-windows-amd-snp]
+    runs-on:
+    - self-hosted
+    - Windows
+    - X64
+    - SNP
+    - Baremetal
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job10
+    - job13
+    - job6
+    - job7
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-15,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15/flowey.exe
+
+        echo '"debug"' | flowey.exe v 23 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 23 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 23 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 23 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 23 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 23 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 23 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 23 flowey_lib_common::cache 0
+        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::cache 2
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 23 flowey_lib_common::git_checkout 0
+        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::git_checkout 3
+        flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 23 flowey_lib_common::cache 8
+        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::cache 10
+        flowey.exe e 23 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 23 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 23 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 23 flowey_lib_common::cache 4
+        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::cache 6
+        flowey.exe e 23 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 23 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 23 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 23 flowey_lib_common::publish_test_results 4
+        flowey.exe e 23 flowey_lib_common::publish_test_results 5
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-snp-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 23 flowey_lib_common::publish_test_results 0
+        flowey.exe e 23 flowey_lib_common::publish_test_results 1
+        flowey.exe e 23 flowey_lib_common::publish_test_results 2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-snp-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 23 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 23 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 23 flowey_lib_common::cache 11
+      shell: bash
+  job24:
+    name: run vmm-tests [x64-linux-amd-kvm]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job10
+    - job11
+    - job6
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -4312,46 +4990,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11/flowey
 
-        echo '"debug"' | flowey v 22 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 22 'verbose' update
+        cat <<'EOF' | flowey v 24 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 22 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 22 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 22 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 22 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 24 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 22 flowey_core::pipeline::artifact::resolve 3
-        flowey e 22 flowey_core::pipeline::artifact::resolve 4
-        flowey e 22 flowey_core::pipeline::artifact::resolve 7
-        flowey e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey e 22 flowey_core::pipeline::artifact::resolve 0
-        flowey e 22 flowey_core::pipeline::artifact::resolve 2
-        flowey e 22 flowey_core::pipeline::artifact::resolve 6
-        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 3
+        flowey e 24 flowey_core::pipeline::artifact::resolve 4
+        flowey e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey e 24 flowey_core::pipeline::artifact::resolve 1
+        flowey e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey e 24 flowey_core::pipeline::artifact::resolve 6
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 22 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 22 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 22 flowey_lib_common::download_gh_release 0
+      run: flowey e 24 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 22 flowey_lib_common::cache 8
-        flowey v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 24 flowey_lib_common::cache 8
+        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4361,31 +5039,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 22 flowey_lib_common::cache 10
-        flowey e 22 flowey_lib_common::download_gh_release 1
+        flowey e 24 flowey_lib_common::cache 10
+        flowey e 24 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 22 flowey_lib_common::download_azcopy 0
+      run: flowey e 24 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 22 flowey_lib_common::download_gh_cli 0
+      run: flowey e 24 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 22 flowey_lib_common::cache 4
-        flowey v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 24 flowey_lib_common::cache 4
+        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4395,54 +5073,54 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 22 flowey_lib_common::cache 6
-        flowey e 22 flowey_lib_common::download_gh_cli 1
-        flowey v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 24 flowey_lib_common::cache 6
+        flowey e 24 flowey_lib_common::download_gh_cli 1
+        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 22 flowey_lib_common::use_gh_cli 0
+      run: flowey e 24 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 22 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 24 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 22 flowey_lib_common::download_cargo_nextest 0
-        flowey e 22 flowey_lib_common::download_cargo_nextest 1
-        flowey e 22 flowey_lib_common::download_cargo_nextest 2
-        flowey e 22 flowey_lib_common::download_cargo_nextest 3
+        flowey e 24 flowey_lib_common::download_cargo_nextest 0
+        flowey e 24 flowey_lib_common::download_cargo_nextest 1
+        flowey e 24 flowey_lib_common::download_cargo_nextest 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 22 flowey_lib_common::cache 0
-        flowey v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 24 flowey_lib_common::cache 0
+        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4452,17 +5130,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 22 flowey_lib_common::cache 2
-        flowey e 22 flowey_lib_common::download_cargo_nextest 4
+        flowey e 24 flowey_lib_common::cache 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 22 flowey_lib_common::git_checkout 0
-        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_common::git_checkout 0
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4474,32 +5152,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 22 flowey_lib_common::git_checkout 3
-        flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 22 flowey_core::pipeline::artifact::resolve 5
-        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey e 24 flowey_lib_common::git_checkout 3
+        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
     - name: generate nextest command
-      run: flowey e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 22 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 22 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 22 flowey_lib_common::publish_test_results 4
-        flowey e 22 flowey_lib_common::publish_test_results 5
-        flowey v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 24 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 24 flowey_lib_common::publish_test_results 4
+        flowey e 24 flowey_lib_common::publish_test_results 5
+        flowey v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4510,12 +5188,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 22 flowey_lib_common::publish_test_results 0
-        flowey e 22 flowey_lib_common::publish_test_results 1
-        flowey e 22 flowey_lib_common::publish_test_results 2
-        flowey v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 24 flowey_lib_common::publish_test_results 0
+        flowey e 24 flowey_lib_common::publish_test_results 1
+        flowey e 24 flowey_lib_common::publish_test_results 2
+        flowey v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4525,31 +5203,31 @@ jobs:
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 22 flowey_lib_common::cache 3
+      run: flowey e 24 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 22 flowey_lib_common::cache 7
+      run: flowey e 24 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 22 flowey_lib_common::cache 11
+      run: flowey e 24 flowey_lib_common::cache 11
       shell: bash
-  job23:
+  job25:
     name: run vmm-tests [x64-linux-intel-mshv]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
-    - job5
-    - job8
-    - job9
+    - job10
+    - job11
+    - job6
     if: github.event.pull_request.draft == false
     steps:
     - run: |
@@ -4616,46 +5294,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 23 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 23 'verbose' update
+        cat <<'EOF' | flowey v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 23 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey e 23 flowey_core::pipeline::artifact::resolve 7
-        flowey e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey e 23 flowey_core::pipeline::artifact::resolve 4
-        flowey e 23 flowey_core::pipeline::artifact::resolve 6
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey e 25 flowey_core::pipeline::artifact::resolve 7
+        flowey e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 4
+        flowey e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 23 flowey_lib_common::download_gh_release 0
+      run: flowey e 25 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 23 flowey_lib_common::cache 8
-        flowey v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 25 flowey_lib_common::cache 8
+        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4665,31 +5343,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 23 flowey_lib_common::cache 10
-        flowey e 23 flowey_lib_common::download_gh_release 1
+        flowey e 25 flowey_lib_common::cache 10
+        flowey e 25 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 23 flowey_lib_common::download_azcopy 0
+      run: flowey e 25 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 23 flowey_lib_common::download_gh_cli 0
+      run: flowey e 25 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 23 flowey_lib_common::cache 4
-        flowey v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 25 flowey_lib_common::cache 4
+        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4699,51 +5377,51 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 23 flowey_lib_common::cache 6
-        flowey e 23 flowey_lib_common::download_gh_cli 1
-        flowey v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 25 flowey_lib_common::cache 6
+        flowey e 25 flowey_lib_common::download_gh_cli 1
+        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 23 flowey_lib_common::use_gh_cli 0
+      run: flowey e 25 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 23 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 25 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 23 flowey_lib_common::download_cargo_nextest 0
-        flowey e 23 flowey_lib_common::download_cargo_nextest 1
-        flowey e 23 flowey_lib_common::download_cargo_nextest 2
-        flowey e 23 flowey_lib_common::download_cargo_nextest 3
+        flowey e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 23 flowey_lib_common::cache 0
-        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 25 flowey_lib_common::cache 0
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4753,17 +5431,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 23 flowey_lib_common::cache 2
-        flowey e 23 flowey_lib_common::download_cargo_nextest 4
+        flowey e 25 flowey_lib_common::cache 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 23 flowey_lib_common::git_checkout 0
-        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4775,31 +5453,31 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 23 flowey_lib_common::git_checkout 3
-        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 23 flowey_core::pipeline::artifact::resolve 5
-        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 25 flowey_lib_common::git_checkout 3
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 25 flowey_core::pipeline::artifact::resolve 5
+        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: generate nextest command
-      run: flowey e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 23 flowey_lib_common::publish_test_results 4
-        flowey e 23 flowey_lib_common::publish_test_results 5
-        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 25 flowey_lib_common::publish_test_results 4
+        flowey e 25 flowey_lib_common::publish_test_results 5
+        flowey v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4810,12 +5488,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 23 flowey_lib_common::publish_test_results 0
-        flowey e 23 flowey_lib_common::publish_test_results 1
-        flowey e 23 flowey_lib_common::publish_test_results 2
-        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 25 flowey_lib_common::publish_test_results 0
+        flowey e 25 flowey_lib_common::publish_test_results 1
+        flowey e 25 flowey_lib_common::publish_test_results 2
+        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4825,18 +5503,18 @@ jobs:
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 23 flowey_lib_common::cache 3
+      run: flowey e 25 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 23 flowey_lib_common::cache 7
+      run: flowey e 25 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 23 flowey_lib_common::cache 11
+      run: flowey e 25 flowey_lib_common::cache 11
       shell: bash
-  job24:
+  job26:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -4847,9 +5525,10 @@ jobs:
       contents: read
       id-token: write
     needs:
-    - job10
+    - job12
     - job3
-    - job6
+    - job4
+    - job8
     if: github.event.pull_request.draft == false
     steps:
     - run: |
@@ -4917,35 +5596,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 24 'verbose' update
+        cat <<'EOF' | flowey.exe v 26 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 24 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 26 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 0
-        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 26 flowey_lib_common::cache 0
+        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4955,17 +5634,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 26 flowey_lib_common::cache 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 24 flowey_lib_common::git_checkout 0
-        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_common::git_checkout 0
+        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4977,35 +5656,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 24 flowey_lib_common::git_checkout 3
-        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 26 flowey_lib_common::git_checkout 3
+        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 8
-        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 26 flowey_lib_common::cache 8
+        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5015,31 +5694,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 10
-        flowey.exe e 24 flowey_lib_common::download_gh_release 1
+        flowey.exe e 26 flowey_lib_common::cache 10
+        flowey.exe e 26 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 26 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 4
-        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 26 flowey_lib_common::cache 4
+        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5049,63 +5728,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 6
-        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 26 flowey_lib_common::cache 6
+        flowey.exe e 26 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 26 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 24 flowey_lib_common::publish_test_results 4
-        flowey.exe e 24 flowey_lib_common::publish_test_results 5
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 26 flowey_lib_common::publish_test_results 4
+        flowey.exe e 26 flowey_lib_common::publish_test_results 5
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5116,12 +5795,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 24 flowey_lib_common::publish_test_results 0
-        flowey.exe e 24 flowey_lib_common::publish_test_results 1
-        flowey.exe e 24 flowey_lib_common::publish_test_results 2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 26 flowey_lib_common::publish_test_results 0
+        flowey.exe e 26 flowey_lib_common::publish_test_results 1
+        flowey.exe e 26 flowey_lib_common::publish_test_results 2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5131,18 +5810,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 24 flowey_lib_common::cache 3
+      run: flowey.exe e 26 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 24 flowey_lib_common::cache 7
+      run: flowey.exe e 26 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 24 flowey_lib_common::cache 11
+      run: flowey.exe e 26 flowey_lib_common::cache 11
       shell: bash
-  job25:
+  job27:
     name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
@@ -5210,18 +5889,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 25 'verbose' update
+        cat <<'EOF' | flowey v 27 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 27 flowey_lib_common::git_checkout 0
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5233,35 +5912,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 27 flowey_lib_common::git_checkout 3
+        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 25 flowey_lib_common::install_rust 0
+      run: flowey e 27 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 25 flowey_lib_common::install_rust 1
+      run: flowey e 27 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 25 flowey_lib_common::install_rust 2
-        flowey v 25 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 27 flowey_lib_common::install_rust 2
+        flowey v 27 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 25 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      run: flowey e 27 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
-  job26:
+  job28:
     name: build openhcl (mi-secure) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job28-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5327,31 +6006,31 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 26 'verbose' update
+        cat <<'EOF' | flowey v 28 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 26 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 28 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 26 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 28 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 26 flowey_lib_common::download_gh_release 0
+      run: flowey e 28 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 26 flowey_lib_common::cache 0
-        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey e 28 flowey_lib_common::cache 0
+        flowey v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5361,31 +6040,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 26 flowey_lib_common::cache 2
-        flowey e 26 flowey_lib_common::download_gh_release 1
+        flowey e 28 flowey_lib_common::cache 2
+        flowey e 28 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 28 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 26 flowey_lib_common::install_rust 0
+      run: flowey e 28 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 26 flowey_lib_common::install_rust 1
+      run: flowey e 28 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 26 flowey_lib_common::install_rust 2
-        flowey e 26 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 28 flowey_lib_common::install_rust 2
+        flowey e 28 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 26 flowey_lib_common::git_checkout 0
-        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 28 flowey_lib_common::git_checkout 0
+        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5397,172 +6076,172 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 26 flowey_lib_common::git_checkout 3
-        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 28 flowey_lib_common::git_checkout 3
+        flowey e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 26 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 28 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 26 flowey_lib_common::resolve_protoc 0
-        flowey e 26 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 28 flowey_lib_common::resolve_protoc 0
+        flowey e 28 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 0
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 28 flowey_lib_hvlite::init_cross_build 0
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 3
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 28 flowey_lib_common::run_cargo_build 3
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 26 flowey_lib_hvlite::build_sidecar 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 1
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 28 flowey_lib_hvlite::build_sidecar 0
+        flowey e 28 flowey_lib_hvlite::init_cross_build 1
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: cargo build openhcl_boot
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 1
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 28 flowey_lib_common::run_cargo_build 1
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 28 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 3
+        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 28 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 2
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 26 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 28 flowey_lib_common::run_cargo_build 2
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 28 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 26 flowey_lib_hvlite::init_cross_build 2
+        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 28 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 0
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 28 flowey_lib_common::run_cargo_build 0
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 26 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 28 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 28 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
-        flowey e 26 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 28 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 26 flowey_lib_common::copy_to_artifact_dir 0
+      run: flowey e 28 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 26 flowey_lib_common::cache 3
+      run: flowey e 28 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -5576,20 +6255,21 @@ jobs:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
         include-hidden-files: true
-  job27:
+  job29:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job29-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
-    - job26
-    - job5
-    - job8
+    - job10
+    - job28
+    - job6
+    - job7
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -5608,39 +6288,39 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15/flowey.exe
 
-        echo '"debug"' | flowey.exe v 27 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 27 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 29 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 29 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 27 'verbose' update
+        cat <<'EOF' | flowey.exe v 29 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 27 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 27 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 27 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 27 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 27 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 27 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 27 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 27 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 29 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 29 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 29 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 29 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 29 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 29 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 29 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 29 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 29 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 27 flowey_lib_common::cache 0
-        flowey.exe v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 29 flowey_lib_common::cache 0
+        flowey.exe v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5650,17 +6330,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 27 flowey_lib_common::cache 2
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 29 flowey_lib_common::cache 2
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 27 flowey_lib_common::git_checkout 0
-        flowey.exe v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 29 flowey_lib_common::git_checkout 0
+        flowey.exe v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5672,38 +6352,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 27 flowey_lib_common::git_checkout 3
-        flowey.exe e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 29 flowey_lib_common::git_checkout 3
+        flowey.exe e 29 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 27 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 29 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 27 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 29 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 27 flowey_lib_common::cache 8
-        flowey.exe v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 29 flowey_lib_common::cache 8
+        flowey.exe v 29 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 29 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5713,31 +6393,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 29 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 27 flowey_lib_common::cache 10
-        flowey.exe e 27 flowey_lib_common::download_gh_release 1
+        flowey.exe e 29 flowey_lib_common::cache 10
+        flowey.exe e 29 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 27 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 29 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 27 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 29 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 27 flowey_lib_common::cache 4
-        flowey.exe v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 29 flowey_lib_common::cache 4
+        flowey.exe v 29 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 29 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5747,63 +6427,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 29 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 27 flowey_lib_common::cache 6
-        flowey.exe e 27 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 29 flowey_lib_common::cache 6
+        flowey.exe e 29 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 27 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 29 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 29 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 27 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 29 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 29 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 29 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 29 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 29 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 29 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 29 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 29 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 27 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 29 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 27 flowey_lib_common::publish_test_results 4
-        flowey.exe e 27 flowey_lib_common::publish_test_results 5
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 29 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 29 flowey_lib_common::publish_test_results 4
+        flowey.exe e 29 flowey_lib_common::publish_test_results 5
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5814,12 +6494,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 27 flowey_lib_common::publish_test_results 0
-        flowey.exe e 27 flowey_lib_common::publish_test_results 1
-        flowey.exe e 27 flowey_lib_common::publish_test_results 2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 29 flowey_lib_common::publish_test_results 0
+        flowey.exe e 29 flowey_lib_common::publish_test_results 1
+        flowey.exe e 29 flowey_lib_common::publish_test_results 2
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5829,160 +6509,19 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 27 flowey_lib_common::cache 3
+      run: flowey.exe e 29 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 27 flowey_lib_common::cache 7
+      run: flowey.exe e 29 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 27 flowey_lib_common::cache 11
-      shell: bash
-  job28:
-    name: publish vmgstool
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-    needs:
-    - job0
-    - job1
-    - job10
-    - job11
-    - job12
-    - job13
-    - job14
-    - job15
-    - job16
-    - job17
-    - job18
-    - job19
-    - job2
-    - job20
-    - job21
-    - job22
-    - job23
-    - job24
-    - job25
-    - job26
-    - job27
-    - job3
-    - job4
-    - job5
-    - job6
-    - job7
-    - job8
-    - job9
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-11,aarch64-linux-vmgstool,aarch64-windows-vmgstool,x64-linux-vmgstool,x64-windows-vmgstool}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11/flowey
-
-        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 28 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 28 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 28 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 28 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 28 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 28 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 28 flowey_lib_common::cache 0
-        flowey v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 28 flowey_lib_common::cache 2
-        flowey e 28 flowey_lib_common::download_gh_cli 1
-        flowey v 28 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: |-
-        flowey e 28 flowey_lib_common::use_gh_cli 0
-        flowey e 28 flowey_core::pipeline::artifact::resolve 1
-        flowey e 28 flowey_core::pipeline::artifact::resolve 0
-        flowey e 28 flowey_core::pipeline::artifact::resolve 3
-        flowey e 28 flowey_core::pipeline::artifact::resolve 2
-      shell: bash
-    - name: enumerate vmgstool release files
-      run: flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 28 flowey_lib_common::git_checkout 0
-        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 28 flowey_lib_common::git_checkout 3
-        flowey e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: get current commit
-      run: |-
-        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
-        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
-      shell: bash
-    - name: get cargo crate version
-      run: |-
-        flowey e 28 flowey_lib_common::get_cargo_crate_version 0
-        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
-        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
-        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
-      shell: bash
-    - name: publish github releases
-      run: flowey e 28 flowey_lib_common::publish_gh_release 0
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 28 flowey_lib_common::cache 3
+      run: flowey.exe e 29 flowey_lib_common::cache 11
       shell: bash
   job3:
-    name: build artifacts (for VMM tests) [aarch64-windows]
+    name: build artifacts (shared VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6059,22 +6598,8 @@ jobs:
         cat <<'EOF' | flowey.exe v 3 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-pipette"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-pipette" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-prep_steps"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-prep_steps" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-test_igvm_agent_rpc_server" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tpm_guest_tests"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tpm_guest_tests" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 3 flowey_lib_common::install_rust 0
@@ -6117,22 +6642,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 3 flowey_lib_common::cache 4
-        flowey.exe v 3 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 3 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 3 flowey_lib_common::cache 0
+        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 3 flowey_lib_common::cache 6
+        flowey.exe e 3 flowey_lib_common::cache 2
         flowey.exe e 3 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -6143,164 +6668,169 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: cargo build prep_steps
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 2
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 3 flowey_lib_hvlite::build_prep_steps 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 5
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 6
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 10
-        flowey.exe e 3 flowey_lib_hvlite::build_vmgstool 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 6
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 3
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 7
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 5
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 9
-        flowey.exe e 3 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 7
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 3
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: cargo build test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 5
-        flowey.exe e 3 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 0
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 3 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 3 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 3 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 3 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 3 flowey_lib_common::cache 0
-        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 3 flowey_lib_common::cache 2
-        flowey.exe e 3 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey.exe e 3 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey.exe e 3 flowey_lib_common::install_cargo_nextest 0
         flowey.exe e 3 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey.exe e 3 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 3 flowey_lib_hvlite::build_openvmm 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 3 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 0
         flowey.exe e 3 flowey_lib_hvlite::build_pipette 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 3
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 4
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 6
-        flowey.exe e 3 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 3 flowey_lib_common::cache 3
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 3 flowey_lib_common::cache 7
+      run: flowey.exe e 3 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-windows-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-openvmm/
-        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-pipette
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-windows-pipette
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-pipette/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-prep_steps
-      uses: actions/upload-artifact@v7
+  job30:
+    name: publish vmgstool
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    needs:
+    - job0
+    - job1
+    - job10
+    - job11
+    - job12
+    - job13
+    - job14
+    - job15
+    - job16
+    - job17
+    - job18
+    - job19
+    - job2
+    - job20
+    - job21
+    - job22
+    - job23
+    - job24
+    - job25
+    - job26
+    - job27
+    - job28
+    - job29
+    - job3
+    - job4
+    - job5
+    - job6
+    - job7
+    - job8
+    - job9
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
       with:
-        name: aarch64-windows-prep_steps
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-prep_steps/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
-      uses: actions/upload-artifact@v7
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-11,aarch64-linux-vmgstool,aarch64-windows-vmgstool,x64-linux-vmgstool,x64-windows-vmgstool}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11/flowey
+
+        echo '"debug"' | flowey v 30 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 30 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 30 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 30 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 30 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 30 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 30 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 30 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 30 flowey_lib_common::cache 0
+        flowey v 30 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 30 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
       with:
-        name: aarch64-windows-test_igvm_agent_rpc_server
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-tmk_vmm
-      uses: actions/upload-artifact@v7
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 30 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 30 flowey_lib_common::cache 2
+        flowey e 30 flowey_lib_common::download_gh_cli 1
+        flowey v 30 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: |-
+        flowey e 30 flowey_lib_common::use_gh_cli 0
+        flowey e 30 flowey_core::pipeline::artifact::resolve 1
+        flowey e 30 flowey_core::pipeline::artifact::resolve 0
+        flowey e 30 flowey_core::pipeline::artifact::resolve 3
+        flowey e 30 flowey_core::pipeline::artifact::resolve 2
+      shell: bash
+    - name: enumerate vmgstool release files
+      run: flowey e 30 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 30 flowey_lib_common::git_checkout 0
+        flowey v 30 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 30 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
       with:
-        name: aarch64-windows-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-tpm_guest_tests
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmm-tests-archive/
-        include-hidden-files: true
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 30 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 30 flowey_lib_common::git_checkout 3
+        flowey e 30 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: get current commit
+      run: |-
+        flowey e 30 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
+        flowey e 30 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
+      shell: bash
+    - name: get cargo crate version
+      run: |-
+        flowey e 30 flowey_lib_common::get_cargo_crate_version 0
+        flowey e 30 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
+        flowey e 30 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
+        flowey e 30 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
+      shell: bash
+    - name: publish github releases
+      run: flowey e 30 flowey_lib_common::publish_gh_release 0
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 30 flowey_lib_common::cache 3
+      shell: bash
   job4:
-    name: build artifacts (not for VMM tests) [x64-windows]
+    name: build artifacts (for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6377,14 +6907,20 @@ jobs:
         cat <<'EOF' | flowey.exe v 4 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 4 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 4 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 4 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 4 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-prep_steps"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-prep_steps" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-test_igvm_agent_rpc_server" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tpm_guest_tests"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tpm_guest_tests" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 4 flowey_lib_common::install_rust 0
@@ -6427,22 +6963,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 4 flowey_lib_common::cache 0
-        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe e 4 flowey_lib_common::cache 4
+        flowey.exe v 4 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 4 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
-    - id: flowey_lib_common__cache__1
+    - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        flowey.exe v 4 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 4 flowey_lib_common::cache 2
+        flowey.exe e 4 flowey_lib_common::cache 6
         flowey.exe e 4 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -6453,73 +6989,150 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 4 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 5
       shell: bash
-    - name: cargo build hypestv
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 4 flowey_lib_hvlite::build_hypestv 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 3
-        flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      shell: bash
-    - name: test vmgs_lib
-      run: |-
-        flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build prep_steps
       run: |-
         flowey.exe e 4 flowey_lib_common::run_cargo_build 1
         flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 4 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 4 flowey_lib_hvlite::build_prep_steps 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 4
         flowey.exe e 4 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build ohcldiag-dev
+    - name: cargo build vmgstool
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 5
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 9
+        flowey.exe e 4 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 5
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 6
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 8
+        flowey.exe e 4 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 6
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 6
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 4 flowey_lib_common::run_cargo_build 2
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 4 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 4 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 0
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 4 flowey_lib_common::cache 0
+        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 4 flowey_lib_common::cache 2
+        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 4 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey.exe e 4 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey.exe e 4 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 4 flowey_lib_hvlite::build_openvmm 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 5
+        flowey.exe e 4 flowey_lib_hvlite::build_tmk_vmm 0
         flowey.exe e 4 flowey_core::pipeline::artifact::publish 3
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 4 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-windows-hypestv
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 4 flowey_lib_common::cache 7
+      shell: bash
+    - name: 🌼📦 Publish aarch64-windows-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-hypestv
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-hypestv/
+        name: aarch64-windows-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-igvmfilegen
+    - name: 🌼📦 Publish aarch64-windows-prep_steps
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-igvmfilegen/
+        name: aarch64-windows-prep_steps
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-prep_steps/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-ohcldiag-dev
+    - name: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
+        name: aarch64-windows-test_igvm_agent_rpc_server
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-vmgs_lib
+    - name: 🌼📦 Publish aarch64-windows-tmk_vmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
+        name: aarch64-windows-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmm-tests-archive/
         include-hidden-files: true
   job5:
-    name: build artifacts (for VMM tests) [x64-windows]
+    name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6596,22 +7209,14 @@ jobs:
         cat <<'EOF' | flowey.exe v 5 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-openvmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-openvmm" | flowey.exe v 5 'artifact_publish_from_x64-windows-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-pipette"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 5 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-prep_steps"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-prep_steps" | flowey.exe v 5 'artifact_publish_from_x64-windows-prep_steps' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-test_igvm_agent_rpc_server"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 5 'artifact_publish_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tmk_vmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 5 'artifact_publish_from_x64-windows-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tpm_guest_tests"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 5 'artifact_publish_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmm-tests-archive"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 5 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 5 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 5 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 5 flowey_lib_common::install_rust 0
@@ -6654,22 +7259,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 5 flowey_lib_common::cache 4
-        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 5 flowey_lib_common::cache 0
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 5 flowey_lib_common::cache 6
+        flowey.exe e 5 flowey_lib_common::cache 2
         flowey.exe e 5 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -6680,176 +7285,77 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 5 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 5
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build openvmm
+    - name: cargo build hypestv
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 0
         flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 5 flowey_lib_hvlite::build_openvmm 0
+        flowey.exe e 5 flowey_lib_hvlite::build_hypestv 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 6
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
       shell: bash
-    - name: cargo build pipette
+    - name: cargo build vmgs_lib
       run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 5 flowey_lib_hvlite::build_pipette 0
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      shell: bash
+    - name: test vmgs_lib
+      run: |-
+        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 1
         flowey.exe e 5 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: cargo build tmk_vmm
+    - name: cargo build igvmfilegen
       run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 4
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 6
-        flowey.exe e 5 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 5 flowey_lib_hvlite::build_igvmfilegen 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 7
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build prep_steps
+    - name: cargo build ohcldiag-dev
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 2
         flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 5 flowey_lib_hvlite::build_prep_steps 0
+        flowey.exe e 5 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 3
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 6
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 10
-        flowey.exe e 5 flowey_lib_hvlite::build_vmgstool 0
-        flowey.exe e 5 flowey_core::pipeline::artifact::publish 4
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 3
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 7
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 5
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 9
-        flowey.exe e 5 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey.exe e 5 flowey_core::pipeline::artifact::publish 5
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: cargo build test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 5
-        flowey.exe e 5 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
-        flowey.exe e 5 flowey_core::pipeline::artifact::publish 6
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 5 flowey_lib_common::cache 0
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 5 flowey_lib_common::cache 2
-        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey.exe e 5 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey.exe e 5 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey.exe e 5 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey.exe e 5 flowey_core::pipeline::artifact::publish 7
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 5 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 5 flowey_lib_common::cache 7
+      run: flowey.exe e 5 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-windows-openvmm
+    - name: 🌼📦 Publish x64-windows-hypestv
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-openvmm/
+        name: x64-windows-hypestv
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-hypestv/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-pipette
+    - name: 🌼📦 Publish x64-windows-igvmfilegen
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-pipette
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
+        name: x64-windows-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-igvmfilegen/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-prep_steps
+    - name: 🌼📦 Publish x64-windows-ohcldiag-dev
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-prep_steps
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-prep_steps/
+        name: x64-windows-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-test_igvm_agent_rpc_server
+    - name: 🌼📦 Publish x64-windows-vmgs_lib
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-test_igvm_agent_rpc_server
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-test_igvm_agent_rpc_server/
+        name: x64-windows-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-tmk_vmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-tpm_guest_tests
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmm-tests-archive/
-        include-hidden-files: true
-    - name: 🌼🧼 Redact bootstrap var db
-      run: rm $AgentTempDirNormal/bootstrapped-flowey/job5.json
-      shell: bash
-    - name: 🌼🥾 Publish bootstrapped flowey
-      uses: actions/upload-artifact@v7
-      with:
-        name: _internal-flowey-bootstrap-x86_64-windows-uid-15
-        path: ${{ runner.temp }}/bootstrapped-flowey
   job6:
-    name: build artifacts (shared VMM tests) [aarch64-linux]
+    name: build artifacts (shared VMM tests) [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=win-amd64
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6889,11 +7395,11 @@ jobs:
     - name: Build flowey
       run: |
         set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
         OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         mkdir -p "$OutDirNormal"
         mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
       working-directory: flowey_bootstrap
       shell: bash
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
@@ -6906,7 +7412,7 @@ jobs:
         ${{ runner.temp }}
         EOF
         )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
       shell: bash
     - name: 🌼🛫 Initialize job
       run: |
@@ -6914,41 +7420,33 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey v 6 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 6 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 6 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 6 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 6 'verbose' update
+        cat <<'EOF' | flowey.exe v 6 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 6 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests" | flowey v 6 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 6 'artifact_publish_from_aarch64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-pipette"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 6 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 6 flowey_lib_common::install_rust 0
+      run: flowey.exe e 6 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 6 flowey_lib_common::install_rust 1
+      run: flowey.exe e 6 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 6 flowey_lib_common::install_rust 2
-        flowey e 6 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 6 flowey_lib_common::install_rust 2
+        flowey.exe e 6 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 6 flowey_lib_common::git_checkout 0
-        flowey v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 6 flowey_lib_common::git_checkout 0
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6960,23 +7458,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 6 flowey_lib_common::git_checkout 3
-        flowey e 6 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 6 flowey_lib_common::git_checkout 3
+        flowey.exe e 6 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 6 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 6 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 6 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 6 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 6 flowey_lib_common::cache 0
-        flowey v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe e 6 flowey_lib_common::cache 0
+        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6986,138 +7484,44 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 6 flowey_lib_common::cache 2
-        flowey e 6 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 6 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 6 flowey_lib_common::install_dist_pkg 1
+        flowey.exe e 6 flowey_lib_common::cache 2
+        flowey.exe e 6 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 6 flowey_lib_common::resolve_protoc 0
-        flowey e 6 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 6 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 6 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build guest_test_uefi
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: build guest_test_uefi.img
-      run: |-
-        flowey e 6 flowey_lib_hvlite::build_guest_test_uefi 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: cargo build simple_tmk
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 6 flowey_lib_hvlite::build_tmks 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 1
-        flowey e 6 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 4
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 6 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 2
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 6 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 6 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 1
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::build_pipette 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 3
-        flowey e 6 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 6 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 4
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 6 flowey_lib_hvlite::build_pipette 0
+        flowey.exe e 6 flowey_core::pipeline::artifact::publish 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 6 flowey_lib_common::cache 3
+      run: flowey.exe e 6 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-guest_test_uefi
+    - name: 🌼📦 Publish x64-windows-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-guest_test_uefi
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-pipette
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-tpm_guest_tests
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-tmks
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-tmks
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
+        name: x64-windows-pipette
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
         include-hidden-files: true
   job7:
-    name: build artifacts (for VMM tests) [aarch64-linux]
+    name: build artifacts (for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=win-amd64
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7157,11 +7561,11 @@ jobs:
     - name: Build flowey
       run: |
         set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
         OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         mkdir -p "$OutDirNormal"
         mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
       working-directory: flowey_bootstrap
       shell: bash
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
@@ -7174,7 +7578,7 @@ jobs:
         ${{ runner.temp }}
         EOF
         )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
       shell: bash
     - name: 🌼🛫 Initialize job
       run: |
@@ -7182,53 +7586,45 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey v 7 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 7 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 7 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 7 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 7 'verbose' update
+        cat <<'EOF' | flowey.exe v 7 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 7 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 7 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 7 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 7 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 7 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 7 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-openvmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-openvmm" | flowey.exe v 7 'artifact_publish_from_x64-windows-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-prep_steps"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-prep_steps" | flowey.exe v 7 'artifact_publish_from_x64-windows-prep_steps' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-test_igvm_agent_rpc_server"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 7 'artifact_publish_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tmk_vmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 7 'artifact_publish_from_x64-windows-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tpm_guest_tests"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 7 'artifact_publish_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool" | flowey.exe v 7 'artifact_publish_from_x64-windows-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmm-tests-archive"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 7 'artifact_publish_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 7 flowey_lib_common::install_rust 0
+      run: flowey.exe e 7 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 7 flowey_lib_common::install_rust 1
+      run: flowey.exe e 7 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 7 flowey_lib_common::install_rust 2
-        flowey e 7 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 7 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 7 flowey_lib_common::install_dist_pkg 1
+        flowey.exe e 7 flowey_lib_common::install_rust 2
+        flowey.exe e 7 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 7 flowey_lib_common::git_checkout 0
-        flowey v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 7 flowey_lib_common::git_checkout 0
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7240,207 +7636,198 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 7 flowey_lib_common::git_checkout 3
-        flowey e 7 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 7 flowey_lib_common::git_checkout 3
+        flowey.exe e 7 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 7 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 7 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 7 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 7 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 7 flowey_lib_common::cache 0
-        flowey v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe e 7 flowey_lib_common::cache 4
+        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 7 flowey_lib_common::cache 6
+        flowey.exe e 7 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey.exe e 7 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 7 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey.exe e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 7 flowey_lib_hvlite::build_openvmm 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 0
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 5
+        flowey.exe e 7 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build prep_steps
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 7 flowey_lib_hvlite::build_prep_steps 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build vmgstool
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 5
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 9
+        flowey.exe e 7 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 6
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 8
+        flowey.exe e 7 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 4
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 6
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 2
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 7 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 5
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 7 flowey_lib_common::cache 0
+        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
       run: |-
-        flowey v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 7 flowey_lib_common::cache 2
-        flowey e 7 flowey_lib_common::download_gh_release 1
+        flowey.exe e 7 flowey_lib_common::cache 2
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 4
       shell: bash
-    - name: unpack protoc
+    - name: report $CARGO_HOME
+      run: flowey.exe e 7 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
       run: |-
-        flowey e 7 flowey_lib_common::resolve_protoc 0
-        flowey e 7 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 7 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 0
       shell: bash
-    - name: symlink protoc
+    - name: build + archive 'vmm_tests' nextests
       run: |-
-        flowey e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 7 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey.exe e 7 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 6
       shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 2
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 7 flowey_lib_hvlite::build_openvmm 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 4
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 7 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 1
-        flowey e 7 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 7
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 7 flowey_lib_hvlite::build_vmgstool 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 2
-        flowey e 7 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 6
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 7 flowey_core::pipeline::artifact::publish 3
-        flowey e 7 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 0
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 7 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 4
-        flowey e 7 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build ohcldiag-dev
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 1
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 5
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 7 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 7 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 7 flowey_lib_hvlite::build_openvmm 1
-        flowey e 7 flowey_core::pipeline::artifact::publish 6
-        flowey e 7 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 5
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 10
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 11
-        flowey e 7 flowey_lib_hvlite::build_openvmm_vhost 1
-        flowey e 7 flowey_core::pipeline::artifact::publish 7
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 7 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 7 flowey_lib_common::cache 3
+      run: flowey.exe e 7 flowey_lib_common::cache 7
       shell: bash
-    - name: 🌼📦 Publish aarch64-linux-igvmfilegen
+    - name: 🌼📦 Publish x64-windows-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
+        name: x64-windows-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
+    - name: 🌼📦 Publish x64-windows-prep_steps
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
+        name: x64-windows-prep_steps
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-prep_steps/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
+    - name: 🌼📦 Publish x64-windows-test_igvm_agent_rpc_server
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
+        name: x64-windows-test_igvm_agent_rpc_server
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-test_igvm_agent_rpc_server/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
+    - name: 🌼📦 Publish x64-windows-tmk_vmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
+        name: x64-windows-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-tmk_vmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-openvmm
+    - name: 🌼📦 Publish x64-windows-tpm_guest_tests
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
+        name: x64-windows-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-tpm_guest_tests/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-openvmm_vhost
+    - name: 🌼📦 Publish x64-windows-vmgstool
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
+        name: x64-windows-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgstool/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-vmgs_lib
+    - name: 🌼📦 Publish x64-windows-vmm-tests-archive
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
+        name: x64-windows-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmm-tests-archive/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-vmgstool
+    - name: 🌼🧼 Redact bootstrap var db
+      run: rm $AgentTempDirNormal/bootstrapped-flowey/job7.json
+      shell: bash
+    - name: 🌼🥾 Publish bootstrapped flowey
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
-        include-hidden-files: true
+        name: _internal-flowey-bootstrap-x86_64-windows-uid-15
+        path: ${{ runner.temp }}/bootstrapped-flowey
   job8:
-    name: build artifacts (shared VMM tests) [x64-linux]
+    name: build artifacts (shared VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7517,16 +7904,16 @@ jobs:
         cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 8 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 8 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 8 'artifact_publish_from_x64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 8 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests" | flowey v 8 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 8 'artifact_publish_from_aarch64-tmks' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 8 flowey_lib_common::install_rust 0
@@ -7644,7 +8031,7 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 8 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
         flowey e 8 flowey_lib_hvlite::init_cross_build 3
@@ -7677,38 +8064,38 @@ jobs:
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-guest_test_uefi
+    - name: 🌼📦 Publish aarch64-guest_test_uefi
       uses: actions/upload-artifact@v7
       with:
-        name: x64-guest_test_uefi
-        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
+        name: aarch64-guest_test_uefi
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-pipette
+    - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
+        name: aarch64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
+    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        name: aarch64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
+    - name: 🌼📦 Publish aarch64-linux-tpm_guest_tests
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
+        name: aarch64-linux-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-tpm_guest_tests/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-tmks
+    - name: 🌼📦 Publish aarch64-tmks
       uses: actions/upload-artifact@v7
       with:
-        name: x64-tmks
-        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
+        name: aarch64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
         include-hidden-files: true
   job9:
-    name: build artifacts (for VMM tests) [x64-linux]
+    name: build artifacts (for VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7785,26 +8172,22 @@ jobs:
         cat <<'EOF' | flowey v 9 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 9 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 9 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 9 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 9 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 9 flowey_lib_common::install_rust 0
@@ -7853,22 +8236,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 9 flowey_lib_common::cache 4
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 9 flowey_lib_common::cache 0
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 9 flowey_lib_common::cache 6
+        flowey e 9 flowey_lib_common::cache 2
         flowey e 9 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -7879,7 +8262,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7892,7 +8275,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 5
         flowey e 9 flowey_lib_hvlite::build_openvmm 0
         flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7905,7 +8288,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 9
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -7918,20 +8301,16 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 14
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_build 6
         flowey e 9 flowey_lib_hvlite::run_cargo_build 12
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      shell: bash
-    - name: test vmgs_lib
-      run: |-
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 9 flowey_core::pipeline::artifact::publish 3
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -7944,7 +8323,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -7961,10 +8340,10 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7977,7 +8356,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
         flowey e 9 flowey_lib_hvlite::build_openvmm 1
         flowey e 9 flowey_core::pipeline::artifact::publish 6
-        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7991,125 +8370,54 @@ jobs:
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 9 flowey_core::pipeline::artifact::publish 7
       shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 9 flowey_lib_common::download_cargo_nextest 0
-        flowey e 9 flowey_lib_common::download_cargo_nextest 1
-        flowey e 9 flowey_lib_common::download_cargo_nextest 2
-        flowey e 9 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 9 flowey_lib_common::cache 2
-        flowey e 9 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 9 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 9 flowey_lib_common::install_cargo_nextest 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 8
-        flowey e 9 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 1
-        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
-        flowey e 9 flowey_core::pipeline::artifact::publish 9
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
+    - name: 'validate cache entry: gh-release-download'
       run: flowey e 9 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 9 flowey_lib_common::cache 7
-      shell: bash
-    - name: 🌼📦 Publish x64-linux-igvmfilegen
+    - name: 🌼📦 Publish aarch64-linux-igvmfilegen
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        name: aarch64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        name: aarch64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
+        name: aarch64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+    - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
+        name: aarch64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
+    - name: 🌼📦 Publish aarch64-linux-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
+        name: aarch64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm
+    - name: 🌼📦 Publish aarch64-linux-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
+        name: aarch64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm_vhost
+    - name: 🌼📦 Publish aarch64-linux-vmgs_lib
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        name: aarch64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgs_lib
+    - name: 🌼📦 Publish aarch64-linux-vmgstool
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
+        name: aarch64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
-        include-hidden-files: true
-    - name: 🌼🧼 Redact bootstrap var db
-      run: rm $AgentTempDirNormal/bootstrapped-flowey/job9.json
-      shell: bash
-    - name: 🌼🥾 Publish bootstrapped flowey
-      uses: actions/upload-artifact@v7
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-11
-        path: ${{ runner.temp }}/bootstrapped-flowey

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -345,11 +345,11 @@ jobs:
       run: flowey e 1 flowey_lib_common::cache 3
       shell: bash
   job10:
-    name: clippy [x64-windows], unit tests [x64-windows]
+    name: build openhcl [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -389,11 +389,11 @@ jobs:
     - name: Build flowey
       run: |
         set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
         OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         mkdir -p "$OutDirNormal"
         mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
       working-directory: flowey_bootstrap
       shell: bash
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
@@ -406,7 +406,7 @@ jobs:
         ${{ runner.temp }}
         EOF
         )
-        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
       shell: bash
     - name: 🌼🛫 Initialize job
       run: |
@@ -414,205 +414,244 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey.exe v 10 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 10 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 10 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 10 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 10 'verbose' update
+        cat <<'EOF' | flowey v 10 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline" | flowey v 10 'artifact_publish_from_aarch64-openhcl-baseline' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 10 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 10 flowey_lib_common::cache 0
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 10 flowey_lib_common::cache 2
+        flowey e 10 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (aarch64)
+      run: flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 10 flowey_lib_common::install_rust 0
+      run: flowey e 10 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 10 flowey_lib_common::install_rust 1
+      run: flowey e 10 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 10 flowey_lib_common::install_rust 2
-        flowey.exe e 10 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 10 flowey_lib_common::install_rust 2
+        flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 10 flowey_lib_common::git_checkout 0
-        flowey.exe v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 10 flowey_lib_common::git_checkout 0
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar7 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 10 flowey_lib_common::git_checkout 3
-        flowey.exe e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 10 flowey_lib_common::git_checkout 3
+        flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 10 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 10 flowey_lib_common::cache 4
-        flowey.exe v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 10 flowey_lib_common::cache 6
-        flowey.exe e 10 flowey_lib_common::download_gh_release 1
+      run: flowey e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 10 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 10 flowey_lib_common::resolve_protoc 0
+        flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 10 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 10 flowey_lib_hvlite::init_cross_build 2
+        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
-    - name: cargo build xtask
+    - name: cargo build openhcl_boot
       run: |-
-        flowey.exe e 10 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 10 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 10 flowey_lib_hvlite::build_xtask 0
+        flowey e 10 flowey_lib_common::run_cargo_build 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
-    - name: determine clippy exclusions
-      run: flowey.exe e 10 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey.exe e 10 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey.exe e 10 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: create cargo-nextest cache dir
+    - name: split debug symbols
       run: |-
-        flowey.exe e 10 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 10 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 10 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 10 flowey_lib_common::download_cargo_nextest 3
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
-    - name: Pre-processing cache vars
+    - name: extract and resolve kernel package
       run: |-
-        flowey.exe e 10 flowey_lib_common::cache 0
-        flowey.exe v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
+    - name: unpack openvmm-deps archive
+      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
       run: |-
-        flowey.exe v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 10 flowey_lib_common::cache 2
-        flowey.exe e 10 flowey_lib_common::download_cargo_nextest 4
+        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: report $CARGO_HOME
-      run: flowey.exe e 10 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
+    - name: cargo build openvmm_hcl
       run: |-
-        flowey.exe e 10 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 10 flowey_lib_hvlite::init_cross_build 3
+        flowey e 10 flowey_lib_common::run_cargo_build 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
-    - name: cargo build xtask
+    - name: split debug symbols
       run: |-
-        flowey.exe e 10 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 10 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 10 flowey_lib_hvlite::build_xtask 1
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
-    - name: determine unit test exclusions
+    - name: building openhcl initrd
       run: |-
-        flowey.exe e 10 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 10 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 10 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 10 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 10 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests' nextest tests
+    - name: cargo build igvmfilegen
       run: |-
-        flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 10 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 10 flowey_lib_common::publish_test_results 5
-        flowey.exe e 10 flowey_lib_common::publish_test_results 6
-        flowey.exe e 10 flowey_lib_common::publish_test_results 4
-        flowey.exe v 10 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 10 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 10 flowey_lib_common::run_cargo_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey.exe e 10 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: split debug symbols
       run: |-
-        flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 10 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 10 flowey_lib_common::publish_test_results 0
-        flowey.exe e 10 flowey_lib_common::publish_test_results 1
-        flowey.exe e 10 flowey_lib_common::publish_test_results 2
-        flowey.exe v 10 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 10 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: building igvm file
       run: |-
-        flowey.exe e 10 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 10 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: run doctests for x86_64-pc-windows-msvc
-      run: flowey.exe e 10 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 10 flowey_lib_common::cache 3
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+      shell: bash
+    - name: copying openhcl build to publish dir
+      run: flowey e 10 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 10 flowey_lib_common::cache 7
+      run: flowey e 10 flowey_lib_common::cache 3
       shell: bash
+    - name: 🌼📦 Publish aarch64-openhcl-baseline
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-baseline
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-baseline/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
+        include-hidden-files: true
   job11:
-    name: clippy [x64-linux, macos], unit tests [x64-linux]
+    name: build openhcl [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -689,6 +728,44 @@ jobs:
         cat <<'EOF' | flowey v 11 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline" | flowey v 11 'artifact_publish_from_x64-openhcl-baseline' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 11 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 11 flowey_lib_common::cache 0
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 11 flowey_lib_common::cache 2
+        flowey e 11 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 11 flowey_lib_common::install_rust 0
@@ -704,7 +781,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
         flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -712,7 +789,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -726,35 +803,6 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 11 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 11 flowey_lib_common::cache 4
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 11 flowey_lib_common::cache 6
-        flowey e 11 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 11 flowey_lib_common::resolve_protoc 0
@@ -763,214 +811,517 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+        flowey e 11 flowey_lib_hvlite::init_cross_build 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
       shell: bash
-    - name: cargo build xtask
+    - name: cargo build sidecar
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 4
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 11 flowey_lib_hvlite::build_sidecar 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
       run: |-
         flowey e 11 flowey_lib_common::run_cargo_build 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 11 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: |-
-        flowey e 11 flowey_lib_hvlite::_jobs::check_clippy 1
-        flowey e 11 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_clippy 1
-        flowey e 11 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 11 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 11 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 5
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 11 flowey_lib_common::download_cargo_nextest 0
-        flowey e 11 flowey_lib_common::download_cargo_nextest 1
-        flowey e 11 flowey_lib_common::download_cargo_nextest 2
-        flowey e 11 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 11 flowey_lib_common::cache 2
-        flowey e 11 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 11 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 11 flowey_lib_common::install_cargo_nextest 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_nextest_run 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 11 flowey_lib_common::publish_test_results 5
-        flowey e 11 flowey_lib_common::publish_test_results 6
-        flowey e 11 flowey_lib_common::publish_test_results 4
-        flowey v 11 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 11 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 11 flowey_lib_common::publish_test_results 8
-        flowey e 11 flowey_lib_common::publish_test_results 9
-        flowey e 11 flowey_lib_common::publish_test_results 10
-        flowey v 11 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 11 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: cargo build xtask
-      run: |-
-        flowey e 11 flowey_lib_hvlite::init_cross_build 2
-        flowey e 11 flowey_lib_common::run_cargo_build 0
         flowey e 11 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 11 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 11 flowey_lib_hvlite::build_xtask 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 11 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 8
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 4
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 11 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: |-
+        flowey e 11 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
+      shell: bash
+    - name: copying openhcl build to publish dir
+      run: flowey e 11 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 11 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish x64-openhcl-baseline
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-baseline
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-baseline/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
+        include-hidden-files: true
+  job12:
+    name: clippy [x64-windows], unit tests [x64-windows]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+
+        echo '"debug"' | flowey.exe v 12 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 12 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 12 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey.exe e 12 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 12 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey.exe e 12 flowey_lib_common::install_rust 2
+        flowey.exe e 12 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 12 flowey_lib_common::git_checkout 0
+        flowey.exe v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar7 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 12 flowey_lib_common::git_checkout 3
+        flowey.exe e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey.exe e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 12 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 12 flowey_lib_common::cache 4
+        flowey.exe v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 12 flowey_lib_common::cache 6
+        flowey.exe e 12 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey.exe e 12 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey.exe e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey.exe e 12 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 12 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 12 flowey_lib_common::cache 0
+        flowey.exe v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 12 flowey_lib_common::cache 2
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 12 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey.exe e 12 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey.exe e 12 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 12 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 11 flowey_lib_common::publish_test_results 12
-        flowey e 11 flowey_lib_common::publish_test_results 13
-        flowey e 11 flowey_lib_common::publish_test_results 14
-        flowey v 11 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 11 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 12 flowey_lib_common::publish_test_results 5
+        flowey.exe e 12 flowey_lib_common::publish_test_results 6
+        flowey.exe e 12 flowey_lib_common::publish_test_results 4
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__15
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+        name: x64-windows-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 11 flowey_lib_common::publish_test_results 0
-        flowey e 11 flowey_lib_common::publish_test_results 1
-        flowey e 11 flowey_lib_common::publish_test_results 2
-        flowey v 11 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 11 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 12 flowey_lib_common::publish_test_results 0
+        flowey.exe e 12 flowey_lib_common::publish_test_results 1
+        flowey.exe e 12 flowey_lib_common::publish_test_results 2
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
-    - name: run doctests for x86_64-unknown-linux-gnu
-      run: flowey e 11 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+    - name: run doctests for x86_64-pc-windows-msvc
+      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 11 flowey_lib_common::cache 3
+      run: flowey.exe e 12 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 11 flowey_lib_common::cache 7
+      run: flowey.exe e 12 flowey_lib_common::cache 7
       shell: bash
-  job12:
-    name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
+  job13:
+    name: clippy [x64-linux, macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1036,29 +1387,382 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 12 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 13 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 13 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 12 'verbose' update
+        cat <<'EOF' | flowey v 13 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 12 flowey_lib_common::install_rust 0
+      run: flowey e 13 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 12 flowey_lib_common::install_rust 1
+      run: flowey e 13 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 12 flowey_lib_common::install_rust 2
-        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 13 flowey_lib_common::install_rust 2
+        flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::git_checkout 0
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar9 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 13 flowey_lib_common::git_checkout 3
+        flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 13 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 13 flowey_lib_common::cache 4
+        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 13 flowey_lib_common::cache 6
+        flowey e 13 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 13 flowey_lib_common::resolve_protoc 0
+        flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: |-
+        flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 1
+        flowey e 13 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_clippy 1
+        flowey e 13 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 2
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 13 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 5
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 13 flowey_lib_common::download_cargo_nextest 0
+        flowey e 13 flowey_lib_common::download_cargo_nextest 1
+        flowey e 13 flowey_lib_common::download_cargo_nextest 2
+        flowey e 13 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 13 flowey_lib_common::cache 0
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 13 flowey_lib_common::cache 2
+        flowey e 13 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 13 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 13 flowey_lib_common::install_cargo_nextest 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 13 flowey_lib_common::publish_test_results 5
+        flowey e 13 flowey_lib_common::publish_test_results 6
+        flowey e 13 flowey_lib_common::publish_test_results 4
+        flowey v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__7
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 13 flowey_lib_common::publish_test_results 8
+        flowey e 13 flowey_lib_common::publish_test_results 9
+        flowey e 13 flowey_lib_common::publish_test_results 10
+        flowey v 13 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 13 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey e 13 flowey_lib_hvlite::init_cross_build 2
+        flowey e 13 flowey_lib_common::run_cargo_build 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 13 flowey_lib_hvlite::build_xtask 2
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 13 flowey_lib_common::publish_test_results 12
+        flowey e 13 flowey_lib_common::publish_test_results 13
+        flowey e 13 flowey_lib_common::publish_test_results 14
+        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 13 flowey_lib_common::publish_test_results 0
+        flowey e 13 flowey_lib_common::publish_test_results 1
+        flowey e 13 flowey_lib_common::publish_test_results 2
+        flowey v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for x86_64-unknown-linux-gnu
+      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 13 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 13 flowey_lib_common::cache 7
+      shell: bash
+  job14:
+    name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
+        echo '"debug"' | flowey v 14 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 14 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 14 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 14 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 14 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 14 flowey_lib_common::install_rust 2
+        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 14 flowey_lib_common::git_checkout 0
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1070,27 +1774,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 12 flowey_lib_common::git_checkout 3
-        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 14 flowey_lib_common::git_checkout 3
+        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 12 flowey_lib_common::download_gh_release 0
+      run: flowey e 14 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 12 flowey_lib_common::cache 4
-        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 14 flowey_lib_common::cache 4
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1100,78 +1804,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 12 flowey_lib_common::cache 6
-        flowey e 12 flowey_lib_common::download_gh_release 1
+        flowey e 14 flowey_lib_common::cache 6
+        flowey e 14 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 12 flowey_lib_common::resolve_protoc 0
+      run: flowey e 14 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 2
+        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_clippy 5
-        flowey e 12 flowey_lib_hvlite::init_cross_build 0
+        flowey e 14 flowey_lib_common::run_cargo_clippy 5
+        flowey e 14 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 0
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 14 flowey_lib_common::run_cargo_build 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 12 flowey_lib_hvlite::build_xtask 0
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 14 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 12 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 14 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 12 flowey_lib_common::download_cargo_nextest 0
-        flowey e 12 flowey_lib_common::download_cargo_nextest 1
-        flowey e 12 flowey_lib_common::download_cargo_nextest 2
-        flowey e 12 flowey_lib_common::download_cargo_nextest 3
+        flowey e 14 flowey_lib_common::download_cargo_nextest 0
+        flowey e 14 flowey_lib_common::download_cargo_nextest 1
+        flowey e 14 flowey_lib_common::download_cargo_nextest 2
+        flowey e 14 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 14 flowey_lib_common::cache 0
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1181,34 +1885,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 12 flowey_lib_common::cache 2
-        flowey e 12 flowey_lib_common::download_cargo_nextest 4
+        flowey e 14 flowey_lib_common::cache 2
+        flowey e 14 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 12 flowey_lib_common::install_rust 3
+      run: flowey e 14 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 12 flowey_lib_common::install_cargo_nextest 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 3
-        flowey e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::install_cargo_nextest 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 3
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 12 flowey_lib_common::publish_test_results 5
-        flowey e 12 flowey_lib_common::publish_test_results 6
-        flowey e 12 flowey_lib_common::publish_test_results 4
-        flowey v 12 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 12 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 14 flowey_lib_common::publish_test_results 5
+        flowey e 14 flowey_lib_common::publish_test_results 6
+        flowey e 14 flowey_lib_common::publish_test_results 4
+        flowey v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1218,18 +1922,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 12 flowey_lib_common::publish_test_results 8
-        flowey e 12 flowey_lib_common::publish_test_results 9
-        flowey e 12 flowey_lib_common::publish_test_results 10
-        flowey v 12 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 14 flowey_lib_common::publish_test_results 8
+        flowey e 14 flowey_lib_common::publish_test_results 9
+        flowey e 14 flowey_lib_common::publish_test_results 10
+        flowey v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -1239,18 +1943,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 12 flowey_lib_common::publish_test_results 12
-        flowey e 12 flowey_lib_common::publish_test_results 13
-        flowey e 12 flowey_lib_common::publish_test_results 14
-        flowey v 12 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 12 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 14 flowey_lib_common::publish_test_results 12
+        flowey e 14 flowey_lib_common::publish_test_results 13
+        flowey e 14 flowey_lib_common::publish_test_results 14
+        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -1260,18 +1964,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 12 flowey_lib_common::publish_test_results 16
-        flowey e 12 flowey_lib_common::publish_test_results 17
-        flowey e 12 flowey_lib_common::publish_test_results 18
-        flowey v 12 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 12 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 14 flowey_lib_common::publish_test_results 16
+        flowey e 14 flowey_lib_common::publish_test_results 17
+        flowey e 14 flowey_lib_common::publish_test_results 18
+        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -1282,32 +1986,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 12 flowey_lib_hvlite::init_cross_build 1
-        flowey e 12 flowey_lib_common::run_cargo_build 1
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 14 flowey_lib_hvlite::init_cross_build 1
+        flowey e 14 flowey_lib_common::run_cargo_build 1
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 12 flowey_lib_hvlite::build_xtask 1
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 14 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 12 flowey_lib_common::publish_test_results 0
-        flowey e 12 flowey_lib_common::publish_test_results 1
-        flowey e 12 flowey_lib_common::publish_test_results 2
-        flowey v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 14 flowey_lib_common::publish_test_results 0
+        flowey e 14 flowey_lib_common::publish_test_results 1
+        flowey e 14 flowey_lib_common::publish_test_results 2
+        flowey v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1318,25 +2022,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 12 flowey_lib_common::cache 3
+      run: flowey e 14 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 12 flowey_lib_common::cache 7
+      run: flowey e 14 flowey_lib_common::cache 7
       shell: bash
-  job13:
+  job15:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=win-arm64
-    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1402,29 +2106,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 13 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 13 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 13 'verbose' update
+        cat <<'EOF' | flowey.exe v 15 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 13 flowey_lib_common::install_rust 0
+      run: flowey.exe e 15 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 13 flowey_lib_common::install_rust 1
+      run: flowey.exe e 15 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 13 flowey_lib_common::install_rust 2
-        flowey.exe e 13 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 15 flowey_lib_common::install_rust 2
+        flowey.exe e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 13 flowey_lib_common::git_checkout 0
-        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::git_checkout 0
+        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1436,23 +2140,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 13 flowey_lib_common::git_checkout 3
-        flowey.exe e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 15 flowey_lib_common::git_checkout 3
+        flowey.exe e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 13 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 15 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 13 flowey_lib_common::cache 4
-        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 15 flowey_lib_common::cache 4
+        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1462,50 +2166,50 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 13 flowey_lib_common::cache 6
-        flowey.exe e 13 flowey_lib_common::download_gh_release 1
+        flowey.exe e 15 flowey_lib_common::cache 6
+        flowey.exe e 15 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 13 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 15 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 13 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 13 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 13 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 15 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 15 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 13 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 13 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 13 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 13 flowey_lib_common::cache 0
-        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe e 15 flowey_lib_common::cache 0
+        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1515,45 +2219,45 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 13 flowey_lib_common::cache 2
-        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 15 flowey_lib_common::cache 2
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 13 flowey_lib_common::install_rust 3
+      run: flowey.exe e 15 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 13 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 15 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 13 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 13 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 13 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 15 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
       run: |-
-        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 13 flowey_lib_common::publish_test_results 5
-        flowey.exe e 13 flowey_lib_common::publish_test_results 6
-        flowey.exe e 13 flowey_lib_common::publish_test_results 4
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 15 flowey_lib_common::publish_test_results 5
+        flowey.exe e 15 flowey_lib_common::publish_test_results 6
+        flowey.exe e 15 flowey_lib_common::publish_test_results 4
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1563,18 +2267,18 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 13 flowey_lib_common::publish_test_results 0
-        flowey.exe e 13 flowey_lib_common::publish_test_results 1
-        flowey.exe e 13 flowey_lib_common::publish_test_results 2
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 15 flowey_lib_common::publish_test_results 0
+        flowey.exe e 15 flowey_lib_common::publish_test_results 1
+        flowey.exe e 15 flowey_lib_common::publish_test_results 2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1585,25 +2289,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
-      run: flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 13 flowey_lib_common::cache 3
+      run: flowey.exe e 15 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 13 flowey_lib_common::cache 7
+      run: flowey.exe e 15 flowey_lib_common::cache 7
       shell: bash
-  job14:
+  job16:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1669,35 +2373,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 14 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 14 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 14 'verbose' update
+        cat <<'EOF' | flowey v 16 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 14 flowey_lib_common::install_rust 0
+      run: flowey e 16 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 14 flowey_lib_common::install_rust 1
+      run: flowey e 16 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 14 flowey_lib_common::install_rust 2
-        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 16 flowey_lib_common::install_rust 2
+        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::git_checkout 0
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1709,23 +2413,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 14 flowey_lib_common::git_checkout 3
-        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 16 flowey_lib_common::git_checkout 3
+        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 14 flowey_lib_common::download_gh_release 0
+      run: flowey e 16 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey e 16 flowey_lib_common::cache 4
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1735,61 +2439,61 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 14 flowey_lib_common::cache 6
-        flowey e 14 flowey_lib_common::download_gh_release 1
+        flowey e 16 flowey_lib_common::cache 6
+        flowey e 16 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 14 flowey_lib_common::resolve_protoc 0
-        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 16 flowey_lib_common::resolve_protoc 0
+        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 2
+        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_build 0
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 16 flowey_lib_common::run_cargo_build 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 14 flowey_lib_hvlite::build_xtask 0
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 14 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 14 flowey_lib_common::download_cargo_nextest 0
-        flowey e 14 flowey_lib_common::download_cargo_nextest 1
-        flowey e 14 flowey_lib_common::download_cargo_nextest 2
-        flowey e 14 flowey_lib_common::download_cargo_nextest 3
+        flowey e 16 flowey_lib_common::download_cargo_nextest 0
+        flowey e 16 flowey_lib_common::download_cargo_nextest 1
+        flowey e 16 flowey_lib_common::download_cargo_nextest 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey e 16 flowey_lib_common::cache 0
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1799,34 +2503,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 14 flowey_lib_common::cache 2
-        flowey e 14 flowey_lib_common::download_cargo_nextest 4
+        flowey e 16 flowey_lib_common::cache 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 14 flowey_lib_common::install_rust 3
+      run: flowey e 16 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 14 flowey_lib_common::install_cargo_nextest 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::install_cargo_nextest 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 14 flowey_lib_common::publish_test_results 5
-        flowey e 14 flowey_lib_common::publish_test_results 6
-        flowey e 14 flowey_lib_common::publish_test_results 4
-        flowey v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 16 flowey_lib_common::publish_test_results 5
+        flowey e 16 flowey_lib_common::publish_test_results 6
+        flowey e 16 flowey_lib_common::publish_test_results 4
+        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1836,18 +2540,18 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 14 flowey_lib_common::publish_test_results 8
-        flowey e 14 flowey_lib_common::publish_test_results 9
-        flowey e 14 flowey_lib_common::publish_test_results 10
-        flowey v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 16 flowey_lib_common::publish_test_results 8
+        flowey e 16 flowey_lib_common::publish_test_results 9
+        flowey e 16 flowey_lib_common::publish_test_results 10
+        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -1858,32 +2562,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_hvlite::init_cross_build 3
-        flowey e 14 flowey_lib_common::run_cargo_build 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 16 flowey_lib_hvlite::init_cross_build 3
+        flowey e 16 flowey_lib_common::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 14 flowey_lib_hvlite::build_xtask 1
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 16 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 14 flowey_lib_common::publish_test_results 12
-        flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey e 14 flowey_lib_common::publish_test_results 14
-        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey e 16 flowey_lib_common::publish_test_results 13
+        flowey e 16 flowey_lib_common::publish_test_results 14
+        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -1893,18 +2597,18 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 14 flowey_lib_common::publish_test_results 0
-        flowey e 14 flowey_lib_common::publish_test_results 1
-        flowey e 14 flowey_lib_common::publish_test_results 2
-        flowey v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 16 flowey_lib_common::publish_test_results 0
+        flowey e 16 flowey_lib_common::publish_test_results 1
+        flowey e 16 flowey_lib_common::publish_test_results 2
+        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1915,25 +2619,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 14 flowey_lib_common::cache 3
+      run: flowey e 16 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 14 flowey_lib_common::cache 7
+      run: flowey e 16 flowey_lib_common::cache 7
       shell: bash
-  job15:
+  job17:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1999,29 +2703,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 15 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 17 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 17 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 15 'verbose' update
+        cat <<'EOF' | flowey v 17 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 15 flowey_lib_common::install_rust 0
+      run: flowey e 17 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 15 flowey_lib_common::install_rust 1
+      run: flowey e 17 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 15 flowey_lib_common::install_rust 2
-        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 17 flowey_lib_common::install_rust 2
+        flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::git_checkout 0
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2033,27 +2737,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 15 flowey_lib_common::git_checkout 3
-        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 17 flowey_lib_common::git_checkout 3
+        flowey e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 15 flowey_lib_common::download_gh_release 0
+      run: flowey e 17 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 17 flowey_lib_common::cache 4
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2063,78 +2767,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 15 flowey_lib_common::cache 6
-        flowey e 15 flowey_lib_common::download_gh_release 1
+        flowey e 17 flowey_lib_common::cache 6
+        flowey e 17 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 15 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 15 flowey_lib_common::resolve_protoc 0
+      run: flowey e 17 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 2
+        flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_clippy 5
-        flowey e 15 flowey_lib_hvlite::init_cross_build 0
+        flowey e 17 flowey_lib_common::run_cargo_clippy 5
+        flowey e 17 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_build 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 17 flowey_lib_common::run_cargo_build 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 15 flowey_lib_hvlite::build_xtask 0
+        flowey e 17 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 17 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 17 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 15 flowey_lib_common::download_cargo_nextest 0
-        flowey e 15 flowey_lib_common::download_cargo_nextest 1
-        flowey e 15 flowey_lib_common::download_cargo_nextest 2
-        flowey e 15 flowey_lib_common::download_cargo_nextest 3
+        flowey e 17 flowey_lib_common::download_cargo_nextest 0
+        flowey e 17 flowey_lib_common::download_cargo_nextest 1
+        flowey e 17 flowey_lib_common::download_cargo_nextest 2
+        flowey e 17 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 17 flowey_lib_common::cache 0
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2144,34 +2848,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 15 flowey_lib_common::cache 2
-        flowey e 15 flowey_lib_common::download_cargo_nextest 4
+        flowey e 17 flowey_lib_common::cache 2
+        flowey e 17 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 15 flowey_lib_common::install_rust 3
+      run: flowey e 17 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 15 flowey_lib_common::install_cargo_nextest 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 3
-        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::install_cargo_nextest 0
+        flowey e 17 flowey_lib_hvlite::init_cross_build 3
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 15 flowey_lib_common::publish_test_results 5
-        flowey e 15 flowey_lib_common::publish_test_results 6
-        flowey e 15 flowey_lib_common::publish_test_results 4
-        flowey v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 17 flowey_lib_common::publish_test_results 5
+        flowey e 17 flowey_lib_common::publish_test_results 6
+        flowey e 17 flowey_lib_common::publish_test_results 4
+        flowey v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2181,18 +2885,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 15 flowey_lib_common::publish_test_results 8
-        flowey e 15 flowey_lib_common::publish_test_results 9
-        flowey e 15 flowey_lib_common::publish_test_results 10
-        flowey v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 17 flowey_lib_common::publish_test_results 8
+        flowey e 17 flowey_lib_common::publish_test_results 9
+        flowey e 17 flowey_lib_common::publish_test_results 10
+        flowey v 17 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 17 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2202,18 +2906,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 15 flowey_lib_common::publish_test_results 12
-        flowey e 15 flowey_lib_common::publish_test_results 13
-        flowey e 15 flowey_lib_common::publish_test_results 14
-        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 17 flowey_lib_common::publish_test_results 12
+        flowey e 17 flowey_lib_common::publish_test_results 13
+        flowey e 17 flowey_lib_common::publish_test_results 14
+        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -2223,18 +2927,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 15 flowey_lib_common::publish_test_results 16
-        flowey e 15 flowey_lib_common::publish_test_results 17
-        flowey e 15 flowey_lib_common::publish_test_results 18
-        flowey v 15 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 17 flowey_lib_common::publish_test_results 16
+        flowey e 17 flowey_lib_common::publish_test_results 17
+        flowey e 17 flowey_lib_common::publish_test_results 18
+        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -2245,32 +2949,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 15 flowey_lib_hvlite::init_cross_build 1
-        flowey e 15 flowey_lib_common::run_cargo_build 1
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 17 flowey_lib_hvlite::init_cross_build 1
+        flowey e 17 flowey_lib_common::run_cargo_build 1
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 15 flowey_lib_hvlite::build_xtask 1
+        flowey e 17 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 17 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 15 flowey_lib_common::publish_test_results 0
-        flowey e 15 flowey_lib_common::publish_test_results 1
-        flowey e 15 flowey_lib_common::publish_test_results 2
-        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 17 flowey_lib_common::publish_test_results 0
+        flowey e 17 flowey_lib_common::publish_test_results 1
+        flowey e 17 flowey_lib_common::publish_test_results 2
+        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2281,574 +2985,40 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
-      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 15 flowey_lib_common::cache 3
+      run: flowey e 17 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 15 flowey_lib_common::cache 7
+      run: flowey e 17 flowey_lib_common::cache 7
       shell: bash
-  job16:
+  job18:
     name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job5
-    - job7
-    - job9
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
-
-        echo '"debug"' | flowey.exe v 16 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 16 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 16 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 16 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 16 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 16 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 16 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 16 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 16 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 16 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 16 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 16 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 16 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 16 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 16 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 16 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 16 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 16 flowey_lib_common::cache 0
-        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 16 flowey_lib_common::cache 2
-        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 16 flowey_lib_common::git_checkout 0
-        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 16 flowey_lib_common::git_checkout 3
-        flowey.exe e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 16 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 16 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 16 flowey_lib_common::cache 8
-        flowey.exe v 16 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 16 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 16 flowey_lib_common::cache 10
-        flowey.exe e 16 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 16 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 16 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 16 flowey_lib_common::cache 4
-        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 16 flowey_lib_common::cache 6
-        flowey.exe e 16 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 16 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 16 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 16 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 16 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 16 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 16 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 16 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 16 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 16 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 16 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 16 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 16 flowey_lib_common::publish_test_results 4
-        flowey.exe e 16 flowey_lib_common::publish_test_results 5
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 16 flowey_lib_common::publish_test_results 0
-        flowey.exe e 16 flowey_lib_common::publish_test_results 1
-        flowey.exe e 16 flowey_lib_common::publish_test_results 2
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 16 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 16 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 16 flowey_lib_common::cache 11
-      shell: bash
-  job17:
-    name: run vmm-tests [x64-windows-intel-tdx]
-    runs-on:
-    - self-hosted
-    - Windows
-    - X64
-    - TDX
-    - Baremetal
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job5
-    - job7
-    - job9
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
-
-        echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 17 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 17 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 17 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 17 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 17 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 17 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 17 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 17 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 17 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 17 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 17 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 17 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 17 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 17 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 17 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 17 flowey_lib_common::cache 0
-        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 17 flowey_lib_common::cache 2
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 17 flowey_lib_common::git_checkout 0
-        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 17 flowey_lib_common::git_checkout 3
-        flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 17 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 17 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 17 flowey_lib_common::cache 8
-        flowey.exe v 17 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 17 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 17 flowey_lib_common::cache 10
-        flowey.exe e 17 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 17 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 17 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 17 flowey_lib_common::cache 4
-        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 17 flowey_lib_common::cache 6
-        flowey.exe e 17 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 17 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 17 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 17 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 17 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 17 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 17 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 17 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 17 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 17 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 17 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 17 flowey_lib_common::publish_test_results 4
-        flowey.exe e 17 flowey_lib_common::publish_test_results 5
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-tdx-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 17 flowey_lib_common::publish_test_results 0
-        flowey.exe e 17 flowey_lib_common::publish_test_results 1
-        flowey.exe e 17 flowey_lib_common::publish_test_results 2
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-tdx-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 17 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 17 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 17 flowey_lib_common::cache 11
-      shell: bash
-  job18:
-    name: run vmm-tests [x64-windows-amd]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
     - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
+    - job11
     - job5
-    - job7
-    - job9
+    - job8
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-15,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
     - name: 🌼🛫 Initialize job
@@ -2857,7 +3027,7 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15/flowey.exe
 
         echo '"debug"' | flowey.exe v 18 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey.exe v 18 '_internal_WORKING_DIR' --is-raw-string update
@@ -3059,9 +3229,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-logs
+        name: x64-windows-intel-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3075,9 +3245,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-junit-xml
+        name: x64-windows-intel-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -3092,27 +3262,28 @@ jobs:
       run: flowey.exe e 18 flowey_lib_common::cache 11
       shell: bash
   job19:
-    name: run vmm-tests [x64-linux-amd-kvm]
+    name: run vmm-tests [x64-windows-intel-tdx]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - Windows
+    - X64
+    - TDX
+    - Baremetal
     permissions:
       contents: read
       id-token: write
     needs:
+    - job11
     - job5
-    - job7
-    - job9
+    - job8
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-9,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-15,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-9" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
     - name: 🌼🛫 Initialize job
@@ -3121,139 +3292,41 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-9/flowey
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15/flowey.exe
 
-        echo '"debug"' | flowey v 19 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 19 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 19 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 19 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 19 'verbose' update
+        cat <<'EOF' | flowey.exe v 19 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 19 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 19 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 19 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 19 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 19 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 19 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      shell: bash
-    - name: creating new test content dir
-      run: |-
-        flowey e 19 flowey_core::pipeline::artifact::resolve 3
-        flowey e 19 flowey_core::pipeline::artifact::resolve 4
-        flowey e 19 flowey_core::pipeline::artifact::resolve 7
-        flowey e 19 flowey_core::pipeline::artifact::resolve 1
-        flowey e 19 flowey_core::pipeline::artifact::resolve 0
-        flowey e 19 flowey_core::pipeline::artifact::resolve 2
-        flowey e 19 flowey_core::pipeline::artifact::resolve 6
-        flowey e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 19 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 19 flowey_lib_common::cache 8
-        flowey v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey e 19 flowey_lib_common::cache 10
-        flowey e 19 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey e 19 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 19 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 19 flowey_lib_common::cache 4
-        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 19 flowey_lib_common::cache 6
-        flowey e 19 flowey_lib_common::download_gh_cli 1
-        flowey v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey e 19 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey e 19 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey e 19 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey e 19 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: flowey e 19 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 19 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 19 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 19 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 19 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 19 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 19 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 19 flowey_lib_common::download_cargo_nextest 0
-        flowey e 19 flowey_lib_common::download_cargo_nextest 1
-        flowey e 19 flowey_lib_common::download_cargo_nextest 2
-        flowey e 19 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 19 flowey_lib_common::cache 0
-        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 19 flowey_lib_common::cache 0
+        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3263,17 +3336,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 19 flowey_lib_common::cache 2
-        flowey e 19 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 19 flowey_lib_common::cache 2
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 19 flowey_lib_common::git_checkout 0
-        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 19 flowey_lib_common::git_checkout 0
+        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3285,67 +3358,178 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 19 flowey_lib_common::git_checkout 3
-        flowey e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 19 flowey_core::pipeline::artifact::resolve 5
-        flowey e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey.exe e 19 flowey_lib_common::git_checkout 3
+        flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 19 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 8
+        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 19 flowey_lib_common::cache 10
+        flowey.exe e 19 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 19 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 19 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 4
+        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 19 flowey_lib_common::cache 6
+        flowey.exe e 19 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 19 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 19 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 19 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 19 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 19 flowey_lib_common::publish_test_results 4
-        flowey e 19 flowey_lib_common::publish_test_results 5
-        flowey v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 19 flowey_lib_common::publish_test_results 4
+        flowey.exe e 19 flowey_lib_common::publish_test_results 5
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-logs
+        name: x64-windows-intel-tdx-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 19 flowey_lib_common::publish_test_results 0
-        flowey e 19 flowey_lib_common::publish_test_results 1
-        flowey e 19 flowey_lib_common::publish_test_results 2
-        flowey v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 19 flowey_lib_common::publish_test_results 0
+        flowey.exe e 19 flowey_lib_common::publish_test_results 1
+        flowey.exe e 19 flowey_lib_common::publish_test_results 2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        name: x64-windows-intel-tdx-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 19 flowey_lib_common::cache 3
+      run: flowey.exe e 19 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 19 flowey_lib_common::cache 7
+      run: flowey.exe e 19 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 19 flowey_lib_common::cache 11
+      run: flowey.exe e 19 flowey_lib_common::cache 11
       shell: bash
   job2:
     name: build artifacts (not for VMM tests) [aarch64-windows]
@@ -3563,213 +3747,70 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-linux-intel-mshv]
+    name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=azurelinux3-amd64-dom0
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
+    - job11
     - job5
-    - job7
-    - job9
+    - job8
     if: github.event.pull_request.draft == false
     steps:
-    - run: |
-        set -x
-        sudo tdnf install -y gcc glibc-devel
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-15,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
-      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15/flowey.exe
 
-        echo '"debug"' | flowey v 20 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 20 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 20 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 20 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 20 'verbose' update
+        cat <<'EOF' | flowey.exe v 20 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 20 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 20 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 20 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 20 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 20 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 20 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 20 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 20 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      shell: bash
-    - name: creating new test content dir
-      run: |-
-        flowey e 20 flowey_core::pipeline::artifact::resolve 7
-        flowey e 20 flowey_core::pipeline::artifact::resolve 3
-        flowey e 20 flowey_core::pipeline::artifact::resolve 0
-        flowey e 20 flowey_core::pipeline::artifact::resolve 4
-        flowey e 20 flowey_core::pipeline::artifact::resolve 6
-        flowey e 20 flowey_core::pipeline::artifact::resolve 1
-        flowey e 20 flowey_core::pipeline::artifact::resolve 2
-        flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 20 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 20 flowey_lib_common::cache 8
-        flowey v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey e 20 flowey_lib_common::cache 10
-        flowey e 20 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey e 20 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 20 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 20 flowey_lib_common::cache 4
-        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 20 flowey_lib_common::cache 6
-        flowey e 20 flowey_lib_common::download_gh_cli 1
-        flowey v 20 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey e 20 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey e 20 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey e 20 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey e 20 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: flowey e 20 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 20 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 20 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 20 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 20 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 20 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 20 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 20 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 20 flowey_lib_common::download_cargo_nextest 0
-        flowey e 20 flowey_lib_common::download_cargo_nextest 1
-        flowey e 20 flowey_lib_common::download_cargo_nextest 2
-        flowey e 20 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 20 flowey_lib_common::cache 0
-        flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 20 flowey_lib_common::cache 0
+        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3779,17 +3820,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 20 flowey_lib_common::cache 2
-        flowey e 20 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 20 flowey_lib_common::cache 2
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 20 flowey_lib_common::git_checkout 0
-        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 20 flowey_lib_common::git_checkout 0
+        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3801,147 +3842,206 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 20 flowey_lib_common::git_checkout 3
-        flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 20 flowey_core::pipeline::artifact::resolve 5
-        flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey.exe e 20 flowey_lib_common::git_checkout 3
+        flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 20 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 20 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 20 flowey_lib_common::cache 8
+        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::cache 10
+        flowey.exe e 20 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 20 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 20 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 20 flowey_lib_common::cache 4
+        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::cache 6
+        flowey.exe e 20 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 20 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 20 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 20 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 20 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 20 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 20 flowey_lib_hvlite::install_vmm_tests_deps 0
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 20 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 20 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 20 flowey_lib_common::publish_test_results 4
-        flowey e 20 flowey_lib_common::publish_test_results 5
-        flowey v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 20 flowey_lib_common::publish_test_results 4
+        flowey.exe e 20 flowey_lib_common::publish_test_results 5
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-intel-mshv-vmm-tests-logs
+        name: x64-windows-amd-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 20 flowey_lib_common::publish_test_results 0
-        flowey e 20 flowey_lib_common::publish_test_results 1
-        flowey e 20 flowey_lib_common::publish_test_results 2
-        flowey v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 20 flowey_lib_common::publish_test_results 0
+        flowey.exe e 20 flowey_lib_common::publish_test_results 1
+        flowey.exe e 20 flowey_lib_common::publish_test_results 2
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-intel-mshv-vmm-tests-junit-xml
+        name: x64-windows-amd-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 20 flowey_lib_common::cache 3
+      run: flowey.exe e 20 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 20 flowey_lib_common::cache 7
+      run: flowey.exe e 20 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 20 flowey_lib_common::cache 11
+      run: flowey.exe e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [aarch64-windows]
+    name: run vmm-tests [x64-windows-amd-snp]
     runs-on:
     - self-hosted
     - Windows
-    - ARM64
+    - X64
+    - SNP
     - Baremetal
     permissions:
       contents: read
       id-token: write
     needs:
-    - job3
-    - job6
+    - job11
+    - job5
     - job8
     if: github.event.pull_request.draft == false
     steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-pc-windows-msvc --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/aarch64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-linux-musl-tmk_vmm,aarch64-openhcl-igvm,aarch64-tmks,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-tmk_vmm,aarch64-windows-vmgstool,aarch64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-15,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
-      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15/flowey.exe
 
         echo '"debug"' | flowey.exe v 21 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey.exe v 21 '_internal_WORKING_DIR' --is-raw-string update
@@ -3949,16 +4049,20 @@ jobs:
         cat <<'EOF' | flowey.exe v 21 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 21 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 21 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 21 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 21 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 21 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 21 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 21 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 21 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 21 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -4009,14 +4113,17 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4099,14 +4206,14 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: unpack mu_msvm package (aarch64)
+    - name: unpack mu_msvm package (x64)
       run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
         flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4116,7 +4223,12 @@ jobs:
       run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4136,9 +4248,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-vmm-tests-logs
+        name: x64-windows-amd-snp-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-windows-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4152,9 +4264,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-vmm-tests-junit-xml
+        name: x64-windows-amd-snp-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4169,72 +4281,36 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
-    name: test flowey local backend
-    runs-on: ubuntu-latest
+    name: run vmm-tests [x64-linux-amd-kvm]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
+    needs:
+    - job5
+    - job8
+    - job9
     if: github.event.pull_request.draft == false
     steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
       with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-11,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
-      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11/flowey
 
         echo '"debug"' | flowey v 22 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --is-raw-string update
@@ -4242,11 +4318,150 @@ jobs:
         cat <<'EOF' | flowey v 22 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 22 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 22 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 22 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 22 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey e 22 flowey_core::pipeline::artifact::resolve 7
+        flowey e 22 flowey_core::pipeline::artifact::resolve 1
+        flowey e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey e 22 flowey_core::pipeline::artifact::resolve 6
+        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 22 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 22 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 22 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 22 flowey_lib_common::cache 8
+        flowey v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 22 flowey_lib_common::cache 10
+        flowey e 22 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 22 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 22 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 22 flowey_lib_common::cache 4
+        flowey v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 22 flowey_lib_common::cache 6
+        flowey e 22 flowey_lib_common::download_gh_cli 1
+        flowey v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 22 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey e 22 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure hypervisor device is accessible
+      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: ensure 2 MiB hugetlb pages are available
+      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 22 flowey_lib_common::download_cargo_nextest 0
+        flowey e 22 flowey_lib_common::download_cargo_nextest 1
+        flowey e 22 flowey_lib_common::download_cargo_nextest 2
+        flowey e 22 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 22 flowey_lib_common::cache 0
+        flowey v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 22 flowey_lib_common::cache 2
+        flowey e 22 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 22 flowey_lib_common::git_checkout 0
-        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
         flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -4254,7 +4469,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -4264,39 +4479,82 @@ jobs:
         EOF
         flowey e 22 flowey_lib_common::git_checkout 3
         flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 22 flowey_core::pipeline::artifact::resolve 5
+        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
-    - name: add default cargo home to path
-      run: flowey e 22 flowey_lib_common::install_rust 0
+    - name: generate nextest command
+      run: flowey e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: install Rust
-      run: flowey e 22 flowey_lib_common::install_rust 1
+    - name: install vmm tests deps (linux)
+      run: flowey e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
-    - name: detect active toolchain
+    - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 22 flowey_lib_common::install_rust 2
-        flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
+        flowey e 22 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 22 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 22 flowey_lib_common::publish_test_results 4
+        flowey e 22 flowey_lib_common::publish_test_results 5
+        flowey v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 22 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 22 flowey_lib_common::publish_test_results 0
+        flowey e 22 flowey_lib_common::publish_test_results 1
+        flowey e 22 flowey_lib_common::publish_test_results 2
+        flowey v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 22 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 22 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 22 flowey_lib_common::cache 11
       shell: bash
   job23:
-    name: build openhcl (mi-secure) [x64-linux]
+    name: run vmm-tests [x64-linux-intel-mshv]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=azurelinux3-amd64-dom0
     - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
+    needs:
+    - job5
+    - job8
+    - job9
     if: github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        sudo tdnf install -y gcc glibc-devel
         curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
@@ -4333,6 +4591,11 @@ jobs:
         mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
       working-directory: flowey_bootstrap
       shell: bash
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
@@ -4359,10 +4622,25 @@ jobs:
         cat <<'EOF' | flowey v 23 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 23 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 23 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 23 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 23 flowey_core::pipeline::artifact::resolve 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey e 23 flowey_core::pipeline::artifact::resolve 6
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 23 flowey_lib_common::install_dist_pkg 0
@@ -4375,37 +4653,111 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
+        flowey e 23 flowey_lib_common::cache 8
+        flowey v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 10
+        flowey e 23 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 23 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 23 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 23 flowey_lib_common::cache 4
+        flowey v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 6
+        flowey e 23 flowey_lib_common::download_gh_cli 1
+        flowey v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 23 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey e 23 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure hypervisor device is accessible
+      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 23 flowey_lib_common::download_cargo_nextest 0
+        flowey e 23 flowey_lib_common::download_cargo_nextest 1
+        flowey e 23 flowey_lib_common::download_cargo_nextest 2
+        flowey e 23 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
         flowey e 23 flowey_lib_common::cache 0
-        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
       run: |-
         flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 23 flowey_lib_common::cache 2
-        flowey e 23 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 23 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 23 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 23 flowey_lib_common::install_rust 2
-        flowey e 23 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 23 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
@@ -4428,212 +4780,142 @@ jobs:
         EOF
         flowey e 23 flowey_lib_common::git_checkout 3
         flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 5
+        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 23 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    - name: generate nextest command
+      run: flowey e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: unpack protoc
+    - name: install vmm tests deps (linux)
+      run: flowey e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 23 flowey_lib_common::resolve_protoc 0
-        flowey e 23 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 23 flowey_lib_common::publish_test_results 4
+        flowey e 23 flowey_lib_common::publish_test_results 5
+        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: symlink protoc
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-intel-mshv-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
       run: |-
-        flowey e 23 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 23 flowey_lib_hvlite::init_cross_build 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 23 flowey_lib_common::publish_test_results 0
+        flowey e 23 flowey_lib_common::publish_test_results 1
+        flowey e 23 flowey_lib_common::publish_test_results 2
+        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: cargo build sidecar
-      run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 3
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 9
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-intel-mshv-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 23 flowey_lib_hvlite::build_sidecar 0
-        flowey e 23 flowey_lib_hvlite::init_cross_build 1
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 1
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 23 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 23 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 23 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 23 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 2
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 23 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 23 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 23 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 23 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 23 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 23 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey e 23 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
-        include-hidden-files: true
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 23 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 23 flowey_lib_common::cache 11
+      shell: bash
   job24:
-    name: run vmm-tests [x64-windows-intel-mi-secure]
+    name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - Windows
+    - ARM64
+    - Baremetal
     permissions:
       contents: read
       id-token: write
     needs:
-    - job23
-    - job5
-    - job7
-    - job9
+    - job10
+    - job3
+    - job6
     if: github.event.pull_request.draft == false
     steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-pc-windows-msvc --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/aarch64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
+      working-directory: flowey_bootstrap
+      shell: bash
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-linux-musl-tmk_vmm,aarch64-openhcl-igvm,aarch64-tmks,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-tmk_vmm,aarch64-windows-vmgstool,aarch64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
         echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
@@ -4641,20 +4923,16 @@ jobs:
         cat <<'EOF' | flowey.exe v 24 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 24 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 24 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 24 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 24 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -4705,17 +4983,14 @@ jobs:
         flowey.exe e 24 flowey_lib_common::git_checkout 3
         flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4798,14 +5073,14 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: unpack mu_msvm package (x64)
+    - name: unpack mu_msvm package (aarch64)
       run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4835,9 +5110,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-mi-secure-vmm-tests-logs
+        name: aarch64-windows-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
+      name: 'publish test results: aarch64-windows-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4851,9 +5126,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-mi-secure-vmm-tests-junit-xml
+        name: aarch64-windows-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
+      name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4868,6 +5143,704 @@ jobs:
       run: flowey.exe e 24 flowey_lib_common::cache 11
       shell: bash
   job25:
+    name: test flowey local backend
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
+        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 25 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 25 flowey_lib_common::git_checkout 3
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 25 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 25 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 25 flowey_lib_common::install_rust 2
+        flowey v 25 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: test cargo xflowey build-igvm x64 --install-missing-deps
+      run: flowey e 25 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      shell: bash
+  job26:
+    name: build openhcl (mi-secure) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
+        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 26 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 26 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 26 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 26 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 26 flowey_lib_common::cache 0
+        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 26 flowey_lib_common::cache 2
+        flowey e 26 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 26 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 26 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 26 flowey_lib_common::install_rust 2
+        flowey e 26 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 26 flowey_lib_common::git_checkout 0
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 26 flowey_lib_common::git_checkout 3
+        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 26 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 26 flowey_lib_common::resolve_protoc 0
+        flowey e 26 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 26 flowey_lib_hvlite::init_cross_build 0
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build sidecar
+      run: |-
+        flowey e 26 flowey_lib_common::run_cargo_build 3
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 26 flowey_lib_hvlite::build_sidecar 0
+        flowey e 26 flowey_lib_hvlite::init_cross_build 1
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 26 flowey_lib_common::run_cargo_build 1
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 26 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 26 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 26 flowey_lib_common::run_cargo_build 2
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 26 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 26 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 26 flowey_lib_common::run_cargo_build 0
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 26 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 26 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 26 flowey_lib_common::copy_to_artifact_dir 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 26 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
+        include-hidden-files: true
+  job27:
+    name: run vmm-tests [x64-windows-intel-mi-secure]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job26
+    - job5
+    - job8
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-15,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15/flowey.exe
+
+        echo '"debug"' | flowey.exe v 27 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 27 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 27 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 27 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 27 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 27 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 27 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 27 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 27 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 27 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 27 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 27 flowey_lib_common::cache 0
+        flowey.exe v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 27 flowey_lib_common::cache 2
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 27 flowey_lib_common::git_checkout 0
+        flowey.exe v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 27 flowey_lib_common::git_checkout 3
+        flowey.exe e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 27 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 27 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 27 flowey_lib_common::cache 8
+        flowey.exe v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 27 flowey_lib_common::cache 10
+        flowey.exe e 27 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 27 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 27 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 27 flowey_lib_common::cache 4
+        flowey.exe v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 27 flowey_lib_common::cache 6
+        flowey.exe e 27 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 27 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 27 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 27 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 27 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 27 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 27 flowey_lib_common::publish_test_results 4
+        flowey.exe e 27 flowey_lib_common::publish_test_results 5
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-mi-secure-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 27 flowey_lib_common::publish_test_results 0
+        flowey.exe e 27 flowey_lib_common::publish_test_results 1
+        flowey.exe e 27 flowey_lib_common::publish_test_results 2
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-mi-secure-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 27 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 27 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 27 flowey_lib_common::cache 11
+      shell: bash
+  job28:
     name: publish vmgstool
     runs-on: ubuntu-latest
     permissions:
@@ -4892,6 +5865,9 @@ jobs:
     - job22
     - job23
     - job24
+    - job25
+    - job26
+    - job27
     - job3
     - job4
     - job5
@@ -4904,9 +5880,9 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-9,aarch64-linux-vmgstool,aarch64-windows-vmgstool,x64-linux-vmgstool,x64-windows-vmgstool}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-11,aarch64-linux-vmgstool,aarch64-windows-vmgstool,x64-linux-vmgstool,x64-windows-vmgstool}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-9" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
     - name: 🌼🛫 Initialize job
@@ -4915,27 +5891,27 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-9/flowey
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11/flowey
 
-        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 25 'verbose' update
+        cat <<'EOF' | flowey v 28 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 25 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 25 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 25 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 25 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 28 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 28 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 28 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 28 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
       shell: bash
     - name: create gh cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_cli 0
+      run: flowey e 28 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey e 28 flowey_lib_common::cache 0
+        flowey v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4945,31 +5921,31 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 2
-        flowey e 25 flowey_lib_common::download_gh_cli 1
-        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 28 flowey_lib_common::cache 2
+        flowey e 28 flowey_lib_common::download_gh_cli 1
+        flowey v 28 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
       run: |-
-        flowey e 25 flowey_lib_common::use_gh_cli 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 3
-        flowey e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey e 28 flowey_lib_common::use_gh_cli 0
+        flowey e 28 flowey_core::pipeline::artifact::resolve 1
+        flowey e 28 flowey_core::pipeline::artifact::resolve 0
+        flowey e 28 flowey_core::pipeline::artifact::resolve 3
+        flowey e 28 flowey_core::pipeline::artifact::resolve 2
       shell: bash
     - name: enumerate vmgstool release files
-      run: flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
+      run: flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 28 flowey_lib_common::git_checkout 0
+        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4981,29 +5957,29 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 28 flowey_lib_common::git_checkout 3
+        flowey e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: get current commit
       run: |-
-        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
-        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
+        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
+        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
       shell: bash
     - name: get cargo crate version
       run: |-
-        flowey e 25 flowey_lib_common::get_cargo_crate_version 0
-        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
-        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
-        flowey e 25 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
+        flowey e 28 flowey_lib_common::get_cargo_crate_version 0
+        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
+        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
+        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
       shell: bash
     - name: publish github releases
-      run: flowey e 25 flowey_lib_common::publish_gh_release 0
+      run: flowey e 28 flowey_lib_common::publish_gh_release 0
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 25 flowey_lib_common::cache 3
+      run: flowey e 28 flowey_lib_common::cache 3
       shell: bash
   job3:
     name: build artifacts (for VMM tests) [aarch64-windows]
@@ -5866,10 +6842,10 @@ jobs:
     - name: 🌼🥾 Publish bootstrapped flowey
       uses: actions/upload-artifact@v7
       with:
-        name: _internal-flowey-bootstrap-x86_64-windows-uid-13
+        name: _internal-flowey-bootstrap-x86_64-windows-uid-15
         path: ${{ runner.temp }}/bootstrapped-flowey
   job6:
-    name: build artifacts [aarch64-linux]
+    name: build artifacts [aarch64-linux] (shared)
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -5948,20 +6924,16 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 6 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 6 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 6 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 6 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 6 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests" | flowey v 6 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 6 'artifact_publish_from_aarch64-tmks' --is-raw-string update
       shell: bash
@@ -5975,12 +6947,6 @@ jobs:
       run: |-
         flowey e 6 flowey_lib_common::install_rust 2
         flowey e 6 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 6 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 6 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
@@ -6030,6 +6996,12 @@ jobs:
         flowey e 6 flowey_lib_common::cache 2
         flowey e 6 flowey_lib_common::download_gh_release 1
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 6 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 6 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 6 flowey_lib_common::resolve_protoc 0
@@ -6038,81 +7010,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 6 flowey_lib_hvlite::build_openvmm 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 4
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 6 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 1
         flowey e 6 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 8
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 16
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 17
-        flowey e 6 flowey_lib_hvlite::build_vmgstool 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 2
-        flowey e 6 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 7
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 15
-        flowey e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-        flowey e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 6 flowey_core::pipeline::artifact::publish 3
-        flowey e 6 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 1
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 4
-        flowey e 6 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build ohcldiag-dev
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 4
-        flowey e 6 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 5
-        flowey e 6 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -6122,23 +7020,23 @@ jobs:
     - name: build guest_test_uefi.img
       run: |-
         flowey e 6 flowey_lib_hvlite::build_guest_test_uefi 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 6
+        flowey e 6 flowey_core::pipeline::artifact::publish 0
         flowey e 6 flowey_lib_hvlite::init_cross_build 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build simple_tmk
       run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 5
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 6 flowey_lib_common::run_cargo_build 4
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 10
         flowey e 6 flowey_lib_hvlite::build_tmks 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 7
-        flowey e 6 flowey_lib_hvlite::init_cross_build 4
+        flowey e 6 flowey_core::pipeline::artifact::publish 1
+        flowey e 6 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build tpm_guest_tests
       run: |-
@@ -6150,7 +7048,66 @@ jobs:
         flowey e 6 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 6 flowey_lib_hvlite::run_cargo_build 14
         flowey e 6 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 8
+        flowey e 6 flowey_core::pipeline::artifact::publish 2
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 6 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 6 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 6 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 3
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 5
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 6 flowey_lib_hvlite::build_pipette 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 3
+        flowey e 6 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 5
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 6 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 4
+        flowey e 6 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 1
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 1
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 6 flowey_lib_hvlite::build_openvmm 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 5
+        flowey e 6 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 2
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 6 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 6
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 6 flowey_lib_common::cache 3
@@ -6161,47 +7118,35 @@ jobs:
         name: aarch64-guest_test_uefi
         path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-igvmfilegen
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
+        name: aarch64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
+        name: aarch64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-openvmm
+    - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
+        name: aarch64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-openvmm_vhost
+    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
+        name: aarch64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-tpm_guest_tests
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-tpm_guest_tests
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-vmgs_lib
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-tmks
       uses: actions/upload-artifact@v7
@@ -6210,7 +7155,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
         include-hidden-files: true
   job7:
-    name: build artifacts [x64-linux]
+    name: build artifacts [aarch64-linux] (for VMM tests)
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6287,26 +7232,18 @@ jobs:
         cat <<'EOF' | flowey v 7 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 7 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 7 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 7 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 7 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 7 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 7 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 7 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 7 'artifact_publish_from_x64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 7 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 7 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 7 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 7 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 7 flowey_lib_common::install_rust 0
@@ -6355,22 +7292,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 7 flowey_lib_common::cache 4
-        flowey v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 7 flowey_lib_common::cache 0
+        flowey v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 7 flowey_lib_common::cache 6
+        flowey e 7 flowey_lib_common::cache 2
         flowey e 7 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -6381,233 +7318,122 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 3
+        flowey e 7 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build openvmm
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 7 flowey_lib_common::run_cargo_build 2
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 7 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 5
         flowey e 7 flowey_lib_hvlite::build_openvmm 0
         flowey e 7 flowey_core::pipeline::artifact::publish 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 4
+        flowey e 7 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 4
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 7 flowey_lib_common::run_cargo_build 3
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 7 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 7
         flowey e 7 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 7 flowey_core::pipeline::artifact::publish 1
-        flowey e 7 flowey_lib_hvlite::init_cross_build 7
+        flowey e 7 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 8
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 16
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 17
-        flowey e 7 flowey_lib_hvlite::build_vmgstool 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 2
-        flowey e 7 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 7
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 15
-        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      shell: bash
-    - name: test vmgs_lib
-      run: |-
-        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-        flowey e 7 flowey_core::pipeline::artifact::publish 3
-        flowey e 7 flowey_lib_hvlite::init_cross_build 8
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 1
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 7 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 4
-        flowey e 7 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build ohcldiag-dev
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 2
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 4
-        flowey e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 5
-        flowey e 7 flowey_lib_hvlite::init_cross_build 9
-      shell: bash
-    - name: cargo build guest_test_uefi
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 0
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: build guest_test_uefi.img
-      run: |-
-        flowey e 7 flowey_lib_hvlite::build_guest_test_uefi 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 6
-        flowey e 7 flowey_lib_hvlite::init_cross_build 0
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 10
-      shell: bash
-    - name: cargo build simple_tmk
-      run: |-
         flowey e 7 flowey_lib_common::run_cargo_build 5
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 7 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 7 flowey_lib_hvlite::build_tmks 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 7
-        flowey e 7 flowey_lib_hvlite::init_cross_build 5
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 7 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 7 flowey_core::pipeline::artifact::publish 2
+        flowey e 7 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build tpm_guest_tests
+    - name: cargo build vmgs_lib
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 6
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 7 flowey_lib_common::run_cargo_build 4
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 7 flowey_core::pipeline::artifact::publish 3
+        flowey e 7 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 7 flowey_lib_common::run_cargo_build 0
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 7 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 7 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 8
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 7 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 7 flowey_core::pipeline::artifact::publish 4
+        flowey e 7 flowey_lib_hvlite::init_cross_build 5
       shell: bash
-    - name: create cargo-nextest cache dir
+    - name: cargo build ohcldiag-dev
       run: |-
-        flowey e 7 flowey_lib_common::download_cargo_nextest 0
-        flowey e 7 flowey_lib_common::download_cargo_nextest 1
-        flowey e 7 flowey_lib_common::download_cargo_nextest 2
-        flowey e 7 flowey_lib_common::download_cargo_nextest 3
+        flowey e 7 flowey_lib_common::run_cargo_build 1
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
-    - name: Pre-processing cache vars
+    - name: split debug symbols
       run: |-
-        flowey e 7 flowey_lib_common::cache 0
-        flowey v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 7 flowey_lib_common::cache 2
-        flowey e 7 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 7 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 7 flowey_lib_common::install_cargo_nextest 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey e 7 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 9
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 7 flowey_lib_common::cache 3
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 7 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 7 flowey_lib_common::cache 7
+      run: flowey e 7 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-guest_test_uefi
+    - name: 🌼📦 Publish aarch64-linux-igvmfilegen
       uses: actions/upload-artifact@v7
       with:
-        name: x64-guest_test_uefi
-        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
+        name: aarch64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-igvmfilegen
+    - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        name: aarch64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
+    - name: 🌼📦 Publish aarch64-linux-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
+        name: aarch64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm
+    - name: 🌼📦 Publish aarch64-linux-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
+        name: aarch64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm_vhost
+    - name: 🌼📦 Publish aarch64-linux-vmgs_lib
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        name: aarch64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
+    - name: 🌼📦 Publish aarch64-linux-vmgstool
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgs_lib
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-tmks
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-tmks
-        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
+        name: aarch64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
         include-hidden-files: true
   job8:
-    name: build openhcl [aarch64-linux]
+    name: build artifacts [x64-linux] (shared)
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6684,48 +7510,20 @@ jobs:
         cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline" | flowey v 8 'artifact_publish_from_aarch64-openhcl-baseline' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 8 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 8 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 8 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 8 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 8 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 8 flowey_lib_common::cache 0
-        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 8 flowey_lib_common::cache 2
-        flowey e 8 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (aarch64)
-      run: flowey e 8 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 8 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 8 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 8 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 8 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 8 'artifact_publish_from_x64-tmks' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 8 flowey_lib_common::install_rust 0
@@ -6741,7 +7539,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 8 flowey_lib_common::git_checkout 0
-        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
         flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -6749,7 +7547,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -6763,6 +7561,35 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 8 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 8 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 8 flowey_lib_common::cache 0
+        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 8 flowey_lib_common::cache 2
+        flowey e 8 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 8 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 8 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 8 flowey_lib_common::resolve_protoc 0
@@ -6771,143 +7598,65 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 0
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 6
       shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 1
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 8 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 8 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 8 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 8 flowey_lib_hvlite::build_openvmm_hcl 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 8 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 8 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build guest_test_uefi
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 0
         flowey e 8 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
-    - name: split debug symbols
+    - name: build guest_test_uefi.img
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 8 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 8 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 8 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 8 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 8 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: |-
-        flowey e 8 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 8 flowey_lib_hvlite::build_guest_test_uefi 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 0
+        flowey e 8 flowey_lib_hvlite::init_cross_build 0
         flowey e 8 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 8 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
-    - name: copying openhcl build to publish dir
-      run: |-
-        flowey e 8 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build pipette
+    - name: cargo build simple_tmk
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 4
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 8 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 8 flowey_lib_hvlite::build_tmks 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 1
+        flowey e 8 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 8 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 2
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 8 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
         flowey e 8 flowey_lib_hvlite::build_pipette 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 3
         flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build tmk_vmm
@@ -6917,46 +7666,84 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 8 flowey_lib_hvlite::run_cargo_build 12
         flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 1
+        flowey e 8 flowey_core::pipeline::artifact::publish 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 1
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 1
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::build_openvmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 5
+        flowey e 8 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 6
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-linux-musl-pipette
+    - name: 🌼📦 Publish x64-guest_test_uefi
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
+        name: x64-guest_test_uefi
+        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-baseline
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-baseline
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-baseline/
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm
+    - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        name: x64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
+    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
+        name: x64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-tmks
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
         include-hidden-files: true
   job9:
-    name: build openhcl [x64-linux]
+    name: build artifacts [x64-linux] (for VMM tests)
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7033,54 +7820,22 @@ jobs:
         cat <<'EOF' | flowey v 9 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 9 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline" | flowey v 9 'artifact_publish_from_x64-openhcl-baseline' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 9 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 9 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 9 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 9 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 9 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 9 flowey_lib_common::cache 4
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 9 flowey_lib_common::cache 6
-        flowey e 9 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 9 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 9 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 9 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 9 flowey_lib_common::install_rust 0
@@ -7093,10 +7848,16 @@ jobs:
         flowey e 9 flowey_lib_common::install_rust 2
         flowey e 9 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 9 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 9 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar5
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
         flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -7104,7 +7865,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -7118,6 +7879,29 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 9 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 9 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 9 flowey_lib_common::cache 4
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 9 flowey_lib_common::cache 6
+        flowey e 9 flowey_lib_common::download_gh_release 1
+      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 9 flowey_lib_common::resolve_protoc 0
@@ -7126,67 +7910,59 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 0
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 15
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 16
-      shell: bash
-    - name: cargo build sidecar
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 7
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 17
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 11
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 18
-        flowey e 9 flowey_lib_hvlite::build_sidecar 0
         flowey e 9 flowey_lib_hvlite::init_cross_build 1
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
-    - name: cargo build openhcl_boot
+    - name: cargo build openvmm
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 1
+        flowey e 9 flowey_lib_common::run_cargo_build 2
         flowey e 9 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 9 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 9 flowey_lib_hvlite::build_openvmm 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: extract and resolve kernel package
+    - name: cargo build openvmm_vhost
       run: |-
-        flowey e 9 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 4
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 9 flowey_lib_hvlite::build_openvmm_hcl 1
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 9 flowey_lib_common::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
-    - name: building openhcl initrd
+    - name: cargo build vmgstool
       run: |-
-        flowey e 9 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 9 flowey_lib_hvlite::init_cross_build 2
+        flowey e 9 flowey_lib_common::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 9 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      shell: bash
+    - name: test vmgs_lib
+      run: |-
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey e 9 flowey_core::pipeline::artifact::publish 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -7195,205 +7971,23 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 9
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 9 flowey_core::pipeline::artifact::publish 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
-    - name: building igvm file
+    - name: cargo build ohcldiag-dev
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 9 flowey_lib_common::run_cargo_build 1
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 9 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 9 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 9 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 9 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 9 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 9 flowey_lib_hvlite::build_openhcl_initrd 3
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_igvmfilegen 3
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 9 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 9 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 9 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 9 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: |-
-        flowey e 9 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 7
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 9 flowey_lib_hvlite::build_openvmm_hcl 0
-      shell: bash
-    - name: copying openhcl build to publish dir
-      run: |-
-        flowey e 9 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 8
-      shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 10
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 9 flowey_lib_hvlite::build_pipette 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 9
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 8
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 19
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 12
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 20
-        flowey e 9 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 2
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 9 flowey_lib_hvlite::build_openvmm 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 8
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -7405,14 +7999,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -7428,13 +8022,27 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 9 flowey_lib_common::install_cargo_nextest 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 4
+        flowey e 9 flowey_core::pipeline::artifact::publish 6
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 1
+        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 9 flowey_lib_common::cache 3
@@ -7442,29 +8050,11 @@ jobs:
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 9 flowey_lib_common::cache 7
       shell: bash
-    - name: 🌼📦 Publish x64-linux-musl-openvmm
+    - name: 🌼📦 Publish x64-linux-igvmfilegen
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-pipette
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        name: x64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
       uses: actions/upload-artifact@v7
@@ -7472,23 +8062,41 @@ jobs:
         name: x64-linux-musl-vmm-tests-archive
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-baseline
+    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v7
       with:
-        name: x64-openhcl-baseline
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-baseline/
+        name: x64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm
+    - name: 🌼📦 Publish x64-linux-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
+        name: x64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-extras
+    - name: 🌼📦 Publish x64-linux-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: x64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
+        name: x64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgs_lib
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
         include-hidden-files: true
     - name: 🌼🧼 Redact bootstrap var db
       run: rm $AgentTempDirNormal/bootstrapped-flowey/job9.json
@@ -7496,5 +8104,5 @@ jobs:
     - name: 🌼🥾 Publish bootstrapped flowey
       uses: actions/upload-artifact@v7
       with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-9
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-11
         path: ${{ runner.temp }}/bootstrapped-flowey

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -3981,283 +3981,12 @@ jobs:
       run: flowey.exe e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [x64-windows-amd-snp]
-    runs-on:
-    - self-hosted
-    - Windows
-    - X64
-    - SNP
-    - Baremetal
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job11
-    - job2
-    - job3
-    - job7
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
-
-        echo '"debug"' | flowey.exe v 21 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 21 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 21 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 21 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 21 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 21 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 21 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 21 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 21 flowey_lib_common::cache 0
-        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 21 flowey_lib_common::cache 2
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 21 flowey_lib_common::git_checkout 3
-        flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 21 flowey_lib_common::cache 8
-        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 21 flowey_lib_common::cache 10
-        flowey.exe e 21 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 21 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 21 flowey_lib_common::cache 4
-        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 21 flowey_lib_common::cache 6
-        flowey.exe e 21 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 21 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 21 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 21 flowey_lib_common::publish_test_results 4
-        flowey.exe e 21 flowey_lib_common::publish_test_results 5
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 21 flowey_lib_common::publish_test_results 0
-        flowey.exe e 21 flowey_lib_common::publish_test_results 1
-        flowey.exe e 21 flowey_lib_common::publish_test_results 2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 21 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 21 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 21 flowey_lib_common::cache 11
-      shell: bash
-  job22:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4283,6 +4012,310 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11/flowey
 
+        echo '"debug"' | flowey v 21 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 21 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 21 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 21 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 21 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 21 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey e 21 flowey_core::pipeline::artifact::resolve 1
+        flowey e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey e 21 flowey_core::pipeline::artifact::resolve 6
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 21 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 8
+        flowey v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 10
+        flowey e 21 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 21 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 21 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 4
+        flowey v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 6
+        flowey e 21 flowey_lib_common::download_gh_cli 1
+        flowey v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 21 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey e 21 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 21 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure hypervisor device is accessible
+      run: flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: ensure 2 MiB hugetlb pages are available
+      run: flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 21 flowey_lib_common::download_cargo_nextest 0
+        flowey e 21 flowey_lib_common::download_cargo_nextest 1
+        flowey e 21 flowey_lib_common::download_cargo_nextest 2
+        flowey e 21 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 0
+        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 2
+        flowey e 21 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 21 flowey_lib_common::git_checkout 0
+        flowey v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 21 flowey_lib_common::git_checkout 3
+        flowey e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 21 flowey_core::pipeline::artifact::resolve 5
+        flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (linux)
+      run: flowey e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 21 flowey_lib_common::publish_test_results 4
+        flowey e 21 flowey_lib_common::publish_test_results 5
+        flowey v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 21 flowey_lib_common::publish_test_results 0
+        flowey e 21 flowey_lib_common::publish_test_results 1
+        flowey e 21 flowey_lib_common::publish_test_results 2
+        flowey v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 21 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 21 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 21 flowey_lib_common::cache 11
+      shell: bash
+  job22:
+    name: run vmm-tests [x64-linux-intel-mshv]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=azurelinux3-amd64-dom0
+    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job2
+    - job3
+    - job9
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        sudo tdnf install -y gcc glibc-devel
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
         echo '"debug"' | flowey v 22 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --is-raw-string update
 
@@ -4290,22 +4323,22 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 22 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 22 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 22 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 22 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 22 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 22 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 22 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 22 flowey_core::pipeline::artifact::resolve 3
-        flowey e 22 flowey_core::pipeline::artifact::resolve 4
-        flowey e 22 flowey_core::pipeline::artifact::resolve 7
         flowey e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey e 22 flowey_core::pipeline::artifact::resolve 0
         flowey e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey e 22 flowey_core::pipeline::artifact::resolve 7
+        flowey e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey e 22 flowey_core::pipeline::artifact::resolve 4
         flowey e 22 flowey_core::pipeline::artifact::resolve 6
         flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -4397,10 +4430,7 @@ jobs:
       run: flowey e 22 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -4451,10 +4481,9 @@ jobs:
         flowey e 22 flowey_lib_common::git_checkout 3
         flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
         flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey e 22 flowey_core::pipeline::artifact::resolve 5
-        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: generate nextest command
       run: flowey e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
@@ -4475,9 +4504,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-logs
+        name: x64-linux-intel-mshv-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4491,9 +4520,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        name: x64-linux-intel-mshv-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
@@ -4508,306 +4537,6 @@ jobs:
       run: flowey e 22 flowey_lib_common::cache 11
       shell: bash
   job23:
-    name: run vmm-tests [x64-linux-intel-mshv]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job2
-    - job3
-    - job9
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        sudo tdnf install -y gcc glibc-devel
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 23 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 23 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 23 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      shell: bash
-    - name: creating new test content dir
-      run: |-
-        flowey e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey e 23 flowey_core::pipeline::artifact::resolve 7
-        flowey e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey e 23 flowey_core::pipeline::artifact::resolve 4
-        flowey e 23 flowey_core::pipeline::artifact::resolve 6
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 23 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 23 flowey_lib_common::cache 8
-        flowey v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey e 23 flowey_lib_common::cache 10
-        flowey e 23 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey e 23 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 23 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 23 flowey_lib_common::cache 4
-        flowey v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 23 flowey_lib_common::cache 6
-        flowey e 23 flowey_lib_common::download_gh_cli 1
-        flowey v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey e 23 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey e 23 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: flowey e 23 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 23 flowey_lib_common::download_cargo_nextest 0
-        flowey e 23 flowey_lib_common::download_cargo_nextest 1
-        flowey e 23 flowey_lib_common::download_cargo_nextest 2
-        flowey e 23 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 23 flowey_lib_common::cache 0
-        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 23 flowey_lib_common::cache 2
-        flowey e 23 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 23 flowey_lib_common::git_checkout 0
-        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 23 flowey_lib_common::git_checkout 3
-        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 23 flowey_core::pipeline::artifact::resolve 5
-        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 23 flowey_lib_common::publish_test_results 4
-        flowey e 23 flowey_lib_common::publish_test_results 5
-        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 23 flowey_lib_common::publish_test_results 0
-        flowey e 23 flowey_lib_common::publish_test_results 1
-        flowey e 23 flowey_lib_common::publish_test_results 2
-        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 23 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 23 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 23 flowey_lib_common::cache 11
-      shell: bash
-  job24:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -4889,35 +4618,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 23 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 23 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 24 'verbose' update
+        cat <<'EOF' | flowey.exe v 23 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 24 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 23 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 23 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 23 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 23 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 23 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 23 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 23 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 0
-        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 23 flowey_lib_common::cache 0
+        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4927,17 +4656,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 23 flowey_lib_common::cache 2
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 24 flowey_lib_common::git_checkout 0
-        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 23 flowey_lib_common::git_checkout 0
+        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4949,35 +4678,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 24 flowey_lib_common::git_checkout 3
-        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 23 flowey_lib_common::git_checkout 3
+        flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 8
-        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 23 flowey_lib_common::cache 8
+        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4987,31 +4716,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 10
-        flowey.exe e 24 flowey_lib_common::download_gh_release 1
+        flowey.exe e 23 flowey_lib_common::cache 10
+        flowey.exe e 23 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 23 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 23 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 4
-        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 23 flowey_lib_common::cache 4
+        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5021,63 +4750,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 6
-        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 23 flowey_lib_common::cache 6
+        flowey.exe e 23 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 23 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 23 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 24 flowey_lib_common::publish_test_results 4
-        flowey.exe e 24 flowey_lib_common::publish_test_results 5
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 23 flowey_lib_common::publish_test_results 4
+        flowey.exe e 23 flowey_lib_common::publish_test_results 5
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5088,12 +4817,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 24 flowey_lib_common::publish_test_results 0
-        flowey.exe e 24 flowey_lib_common::publish_test_results 1
-        flowey.exe e 24 flowey_lib_common::publish_test_results 2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 23 flowey_lib_common::publish_test_results 0
+        flowey.exe e 23 flowey_lib_common::publish_test_results 1
+        flowey.exe e 23 flowey_lib_common::publish_test_results 2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5103,20 +4832,137 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 24 flowey_lib_common::cache 3
+      run: flowey.exe e 23 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 24 flowey_lib_common::cache 7
+      run: flowey.exe e 23 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 24 flowey_lib_common::cache 11
+      run: flowey.exe e 23 flowey_lib_common::cache 11
       shell: bash
-  job25:
+  job24:
     name: test flowey local backend
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
+        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 24 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 24 flowey_lib_common::git_checkout 0
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 24 flowey_lib_common::git_checkout 3
+        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 24 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 24 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 24 flowey_lib_common::install_rust 2
+        flowey v 24 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: test cargo xflowey build-igvm x64 --install-missing-deps
+      run: flowey e 24 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      shell: bash
+  job25:
+    name: build openhcl (mi-secure) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5188,28 +5034,42 @@ jobs:
         cat <<'EOF' | flowey v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 25 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 25 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
-    - name: check if openvmm needs to be cloned
+    - name: checking if packages need to be installed
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 25 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::cache 0
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
       with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
+        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_common::cache 2
+        flowey e 25 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 25 flowey_lib_common::install_rust 0
@@ -5220,144 +5080,13 @@ jobs:
     - name: detect active toolchain
       run: |-
         flowey e 25 flowey_lib_common::install_rust 2
-        flowey v 25 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 25 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
-      shell: bash
-  job26:
-    name: build openhcl (mi-secure) [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 26 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 26 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 26 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 26 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 26 flowey_lib_common::cache 0
-        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 26 flowey_lib_common::cache 2
-        flowey e 26 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 26 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 26 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 26 flowey_lib_common::install_rust 2
-        flowey e 26 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 25 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 26 flowey_lib_common::git_checkout 0
-        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5369,172 +5098,172 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 26 flowey_lib_common::git_checkout 3
-        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_common::git_checkout 3
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 26 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 25 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 26 flowey_lib_common::resolve_protoc 0
-        flowey e 26 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 25 flowey_lib_common::resolve_protoc 0
+        flowey e 25 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 0
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 25 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 25 flowey_lib_hvlite::init_cross_build 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 3
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 25 flowey_lib_common::run_cargo_build 3
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 26 flowey_lib_hvlite::build_sidecar 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 1
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 25 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 25 flowey_lib_hvlite::build_sidecar 0
+        flowey e 25 flowey_lib_hvlite::init_cross_build 1
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: cargo build openhcl_boot
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 1
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 25 flowey_lib_common::run_cargo_build 1
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 25 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 25 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 25 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 3
+        flowey e 25 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 25 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 2
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 26 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 25 flowey_lib_common::run_cargo_build 2
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 25 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 25 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 26 flowey_lib_hvlite::init_cross_build 2
+        flowey e 25 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 25 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 0
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 25 flowey_lib_common::run_cargo_build 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 26 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 25 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 25 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 25 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 25 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 25 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 25 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 25 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 25 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 25 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 25 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
-        flowey e 26 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 25 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 26 flowey_lib_common::copy_to_artifact_dir 0
+      run: flowey e 25 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 26 flowey_lib_common::cache 3
+      run: flowey e 25 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -5548,19 +5277,19 @@ jobs:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
         include-hidden-files: true
-  job27:
+  job26:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job2
-    - job26
+    - job25
     - job3
     - job7
     if: github.event.pull_request.draft == false
@@ -5581,39 +5310,39 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
 
-        echo '"debug"' | flowey.exe v 27 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 27 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 27 'verbose' update
+        cat <<'EOF' | flowey.exe v 26 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 27 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 27 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 27 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 27 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 27 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 27 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 27 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 27 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 26 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 26 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 26 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 26 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 26 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 26 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 27 flowey_lib_common::cache 0
-        flowey.exe v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 26 flowey_lib_common::cache 0
+        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5623,17 +5352,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 27 flowey_lib_common::cache 2
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 26 flowey_lib_common::cache 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 27 flowey_lib_common::git_checkout 0
-        flowey.exe v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_common::git_checkout 0
+        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5645,38 +5374,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 27 flowey_lib_common::git_checkout 3
-        flowey.exe e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 26 flowey_lib_common::git_checkout 3
+        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 27 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 27 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 27 flowey_lib_common::cache 8
-        flowey.exe v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 26 flowey_lib_common::cache 8
+        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5686,31 +5415,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 27 flowey_lib_common::cache 10
-        flowey.exe e 27 flowey_lib_common::download_gh_release 1
+        flowey.exe e 26 flowey_lib_common::cache 10
+        flowey.exe e 26 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 27 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 26 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 27 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 27 flowey_lib_common::cache 4
-        flowey.exe v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 26 flowey_lib_common::cache 4
+        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5720,63 +5449,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 27 flowey_lib_common::cache 6
-        flowey.exe e 27 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 26 flowey_lib_common::cache 6
+        flowey.exe e 26 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 27 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 26 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 27 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 27 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 27 flowey_lib_common::publish_test_results 4
-        flowey.exe e 27 flowey_lib_common::publish_test_results 5
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 26 flowey_lib_common::publish_test_results 4
+        flowey.exe e 26 flowey_lib_common::publish_test_results 5
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5787,12 +5516,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 27 flowey_lib_common::publish_test_results 0
-        flowey.exe e 27 flowey_lib_common::publish_test_results 1
-        flowey.exe e 27 flowey_lib_common::publish_test_results 2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 26 flowey_lib_common::publish_test_results 0
+        flowey.exe e 26 flowey_lib_common::publish_test_results 1
+        flowey.exe e 26 flowey_lib_common::publish_test_results 2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5802,18 +5531,18 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 27 flowey_lib_common::cache 3
+      run: flowey.exe e 26 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 27 flowey_lib_common::cache 7
+      run: flowey.exe e 26 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 27 flowey_lib_common::cache 11
+      run: flowey.exe e 26 flowey_lib_common::cache 11
       shell: bash
-  job28:
+  job27:
     name: publish vmgstool
     runs-on: ubuntu-latest
     permissions:
@@ -5840,7 +5569,6 @@ jobs:
     - job24
     - job25
     - job26
-    - job27
     - job3
     - job4
     - job5
@@ -5866,25 +5594,25 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11/flowey
 
-        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 28 'verbose' update
+        cat <<'EOF' | flowey v 27 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 28 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 28 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 28 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 28 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 27 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 27 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 27 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 27 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
       shell: bash
     - name: create gh cache dir
-      run: flowey e 28 flowey_lib_common::download_gh_cli 0
+      run: flowey e 27 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 28 flowey_lib_common::cache 0
-        flowey v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey e 27 flowey_lib_common::cache 0
+        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5894,31 +5622,31 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 28 flowey_lib_common::cache 2
-        flowey e 28 flowey_lib_common::download_gh_cli 1
-        flowey v 28 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 27 flowey_lib_common::cache 2
+        flowey e 27 flowey_lib_common::download_gh_cli 1
+        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
       run: |-
-        flowey e 28 flowey_lib_common::use_gh_cli 0
-        flowey e 28 flowey_core::pipeline::artifact::resolve 1
-        flowey e 28 flowey_core::pipeline::artifact::resolve 0
-        flowey e 28 flowey_core::pipeline::artifact::resolve 3
-        flowey e 28 flowey_core::pipeline::artifact::resolve 2
+        flowey e 27 flowey_lib_common::use_gh_cli 0
+        flowey e 27 flowey_core::pipeline::artifact::resolve 1
+        flowey e 27 flowey_core::pipeline::artifact::resolve 0
+        flowey e 27 flowey_core::pipeline::artifact::resolve 3
+        flowey e 27 flowey_core::pipeline::artifact::resolve 2
       shell: bash
     - name: enumerate vmgstool release files
-      run: flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
+      run: flowey e 27 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 28 flowey_lib_common::git_checkout 0
-        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 27 flowey_lib_common::git_checkout 0
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5930,29 +5658,29 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 28 flowey_lib_common::git_checkout 3
-        flowey e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 27 flowey_lib_common::git_checkout 3
+        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: get current commit
       run: |-
-        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
-        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
+        flowey e 27 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
+        flowey e 27 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
       shell: bash
     - name: get cargo crate version
       run: |-
-        flowey e 28 flowey_lib_common::get_cargo_crate_version 0
-        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
-        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
-        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
+        flowey e 27 flowey_lib_common::get_cargo_crate_version 0
+        flowey e 27 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
+        flowey e 27 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
+        flowey e 27 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
       shell: bash
     - name: publish github releases
-      run: flowey e 28 flowey_lib_common::publish_gh_release 0
+      run: flowey e 27 flowey_lib_common::publish_gh_release 0
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 28 flowey_lib_common::cache 3
+      run: flowey e 27 flowey_lib_common::cache 3
       shell: bash
   job3:
     name: build artifacts (shared VMM tests) [linux]

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -345,7 +345,7 @@ jobs:
       run: flowey e 1 flowey_lib_common::cache 3
       shell: bash
   job10:
-    name: build artifacts (shared VMM tests) [x64-linux]
+    name: build openhcl [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -422,16 +422,44 @@ jobs:
         cat <<'EOF' | flowey v 10 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 10 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 10 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 10 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 10 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 10 'artifact_publish_from_x64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline" | flowey v 10 'artifact_publish_from_aarch64-openhcl-baseline' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 10 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 10 flowey_lib_common::cache 0
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 10 flowey_lib_common::cache 2
+        flowey e 10 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (aarch64)
+      run: flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 10 flowey_lib_common::install_rust 0
@@ -447,7 +475,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
         flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -455,7 +483,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -469,35 +497,6 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 10 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 10 flowey_lib_common::cache 2
-        flowey e 10 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 10 flowey_lib_common::resolve_protoc 0
@@ -506,114 +505,153 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build guest_test_uefi
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 0
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: build guest_test_uefi.img
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_guest_test_uefi 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 0
         flowey e 10 flowey_lib_hvlite::init_cross_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 1
         flowey e 10 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: cargo build simple_tmk
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 10 flowey_lib_hvlite::build_tmks 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 1
-        flowey e 10 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 4
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 10 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 1
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::build_pipette 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 3
         flowey e 10 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: cargo build tmk_vmm
+    - name: cargo build openvmm_hcl
       run: |-
         flowey e 10 flowey_lib_common::run_cargo_build 3
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 10 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 4
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 10 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+      shell: bash
+    - name: copying openhcl build to publish dir
+      run: flowey e 10 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-guest_test_uefi
+    - name: 🌼📦 Publish aarch64-openhcl-baseline
       uses: actions/upload-artifact@v7
       with:
-        name: x64-guest_test_uefi
-        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
+        name: aarch64-openhcl-baseline
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-baseline/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-pipette
+    - name: 🌼📦 Publish aarch64-openhcl-igvm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
+        name: aarch64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
+    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-tmks
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-tmks
-        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
+        name: aarch64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
         include-hidden-files: true
   job11:
-    name: build artifacts (for VMM tests) [x64-linux]
+    name: build openhcl [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -690,26 +728,44 @@ jobs:
         cat <<'EOF' | flowey v 11 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 11 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 11 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 11 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 11 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 11 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 11 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 11 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 11 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 11 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 11 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline" | flowey v 11 'artifact_publish_from_x64-openhcl-baseline' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 11 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 11 flowey_lib_common::cache 0
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 11 flowey_lib_common::cache 2
+        flowey e 11 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 11 flowey_lib_common::install_rust 0
@@ -722,16 +778,10 @@ jobs:
         flowey e 11 flowey_lib_common::install_rust 2
         flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
         flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -739,7 +789,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -753,29 +803,6 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 11 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 11 flowey_lib_common::cache 4
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 11 flowey_lib_common::cache 6
-        flowey e 11 flowey_lib_common::download_gh_release 1
-      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 11 flowey_lib_common::resolve_protoc 0
@@ -784,58 +811,66 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+        flowey e 11 flowey_lib_hvlite::init_cross_build 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
       shell: bash
-    - name: cargo build openvmm
+    - name: cargo build sidecar
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 2
+        flowey e 11 flowey_lib_common::run_cargo_build 4
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 11 flowey_lib_hvlite::build_sidecar 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 11 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 11 flowey_lib_hvlite::build_openvmm 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
-    - name: cargo build openvmm_vhost
+    - name: extract and resolve kernel package
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 4
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 11 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 1
-        flowey e 11 flowey_lib_hvlite::init_cross_build 5
+    - name: unpack openvmm-deps archive
+      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: cargo build vmgstool
+    - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 7
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 11 flowey_lib_hvlite::build_vmgstool 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 2
+        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
         flowey e 11 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: cargo build vmgs_lib
+    - name: cargo build openvmm_hcl
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 6
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey e 11 flowey_lib_common::run_cargo_build 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
-    - name: test vmgs_lib
+    - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-        flowey e 11 flowey_core::pipeline::artifact::publish 3
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 11 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -845,185 +880,180 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 8
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 4
-        flowey e 11 flowey_lib_hvlite::init_cross_build 6
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
-    - name: cargo build ohcldiag-dev
+    - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 4
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 11 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: extract and resolve kernel package
+      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
       shell: bash
-    - name: cargo build openvmm
+    - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 3
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 11 flowey_lib_hvlite::build_openvmm 1
-        flowey e 11 flowey_core::pipeline::artifact::publish 6
-        flowey e 11 flowey_lib_hvlite::init_cross_build 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
-    - name: cargo build openvmm_vhost
+    - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 5
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 11 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: |-
+        flowey e 11 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 11
-        flowey e 11 flowey_lib_hvlite::build_openvmm_vhost 1
-        flowey e 11 flowey_core::pipeline::artifact::publish 7
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
       shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 11 flowey_lib_common::download_cargo_nextest 0
-        flowey e 11 flowey_lib_common::download_cargo_nextest 1
-        flowey e 11 flowey_lib_common::download_cargo_nextest 2
-        flowey e 11 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 11 flowey_lib_common::cache 2
-        flowey e 11 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 11 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 11 flowey_lib_common::install_cargo_nextest 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 8
-        flowey e 11 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_archive 1
-        flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 1
-        flowey e 11 flowey_core::pipeline::artifact::publish 9
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 11 flowey_lib_common::cache 3
+    - name: copying openhcl build to publish dir
+      run: flowey e 11 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 11 flowey_lib_common::cache 7
+      run: flowey e 11 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-linux-igvmfilegen
+    - name: 🌼📦 Publish x64-openhcl-baseline
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        name: x64-openhcl-baseline
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-baseline/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm
+    - name: 🌼📦 Publish x64-openhcl-igvm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        name: x64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+    - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
+        name: x64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgs_lib
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
-        include-hidden-files: true
-    - name: 🌼🧼 Redact bootstrap var db
-      run: rm $AgentTempDirNormal/bootstrapped-flowey/job11.json
-      shell: bash
-    - name: 🌼🥾 Publish bootstrapped flowey
-      uses: actions/upload-artifact@v7
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-11
-        path: ${{ runner.temp }}/bootstrapped-flowey
   job12:
-    name: build openhcl [aarch64-linux]
+    name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=win-amd64
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1063,11 +1093,11 @@ jobs:
     - name: Build flowey
       run: |
         set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
         OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         mkdir -p "$OutDirNormal"
         mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
       working-directory: flowey_bootstrap
       shell: bash
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
@@ -1080,7 +1110,7 @@ jobs:
         ${{ runner.temp }}
         EOF
         )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
       shell: bash
     - name: 🌼🛫 Initialize job
       run: |
@@ -1088,244 +1118,205 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey v 12 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 12 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 12 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 12 'verbose' update
+        cat <<'EOF' | flowey.exe v 12 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline" | flowey v 12 'artifact_publish_from_aarch64-openhcl-baseline' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 12 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 12 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 12 flowey_lib_common::cache 2
-        flowey e 12 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (aarch64)
-      run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 12 flowey_lib_common::install_rust 0
+      run: flowey.exe e 12 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 12 flowey_lib_common::install_rust 1
+      run: flowey.exe e 12 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 12 flowey_lib_common::install_rust 2
-        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 12 flowey_lib_common::install_rust 2
+        flowey.exe e 12 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 12 flowey_lib_common::git_checkout 0
+        flowey.exe v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar7 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 12 flowey_lib_common::git_checkout 3
-        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 12 flowey_lib_common::git_checkout 3
+        flowey.exe e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 12 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 12 flowey_lib_common::cache 4
+        flowey.exe v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 12 flowey_lib_common::cache 6
+        flowey.exe e 12 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 12 flowey_lib_common::resolve_protoc 0
-        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 12 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 0
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: cargo build openhcl_boot
+    - name: cargo build xtask
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 1
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 12 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 12 flowey_lib_hvlite::build_xtask 0
       shell: bash
-    - name: split debug symbols
+    - name: determine clippy exclusions
+      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: create cargo-nextest cache dir
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 3
       shell: bash
-    - name: extract and resolve kernel package
+    - name: Pre-processing cache vars
       run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey.exe e 12 flowey_lib_common::cache 0
+        flowey.exe v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
       run: |-
-        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 12 flowey_lib_common::cache 2
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 4
       shell: bash
-    - name: cargo build openvmm_hcl
+    - name: report $CARGO_HOME
+      run: flowey.exe e 12 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 3
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey.exe e 12 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: split debug symbols
+    - name: cargo build xtask
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey.exe e 12 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 12 flowey_lib_hvlite::build_xtask 1
       shell: bash
-    - name: building openhcl initrd
+    - name: determine unit test exclusions
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
-    - name: cargo build igvmfilegen
+    - name: generate nextest command
+      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 0
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 12 flowey_lib_common::publish_test_results 5
+        flowey.exe e 12 flowey_lib_common::publish_test_results 6
+        flowey.exe e 12 flowey_lib_common::publish_test_results 4
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: split debug symbols
+    - id: flowey_lib_common__publish_test_results__7
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 12 flowey_lib_common::publish_test_results 0
+        flowey.exe e 12 flowey_lib_common::publish_test_results 1
+        flowey.exe e 12 flowey_lib_common::publish_test_results 2
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: building igvm file
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+    - name: run doctests for x86_64-pc-windows-msvc
+      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: |-
-        flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 2
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
-      shell: bash
-    - name: copying openhcl build to publish dir
-      run: flowey e 12 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 12 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 12 flowey_lib_common::cache 3
+      run: flowey.exe e 12 flowey_lib_common::cache 7
       shell: bash
-    - name: 🌼📦 Publish aarch64-openhcl-baseline
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-baseline
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-baseline/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
-        include-hidden-files: true
   job13:
-    name: build openhcl [x64-linux]
+    name: clippy [x64-linux, macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -1402,44 +1393,6 @@ jobs:
         cat <<'EOF' | flowey v 13 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline" | flowey v 13 'artifact_publish_from_x64-openhcl-baseline' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 13 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 13 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 13 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 13 flowey_lib_common::cache 2
-        flowey e 13 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 13 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 13 flowey_lib_common::install_rust 0
@@ -1455,7 +1408,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 13 flowey_lib_common::git_checkout 0
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1463,7 +1416,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1477,6 +1430,35 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 13 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 13 flowey_lib_common::cache 4
+        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 13 flowey_lib_common::cache 6
+        flowey e 13 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 13 flowey_lib_common::resolve_protoc 0
@@ -1485,249 +1467,213 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 13 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build sidecar
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_build 4
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 11
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 7
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 13 flowey_lib_hvlite::build_sidecar 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build openhcl_boot
+    - name: cargo build xtask
       run: |-
         flowey e 13 flowey_lib_common::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 13 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 13 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_build 3
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 1
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 13 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_build 0
         flowey e 13 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 8
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 13 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 13 flowey_lib_hvlite::build_xtask 0
       shell: bash
-    - name: building igvm file
+    - name: determine clippy exclusions
       run: |-
-        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 1
+        flowey e 13 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_clippy 1
+        flowey e 13 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 2
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 13 flowey_lib_hvlite::build_xtask 1
       shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+    - name: determine clippy exclusions
+      run: flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
-    - name: building openhcl initrd
+    - name: cargo clippy
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 5
+      shell: bash
+    - name: create cargo-nextest cache dir
       run: |-
-        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+        flowey e 13 flowey_lib_common::download_cargo_nextest 0
+        flowey e 13 flowey_lib_common::download_cargo_nextest 1
+        flowey e 13 flowey_lib_common::download_cargo_nextest 2
+        flowey e 13 flowey_lib_common::download_cargo_nextest 3
       shell: bash
-    - name: building igvm file
+    - name: Pre-processing cache vars
       run: |-
-        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+        flowey e 13 flowey_lib_common::cache 0
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 13 flowey_lib_common::cache 2
+        flowey e 13 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 13 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 13 flowey_lib_common::install_cargo_nextest 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 13 flowey_lib_common::publish_test_results 5
+        flowey e 13 flowey_lib_common::publish_test_results 6
+        flowey e 13 flowey_lib_common::publish_test_results 4
+        flowey v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__7
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 13 flowey_lib_common::publish_test_results 8
+        flowey e 13 flowey_lib_common::publish_test_results 9
+        flowey e 13 flowey_lib_common::publish_test_results 10
+        flowey v 13 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 13 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey e 13 flowey_lib_hvlite::init_cross_build 2
+        flowey e 13 flowey_lib_common::run_cargo_build 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 13 flowey_lib_hvlite::build_xtask 2
       shell: bash
-    - name: building openhcl initrd
+    - name: determine unit test exclusions
+      run: flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 13 flowey_lib_common::publish_test_results 12
+        flowey e 13 flowey_lib_common::publish_test_results 13
+        flowey e 13 flowey_lib_common::publish_test_results 14
+        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: building igvm file
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 13 flowey_lib_common::publish_test_results 0
+        flowey e 13 flowey_lib_common::publish_test_results 1
+        flowey e 13 flowey_lib_common::publish_test_results 2
+        flowey v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: extract and resolve kernel package
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
       run: |-
-        flowey e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+    - name: run doctests for x86_64-unknown-linux-gnu
+      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 3
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 3
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 13 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: |-
-        flowey e 13 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_build 2
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 0
-      shell: bash
-    - name: copying openhcl build to publish dir
-      run: flowey e 13 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey e 13 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-openhcl-baseline
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-baseline
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-baseline/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
-        include-hidden-files: true
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 13 flowey_lib_common::cache 7
+      shell: bash
   job14:
-    name: clippy [x64-windows], unit tests [x64-windows]
+    name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1767,273 +1713,6 @@ jobs:
     - name: Build flowey
       run: |
         set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
-
-        echo '"debug"' | flowey.exe v 14 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 14 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 14 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey.exe e 14 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey.exe e 14 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey.exe e 14 flowey_lib_common::install_rust 2
-        flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 14 flowey_lib_common::git_checkout 0
-        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar7 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 14 flowey_lib_common::git_checkout 3
-        flowey.exe e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 14 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 14 flowey_lib_common::cache 4
-        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 14 flowey_lib_common::cache 6
-        flowey.exe e 14 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey.exe e 14 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey.exe e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 14 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 14 flowey_lib_common::cache 0
-        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 14 flowey_lib_common::cache 2
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey.exe e 14 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey.exe e 14 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 14 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: |-
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests' nextest tests
-      run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 14 flowey_lib_common::publish_test_results 5
-        flowey.exe e 14 flowey_lib_common::publish_test_results 6
-        flowey.exe e 14 flowey_lib_common::publish_test_results 4
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 14 flowey_lib_common::publish_test_results 0
-        flowey.exe e 14 flowey_lib_common::publish_test_results 1
-        flowey.exe e 14 flowey_lib_common::publish_test_results 2
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: |-
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: run doctests for x86_64-pc-windows-msvc
-      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 14 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 14 flowey_lib_common::cache 7
-      shell: bash
-  job15:
-    name: clippy [x64-linux, macos], unit tests [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
         CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
         OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         mkdir -p "$OutDirNormal"
@@ -2061,382 +1740,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 15 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 14 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 14 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 15 'verbose' update
+        cat <<'EOF' | flowey v 14 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 15 flowey_lib_common::install_rust 0
+      run: flowey e 14 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 15 flowey_lib_common::install_rust 1
+      run: flowey e 14 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 15 flowey_lib_common::install_rust 2
-        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 14 flowey_lib_common::install_rust 2
+        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 15 flowey_lib_common::git_checkout 3
-        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 15 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 15 flowey_lib_common::cache 6
-        flowey e 15 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 15 flowey_lib_common::resolve_protoc 0
-        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_build 1
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 15 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 15 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: |-
-        flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 1
-        flowey e 15 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_clippy 1
-        flowey e 15 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_build 2
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 15 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 5
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 15 flowey_lib_common::download_cargo_nextest 0
-        flowey e 15 flowey_lib_common::download_cargo_nextest 1
-        flowey e 15 flowey_lib_common::download_cargo_nextest 2
-        flowey e 15 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 15 flowey_lib_common::cache 2
-        flowey e 15 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 15 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 15 flowey_lib_common::install_cargo_nextest 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 1
-        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 15 flowey_lib_common::publish_test_results 5
-        flowey e 15 flowey_lib_common::publish_test_results 6
-        flowey e 15 flowey_lib_common::publish_test_results 4
-        flowey v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 15 flowey_lib_common::publish_test_results 8
-        flowey e 15 flowey_lib_common::publish_test_results 9
-        flowey e 15 flowey_lib_common::publish_test_results 10
-        flowey v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: cargo build xtask
-      run: |-
-        flowey e 15 flowey_lib_hvlite::init_cross_build 2
-        flowey e 15 flowey_lib_common::run_cargo_build 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 15 flowey_lib_hvlite::build_xtask 2
-      shell: bash
-    - name: determine unit test exclusions
-      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 15 flowey_lib_common::publish_test_results 12
-        flowey e 15 flowey_lib_common::publish_test_results 13
-        flowey e 15 flowey_lib_common::publish_test_results 14
-        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 15 flowey_lib_common::publish_test_results 0
-        flowey e 15 flowey_lib_common::publish_test_results 1
-        flowey e 15 flowey_lib_common::publish_test_results 2
-        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: run doctests for x86_64-unknown-linux-gnu
-      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 15 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 15 flowey_lib_common::cache 7
-      shell: bash
-  job16:
-    name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 16 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 16 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 16 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 16 flowey_lib_common::install_rust 2
-        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::git_checkout 0
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2448,27 +1774,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 16 flowey_lib_common::git_checkout 3
-        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 14 flowey_lib_common::git_checkout 3
+        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 16 flowey_lib_common::download_gh_release 0
+      run: flowey e 14 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 14 flowey_lib_common::cache 4
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2478,78 +1804,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 16 flowey_lib_common::cache 6
-        flowey e 16 flowey_lib_common::download_gh_release 1
+        flowey e 14 flowey_lib_common::cache 6
+        flowey e 14 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 16 flowey_lib_common::resolve_protoc 0
+      run: flowey e 14 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 2
+        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_clippy 5
-        flowey e 16 flowey_lib_hvlite::init_cross_build 0
+        flowey e 14 flowey_lib_common::run_cargo_clippy 5
+        flowey e 14 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_build 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 14 flowey_lib_common::run_cargo_build 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::build_xtask 0
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 14 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 14 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 16 flowey_lib_common::download_cargo_nextest 0
-        flowey e 16 flowey_lib_common::download_cargo_nextest 1
-        flowey e 16 flowey_lib_common::download_cargo_nextest 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 3
+        flowey e 14 flowey_lib_common::download_cargo_nextest 0
+        flowey e 14 flowey_lib_common::download_cargo_nextest 1
+        flowey e 14 flowey_lib_common::download_cargo_nextest 2
+        flowey e 14 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 14 flowey_lib_common::cache 0
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2559,34 +1885,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 16 flowey_lib_common::cache 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 4
+        flowey e 14 flowey_lib_common::cache 2
+        flowey e 14 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 16 flowey_lib_common::install_rust 3
+      run: flowey e 14 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 16 flowey_lib_common::install_cargo_nextest 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 3
-        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::install_cargo_nextest 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 3
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 16 flowey_lib_common::publish_test_results 5
-        flowey e 16 flowey_lib_common::publish_test_results 6
-        flowey e 16 flowey_lib_common::publish_test_results 4
-        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 14 flowey_lib_common::publish_test_results 5
+        flowey e 14 flowey_lib_common::publish_test_results 6
+        flowey e 14 flowey_lib_common::publish_test_results 4
+        flowey v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2596,18 +1922,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 16 flowey_lib_common::publish_test_results 8
-        flowey e 16 flowey_lib_common::publish_test_results 9
-        flowey e 16 flowey_lib_common::publish_test_results 10
-        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 14 flowey_lib_common::publish_test_results 8
+        flowey e 14 flowey_lib_common::publish_test_results 9
+        flowey e 14 flowey_lib_common::publish_test_results 10
+        flowey v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2617,18 +1943,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 14 flowey_lib_common::publish_test_results 12
+        flowey e 14 flowey_lib_common::publish_test_results 13
+        flowey e 14 flowey_lib_common::publish_test_results 14
+        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -2638,18 +1964,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 16 flowey_lib_common::publish_test_results 16
-        flowey e 16 flowey_lib_common::publish_test_results 17
-        flowey e 16 flowey_lib_common::publish_test_results 18
-        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 14 flowey_lib_common::publish_test_results 16
+        flowey e 14 flowey_lib_common::publish_test_results 17
+        flowey e 14 flowey_lib_common::publish_test_results 18
+        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -2660,32 +1986,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_cross_build 1
-        flowey e 16 flowey_lib_common::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 14 flowey_lib_hvlite::init_cross_build 1
+        flowey e 14 flowey_lib_common::run_cargo_build 1
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 16 flowey_lib_hvlite::build_xtask 1
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 14 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 16 flowey_lib_common::publish_test_results 0
-        flowey e 16 flowey_lib_common::publish_test_results 1
-        flowey e 16 flowey_lib_common::publish_test_results 2
-        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 14 flowey_lib_common::publish_test_results 0
+        flowey e 14 flowey_lib_common::publish_test_results 1
+        flowey e 14 flowey_lib_common::publish_test_results 2
+        flowey v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2696,25 +2022,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
-      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 16 flowey_lib_common::cache 3
+      run: flowey e 14 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 16 flowey_lib_common::cache 7
+      run: flowey e 14 flowey_lib_common::cache 7
       shell: bash
-  job17:
+  job15:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=win-arm64
-    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2780,29 +2106,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 17 'verbose' update
+        cat <<'EOF' | flowey.exe v 15 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 17 flowey_lib_common::install_rust 0
+      run: flowey.exe e 15 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 17 flowey_lib_common::install_rust 1
+      run: flowey.exe e 15 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 17 flowey_lib_common::install_rust 2
-        flowey.exe e 17 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 15 flowey_lib_common::install_rust 2
+        flowey.exe e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 17 flowey_lib_common::git_checkout 0
-        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::git_checkout 0
+        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2814,23 +2140,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 17 flowey_lib_common::git_checkout 3
-        flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 15 flowey_lib_common::git_checkout 3
+        flowey.exe e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 17 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 15 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 17 flowey_lib_common::cache 4
-        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 15 flowey_lib_common::cache 4
+        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2840,50 +2166,50 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 17 flowey_lib_common::cache 6
-        flowey.exe e 17 flowey_lib_common::download_gh_release 1
+        flowey.exe e 15 flowey_lib_common::cache 6
+        flowey.exe e 15 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 17 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 15 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 17 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 15 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 15 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 17 flowey_lib_common::cache 0
-        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe e 15 flowey_lib_common::cache 0
+        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2893,45 +2219,45 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 17 flowey_lib_common::cache 2
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 15 flowey_lib_common::cache 2
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 17 flowey_lib_common::install_rust 3
+      run: flowey.exe e 15 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 17 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 15 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 17 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 15 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
       run: |-
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 17 flowey_lib_common::publish_test_results 5
-        flowey.exe e 17 flowey_lib_common::publish_test_results 6
-        flowey.exe e 17 flowey_lib_common::publish_test_results 4
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 15 flowey_lib_common::publish_test_results 5
+        flowey.exe e 15 flowey_lib_common::publish_test_results 6
+        flowey.exe e 15 flowey_lib_common::publish_test_results 4
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2941,18 +2267,18 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 17 flowey_lib_common::publish_test_results 0
-        flowey.exe e 17 flowey_lib_common::publish_test_results 1
-        flowey.exe e 17 flowey_lib_common::publish_test_results 2
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 15 flowey_lib_common::publish_test_results 0
+        flowey.exe e 15 flowey_lib_common::publish_test_results 1
+        flowey.exe e 15 flowey_lib_common::publish_test_results 2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2963,25 +2289,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 17 flowey_lib_common::cache 3
+      run: flowey.exe e 15 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 17 flowey_lib_common::cache 7
+      run: flowey.exe e 15 flowey_lib_common::cache 7
       shell: bash
-  job18:
+  job16:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3047,35 +2373,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 18 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 18 'verbose' update
+        cat <<'EOF' | flowey v 16 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 18 flowey_lib_common::install_rust 0
+      run: flowey e 16 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 18 flowey_lib_common::install_rust 1
+      run: flowey e 16 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 18 flowey_lib_common::install_rust 2
-        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 16 flowey_lib_common::install_rust 2
+        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::git_checkout 0
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3087,23 +2413,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 18 flowey_lib_common::git_checkout 3
-        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 16 flowey_lib_common::git_checkout 3
+        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 18 flowey_lib_common::download_gh_release 0
+      run: flowey e 16 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey e 16 flowey_lib_common::cache 4
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3113,61 +2439,61 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 18 flowey_lib_common::cache 6
-        flowey e 18 flowey_lib_common::download_gh_release 1
+        flowey e 16 flowey_lib_common::cache 6
+        flowey e 16 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 18 flowey_lib_common::resolve_protoc 0
-        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 16 flowey_lib_common::resolve_protoc 0
+        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 2
+        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_build 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 16 flowey_lib_common::run_cargo_build 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 18 flowey_lib_hvlite::build_xtask 0
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 18 flowey_lib_common::download_cargo_nextest 0
-        flowey e 18 flowey_lib_common::download_cargo_nextest 1
-        flowey e 18 flowey_lib_common::download_cargo_nextest 2
-        flowey e 18 flowey_lib_common::download_cargo_nextest 3
+        flowey e 16 flowey_lib_common::download_cargo_nextest 0
+        flowey e 16 flowey_lib_common::download_cargo_nextest 1
+        flowey e 16 flowey_lib_common::download_cargo_nextest 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey e 16 flowey_lib_common::cache 0
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3177,34 +2503,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 18 flowey_lib_common::cache 2
-        flowey e 18 flowey_lib_common::download_cargo_nextest 4
+        flowey e 16 flowey_lib_common::cache 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 18 flowey_lib_common::install_rust 3
+      run: flowey e 16 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 18 flowey_lib_common::install_cargo_nextest 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::install_cargo_nextest 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 18 flowey_lib_common::publish_test_results 5
-        flowey e 18 flowey_lib_common::publish_test_results 6
-        flowey e 18 flowey_lib_common::publish_test_results 4
-        flowey v 18 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 16 flowey_lib_common::publish_test_results 5
+        flowey e 16 flowey_lib_common::publish_test_results 6
+        flowey e 16 flowey_lib_common::publish_test_results 4
+        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -3214,18 +2540,18 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 18 flowey_lib_common::publish_test_results 8
-        flowey e 18 flowey_lib_common::publish_test_results 9
-        flowey e 18 flowey_lib_common::publish_test_results 10
-        flowey v 18 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 16 flowey_lib_common::publish_test_results 8
+        flowey e 16 flowey_lib_common::publish_test_results 9
+        flowey e 16 flowey_lib_common::publish_test_results 10
+        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -3236,32 +2562,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 18 flowey_lib_hvlite::init_cross_build 3
-        flowey e 18 flowey_lib_common::run_cargo_build 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 16 flowey_lib_hvlite::init_cross_build 3
+        flowey e 16 flowey_lib_common::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 18 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 18 flowey_lib_hvlite::build_xtask 1
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 16 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 18 flowey_lib_common::publish_test_results 12
-        flowey e 18 flowey_lib_common::publish_test_results 13
-        flowey e 18 flowey_lib_common::publish_test_results 14
-        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 18 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey e 16 flowey_lib_common::publish_test_results 13
+        flowey e 16 flowey_lib_common::publish_test_results 14
+        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -3271,18 +2597,18 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 18 flowey_lib_common::publish_test_results 0
-        flowey e 18 flowey_lib_common::publish_test_results 1
-        flowey e 18 flowey_lib_common::publish_test_results 2
-        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 16 flowey_lib_common::publish_test_results 0
+        flowey e 16 flowey_lib_common::publish_test_results 1
+        flowey e 16 flowey_lib_common::publish_test_results 2
+        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -3293,25 +2619,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 18 flowey_lib_common::cache 3
+      run: flowey e 16 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 18 flowey_lib_common::cache 7
+      run: flowey e 16 flowey_lib_common::cache 7
       shell: bash
-  job19:
+  job17:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3377,29 +2703,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 19 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 19 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 17 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 17 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 19 'verbose' update
+        cat <<'EOF' | flowey v 17 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 19 flowey_lib_common::install_rust 0
+      run: flowey e 17 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 19 flowey_lib_common::install_rust 1
+      run: flowey e 17 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 19 flowey_lib_common::install_rust 2
-        flowey e 19 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 17 flowey_lib_common::install_rust 2
+        flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 19 flowey_lib_common::git_checkout 0
-        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::git_checkout 0
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3411,27 +2737,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 19 flowey_lib_common::git_checkout 3
-        flowey e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 17 flowey_lib_common::git_checkout 3
+        flowey e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 19 flowey_lib_common::download_gh_release 0
+      run: flowey e 17 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 19 flowey_lib_common::cache 4
-        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 17 flowey_lib_common::cache 4
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3441,78 +2767,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 19 flowey_lib_common::cache 6
-        flowey e 19 flowey_lib_common::download_gh_release 1
+        flowey e 17 flowey_lib_common::cache 6
+        flowey e 17 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 19 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 19 flowey_lib_common::resolve_protoc 0
+      run: flowey e 17 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 19 flowey_lib_hvlite::init_cross_build 2
+        flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_clippy 5
-        flowey e 19 flowey_lib_hvlite::init_cross_build 0
+        flowey e 17 flowey_lib_common::run_cargo_clippy 5
+        flowey e 17 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_build 0
-        flowey e 19 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 17 flowey_lib_common::run_cargo_build 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 19 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 19 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 19 flowey_lib_hvlite::build_xtask 0
+        flowey e 17 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 17 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 19 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 17 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 19 flowey_lib_common::download_cargo_nextest 0
-        flowey e 19 flowey_lib_common::download_cargo_nextest 1
-        flowey e 19 flowey_lib_common::download_cargo_nextest 2
-        flowey e 19 flowey_lib_common::download_cargo_nextest 3
+        flowey e 17 flowey_lib_common::download_cargo_nextest 0
+        flowey e 17 flowey_lib_common::download_cargo_nextest 1
+        flowey e 17 flowey_lib_common::download_cargo_nextest 2
+        flowey e 17 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 19 flowey_lib_common::cache 0
-        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 17 flowey_lib_common::cache 0
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3522,34 +2848,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 19 flowey_lib_common::cache 2
-        flowey e 19 flowey_lib_common::download_cargo_nextest 4
+        flowey e 17 flowey_lib_common::cache 2
+        flowey e 17 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 19 flowey_lib_common::install_rust 3
+      run: flowey e 17 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 19 flowey_lib_common::install_cargo_nextest 0
-        flowey e 19 flowey_lib_hvlite::init_cross_build 3
-        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::install_cargo_nextest 0
+        flowey e 17 flowey_lib_hvlite::init_cross_build 3
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 19 flowey_lib_common::publish_test_results 5
-        flowey e 19 flowey_lib_common::publish_test_results 6
-        flowey e 19 flowey_lib_common::publish_test_results 4
-        flowey v 19 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 17 flowey_lib_common::publish_test_results 5
+        flowey e 17 flowey_lib_common::publish_test_results 6
+        flowey e 17 flowey_lib_common::publish_test_results 4
+        flowey v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -3559,18 +2885,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 19 flowey_lib_common::publish_test_results 8
-        flowey e 19 flowey_lib_common::publish_test_results 9
-        flowey e 19 flowey_lib_common::publish_test_results 10
-        flowey v 19 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 19 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 17 flowey_lib_common::publish_test_results 8
+        flowey e 17 flowey_lib_common::publish_test_results 9
+        flowey e 17 flowey_lib_common::publish_test_results 10
+        flowey v 17 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 17 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -3580,18 +2906,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 19 flowey_lib_common::publish_test_results 12
-        flowey e 19 flowey_lib_common::publish_test_results 13
-        flowey e 19 flowey_lib_common::publish_test_results 14
-        flowey v 19 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 19 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 17 flowey_lib_common::publish_test_results 12
+        flowey e 17 flowey_lib_common::publish_test_results 13
+        flowey e 17 flowey_lib_common::publish_test_results 14
+        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -3601,18 +2927,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 19 flowey_lib_common::publish_test_results 16
-        flowey e 19 flowey_lib_common::publish_test_results 17
-        flowey e 19 flowey_lib_common::publish_test_results 18
-        flowey v 19 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 19 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 17 flowey_lib_common::publish_test_results 16
+        flowey e 17 flowey_lib_common::publish_test_results 17
+        flowey e 17 flowey_lib_common::publish_test_results 18
+        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -3623,32 +2949,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 19 flowey_lib_hvlite::init_cross_build 1
-        flowey e 19 flowey_lib_common::run_cargo_build 1
-        flowey e 19 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 17 flowey_lib_hvlite::init_cross_build 1
+        flowey e 17 flowey_lib_common::run_cargo_build 1
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 19 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 19 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 19 flowey_lib_hvlite::build_xtask 1
+        flowey e 17 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 17 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 19 flowey_lib_common::publish_test_results 0
-        flowey e 19 flowey_lib_common::publish_test_results 1
-        flowey e 19 flowey_lib_common::publish_test_results 2
-        flowey v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 17 flowey_lib_common::publish_test_results 0
+        flowey e 17 flowey_lib_common::publish_test_results 1
+        flowey e 17 flowey_lib_common::publish_test_results 2
+        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -3659,20 +2985,556 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
-      run: flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 19 flowey_lib_common::cache 3
+      run: flowey e 17 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 19 flowey_lib_common::cache 7
+      run: flowey e 17 flowey_lib_common::cache 7
+      shell: bash
+  job18:
+    name: run vmm-tests [x64-windows-intel]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job11
+    - job2
+    - job3
+    - job7
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
+
+        echo '"debug"' | flowey.exe v 18 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 18 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 18 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 18 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 18 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 18 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 18 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 18 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 18 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 18 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 18 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 18 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 18 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 18 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 18 flowey_lib_common::cache 0
+        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 18 flowey_lib_common::cache 2
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 18 flowey_lib_common::git_checkout 0
+        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 18 flowey_lib_common::git_checkout 3
+        flowey.exe e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 18 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 18 flowey_lib_common::cache 8
+        flowey.exe v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 18 flowey_lib_common::cache 10
+        flowey.exe e 18 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 18 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 18 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 18 flowey_lib_common::cache 4
+        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 18 flowey_lib_common::cache 6
+        flowey.exe e 18 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 18 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 18 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 18 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 18 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 18 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 18 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 18 flowey_lib_common::publish_test_results 4
+        flowey.exe e 18 flowey_lib_common::publish_test_results 5
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 18 flowey_lib_common::publish_test_results 0
+        flowey.exe e 18 flowey_lib_common::publish_test_results 1
+        flowey.exe e 18 flowey_lib_common::publish_test_results 2
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 18 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 18 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 18 flowey_lib_common::cache 11
+      shell: bash
+  job19:
+    name: run vmm-tests [x64-windows-intel-tdx]
+    runs-on:
+    - self-hosted
+    - Windows
+    - X64
+    - TDX
+    - Baremetal
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job11
+    - job2
+    - job3
+    - job7
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
+
+        echo '"debug"' | flowey.exe v 19 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 19 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 19 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 19 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 19 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 19 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 19 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 19 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 19 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 0
+        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 19 flowey_lib_common::cache 2
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 19 flowey_lib_common::git_checkout 0
+        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 19 flowey_lib_common::git_checkout 3
+        flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 19 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 8
+        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 19 flowey_lib_common::cache 10
+        flowey.exe e 19 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 19 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 19 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 4
+        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 19 flowey_lib_common::cache 6
+        flowey.exe e 19 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 19 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 19 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 19 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 19 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 19 flowey_lib_common::publish_test_results 4
+        flowey.exe e 19 flowey_lib_common::publish_test_results 5
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-tdx-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 19 flowey_lib_common::publish_test_results 0
+        flowey.exe e 19 flowey_lib_common::publish_test_results 1
+        flowey.exe e 19 flowey_lib_common::publish_test_results 2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-tdx-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 19 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 19 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 19 flowey_lib_common::cache 11
       shell: bash
   job2:
-    name: build artifacts (not for VMM tests) [aarch64-windows]
+    name: build artifacts (shared VMM tests) [windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -3749,14 +3611,10 @@ jobs:
         cat <<'EOF' | flowey.exe v 2 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-hypestv"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-hypestv" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-hypestv' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-igvmfilegen"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-igvmfilegen" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-ohcldiag-dev"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-ohcldiag-dev" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgs_lib"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgs_lib" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-pipette"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-pipette" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-pipette"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 2 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 2 flowey_lib_common::install_rust 0
@@ -3825,90 +3683,61 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 2 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 0
       shell: bash
-    - name: cargo build hypestv
+    - name: cargo build pipette
       run: |-
         flowey.exe e 2 flowey_lib_common::run_cargo_build 0
         flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 2 flowey_lib_hvlite::build_hypestv 0
+        flowey.exe e 2 flowey_lib_hvlite::build_pipette 0
         flowey.exe e 2 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey.exe e 2 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 3
-        flowey.exe e 2 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-        flowey.exe e 2 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey.exe e 2 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build pipette
       run: |-
         flowey.exe e 2 flowey_lib_common::run_cargo_build 1
         flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 2 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey.exe e 2 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build ohcldiag-dev
-      run: |-
-        flowey.exe e 2 flowey_lib_common::run_cargo_build 2
-        flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 2 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey.exe e 2 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 2 flowey_lib_hvlite::build_pipette 1
+        flowey.exe e 2 flowey_core::pipeline::artifact::publish 1
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey.exe e 2 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-windows-hypestv
+    - name: 🌼📦 Publish aarch64-windows-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-hypestv
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-hypestv/
+        name: aarch64-windows-pipette
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-pipette/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-igvmfilegen
+    - name: 🌼📦 Publish x64-windows-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-igvmfilegen/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-ohcldiag-dev
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-ohcldiag-dev/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-vmgs_lib
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
+        name: x64-windows-pipette
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-windows-intel]
+    name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
-    - job10
-    - job13
-    - job6
+    - job11
+    - job2
+    - job3
     - job7
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-15,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
     - name: 🌼🛫 Initialize job
@@ -3917,7 +3746,7 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15/flowey.exe
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
 
         echo '"debug"' | flowey.exe v 20 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey.exe v 20 '_internal_WORKING_DIR' --is-raw-string update
@@ -4119,9 +3948,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-vmm-tests-logs
+        name: x64-windows-amd-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4135,9 +3964,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-vmm-tests-junit-xml
+        name: x64-windows-amd-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4152,29 +3981,29 @@ jobs:
       run: flowey.exe e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [x64-windows-intel-tdx]
+    name: run vmm-tests [x64-windows-amd-snp]
     runs-on:
     - self-hosted
     - Windows
     - X64
-    - TDX
+    - SNP
     - Baremetal
     permissions:
       contents: read
       id-token: write
     needs:
-    - job10
-    - job13
-    - job6
+    - job11
+    - job2
+    - job3
     - job7
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-15,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
     - name: 🌼🛫 Initialize job
@@ -4183,7 +4012,7 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15/flowey.exe
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
 
         echo '"debug"' | flowey.exe v 21 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey.exe v 21 '_internal_WORKING_DIR' --is-raw-string update
@@ -4255,6 +4084,10 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
@@ -4262,10 +4095,6 @@ jobs:
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4390,9 +4219,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-logs
+        name: x64-windows-amd-snp-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4406,9 +4235,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-junit-xml
+        name: x64-windows-amd-snp-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4423,555 +4252,19 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
-    name: run vmm-tests [x64-windows-amd]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job10
-    - job13
-    - job6
-    - job7
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-15,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15/flowey.exe
-
-        echo '"debug"' | flowey.exe v 22 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 22 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 22 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 22 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 22 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 22 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 22 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 22 flowey_lib_common::cache 0
-        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 22 flowey_lib_common::cache 2
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 22 flowey_lib_common::git_checkout 0
-        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 22 flowey_lib_common::git_checkout 3
-        flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 22 flowey_lib_common::cache 8
-        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 22 flowey_lib_common::cache 10
-        flowey.exe e 22 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 22 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 22 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 22 flowey_lib_common::cache 4
-        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 22 flowey_lib_common::cache 6
-        flowey.exe e 22 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 22 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 22 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 22 flowey_lib_common::publish_test_results 4
-        flowey.exe e 22 flowey_lib_common::publish_test_results 5
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 22 flowey_lib_common::publish_test_results 0
-        flowey.exe e 22 flowey_lib_common::publish_test_results 1
-        flowey.exe e 22 flowey_lib_common::publish_test_results 2
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 22 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 22 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 22 flowey_lib_common::cache 11
-      shell: bash
-  job23:
-    name: run vmm-tests [x64-windows-amd-snp]
-    runs-on:
-    - self-hosted
-    - Windows
-    - X64
-    - SNP
-    - Baremetal
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job10
-    - job13
-    - job6
-    - job7
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-15,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15/flowey.exe
-
-        echo '"debug"' | flowey.exe v 23 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 23 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 23 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 23 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 23 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 23 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 23 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 23 flowey_lib_common::cache 0
-        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::cache 2
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 23 flowey_lib_common::git_checkout 0
-        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::git_checkout 3
-        flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 23 flowey_lib_common::cache 8
-        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::cache 10
-        flowey.exe e 23 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 23 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 23 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 23 flowey_lib_common::cache 4
-        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::cache 6
-        flowey.exe e 23 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 23 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 23 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 23 flowey_lib_common::publish_test_results 4
-        flowey.exe e 23 flowey_lib_common::publish_test_results 5
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 23 flowey_lib_common::publish_test_results 0
-        flowey.exe e 23 flowey_lib_common::publish_test_results 1
-        flowey.exe e 23 flowey_lib_common::publish_test_results 2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 23 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 23 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 23 flowey_lib_common::cache 11
-      shell: bash
-  job24:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
-    - job10
-    - job11
-    - job6
+    - job2
+    - job3
+    - job9
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -4990,46 +4283,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11/flowey
 
-        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 22 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 24 'verbose' update
+        cat <<'EOF' | flowey v 22 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 24 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 22 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 22 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 22 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 22 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey e 24 flowey_core::pipeline::artifact::resolve 7
-        flowey e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey e 22 flowey_core::pipeline::artifact::resolve 7
+        flowey e 22 flowey_core::pipeline::artifact::resolve 1
+        flowey e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey e 22 flowey_core::pipeline::artifact::resolve 6
+        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 22 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 24 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 22 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 24 flowey_lib_common::download_gh_release 0
+      run: flowey e 22 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 24 flowey_lib_common::cache 8
-        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 22 flowey_lib_common::cache 8
+        flowey v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5039,31 +4332,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 24 flowey_lib_common::cache 10
-        flowey e 24 flowey_lib_common::download_gh_release 1
+        flowey e 22 flowey_lib_common::cache 10
+        flowey e 22 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 24 flowey_lib_common::download_azcopy 0
+      run: flowey e 22 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 24 flowey_lib_common::download_gh_cli 0
+      run: flowey e 22 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 24 flowey_lib_common::cache 4
-        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 22 flowey_lib_common::cache 4
+        flowey v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5073,54 +4366,54 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 24 flowey_lib_common::cache 6
-        flowey e 24 flowey_lib_common::download_gh_cli 1
-        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 22 flowey_lib_common::cache 6
+        flowey e 22 flowey_lib_common::download_gh_cli 1
+        flowey v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 24 flowey_lib_common::use_gh_cli 0
+      run: flowey e 22 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 24 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 22 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 22 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey e 24 flowey_lib_common::download_cargo_nextest 3
+        flowey e 22 flowey_lib_common::download_cargo_nextest 0
+        flowey e 22 flowey_lib_common::download_cargo_nextest 1
+        flowey e 22 flowey_lib_common::download_cargo_nextest 2
+        flowey e 22 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 24 flowey_lib_common::cache 0
-        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 22 flowey_lib_common::cache 0
+        flowey v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5130,17 +4423,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 24 flowey_lib_common::cache 2
-        flowey e 24 flowey_lib_common::download_cargo_nextest 4
+        flowey e 22 flowey_lib_common::cache 2
+        flowey e 22 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 24 flowey_lib_common::git_checkout 0
-        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 22 flowey_lib_common::git_checkout 0
+        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5152,32 +4445,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 24 flowey_lib_common::git_checkout 3
-        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey e 22 flowey_lib_common::git_checkout 3
+        flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 22 flowey_core::pipeline::artifact::resolve 5
+        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
     - name: generate nextest command
-      run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 24 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 24 flowey_lib_common::publish_test_results 4
-        flowey e 24 flowey_lib_common::publish_test_results 5
-        flowey v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 22 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 22 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 22 flowey_lib_common::publish_test_results 4
+        flowey e 22 flowey_lib_common::publish_test_results 5
+        flowey v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5188,12 +4481,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 24 flowey_lib_common::publish_test_results 0
-        flowey e 24 flowey_lib_common::publish_test_results 1
-        flowey e 24 flowey_lib_common::publish_test_results 2
-        flowey v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 22 flowey_lib_common::publish_test_results 0
+        flowey e 22 flowey_lib_common::publish_test_results 1
+        flowey e 22 flowey_lib_common::publish_test_results 2
+        flowey v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5203,31 +4496,31 @@ jobs:
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 24 flowey_lib_common::cache 3
+      run: flowey e 22 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 24 flowey_lib_common::cache 7
+      run: flowey e 22 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 24 flowey_lib_common::cache 11
+      run: flowey e 22 flowey_lib_common::cache 11
       shell: bash
-  job25:
+  job23:
     name: run vmm-tests [x64-linux-intel-mshv]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
-    - job10
-    - job11
-    - job6
+    - job2
+    - job3
+    - job9
     if: github.event.pull_request.draft == false
     steps:
     - run: |
@@ -5294,46 +4587,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 23 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 25 'verbose' update
+        cat <<'EOF' | flowey v 23 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 23 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 25 flowey_core::pipeline::artifact::resolve 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 2
-        flowey e 25 flowey_core::pipeline::artifact::resolve 7
-        flowey e 25 flowey_core::pipeline::artifact::resolve 3
-        flowey e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 4
-        flowey e 25 flowey_core::pipeline::artifact::resolve 6
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 23 flowey_core::pipeline::artifact::resolve 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey e 23 flowey_core::pipeline::artifact::resolve 6
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_release 0
+      run: flowey e 23 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 8
-        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 23 flowey_lib_common::cache 8
+        flowey v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5343,31 +4636,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 10
-        flowey e 25 flowey_lib_common::download_gh_release 1
+        flowey e 23 flowey_lib_common::cache 10
+        flowey e 23 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 25 flowey_lib_common::download_azcopy 0
+      run: flowey e 23 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_cli 0
+      run: flowey e 23 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 4
-        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 23 flowey_lib_common::cache 4
+        flowey v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5377,51 +4670,51 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 6
-        flowey e 25 flowey_lib_common::download_gh_cli 1
-        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 23 flowey_lib_common::cache 6
+        flowey e 23 flowey_lib_common::download_gh_cli 1
+        flowey v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 25 flowey_lib_common::use_gh_cli 0
+      run: flowey e 23 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 25 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 23 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 23 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 25 flowey_lib_common::download_cargo_nextest 0
-        flowey e 25 flowey_lib_common::download_cargo_nextest 1
-        flowey e 25 flowey_lib_common::download_cargo_nextest 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 3
+        flowey e 23 flowey_lib_common::download_cargo_nextest 0
+        flowey e 23 flowey_lib_common::download_cargo_nextest 1
+        flowey e 23 flowey_lib_common::download_cargo_nextest 2
+        flowey e 23 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 23 flowey_lib_common::cache 0
+        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5431,17 +4724,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 4
+        flowey e 23 flowey_lib_common::cache 2
+        flowey e 23 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 23 flowey_lib_common::git_checkout 0
+        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5453,31 +4746,31 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 5
-        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 23 flowey_lib_common::git_checkout 3
+        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 5
+        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: generate nextest command
-      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 25 flowey_lib_common::publish_test_results 4
-        flowey e 25 flowey_lib_common::publish_test_results 5
-        flowey v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 23 flowey_lib_common::publish_test_results 4
+        flowey e 23 flowey_lib_common::publish_test_results 5
+        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5488,12 +4781,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 25 flowey_lib_common::publish_test_results 0
-        flowey e 25 flowey_lib_common::publish_test_results 1
-        flowey e 25 flowey_lib_common::publish_test_results 2
-        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 23 flowey_lib_common::publish_test_results 0
+        flowey e 23 flowey_lib_common::publish_test_results 1
+        flowey e 23 flowey_lib_common::publish_test_results 2
+        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5503,18 +4796,18 @@ jobs:
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 25 flowey_lib_common::cache 3
+      run: flowey e 23 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 25 flowey_lib_common::cache 7
+      run: flowey e 23 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 25 flowey_lib_common::cache 11
+      run: flowey e 23 flowey_lib_common::cache 11
       shell: bash
-  job26:
+  job24:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -5525,10 +4818,10 @@ jobs:
       contents: read
       id-token: write
     needs:
-    - job12
+    - job10
+    - job2
     - job3
-    - job4
-    - job8
+    - job5
     if: github.event.pull_request.draft == false
     steps:
     - run: |
@@ -5596,35 +4889,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 26 'verbose' update
+        cat <<'EOF' | flowey.exe v 24 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 26 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 24 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 0
-        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 24 flowey_lib_common::cache 0
+        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5634,17 +4927,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 24 flowey_lib_common::cache 2
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 24 flowey_lib_common::git_checkout 0
+        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5656,35 +4949,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 26 flowey_lib_common::git_checkout 3
-        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 24 flowey_lib_common::git_checkout 3
+        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 8
-        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 24 flowey_lib_common::cache 8
+        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5694,31 +4987,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 10
-        flowey.exe e 26 flowey_lib_common::download_gh_release 1
+        flowey.exe e 24 flowey_lib_common::cache 10
+        flowey.exe e 24 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 26 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 4
-        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 24 flowey_lib_common::cache 4
+        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5728,63 +5021,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 6
-        flowey.exe e 26 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 24 flowey_lib_common::cache 6
+        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 26 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 26 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 26 flowey_lib_common::publish_test_results 4
-        flowey.exe e 26 flowey_lib_common::publish_test_results 5
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 24 flowey_lib_common::publish_test_results 4
+        flowey.exe e 24 flowey_lib_common::publish_test_results 5
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5795,12 +5088,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 26 flowey_lib_common::publish_test_results 0
-        flowey.exe e 26 flowey_lib_common::publish_test_results 1
-        flowey.exe e 26 flowey_lib_common::publish_test_results 2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 24 flowey_lib_common::publish_test_results 0
+        flowey.exe e 24 flowey_lib_common::publish_test_results 1
+        flowey.exe e 24 flowey_lib_common::publish_test_results 2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5810,18 +5103,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 26 flowey_lib_common::cache 3
+      run: flowey.exe e 24 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 26 flowey_lib_common::cache 7
+      run: flowey.exe e 24 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 26 flowey_lib_common::cache 11
+      run: flowey.exe e 24 flowey_lib_common::cache 11
       shell: bash
-  job27:
+  job25:
     name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
@@ -5889,18 +5182,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 27 'verbose' update
+        cat <<'EOF' | flowey v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5912,35 +5205,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 27 flowey_lib_common::git_checkout 3
-        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_common::git_checkout 3
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 27 flowey_lib_common::install_rust 0
+      run: flowey e 25 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 27 flowey_lib_common::install_rust 1
+      run: flowey e 25 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 27 flowey_lib_common::install_rust 2
-        flowey v 27 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 25 flowey_lib_common::install_rust 2
+        flowey v 25 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 27 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      run: flowey e 25 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
-  job28:
+  job26:
     name: build openhcl (mi-secure) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job28-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -6006,31 +5299,31 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 28 'verbose' update
+        cat <<'EOF' | flowey v 26 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 28 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 26 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 28 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 26 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 28 flowey_lib_common::download_gh_release 0
+      run: flowey e 26 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 28 flowey_lib_common::cache 0
-        flowey v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey e 26 flowey_lib_common::cache 0
+        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6040,31 +5333,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 28 flowey_lib_common::cache 2
-        flowey e 28 flowey_lib_common::download_gh_release 1
+        flowey e 26 flowey_lib_common::cache 2
+        flowey e 26 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 28 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 28 flowey_lib_common::install_rust 0
+      run: flowey e 26 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 28 flowey_lib_common::install_rust 1
+      run: flowey e 26 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 28 flowey_lib_common::install_rust 2
-        flowey e 28 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 26 flowey_lib_common::install_rust 2
+        flowey e 26 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 28 flowey_lib_common::git_checkout 0
-        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 26 flowey_lib_common::git_checkout 0
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6076,172 +5369,172 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 28 flowey_lib_common::git_checkout 3
-        flowey e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 26 flowey_lib_common::git_checkout 3
+        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 28 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 26 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 28 flowey_lib_common::resolve_protoc 0
-        flowey e 28 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 26 flowey_lib_common::resolve_protoc 0
+        flowey e 26 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 28 flowey_lib_hvlite::init_cross_build 0
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 26 flowey_lib_hvlite::init_cross_build 0
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 3
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 26 flowey_lib_common::run_cargo_build 3
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 28 flowey_lib_hvlite::build_sidecar 0
-        flowey e 28 flowey_lib_hvlite::init_cross_build 1
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 26 flowey_lib_hvlite::build_sidecar 0
+        flowey e 26 flowey_lib_hvlite::init_cross_build 1
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: cargo build openhcl_boot
       run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 1
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 26 flowey_lib_common::run_cargo_build 1
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 28 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 26 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 28 flowey_lib_hvlite::init_cross_build 3
+        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 26 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 2
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 28 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 26 flowey_lib_common::run_cargo_build 2
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 26 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 28 flowey_lib_hvlite::init_cross_build 2
+        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 26 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 0
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 26 flowey_lib_common::run_cargo_build 0
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 28 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 26 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 28 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
-        flowey e 28 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 26 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 28 flowey_lib_common::copy_to_artifact_dir 0
+      run: flowey e 26 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 28 flowey_lib_common::cache 3
+      run: flowey e 26 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -6255,29 +5548,29 @@ jobs:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
         include-hidden-files: true
-  job29:
+  job27:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job29-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
-    - job10
-    - job28
-    - job6
+    - job2
+    - job26
+    - job3
     - job7
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-15,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
     - name: 🌼🛫 Initialize job
@@ -6286,41 +5579,41 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-15/flowey.exe
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
 
-        echo '"debug"' | flowey.exe v 29 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 29 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 27 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 27 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 29 'verbose' update
+        cat <<'EOF' | flowey.exe v 27 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 29 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 29 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 29 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 29 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 29 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 29 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 29 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 29 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 29 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 27 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 27 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 27 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 27 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 27 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 27 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 27 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 27 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 29 flowey_lib_common::cache 0
-        flowey.exe v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 27 flowey_lib_common::cache 0
+        flowey.exe v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6330,17 +5623,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 29 flowey_lib_common::cache 2
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 27 flowey_lib_common::cache 2
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 29 flowey_lib_common::git_checkout 0
-        flowey.exe v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 27 flowey_lib_common::git_checkout 0
+        flowey.exe v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6352,38 +5645,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 29 flowey_lib_common::git_checkout 3
-        flowey.exe e 29 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 27 flowey_lib_common::git_checkout 3
+        flowey.exe e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 29 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 27 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 29 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 27 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 29 flowey_lib_common::cache 8
-        flowey.exe v 29 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 29 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 27 flowey_lib_common::cache 8
+        flowey.exe v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -6393,31 +5686,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 29 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 29 flowey_lib_common::cache 10
-        flowey.exe e 29 flowey_lib_common::download_gh_release 1
+        flowey.exe e 27 flowey_lib_common::cache 10
+        flowey.exe e 27 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 29 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 27 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 29 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 27 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 29 flowey_lib_common::cache 4
-        flowey.exe v 29 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 29 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 27 flowey_lib_common::cache 4
+        flowey.exe v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -6427,63 +5720,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 29 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 29 flowey_lib_common::cache 6
-        flowey.exe e 29 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 27 flowey_lib_common::cache 6
+        flowey.exe e 27 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 29 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 27 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 29 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 29 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 27 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 29 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 29 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 29 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 29 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 29 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 27 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 29 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 29 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 29 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 27 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 29 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 29 flowey_lib_common::publish_test_results 4
-        flowey.exe e 29 flowey_lib_common::publish_test_results 5
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 27 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 27 flowey_lib_common::publish_test_results 4
+        flowey.exe e 27 flowey_lib_common::publish_test_results 5
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -6494,12 +5787,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 29 flowey_lib_common::publish_test_results 0
-        flowey.exe e 29 flowey_lib_common::publish_test_results 1
-        flowey.exe e 29 flowey_lib_common::publish_test_results 2
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 27 flowey_lib_common::publish_test_results 0
+        flowey.exe e 27 flowey_lib_common::publish_test_results 1
+        flowey.exe e 27 flowey_lib_common::publish_test_results 2
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -6509,23 +5802,164 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 29 flowey_lib_common::cache 3
+      run: flowey.exe e 27 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 29 flowey_lib_common::cache 7
+      run: flowey.exe e 27 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 29 flowey_lib_common::cache 11
+      run: flowey.exe e 27 flowey_lib_common::cache 11
+      shell: bash
+  job28:
+    name: publish vmgstool
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    needs:
+    - job0
+    - job1
+    - job10
+    - job11
+    - job12
+    - job13
+    - job14
+    - job15
+    - job16
+    - job17
+    - job18
+    - job19
+    - job2
+    - job20
+    - job21
+    - job22
+    - job23
+    - job24
+    - job25
+    - job26
+    - job27
+    - job3
+    - job4
+    - job5
+    - job6
+    - job7
+    - job8
+    - job9
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-11,aarch64-linux-vmgstool,aarch64-windows-vmgstool,x64-linux-vmgstool,x64-windows-vmgstool}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11/flowey
+
+        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 28 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 28 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 28 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 28 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 28 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 28 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 28 flowey_lib_common::cache 0
+        flowey v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 28 flowey_lib_common::cache 2
+        flowey e 28 flowey_lib_common::download_gh_cli 1
+        flowey v 28 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: |-
+        flowey e 28 flowey_lib_common::use_gh_cli 0
+        flowey e 28 flowey_core::pipeline::artifact::resolve 1
+        flowey e 28 flowey_core::pipeline::artifact::resolve 0
+        flowey e 28 flowey_core::pipeline::artifact::resolve 3
+        flowey e 28 flowey_core::pipeline::artifact::resolve 2
+      shell: bash
+    - name: enumerate vmgstool release files
+      run: flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 28 flowey_lib_common::git_checkout 0
+        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 28 flowey_lib_common::git_checkout 3
+        flowey e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: get current commit
+      run: |-
+        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
+        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
+      shell: bash
+    - name: get cargo crate version
+      run: |-
+        flowey e 28 flowey_lib_common::get_cargo_crate_version 0
+        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
+        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
+        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
+      shell: bash
+    - name: publish github releases
+      run: flowey e 28 flowey_lib_common::publish_gh_release 0
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 28 flowey_lib_common::cache 3
       shell: bash
   job3:
-    name: build artifacts (shared VMM tests) [aarch64-windows]
+    name: build artifacts (shared VMM tests) [linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6565,11 +5999,11 @@ jobs:
     - name: Build flowey
       run: |
         set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
         OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         mkdir -p "$OutDirNormal"
         mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
       working-directory: flowey_bootstrap
       shell: bash
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
@@ -6582,7 +6016,7 @@ jobs:
         ${{ runner.temp }}
         EOF
         )
-        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
       shell: bash
     - name: 🌼🛫 Initialize job
       run: |
@@ -6590,33 +6024,51 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey.exe v 3 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 3 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 3 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 3 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 3 'verbose' update
+        cat <<'EOF' | flowey v 3 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-pipette"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-pipette" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 3 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 3 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 3 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests" | flowey v 3 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 3 'artifact_publish_from_aarch64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 3 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 3 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 3 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 3 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 3 'artifact_publish_from_x64-tmks' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 3 flowey_lib_common::install_rust 0
+      run: flowey e 3 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 3 flowey_lib_common::install_rust 1
+      run: flowey e 3 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 3 flowey_lib_common::install_rust 2
-        flowey.exe e 3 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 3 flowey_lib_common::install_rust 2
+        flowey e 3 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 3 flowey_lib_common::git_checkout 0
-        flowey.exe v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 3 flowey_lib_common::git_checkout 0
+        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6628,23 +6080,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 3 flowey_lib_common::git_checkout 3
-        flowey.exe e 3 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 3 flowey_lib_common::git_checkout 3
+        flowey e 3 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 3 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 3 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 3 flowey_lib_common::download_gh_release 0
+      run: flowey e 3 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 3 flowey_lib_common::cache 0
-        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey e 3 flowey_lib_common::cache 0
+        flowey v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6654,183 +6106,233 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 3 flowey_lib_common::cache 2
-        flowey.exe e 3 flowey_lib_common::download_gh_release 1
+        flowey e 3 flowey_lib_common::cache 2
+        flowey e 3 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 3 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 3 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 3 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 3 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 3 flowey_lib_common::resolve_protoc 0
+        flowey e 3 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 0
+        flowey e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 3 flowey_lib_hvlite::init_cross_build 9
+      shell: bash
+    - name: cargo build guest_test_uefi
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 1
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 1
+      shell: bash
+    - name: build guest_test_uefi.img
+      run: |-
+        flowey e 3 flowey_lib_hvlite::build_guest_test_uefi 0
+        flowey e 3 flowey_core::pipeline::artifact::publish 7
+        flowey e 3 flowey_lib_hvlite::init_cross_build 5
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: cargo build simple_tmk
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 4
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 12
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 3 flowey_lib_hvlite::build_tmks 0
+        flowey e 3 flowey_core::pipeline::artifact::publish 8
+        flowey e 3 flowey_lib_hvlite::init_cross_build 6
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 9
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 20
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 21
+        flowey e 3 flowey_lib_hvlite::build_tpm_guest_tests 1
+        flowey e 3 flowey_core::pipeline::artifact::publish 9
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 3 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 3 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 3 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 3 flowey_lib_hvlite::build_pipette 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 0
+        flowey e 3 flowey_lib_common::run_cargo_build 3
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 3 flowey_lib_hvlite::build_pipette 1
+        flowey e 3 flowey_core::pipeline::artifact::publish 0
+        flowey e 3 flowey_lib_hvlite::init_cross_build 8
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 7
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 16
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 17
+        flowey e 3 flowey_lib_hvlite::build_tmk_vmm 1
+        flowey e 3 flowey_core::pipeline::artifact::publish 1
+        flowey e 3 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build guest_test_uefi
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 0
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: build guest_test_uefi.img
+      run: |-
+        flowey e 3 flowey_lib_hvlite::build_guest_test_uefi 1
+        flowey e 3 flowey_core::pipeline::artifact::publish 2
+        flowey e 3 flowey_lib_hvlite::init_cross_build 0
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build simple_tmk
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 5
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 3 flowey_lib_hvlite::build_tmks 1
+        flowey e 3 flowey_core::pipeline::artifact::publish 3
+        flowey e 3 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 8
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 18
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 19
+        flowey e 3 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey e 3 flowey_core::pipeline::artifact::publish 4
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 3 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 1
+        flowey e 3 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 2
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 3 flowey_lib_hvlite::build_pipette 0
+        flowey e 3 flowey_core::pipeline::artifact::publish 5
+        flowey e 3 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 6
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 14
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 15
+        flowey e 3 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 3 flowey_core::pipeline::artifact::publish 6
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 3 flowey_lib_common::cache 3
+      run: flowey e 3 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-windows-pipette
+    - name: 🌼📦 Publish aarch64-guest_test_uefi
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-pipette
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-pipette/
+        name: aarch64-guest_test_uefi
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
         include-hidden-files: true
-  job30:
-    name: publish vmgstool
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-    needs:
-    - job0
-    - job1
-    - job10
-    - job11
-    - job12
-    - job13
-    - job14
-    - job15
-    - job16
-    - job17
-    - job18
-    - job19
-    - job2
-    - job20
-    - job21
-    - job22
-    - job23
-    - job24
-    - job25
-    - job26
-    - job27
-    - job28
-    - job29
-    - job3
-    - job4
-    - job5
-    - job6
-    - job7
-    - job8
-    - job9
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
+    - name: 🌼📦 Publish aarch64-linux-musl-pipette
+      uses: actions/upload-artifact@v7
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-11,aarch64-linux-vmgstool,aarch64-windows-vmgstool,x64-linux-vmgstool,x64-windows-vmgstool}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11/flowey
-
-        echo '"debug"' | flowey v 30 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 30 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 30 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 30 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 30 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 30 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 30 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 30 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 30 flowey_lib_common::cache 0
-        flowey v 30 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 30 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
+        name: aarch64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
+      uses: actions/upload-artifact@v7
       with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 30 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 30 flowey_lib_common::cache 2
-        flowey e 30 flowey_lib_common::download_gh_cli 1
-        flowey v 30 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: |-
-        flowey e 30 flowey_lib_common::use_gh_cli 0
-        flowey e 30 flowey_core::pipeline::artifact::resolve 1
-        flowey e 30 flowey_core::pipeline::artifact::resolve 0
-        flowey e 30 flowey_core::pipeline::artifact::resolve 3
-        flowey e 30 flowey_core::pipeline::artifact::resolve 2
-      shell: bash
-    - name: enumerate vmgstool release files
-      run: flowey e 30 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 30 flowey_lib_common::git_checkout 0
-        flowey v 30 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 30 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
+        name: aarch64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-tpm_guest_tests
+      uses: actions/upload-artifact@v7
       with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 30 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 30 flowey_lib_common::git_checkout 3
-        flowey e 30 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: get current commit
-      run: |-
-        flowey e 30 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
-        flowey e 30 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
-      shell: bash
-    - name: get cargo crate version
-      run: |-
-        flowey e 30 flowey_lib_common::get_cargo_crate_version 0
-        flowey e 30 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
-        flowey e 30 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
-        flowey e 30 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
-      shell: bash
-    - name: publish github releases
-      run: flowey e 30 flowey_lib_common::publish_gh_release 0
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 30 flowey_lib_common::cache 3
-      shell: bash
+        name: aarch64-linux-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-tmks
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-guest_test_uefi
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-guest_test_uefi
+        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-pipette
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-tmks
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
+        include-hidden-files: true
   job4:
-    name: build artifacts (for VMM tests) [aarch64-windows]
+    name: build artifacts (not for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6907,20 +6409,14 @@ jobs:
         cat <<'EOF' | flowey.exe v 4 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-prep_steps"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-prep_steps" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-test_igvm_agent_rpc_server" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tpm_guest_tests"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tpm_guest_tests" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-hypestv"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-hypestv" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-hypestv' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-igvmfilegen"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-igvmfilegen" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-ohcldiag-dev"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-ohcldiag-dev" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgs_lib"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgs_lib" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-vmgs_lib' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 4 flowey_lib_common::install_rust 0
@@ -6963,22 +6459,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 4 flowey_lib_common::cache 4
-        flowey.exe v 4 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 4 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 4 flowey_lib_common::cache 0
+        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 4 flowey_lib_common::cache 6
+        flowey.exe e 4 flowey_lib_common::cache 2
         flowey.exe e 4 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -6989,150 +6485,69 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 4 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 5
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build prep_steps
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 4 flowey_lib_hvlite::build_prep_steps 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 4
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 5
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 9
-        flowey.exe e 4 flowey_lib_hvlite::build_vmgstool 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 5
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 6
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 4
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 8
-        flowey.exe e 4 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 6
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 6
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 2
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 4
-        flowey.exe e 4 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 0
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 4 flowey_lib_common::cache 0
-        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 4 flowey_lib_common::cache 2
-        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey.exe e 4 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey.exe e 4 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey.exe e 4 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build openvmm
+    - name: cargo build hypestv
       run: |-
         flowey.exe e 4 flowey_lib_common::run_cargo_build 0
         flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 4 flowey_lib_hvlite::build_openvmm 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 4 flowey_lib_hvlite::build_hypestv 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 0
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 0
       shell: bash
-    - name: cargo build tmk_vmm
+    - name: cargo build vmgs_lib
       run: |-
         flowey.exe e 4 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 5
-        flowey.exe e 4 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 4 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build ohcldiag-dev
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 2
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 4 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey.exe e 4 flowey_core::pipeline::artifact::publish 3
       shell: bash
-    - name: 'validate cache entry: cargo-nextest'
+    - name: 'validate cache entry: gh-release-download'
       run: flowey.exe e 4 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 4 flowey_lib_common::cache 7
-      shell: bash
-    - name: 🌼📦 Publish aarch64-windows-openvmm
+    - name: 🌼📦 Publish aarch64-windows-hypestv
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-openvmm/
+        name: aarch64-windows-hypestv
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-hypestv/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-prep_steps
+    - name: 🌼📦 Publish aarch64-windows-igvmfilegen
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-prep_steps
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-prep_steps/
+        name: aarch64-windows-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-igvmfilegen/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
+    - name: 🌼📦 Publish aarch64-windows-ohcldiag-dev
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-test_igvm_agent_rpc_server
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server/
+        name: aarch64-windows-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-ohcldiag-dev/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-tmk_vmm
+    - name: 🌼📦 Publish aarch64-windows-vmgs_lib
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-tpm_guest_tests
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmm-tests-archive/
+        name: aarch64-windows-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
         include-hidden-files: true
   job5:
-    name: build artifacts (not for VMM tests) [x64-windows]
+    name: build artifacts (for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7209,14 +6624,20 @@ jobs:
         cat <<'EOF' | flowey.exe v 5 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 5 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 5 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 5 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-prep_steps"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-prep_steps" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-test_igvm_agent_rpc_server" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tpm_guest_tests"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tpm_guest_tests" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 5 flowey_lib_common::install_rust 0
@@ -7259,22 +6680,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 5 flowey_lib_common::cache 0
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe e 5 flowey_lib_common::cache 4
+        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
-    - id: flowey_lib_common__cache__1
+    - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 5 flowey_lib_common::cache 2
+        flowey.exe e 5 flowey_lib_common::cache 6
         flowey.exe e 5 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -7285,73 +6706,150 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 5 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: cargo build hypestv
+    - name: cargo build openvmm
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 0
         flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 5 flowey_lib_hvlite::build_hypestv 0
+        flowey.exe e 5 flowey_lib_hvlite::build_openvmm 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build vmgs_lib
+    - name: cargo build tmk_vmm
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
-        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      shell: bash
-    - name: test vmgs_lib
-      run: |-
-        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 5
+        flowey.exe e 5 flowey_lib_hvlite::build_tmk_vmm 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 5
       shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build prep_steps
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 1
         flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 5 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey.exe e 5 flowey_lib_hvlite::build_prep_steps 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 2
         flowey.exe e 5 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build ohcldiag-dev
+    - name: cargo build vmgstool
+      run: |-
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 5
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 9
+        flowey.exe e 5 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 5 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 6
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 8
+        flowey.exe e 5 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey.exe e 5 flowey_core::pipeline::artifact::publish 4
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 6
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 2
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 5 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey.exe e 5 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 5 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
+        flowey.exe e 5 flowey_core::pipeline::artifact::publish 5
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 5 flowey_lib_common::cache 0
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 5 flowey_lib_common::cache 2
+        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 5 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey.exe e 5 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey.exe e 5 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey.exe e 5 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey.exe e 5 flowey_core::pipeline::artifact::publish 6
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 5 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-windows-hypestv
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 5 flowey_lib_common::cache 7
+      shell: bash
+    - name: 🌼📦 Publish aarch64-windows-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-hypestv
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-hypestv/
+        name: aarch64-windows-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-igvmfilegen
+    - name: 🌼📦 Publish aarch64-windows-prep_steps
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-igvmfilegen/
+        name: aarch64-windows-prep_steps
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-prep_steps/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-ohcldiag-dev
+    - name: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
+        name: aarch64-windows-test_igvm_agent_rpc_server
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-vmgs_lib
+    - name: 🌼📦 Publish aarch64-windows-tmk_vmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
+        name: aarch64-windows-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmm-tests-archive/
         include-hidden-files: true
   job6:
-    name: build artifacts (shared VMM tests) [x64-windows]
+    name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7428,8 +6926,14 @@ jobs:
         cat <<'EOF' | flowey.exe v 6 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-pipette"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 6 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 6 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 6 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 6 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 6 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 6 flowey_lib_common::install_rust 0
@@ -7498,23 +7002,70 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build pipette
+    - name: cargo build hypestv
       run: |-
         flowey.exe e 6 flowey_lib_common::run_cargo_build 0
         flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 6 flowey_lib_hvlite::build_pipette 0
+        flowey.exe e 6 flowey_lib_hvlite::build_hypestv 0
         flowey.exe e 6 flowey_core::pipeline::artifact::publish 0
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      shell: bash
+    - name: test vmgs_lib
+      run: |-
+        flowey.exe e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey.exe e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey.exe e 6 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 6 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey.exe e 6 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build ohcldiag-dev
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 2
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 6 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey.exe e 6 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey.exe e 6 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-windows-pipette
+    - name: 🌼📦 Publish x64-windows-hypestv
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-pipette
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
+        name: x64-windows-hypestv
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-hypestv/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-igvmfilegen
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-ohcldiag-dev
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-vmgs_lib
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
         include-hidden-files: true
   job7:
     name: build artifacts (for VMM tests) [x64-windows]
@@ -7824,10 +7375,10 @@ jobs:
     - name: 🌼🥾 Publish bootstrapped flowey
       uses: actions/upload-artifact@v7
       with:
-        name: _internal-flowey-bootstrap-x86_64-windows-uid-15
+        name: _internal-flowey-bootstrap-x86_64-windows-uid-13
         path: ${{ runner.temp }}/bootstrapped-flowey
   job8:
-    name: build artifacts (shared VMM tests) [aarch64-linux]
+    name: build artifacts (for VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7904,16 +7455,22 @@ jobs:
         cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 8 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests" | flowey v 8 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 8 'artifact_publish_from_aarch64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 8 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 8 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 8 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 8 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 8 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 8 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 8 flowey_lib_common::install_rust 0
@@ -7925,6 +7482,12 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_common::install_rust 2
         flowey e 8 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 8 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 8 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
@@ -7974,12 +7537,6 @@ jobs:
         flowey e 8 flowey_lib_common::cache 2
         flowey e 8 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 8 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 8 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 8 flowey_lib_common::resolve_protoc 0
@@ -7988,45 +7545,80 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 8 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 8 flowey_lib_hvlite::build_openvmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 0
+        flowey e 8 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 4
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 1
         flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: cargo build guest_test_uefi
+    - name: cargo build vmgstool
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 8 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 2
+        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 8 flowey_core::pipeline::artifact::publish 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build igvmfilegen
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 0
         flowey e 8 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
-    - name: build guest_test_uefi.img
+    - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::build_guest_test_uefi 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 0
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
       shell: bash
-    - name: cargo build simple_tmk
+    - name: cargo build ohcldiag-dev
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 8 flowey_lib_common::run_cargo_build 1
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::build_tmks 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 1
-        flowey e 8 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 4
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 8 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 8 flowey_lib_hvlite::resolve_openvmm_deps 0
@@ -8034,68 +7626,86 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 6
       shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 1
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::build_pipette 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 3
-        flowey e 8 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build tmk_vmm
+    - name: cargo build openvmm
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 4
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::build_openvmm 1
+        flowey e 8 flowey_core::pipeline::artifact::publish 6
+        flowey e 8 flowey_lib_hvlite::init_cross_build 7
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 10
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 1
+        flowey e 8 flowey_core::pipeline::artifact::publish 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-guest_test_uefi
+    - name: 🌼📦 Publish aarch64-linux-igvmfilegen
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-guest_test_uefi
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
+        name: aarch64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-pipette
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
+        name: aarch64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
+        name: aarch64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-tpm_guest_tests
+    - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-tpm_guest_tests/
+        name: aarch64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-tmks
+    - name: 🌼📦 Publish aarch64-linux-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-tmks
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
+        name: aarch64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-vmgs_lib
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
         include-hidden-files: true
   job9:
-    name: build artifacts (for VMM tests) [aarch64-linux]
+    name: build artifacts (for VMM tests) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -8172,22 +7782,26 @@ jobs:
         cat <<'EOF' | flowey v 9 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 9 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 9 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 9 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 9 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 9 flowey_lib_common::install_rust 0
@@ -8236,22 +7850,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey e 9 flowey_lib_common::cache 4
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
-    - id: flowey_lib_common__cache__1
+    - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 9 flowey_lib_common::cache 2
+        flowey e 9 flowey_lib_common::cache 6
         flowey e 9 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -8262,7 +7876,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -8275,7 +7889,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 5
         flowey e 9 flowey_lib_hvlite::build_openvmm 0
         flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -8288,7 +7902,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 9
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -8301,16 +7915,20 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 14
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_build 6
         flowey e 9 flowey_lib_hvlite::run_cargo_build 12
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      shell: bash
+    - name: test vmgs_lib
+      run: |-
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 9 flowey_core::pipeline::artifact::publish 3
-        flowey e 9 flowey_lib_hvlite::init_cross_build 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -8323,7 +7941,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -8340,10 +7958,10 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
+    - name: extract X86_64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -8356,7 +7974,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
         flowey e 9 flowey_lib_hvlite::build_openvmm 1
         flowey e 9 flowey_core::pipeline::artifact::publish 6
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+        flowey e 9 flowey_lib_hvlite::init_cross_build 9
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -8370,54 +7988,125 @@ jobs:
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 9 flowey_core::pipeline::artifact::publish 7
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 9 flowey_lib_common::download_cargo_nextest 0
+        flowey e 9 flowey_lib_common::download_cargo_nextest 1
+        flowey e 9 flowey_lib_common::download_cargo_nextest 2
+        flowey e 9 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 9 flowey_lib_common::cache 0
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 9 flowey_lib_common::cache 2
+        flowey e 9 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 9 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 9 flowey_lib_common::install_cargo_nextest 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 8
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 1
+        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 9
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey e 9 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-linux-igvmfilegen
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 9 flowey_lib_common::cache 7
+      shell: bash
+    - name: 🌼📦 Publish x64-linux-igvmfilegen
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
+        name: x64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
+    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
+        name: x64-linux-musl-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-openvmm
+    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
+        name: x64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-openvmm_vhost
+    - name: 🌼📦 Publish x64-linux-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
+        name: x64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-vmgs_lib
+    - name: 🌼📦 Publish x64-linux-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
+        name: x64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-vmgstool
+    - name: 🌼📦 Publish x64-linux-vmgs_lib
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
+        name: x64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
         include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
+        include-hidden-files: true
+    - name: 🌼🧼 Redact bootstrap var db
+      run: rm $AgentTempDirNormal/bootstrapped-flowey/job9.json
+      shell: bash
+    - name: 🌼🥾 Publish bootstrapped flowey
+      uses: actions/upload-artifact@v7
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-11
+        path: ${{ runner.temp }}/bootstrapped-flowey

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -6445,7 +6445,7 @@ jobs:
         name: _internal-flowey-bootstrap-x86_64-windows-uid-6
         path: ${{ runner.temp }}/bootstrapped-flowey
   job6:
-    name: build artifacts [aarch64-linux] (shared)
+    name: build artifacts (shared VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6713,7 +6713,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
         include-hidden-files: true
   job7:
-    name: build artifacts [aarch64-linux] (for VMM tests)
+    name: build artifacts (for VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6949,7 +6949,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
         include-hidden-files: true
   job8:
-    name: build artifacts [x64-linux] (shared)
+    name: build artifacts (shared VMM tests) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7217,7 +7217,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
         include-hidden-files: true
   job9:
-    name: build artifacts [x64-linux] (for VMM tests)
+    name: build artifacts (for VMM tests) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7342,7 +7342,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7355,7 +7355,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 5
         flowey e 9 flowey_lib_hvlite::build_openvmm 0
         flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7368,7 +7368,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -7381,7 +7381,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 10
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
@@ -7394,7 +7394,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 9 flowey_core::pipeline::artifact::publish 3
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -7407,7 +7407,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -7461,14 +7461,7 @@ jobs:
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
         flowey e 9 flowey_core::pipeline::artifact::publish 6
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+        flowey e 9 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -6482,10 +6482,6 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 6 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
@@ -6568,7 +6564,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 6
+        flowey e 6 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -6580,10 +6576,23 @@ jobs:
         flowey e 6 flowey_lib_hvlite::build_guest_test_uefi 0
         flowey e 6 flowey_core::pipeline::artifact::publish 0
         flowey e 6 flowey_lib_hvlite::init_cross_build 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: cargo build simple_tmk
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 2
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 5
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 6 flowey_lib_hvlite::build_tmks 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 1
+        flowey e 6 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tpm_guest_tests
       run: |-
         flowey e 6 flowey_lib_common::run_cargo_build 4
         flowey e 6 flowey_lib_hvlite::run_cargo_build 9
@@ -6592,19 +6601,6 @@ jobs:
       run: |-
         flowey e 6 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 6 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 6 flowey_lib_hvlite::build_tmks 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 1
-        flowey e 6 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 6
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 14
         flowey e 6 flowey_lib_hvlite::build_tpm_guest_tests 0
         flowey e 6 flowey_core::pipeline::artifact::publish 2
       shell: bash
@@ -6618,54 +6614,28 @@ jobs:
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 6 flowey_lib_hvlite::build_pipette 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 3
-        flowey e 6 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 5
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 11
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 6 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 4
-        flowey e 6 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
         flowey e 6 flowey_lib_common::run_cargo_build 1
         flowey e 6 flowey_lib_hvlite::run_cargo_build 1
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 6 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::build_openvmm 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 5
+        flowey e 6 flowey_lib_hvlite::build_pipette 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 3
         flowey e 6 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: cargo build openvmm_vhost
+    - name: cargo build tmk_vmm
       run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 6 flowey_lib_common::run_cargo_build 3
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 7
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 4
-        flowey e 6 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 6
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 6 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 6 flowey_lib_common::cache 3
@@ -6675,18 +6645,6 @@ jobs:
       with:
         name: aarch64-guest_test_uefi
         path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v7
@@ -6750,6 +6708,10 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 7 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 7 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
@@ -6847,42 +6809,42 @@ jobs:
         flowey e 7 flowey_lib_hvlite::run_cargo_build 5
         flowey e 7 flowey_lib_hvlite::build_openvmm 0
         flowey e 7 flowey_core::pipeline::artifact::publish 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 1
+        flowey e 7 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 7 flowey_lib_common::run_cargo_build 4
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 9
         flowey e 7 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 7 flowey_core::pipeline::artifact::publish 1
         flowey e 7 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 5
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 7 flowey_lib_common::run_cargo_build 7
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 14
         flowey e 7 flowey_lib_hvlite::build_vmgstool 0
         flowey e 7 flowey_core::pipeline::artifact::publish 2
         flowey e 7 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 4
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 7 flowey_lib_common::run_cargo_build 6
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 12
         flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
         flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 7 flowey_core::pipeline::artifact::publish 3
-        flowey e 7 flowey_lib_hvlite::init_cross_build 2
+        flowey e 7 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -6891,7 +6853,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 7 flowey_lib_hvlite::run_cargo_build 1
         flowey e 7 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 7 flowey_core::pipeline::artifact::publish 4
@@ -6909,6 +6871,39 @@ jobs:
         flowey e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey e 7 flowey_core::pipeline::artifact::publish 5
       shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 7 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 7 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 7 flowey_lib_hvlite::init_cross_build 6
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 7 flowey_lib_common::run_cargo_build 3
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 7 flowey_lib_hvlite::build_openvmm 1
+        flowey e 7 flowey_core::pipeline::artifact::publish 6
+        flowey e 7 flowey_lib_hvlite::init_cross_build 7
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 7 flowey_lib_common::run_cargo_build 5
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 10
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 7 flowey_lib_hvlite::build_openvmm_vhost 1
+        flowey e 7 flowey_core::pipeline::artifact::publish 7
+      shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 7 flowey_lib_common::cache 3
       shell: bash
@@ -6917,6 +6912,18 @@ jobs:
       with:
         name: aarch64-linux-igvmfilegen
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v7
@@ -6986,10 +6993,6 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 8 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 8 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 8 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
@@ -7072,7 +7075,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 6
+        flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -7084,10 +7087,23 @@ jobs:
         flowey e 8 flowey_lib_hvlite::build_guest_test_uefi 0
         flowey e 8 flowey_core::pipeline::artifact::publish 0
         flowey e 8 flowey_lib_hvlite::init_cross_build 0
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: cargo build simple_tmk
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::build_tmks 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 1
+        flowey e 8 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tpm_guest_tests
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 4
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
@@ -7096,19 +7112,6 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 8 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 8 flowey_lib_hvlite::build_tmks 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 1
-        flowey e 8 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
         flowey e 8 flowey_lib_hvlite::build_tpm_guest_tests 0
         flowey e 8 flowey_core::pipeline::artifact::publish 2
       shell: bash
@@ -7122,54 +7125,28 @@ jobs:
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::build_pipette 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 3
-        flowey e 8 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 5
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 11
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 4
-        flowey e 8 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 1
         flowey e 8 flowey_lib_hvlite::run_cargo_build 1
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 8 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::build_openvmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 5
+        flowey e 8 flowey_lib_hvlite::build_pipette 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 3
         flowey e 8 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: cargo build openvmm_vhost
+    - name: cargo build tmk_vmm
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 8 flowey_lib_common::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
-        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 6
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
@@ -7179,18 +7156,6 @@ jobs:
       with:
         name: x64-guest_test_uefi
         path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v7
@@ -7254,6 +7219,10 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
@@ -7355,38 +7324,38 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 5
         flowey e 9 flowey_lib_hvlite::build_openvmm 0
         flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 9 flowey_lib_common::run_cargo_build 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
         flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 9 flowey_lib_common::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
         flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 4
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 9 flowey_lib_common::run_cargo_build 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       shell: bash
     - name: test vmgs_lib
@@ -7394,7 +7363,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 9 flowey_core::pipeline::artifact::publish 3
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -7403,7 +7372,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
@@ -7420,6 +7389,39 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 3
         flowey e 9 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey e 9 flowey_core::pipeline::artifact::publish 5
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::build_openvmm 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 7
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -7460,14 +7462,14 @@ jobs:
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 6
+        flowey e 9 flowey_core::pipeline::artifact::publish 8
         flowey e 9 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 1
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
-        flowey e 9 flowey_core::pipeline::artifact::publish 7
+        flowey e 9 flowey_core::pipeline::artifact::publish 9
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 9 flowey_lib_common::cache 3
@@ -7480,6 +7482,18 @@ jobs:
       with:
         name: x64-linux-igvmfilegen
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
       uses: actions/upload-artifact@v7

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -747,7 +747,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 2
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -760,7 +760,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_build 5
         flowey e 11 flowey_lib_hvlite::build_openvmm 0
         flowey e 11 flowey_core::pipeline::artifact::publish 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 4
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -773,7 +773,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_build 9
         flowey e 11 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 11 flowey_core::pipeline::artifact::publish 1
-        flowey e 11 flowey_lib_hvlite::init_cross_build 6
+        flowey e 11 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -786,7 +786,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_build 14
         flowey e 11 flowey_lib_hvlite::build_vmgstool 0
         flowey e 11 flowey_core::pipeline::artifact::publish 2
-        flowey e 11 flowey_lib_hvlite::init_cross_build 5
+        flowey e 11 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
@@ -799,7 +799,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 11 flowey_core::pipeline::artifact::publish 3
-        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+        flowey e 11 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -812,7 +812,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 11 flowey_core::pipeline::artifact::publish 4
-        flowey e 11 flowey_lib_hvlite::init_cross_build 7
+        flowey e 11 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -899,7 +899,7 @@ jobs:
         flowey e 11 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 0
         flowey e 11 flowey_core::pipeline::artifact::publish 8
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+        flowey e 11 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -392,7 +392,7 @@ jobs:
       run: flowey.exe e 1 flowey_lib_common::cache 3
       shell: bash
   job10:
-    name: build openhcl [aarch64-linux]
+    name: build artifacts (shared VMM tests) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -427,42 +427,16 @@ jobs:
         cat <<'EOF' | flowey v 10 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 10 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 10 flowey_lib_common::cache 2
-        flowey e 10 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (aarch64)
-      run: flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 10 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 10 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 10 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 10 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 10 'artifact_publish_from_x64-tmks' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 10 flowey_lib_common::install_rust 0
@@ -478,7 +452,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
         flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -486,7 +460,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -500,6 +474,35 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 10 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 10 flowey_lib_common::cache 0
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 10 flowey_lib_common::cache 2
+        flowey e 10 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 10 flowey_lib_common::resolve_protoc 0
@@ -508,131 +511,114 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 0
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 10 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 1
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 10 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build guest_test_uefi
       run: |-
         flowey e 10 flowey_lib_common::run_cargo_build 0
         flowey e 10 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
-    - name: split debug symbols
+    - name: build guest_test_uefi.img
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 10 flowey_lib_hvlite::build_guest_test_uefi 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
-    - name: building igvm file
+    - name: cargo build simple_tmk
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::build_tmks 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 1
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: building openhcl initrd
+    - name: cargo build tpm_guest_tests
       run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 10 flowey_lib_common::run_cargo_build 4
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
-    - name: building igvm file
+    - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 10 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 2
       shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
+    - name: unpack openvmm-deps archive
+      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
+    - name: cargo build pipette
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::build_pipette 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 3
+        flowey e 10 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 10 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-openhcl-igvm
+    - name: 🌼📦 Publish x64-guest_test_uefi
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        name: x64-guest_test_uefi
+        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
+    - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
+        name: x64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-tmks
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
         include-hidden-files: true
   job11:
-    name: build openhcl [x64-linux]
+    name: build artifacts (for VMM tests) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -667,42 +653,26 @@ jobs:
         cat <<'EOF' | flowey v 11 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 11 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 11 flowey_lib_common::cache 2
-        flowey e 11 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 11 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 11 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 11 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 11 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 11 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 11 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 11 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 11 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 11 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 11 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 11 flowey_lib_common::install_rust 0
@@ -715,10 +685,16 @@ jobs:
         flowey e 11 flowey_lib_common::install_rust 2
         flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
         flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -726,7 +702,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -740,6 +716,29 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 11 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 11 flowey_lib_common::cache 4
+        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 11 flowey_lib_common::cache 6
+        flowey e 11 flowey_lib_common::download_gh_release 1
+      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 11 flowey_lib_common::resolve_protoc 0
@@ -748,67 +747,59 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 0
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 11 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: cargo build sidecar
+    - name: cargo build openvmm
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 3
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 11 flowey_lib_hvlite::build_sidecar 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 1
+        flowey e 11 flowey_lib_common::run_cargo_build 2
         flowey e 11 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 11 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 11 flowey_lib_hvlite::build_openvmm 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: extract and resolve kernel package
+    - name: cargo build openvmm_vhost
       run: |-
-        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 11 flowey_lib_common::run_cargo_build 4
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 11 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 1
+        flowey e 11 flowey_lib_hvlite::init_cross_build 6
       shell: bash
-    - name: building openhcl initrd
+    - name: cargo build vmgstool
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 11 flowey_lib_hvlite::init_cross_build 2
+        flowey e 11 flowey_lib_common::run_cargo_build 7
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 11 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 2
+        flowey e 11 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 6
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      shell: bash
+    - name: test vmgs_lib
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey e 11 flowey_core::pipeline::artifact::publish 3
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -817,139 +808,730 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 11 flowey_core::pipeline::artifact::publish 4
+        flowey e 11 flowey_lib_hvlite::init_cross_build 7
       shell: bash
-    - name: building igvm file
+    - name: cargo build ohcldiag-dev
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 11 flowey_lib_common::run_cargo_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 11 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 5
       shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+    - name: unpack openvmm-deps archive
+      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: building openhcl initrd
+    - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 8
       shell: bash
-    - name: building igvm file
+    - name: cargo build openvmm
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 3
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 11 flowey_lib_common::run_cargo_build 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 11 flowey_lib_hvlite::build_openvmm 1
+        flowey e 11 flowey_core::pipeline::artifact::publish 6
+        flowey e 11 flowey_lib_hvlite::init_cross_build 9
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 5
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 11 flowey_lib_hvlite::build_openvmm_vhost 1
+        flowey e 11 flowey_core::pipeline::artifact::publish 7
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 11 flowey_lib_common::download_cargo_nextest 0
+        flowey e 11 flowey_lib_common::download_cargo_nextest 1
+        flowey e 11 flowey_lib_common::download_cargo_nextest 2
+        flowey e 11 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 11 flowey_lib_common::cache 0
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 11 flowey_lib_common::cache 2
+        flowey e 11 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 11 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 11 flowey_lib_common::install_cargo_nextest 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 8
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_nextest_archive 1
+        flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 1
+        flowey e 11 flowey_core::pipeline::artifact::publish 9
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 11 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 11 flowey_lib_common::cache 7
+      shell: bash
+    - name: 🌼📦 Publish x64-linux-igvmfilegen
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgs_lib
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
+        include-hidden-files: true
+  job12:
+    name: build openhcl [aarch64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 12 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 12 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 12 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 12 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 12 flowey_lib_common::cache 0
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 12 flowey_lib_common::cache 2
+        flowey e 12 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (aarch64)
+      run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 12 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 12 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 12 flowey_lib_common::install_rust 2
+        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 12 flowey_lib_common::git_checkout 0
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 12 flowey_lib_common::git_checkout 3
+        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 12 flowey_lib_common::resolve_protoc 0
+        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 0
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 1
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 12 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 0
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
-        flowey e 11 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 11 flowey_lib_common::copy_to_artifact_dir 0
+      run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 11 flowey_lib_common::cache 3
+      run: flowey e 12 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish aarch64-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
+        include-hidden-files: true
+  job13:
+    name: build openhcl [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 13 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 13 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 13 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 13 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 13 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 13 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 13 flowey_lib_common::cache 0
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 13 flowey_lib_common::cache 2
+        flowey e 13 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 13 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 13 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 13 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 13 flowey_lib_common::install_rust 2
+        flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 13 flowey_lib_common::git_checkout 0
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 13 flowey_lib_common::git_checkout 3
+        flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 13 flowey_lib_common::resolve_protoc 0
+        flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build sidecar
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 3
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 13 flowey_lib_hvlite::build_sidecar 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 13 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 13 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 2
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 13 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 4
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 13 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 13 flowey_lib_common::copy_to_artifact_dir 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 13 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -963,13 +1545,13 @@ jobs:
         name: x64-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
         include-hidden-files: true
-  job12:
+  job14:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1037,29 +1619,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 12 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 12 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 14 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 14 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 12 'verbose' update
+        cat <<'EOF' | flowey.exe v 14 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 12 flowey_lib_common::install_rust 0
+      run: flowey.exe e 14 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 12 flowey_lib_common::install_rust 1
+      run: flowey.exe e 14 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 12 flowey_lib_common::install_rust 2
-        flowey.exe e 12 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 14 flowey_lib_common::install_rust 2
+        flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 12 flowey_lib_common::git_checkout 0
-        flowey.exe v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 14 flowey_lib_common::git_checkout 0
+        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1071,23 +1653,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 12 flowey_lib_common::git_checkout 3
-        flowey.exe e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 14 flowey_lib_common::git_checkout 3
+        flowey.exe e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 12 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 14 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 12 flowey_lib_common::cache 4
-        flowey.exe v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 14 flowey_lib_common::cache 4
+        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1097,50 +1679,50 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 12 flowey_lib_common::cache 6
-        flowey.exe e 12 flowey_lib_common::download_gh_release 1
+        flowey.exe e 14 flowey_lib_common::cache 6
+        flowey.exe e 14 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 12 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 14 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 12 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 14 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 14 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 12 flowey_lib_common::cache 0
-        flowey.exe v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe e 14 flowey_lib_common::cache 0
+        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1150,45 +1732,45 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 12 flowey_lib_common::cache 2
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 14 flowey_lib_common::cache 2
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 12 flowey_lib_common::install_rust 3
+      run: flowey.exe e 14 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 12 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 14 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 12 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 14 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 14 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 12 flowey_lib_common::publish_test_results 5
-        flowey.exe e 12 flowey_lib_common::publish_test_results 6
-        flowey.exe e 12 flowey_lib_common::publish_test_results 4
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 14 flowey_lib_common::publish_test_results 5
+        flowey.exe e 14 flowey_lib_common::publish_test_results 6
+        flowey.exe e 14 flowey_lib_common::publish_test_results 4
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1198,18 +1780,18 @@ jobs:
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 12 flowey_lib_common::publish_test_results 0
-        flowey.exe e 12 flowey_lib_common::publish_test_results 1
-        flowey.exe e 12 flowey_lib_common::publish_test_results 2
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 14 flowey_lib_common::publish_test_results 0
+        flowey.exe e 14 flowey_lib_common::publish_test_results 1
+        flowey.exe e 14 flowey_lib_common::publish_test_results 2
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1220,25 +1802,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
-      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 12 flowey_lib_common::cache 3
+      run: flowey.exe e 14 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 12 flowey_lib_common::cache 7
+      run: flowey.exe e 14 flowey_lib_common::cache 7
       shell: bash
-  job13:
+  job15:
     name: clippy [macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1262,35 +1844,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 13 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 13 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 15 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 13 'verbose' update
+        cat <<'EOF' | flowey v 15 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 13 flowey_lib_common::install_rust 0
+      run: flowey e 15 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 13 flowey_lib_common::install_rust 1
+      run: flowey e 15 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 13 flowey_lib_common::install_rust 2
-        flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 15 flowey_lib_common::install_rust 2
+        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 13 flowey_lib_common::git_checkout 0
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::git_checkout 0
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1302,23 +1884,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 13 flowey_lib_common::git_checkout 3
-        flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 15 flowey_lib_common::git_checkout 3
+        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 13 flowey_lib_common::download_gh_release 0
+      run: flowey e 15 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 13 flowey_lib_common::cache 4
-        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey e 15 flowey_lib_common::cache 4
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1328,54 +1910,54 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 13 flowey_lib_common::cache 6
-        flowey e 13 flowey_lib_common::download_gh_release 1
+        flowey e 15 flowey_lib_common::cache 6
+        flowey e 15 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 13 flowey_lib_common::resolve_protoc 0
-        flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 15 flowey_lib_common::resolve_protoc 0
+        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 1
+        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_build 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 15 flowey_lib_common::run_cargo_build 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::build_xtask 0
+        flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 13 flowey_lib_common::download_cargo_nextest 0
-        flowey e 13 flowey_lib_common::download_cargo_nextest 1
-        flowey e 13 flowey_lib_common::download_cargo_nextest 2
-        flowey e 13 flowey_lib_common::download_cargo_nextest 3
+        flowey e 15 flowey_lib_common::download_cargo_nextest 0
+        flowey e 15 flowey_lib_common::download_cargo_nextest 1
+        flowey e 15 flowey_lib_common::download_cargo_nextest 2
+        flowey e 15 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey e 15 flowey_lib_common::cache 0
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1385,34 +1967,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 13 flowey_lib_common::cache 2
-        flowey e 13 flowey_lib_common::download_cargo_nextest 4
+        flowey e 15 flowey_lib_common::cache 2
+        flowey e 15 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 13 flowey_lib_common::install_rust 3
+      run: flowey e 15 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 13 flowey_lib_common::install_cargo_nextest 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::install_cargo_nextest 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 13 flowey_lib_common::publish_test_results 5
-        flowey e 13 flowey_lib_common::publish_test_results 6
-        flowey e 13 flowey_lib_common::publish_test_results 4
-        flowey v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 15 flowey_lib_common::publish_test_results 5
+        flowey e 15 flowey_lib_common::publish_test_results 6
+        flowey e 15 flowey_lib_common::publish_test_results 4
+        flowey v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1422,18 +2004,18 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 13 flowey_lib_common::publish_test_results 8
-        flowey e 13 flowey_lib_common::publish_test_results 9
-        flowey e 13 flowey_lib_common::publish_test_results 10
-        flowey v 13 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 13 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 15 flowey_lib_common::publish_test_results 8
+        flowey e 15 flowey_lib_common::publish_test_results 9
+        flowey e 15 flowey_lib_common::publish_test_results 10
+        flowey v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -1444,32 +2026,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 13 flowey_lib_hvlite::init_cross_build 2
-        flowey e 13 flowey_lib_common::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 15 flowey_lib_hvlite::init_cross_build 2
+        flowey e 15 flowey_lib_common::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 13 flowey_lib_hvlite::build_xtask 1
+        flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 15 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 13 flowey_lib_common::publish_test_results 12
-        flowey e 13 flowey_lib_common::publish_test_results 13
-        flowey e 13 flowey_lib_common::publish_test_results 14
-        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 15 flowey_lib_common::publish_test_results 12
+        flowey e 15 flowey_lib_common::publish_test_results 13
+        flowey e 15 flowey_lib_common::publish_test_results 14
+        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -1479,18 +2061,18 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 13 flowey_lib_common::publish_test_results 0
-        flowey e 13 flowey_lib_common::publish_test_results 1
-        flowey e 13 flowey_lib_common::publish_test_results 2
-        flowey v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 15 flowey_lib_common::publish_test_results 0
+        flowey e 15 flowey_lib_common::publish_test_results 1
+        flowey e 15 flowey_lib_common::publish_test_results 2
+        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1501,25 +2083,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 13 flowey_lib_common::cache 3
+      run: flowey e 15 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 13 flowey_lib_common::cache 7
+      run: flowey e 15 flowey_lib_common::cache 7
       shell: bash
-  job14:
+  job16:
     name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1543,29 +2125,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 14 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 14 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 14 'verbose' update
+        cat <<'EOF' | flowey v 16 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 14 flowey_lib_common::install_rust 0
+      run: flowey e 16 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 14 flowey_lib_common::install_rust 1
+      run: flowey e 16 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 14 flowey_lib_common::install_rust 2
-        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 16 flowey_lib_common::install_rust 2
+        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::git_checkout 0
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1577,27 +2159,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 14 flowey_lib_common::git_checkout 3
-        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 16 flowey_lib_common::git_checkout 3
+        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 14 flowey_lib_common::download_gh_release 0
+      run: flowey e 16 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 16 flowey_lib_common::cache 4
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1607,78 +2189,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 14 flowey_lib_common::cache 6
-        flowey e 14 flowey_lib_common::download_gh_release 1
+        flowey e 16 flowey_lib_common::cache 6
+        flowey e 16 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 14 flowey_lib_common::resolve_protoc 0
+      run: flowey e 16 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 2
+        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_clippy 5
-        flowey e 14 flowey_lib_hvlite::init_cross_build 0
+        flowey e 16 flowey_lib_common::run_cargo_clippy 5
+        flowey e 16 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_build 0
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 16 flowey_lib_common::run_cargo_build 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 14 flowey_lib_hvlite::build_xtask 0
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 14 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 14 flowey_lib_common::download_cargo_nextest 0
-        flowey e 14 flowey_lib_common::download_cargo_nextest 1
-        flowey e 14 flowey_lib_common::download_cargo_nextest 2
-        flowey e 14 flowey_lib_common::download_cargo_nextest 3
+        flowey e 16 flowey_lib_common::download_cargo_nextest 0
+        flowey e 16 flowey_lib_common::download_cargo_nextest 1
+        flowey e 16 flowey_lib_common::download_cargo_nextest 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 16 flowey_lib_common::cache 0
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1688,34 +2270,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 14 flowey_lib_common::cache 2
-        flowey e 14 flowey_lib_common::download_cargo_nextest 4
+        flowey e 16 flowey_lib_common::cache 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 14 flowey_lib_common::install_rust 3
+      run: flowey e 16 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 14 flowey_lib_common::install_cargo_nextest 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 3
-        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::install_cargo_nextest 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 3
+        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 14 flowey_lib_common::publish_test_results 5
-        flowey e 14 flowey_lib_common::publish_test_results 6
-        flowey e 14 flowey_lib_common::publish_test_results 4
-        flowey v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 16 flowey_lib_common::publish_test_results 5
+        flowey e 16 flowey_lib_common::publish_test_results 6
+        flowey e 16 flowey_lib_common::publish_test_results 4
+        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1725,18 +2307,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 14 flowey_lib_common::publish_test_results 8
-        flowey e 14 flowey_lib_common::publish_test_results 9
-        flowey e 14 flowey_lib_common::publish_test_results 10
-        flowey v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 16 flowey_lib_common::publish_test_results 8
+        flowey e 16 flowey_lib_common::publish_test_results 9
+        flowey e 16 flowey_lib_common::publish_test_results 10
+        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -1746,18 +2328,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 14 flowey_lib_common::publish_test_results 12
-        flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey e 14 flowey_lib_common::publish_test_results 14
-        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey e 16 flowey_lib_common::publish_test_results 13
+        flowey e 16 flowey_lib_common::publish_test_results 14
+        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -1767,18 +2349,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 14 flowey_lib_common::publish_test_results 16
-        flowey e 14 flowey_lib_common::publish_test_results 17
-        flowey e 14 flowey_lib_common::publish_test_results 18
-        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 16 flowey_lib_common::publish_test_results 16
+        flowey e 16 flowey_lib_common::publish_test_results 17
+        flowey e 16 flowey_lib_common::publish_test_results 18
+        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -1789,32 +2371,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_hvlite::init_cross_build 1
-        flowey e 14 flowey_lib_common::run_cargo_build 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 16 flowey_lib_hvlite::init_cross_build 1
+        flowey e 16 flowey_lib_common::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 14 flowey_lib_hvlite::build_xtask 1
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 16 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 14 flowey_lib_common::publish_test_results 0
-        flowey e 14 flowey_lib_common::publish_test_results 1
-        flowey e 14 flowey_lib_common::publish_test_results 2
-        flowey v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 16 flowey_lib_common::publish_test_results 0
+        flowey e 16 flowey_lib_common::publish_test_results 1
+        flowey e 16 flowey_lib_common::publish_test_results 2
+        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1825,25 +2407,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
-      run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 14 flowey_lib_common::cache 3
+      run: flowey e 16 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 14 flowey_lib_common::cache 7
+      run: flowey e 16 flowey_lib_common::cache 7
       shell: bash
-  job15:
+  job17:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=win-arm64
-    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1911,29 +2493,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 15 'verbose' update
+        cat <<'EOF' | flowey.exe v 17 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 15 flowey_lib_common::install_rust 0
+      run: flowey.exe e 17 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 15 flowey_lib_common::install_rust 1
+      run: flowey.exe e 17 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 15 flowey_lib_common::install_rust 2
-        flowey.exe e 15 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 17 flowey_lib_common::install_rust 2
+        flowey.exe e 17 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 15 flowey_lib_common::git_checkout 0
-        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 17 flowey_lib_common::git_checkout 0
+        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1945,23 +2527,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 15 flowey_lib_common::git_checkout 3
-        flowey.exe e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 17 flowey_lib_common::git_checkout 3
+        flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 15 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 17 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 15 flowey_lib_common::cache 4
-        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 17 flowey_lib_common::cache 4
+        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1971,50 +2553,50 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 15 flowey_lib_common::cache 6
-        flowey.exe e 15 flowey_lib_common::download_gh_release 1
+        flowey.exe e 17 flowey_lib_common::cache 6
+        flowey.exe e 17 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 15 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 17 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 15 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 17 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 17 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 15 flowey_lib_common::cache 0
-        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe e 17 flowey_lib_common::cache 0
+        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2024,45 +2606,45 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 15 flowey_lib_common::cache 2
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 17 flowey_lib_common::cache 2
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 15 flowey_lib_common::install_rust 3
+      run: flowey.exe e 17 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 15 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 17 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 17 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 17 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 15 flowey_lib_common::publish_test_results 5
-        flowey.exe e 15 flowey_lib_common::publish_test_results 6
-        flowey.exe e 15 flowey_lib_common::publish_test_results 4
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 17 flowey_lib_common::publish_test_results 5
+        flowey.exe e 17 flowey_lib_common::publish_test_results 6
+        flowey.exe e 17 flowey_lib_common::publish_test_results 4
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2072,18 +2654,18 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 15 flowey_lib_common::publish_test_results 0
-        flowey.exe e 15 flowey_lib_common::publish_test_results 1
-        flowey.exe e 15 flowey_lib_common::publish_test_results 2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 17 flowey_lib_common::publish_test_results 0
+        flowey.exe e 17 flowey_lib_common::publish_test_results 1
+        flowey.exe e 17 flowey_lib_common::publish_test_results 2
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2094,25 +2676,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
-      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 15 flowey_lib_common::cache 3
+      run: flowey.exe e 17 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 15 flowey_lib_common::cache 7
+      run: flowey.exe e 17 flowey_lib_common::cache 7
       shell: bash
-  job16:
+  job18:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2180,35 +2762,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 18 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 16 'verbose' update
+        cat <<'EOF' | flowey v 18 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 16 flowey_lib_common::install_rust 0
+      run: flowey e 18 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 16 flowey_lib_common::install_rust 1
+      run: flowey e 18 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 16 flowey_lib_common::install_rust 2
-        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 18 flowey_lib_common::install_rust 2
+        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::git_checkout 0
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2220,23 +2802,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 16 flowey_lib_common::git_checkout 3
-        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 18 flowey_lib_common::git_checkout 3
+        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 16 flowey_lib_common::download_gh_release 0
+      run: flowey e 18 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey e 18 flowey_lib_common::cache 4
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2246,61 +2828,61 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 16 flowey_lib_common::cache 6
-        flowey e 16 flowey_lib_common::download_gh_release 1
+        flowey e 18 flowey_lib_common::cache 6
+        flowey e 18 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 16 flowey_lib_common::resolve_protoc 0
-        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 18 flowey_lib_common::resolve_protoc 0
+        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 2
+        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_build 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 18 flowey_lib_common::run_cargo_build 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::build_xtask 0
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 16 flowey_lib_common::download_cargo_nextest 0
-        flowey e 16 flowey_lib_common::download_cargo_nextest 1
-        flowey e 16 flowey_lib_common::download_cargo_nextest 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 3
+        flowey e 18 flowey_lib_common::download_cargo_nextest 0
+        flowey e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey e 18 flowey_lib_common::download_cargo_nextest 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey e 18 flowey_lib_common::cache 0
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2310,34 +2892,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 16 flowey_lib_common::cache 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 4
+        flowey e 18 flowey_lib_common::cache 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 16 flowey_lib_common::install_rust 3
+      run: flowey e 18 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 16 flowey_lib_common::install_cargo_nextest 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::install_cargo_nextest 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 16 flowey_lib_common::publish_test_results 5
-        flowey e 16 flowey_lib_common::publish_test_results 6
-        flowey e 16 flowey_lib_common::publish_test_results 4
-        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 18 flowey_lib_common::publish_test_results 5
+        flowey e 18 flowey_lib_common::publish_test_results 6
+        flowey e 18 flowey_lib_common::publish_test_results 4
+        flowey v 18 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2347,18 +2929,18 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 16 flowey_lib_common::publish_test_results 8
-        flowey e 16 flowey_lib_common::publish_test_results 9
-        flowey e 16 flowey_lib_common::publish_test_results 10
-        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 18 flowey_lib_common::publish_test_results 8
+        flowey e 18 flowey_lib_common::publish_test_results 9
+        flowey e 18 flowey_lib_common::publish_test_results 10
+        flowey v 18 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2369,32 +2951,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_cross_build 3
-        flowey e 16 flowey_lib_common::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 18 flowey_lib_hvlite::init_cross_build 3
+        flowey e 18 flowey_lib_common::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 16 flowey_lib_hvlite::build_xtask 1
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 18 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 18 flowey_lib_common::publish_test_results 12
+        flowey e 18 flowey_lib_common::publish_test_results 13
+        flowey e 18 flowey_lib_common::publish_test_results 14
+        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 18 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -2404,18 +2986,18 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 16 flowey_lib_common::publish_test_results 0
-        flowey e 16 flowey_lib_common::publish_test_results 1
-        flowey e 16 flowey_lib_common::publish_test_results 2
-        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 18 flowey_lib_common::publish_test_results 0
+        flowey e 18 flowey_lib_common::publish_test_results 1
+        flowey e 18 flowey_lib_common::publish_test_results 2
+        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2426,25 +3008,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 16 flowey_lib_common::cache 3
+      run: flowey e 18 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 16 flowey_lib_common::cache 7
+      run: flowey e 18 flowey_lib_common::cache 7
       shell: bash
-  job17:
+  job19:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2512,29 +3094,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 17 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 17 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 19 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 19 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 17 'verbose' update
+        cat <<'EOF' | flowey v 19 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 17 flowey_lib_common::install_rust 0
+      run: flowey e 19 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 17 flowey_lib_common::install_rust 1
+      run: flowey e 19 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 17 flowey_lib_common::install_rust 2
-        flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 19 flowey_lib_common::install_rust 2
+        flowey e 19 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::git_checkout 0
+        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2546,27 +3128,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 17 flowey_lib_common::git_checkout 3
-        flowey e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 19 flowey_lib_common::git_checkout 3
+        flowey e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 19 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 19 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 17 flowey_lib_common::download_gh_release 0
+      run: flowey e 19 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 19 flowey_lib_common::cache 4
+        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2576,78 +3158,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 17 flowey_lib_common::cache 6
-        flowey e 17 flowey_lib_common::download_gh_release 1
+        flowey e 19 flowey_lib_common::cache 6
+        flowey e 19 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 19 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 17 flowey_lib_common::resolve_protoc 0
+      run: flowey e 19 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 17 flowey_lib_hvlite::init_cross_build 2
+        flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 19 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_clippy 5
-        flowey e 17 flowey_lib_hvlite::init_cross_build 0
+        flowey e 19 flowey_lib_common::run_cargo_clippy 5
+        flowey e 19 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_build 0
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 19 flowey_lib_common::run_cargo_build 0
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 17 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 17 flowey_lib_hvlite::build_xtask 0
+        flowey e 19 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 19 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 17 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 19 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 17 flowey_lib_common::download_cargo_nextest 0
-        flowey e 17 flowey_lib_common::download_cargo_nextest 1
-        flowey e 17 flowey_lib_common::download_cargo_nextest 2
-        flowey e 17 flowey_lib_common::download_cargo_nextest 3
+        flowey e 19 flowey_lib_common::download_cargo_nextest 0
+        flowey e 19 flowey_lib_common::download_cargo_nextest 1
+        flowey e 19 flowey_lib_common::download_cargo_nextest 2
+        flowey e 19 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 19 flowey_lib_common::cache 0
+        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2657,34 +3239,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 17 flowey_lib_common::cache 2
-        flowey e 17 flowey_lib_common::download_cargo_nextest 4
+        flowey e 19 flowey_lib_common::cache 2
+        flowey e 19 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 17 flowey_lib_common::install_rust 3
+      run: flowey e 19 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 17 flowey_lib_common::install_cargo_nextest 0
-        flowey e 17 flowey_lib_hvlite::init_cross_build 3
-        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 19 flowey_lib_common::install_cargo_nextest 0
+        flowey e 19 flowey_lib_hvlite::init_cross_build 3
+        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 17 flowey_lib_common::publish_test_results 5
-        flowey e 17 flowey_lib_common::publish_test_results 6
-        flowey e 17 flowey_lib_common::publish_test_results 4
-        flowey v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 19 flowey_lib_common::publish_test_results 5
+        flowey e 19 flowey_lib_common::publish_test_results 6
+        flowey e 19 flowey_lib_common::publish_test_results 4
+        flowey v 19 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2694,18 +3276,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 17 flowey_lib_common::publish_test_results 8
-        flowey e 17 flowey_lib_common::publish_test_results 9
-        flowey e 17 flowey_lib_common::publish_test_results 10
-        flowey v 17 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 17 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 19 flowey_lib_common::publish_test_results 8
+        flowey e 19 flowey_lib_common::publish_test_results 9
+        flowey e 19 flowey_lib_common::publish_test_results 10
+        flowey v 19 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 19 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2715,18 +3297,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 17 flowey_lib_common::publish_test_results 12
-        flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey e 17 flowey_lib_common::publish_test_results 14
-        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 19 flowey_lib_common::publish_test_results 12
+        flowey e 19 flowey_lib_common::publish_test_results 13
+        flowey e 19 flowey_lib_common::publish_test_results 14
+        flowey v 19 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 19 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -2736,18 +3318,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 17 flowey_lib_common::publish_test_results 16
-        flowey e 17 flowey_lib_common::publish_test_results 17
-        flowey e 17 flowey_lib_common::publish_test_results 18
-        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 19 flowey_lib_common::publish_test_results 16
+        flowey e 19 flowey_lib_common::publish_test_results 17
+        flowey e 19 flowey_lib_common::publish_test_results 18
+        flowey v 19 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 19 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -2758,32 +3340,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 17 flowey_lib_hvlite::init_cross_build 1
-        flowey e 17 flowey_lib_common::run_cargo_build 1
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 19 flowey_lib_hvlite::init_cross_build 1
+        flowey e 19 flowey_lib_common::run_cargo_build 1
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 17 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 17 flowey_lib_hvlite::build_xtask 1
+        flowey e 19 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 19 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 17 flowey_lib_common::publish_test_results 0
-        flowey e 17 flowey_lib_common::publish_test_results 1
-        flowey e 17 flowey_lib_common::publish_test_results 2
-        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 19 flowey_lib_common::publish_test_results 0
+        flowey e 19 flowey_lib_common::publish_test_results 1
+        flowey e 19 flowey_lib_common::publish_test_results 2
+        flowey v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2794,553 +3376,17 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
-      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 17 flowey_lib_common::cache 3
+      run: flowey e 19 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 17 flowey_lib_common::cache 7
-      shell: bash
-  job18:
-    name: run vmm-tests [x64-windows-intel]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job11
-    - job5
-    - job8
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 18 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 18 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 18 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 18 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 18 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 18 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 18 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 18 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 18 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 18 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 18 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 18 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 18 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 18 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 18 flowey_lib_common::cache 0
-        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::cache 2
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 18 flowey_lib_common::git_checkout 0
-        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::git_checkout 3
-        flowey.exe e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 18 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 18 flowey_lib_common::cache 8
-        flowey.exe v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::cache 10
-        flowey.exe e 18 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 18 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 18 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 18 flowey_lib_common::cache 4
-        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::cache 6
-        flowey.exe e 18 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 18 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 18 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 18 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 18 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 18 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 18 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 18 flowey_lib_common::publish_test_results 4
-        flowey.exe e 18 flowey_lib_common::publish_test_results 5
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 18 flowey_lib_common::publish_test_results 0
-        flowey.exe e 18 flowey_lib_common::publish_test_results 1
-        flowey.exe e 18 flowey_lib_common::publish_test_results 2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 18 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 18 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 18 flowey_lib_common::cache 11
-      shell: bash
-  job19:
-    name: run vmm-tests [x64-windows-intel-tdx]
-    runs-on:
-    - self-hosted
-    - Windows
-    - X64
-    - TDX
-    - Baremetal
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job11
-    - job5
-    - job8
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 19 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 19 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 19 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 19 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 19 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 19 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 19 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 19 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 19 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 19 flowey_lib_common::cache 0
-        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 19 flowey_lib_common::cache 2
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 19 flowey_lib_common::git_checkout 0
-        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 19 flowey_lib_common::git_checkout 3
-        flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 19 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 19 flowey_lib_common::cache 8
-        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 19 flowey_lib_common::cache 10
-        flowey.exe e 19 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 19 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 19 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 19 flowey_lib_common::cache 4
-        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 19 flowey_lib_common::cache 6
-        flowey.exe e 19 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 19 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 19 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 19 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 19 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 19 flowey_lib_common::publish_test_results 4
-        flowey.exe e 19 flowey_lib_common::publish_test_results 5
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-tdx-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 19 flowey_lib_common::publish_test_results 0
-        flowey.exe e 19 flowey_lib_common::publish_test_results 1
-        flowey.exe e 19 flowey_lib_common::publish_test_results 2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-tdx-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 19 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 19 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 19 flowey_lib_common::cache 11
+      run: flowey e 19 flowey_lib_common::cache 7
       shell: bash
   job2:
     name: build artifacts (not for VMM tests) [aarch64-windows]
@@ -3560,10 +3606,10 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-windows-amd]
+    name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3571,9 +3617,10 @@ jobs:
       id-token: write
     needs:
     - job0
-    - job11
-    - job5
-    - job8
+    - job10
+    - job13
+    - job6
+    - job7
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -3792,9 +3839,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-logs
+        name: x64-windows-intel-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3808,9 +3855,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-junit-xml
+        name: x64-windows-intel-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -3825,21 +3872,22 @@ jobs:
       run: flowey.exe e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [x64-windows-amd-snp]
+    name: run vmm-tests [x64-windows-intel-tdx]
     runs-on:
     - self-hosted
     - Windows
     - X64
-    - SNP
+    - TDX
     - Baremetal
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job11
-    - job5
-    - job8
+    - job10
+    - job13
+    - job6
+    - job7
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -3928,10 +3976,6 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
@@ -3939,6 +3983,10 @@ jobs:
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4063,9 +4111,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-snp-vmm-tests-logs
+        name: x64-windows-intel-tdx-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4079,9 +4127,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-snp-vmm-tests-junit-xml
+        name: x64-windows-intel-tdx-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4096,20 +4144,558 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
-    name: run vmm-tests [x64-linux-amd-kvm]
+    name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=win-amd64
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job5
-    - job8
-    - job9
+    - job10
+    - job13
+    - job6
+    - job7
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 22 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 22 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 22 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 22 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 22 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 22 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 22 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 0
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 22 flowey_lib_common::git_checkout 0
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::git_checkout 3
+        flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 8
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 10
+        flowey.exe e 22 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 22 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 22 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 4
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 6
+        flowey.exe e 22 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 22 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 22 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 22 flowey_lib_common::publish_test_results 4
+        flowey.exe e 22 flowey_lib_common::publish_test_results 5
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 22 flowey_lib_common::publish_test_results 0
+        flowey.exe e 22 flowey_lib_common::publish_test_results 1
+        flowey.exe e 22 flowey_lib_common::publish_test_results 2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 22 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 22 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 22 flowey_lib_common::cache 11
+      shell: bash
+  job23:
+    name: run vmm-tests [x64-windows-amd-snp]
+    runs-on:
+    - self-hosted
+    - Windows
+    - X64
+    - SNP
+    - Baremetal
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job10
+    - job13
+    - job6
+    - job7
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 23 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 23 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 23 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 23 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 23 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 23 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 23 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 23 flowey_lib_common::cache 0
+        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::cache 2
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 23 flowey_lib_common::git_checkout 0
+        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::git_checkout 3
+        flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 23 flowey_lib_common::cache 8
+        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::cache 10
+        flowey.exe e 23 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 23 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 23 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 23 flowey_lib_common::cache 4
+        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::cache 6
+        flowey.exe e 23 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 23 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 23 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 23 flowey_lib_common::publish_test_results 4
+        flowey.exe e 23 flowey_lib_common::publish_test_results 5
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-snp-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 23 flowey_lib_common::publish_test_results 0
+        flowey.exe e 23 flowey_lib_common::publish_test_results 1
+        flowey.exe e 23 flowey_lib_common::publish_test_results 2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-snp-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 23 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 23 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 23 flowey_lib_common::cache 11
+      shell: bash
+  job24:
+    name: run vmm-tests [x64-linux-amd-kvm]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job10
+    - job11
+    - job6
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -4128,46 +4714,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 22 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 22 'verbose' update
+        cat <<'EOF' | flowey v 24 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 22 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 22 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 22 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 22 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 24 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 22 flowey_core::pipeline::artifact::resolve 3
-        flowey e 22 flowey_core::pipeline::artifact::resolve 4
-        flowey e 22 flowey_core::pipeline::artifact::resolve 7
-        flowey e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey e 22 flowey_core::pipeline::artifact::resolve 0
-        flowey e 22 flowey_core::pipeline::artifact::resolve 2
-        flowey e 22 flowey_core::pipeline::artifact::resolve 6
-        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 3
+        flowey e 24 flowey_core::pipeline::artifact::resolve 4
+        flowey e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey e 24 flowey_core::pipeline::artifact::resolve 1
+        flowey e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey e 24 flowey_core::pipeline::artifact::resolve 6
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 22 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 22 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 22 flowey_lib_common::download_gh_release 0
+      run: flowey e 24 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 22 flowey_lib_common::cache 8
-        flowey v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 24 flowey_lib_common::cache 8
+        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4177,31 +4763,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 22 flowey_lib_common::cache 10
-        flowey e 22 flowey_lib_common::download_gh_release 1
+        flowey e 24 flowey_lib_common::cache 10
+        flowey e 24 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 22 flowey_lib_common::download_azcopy 0
+      run: flowey e 24 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 22 flowey_lib_common::download_gh_cli 0
+      run: flowey e 24 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 22 flowey_lib_common::cache 4
-        flowey v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 24 flowey_lib_common::cache 4
+        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4211,54 +4797,54 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 22 flowey_lib_common::cache 6
-        flowey e 22 flowey_lib_common::download_gh_cli 1
-        flowey v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 24 flowey_lib_common::cache 6
+        flowey e 24 flowey_lib_common::download_gh_cli 1
+        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 22 flowey_lib_common::use_gh_cli 0
+      run: flowey e 24 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 22 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 24 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 22 flowey_lib_common::download_cargo_nextest 0
-        flowey e 22 flowey_lib_common::download_cargo_nextest 1
-        flowey e 22 flowey_lib_common::download_cargo_nextest 2
-        flowey e 22 flowey_lib_common::download_cargo_nextest 3
+        flowey e 24 flowey_lib_common::download_cargo_nextest 0
+        flowey e 24 flowey_lib_common::download_cargo_nextest 1
+        flowey e 24 flowey_lib_common::download_cargo_nextest 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 22 flowey_lib_common::cache 0
-        flowey v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 24 flowey_lib_common::cache 0
+        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4268,17 +4854,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 22 flowey_lib_common::cache 2
-        flowey e 22 flowey_lib_common::download_cargo_nextest 4
+        flowey e 24 flowey_lib_common::cache 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 22 flowey_lib_common::git_checkout 0
-        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_common::git_checkout 0
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4290,32 +4876,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 22 flowey_lib_common::git_checkout 3
-        flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 22 flowey_core::pipeline::artifact::resolve 5
-        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey e 24 flowey_lib_common::git_checkout 3
+        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
     - name: generate nextest command
-      run: flowey e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 22 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 22 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 22 flowey_lib_common::publish_test_results 4
-        flowey e 22 flowey_lib_common::publish_test_results 5
-        flowey v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 24 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 24 flowey_lib_common::publish_test_results 4
+        flowey e 24 flowey_lib_common::publish_test_results 5
+        flowey v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4326,12 +4912,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 22 flowey_lib_common::publish_test_results 0
-        flowey e 22 flowey_lib_common::publish_test_results 1
-        flowey e 22 flowey_lib_common::publish_test_results 2
-        flowey v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 24 flowey_lib_common::publish_test_results 0
+        flowey e 24 flowey_lib_common::publish_test_results 1
+        flowey e 24 flowey_lib_common::publish_test_results 2
+        flowey v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4341,32 +4927,32 @@ jobs:
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 22 flowey_lib_common::cache 3
+      run: flowey e 24 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 22 flowey_lib_common::cache 7
+      run: flowey e 24 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 22 flowey_lib_common::cache 11
+      run: flowey e 24 flowey_lib_common::cache 11
       shell: bash
-  job23:
+  job25:
     name: run vmm-tests [x64-linux-intel-mshv]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job5
-    - job8
-    - job9
+    - job10
+    - job11
+    - job6
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
@@ -4433,46 +5019,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 23 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 23 'verbose' update
+        cat <<'EOF' | flowey v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 23 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey e 23 flowey_core::pipeline::artifact::resolve 7
-        flowey e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey e 23 flowey_core::pipeline::artifact::resolve 4
-        flowey e 23 flowey_core::pipeline::artifact::resolve 6
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey e 25 flowey_core::pipeline::artifact::resolve 7
+        flowey e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 4
+        flowey e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 23 flowey_lib_common::download_gh_release 0
+      run: flowey e 25 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 23 flowey_lib_common::cache 8
-        flowey v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 25 flowey_lib_common::cache 8
+        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4482,31 +5068,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 23 flowey_lib_common::cache 10
-        flowey e 23 flowey_lib_common::download_gh_release 1
+        flowey e 25 flowey_lib_common::cache 10
+        flowey e 25 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 23 flowey_lib_common::download_azcopy 0
+      run: flowey e 25 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 23 flowey_lib_common::download_gh_cli 0
+      run: flowey e 25 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 23 flowey_lib_common::cache 4
-        flowey v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 25 flowey_lib_common::cache 4
+        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4516,51 +5102,51 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 23 flowey_lib_common::cache 6
-        flowey e 23 flowey_lib_common::download_gh_cli 1
-        flowey v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 25 flowey_lib_common::cache 6
+        flowey e 25 flowey_lib_common::download_gh_cli 1
+        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 23 flowey_lib_common::use_gh_cli 0
+      run: flowey e 25 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 23 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 25 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 23 flowey_lib_common::download_cargo_nextest 0
-        flowey e 23 flowey_lib_common::download_cargo_nextest 1
-        flowey e 23 flowey_lib_common::download_cargo_nextest 2
-        flowey e 23 flowey_lib_common::download_cargo_nextest 3
+        flowey e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 23 flowey_lib_common::cache 0
-        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 25 flowey_lib_common::cache 0
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4570,17 +5156,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 23 flowey_lib_common::cache 2
-        flowey e 23 flowey_lib_common::download_cargo_nextest 4
+        flowey e 25 flowey_lib_common::cache 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 23 flowey_lib_common::git_checkout 0
-        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4592,31 +5178,31 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 23 flowey_lib_common::git_checkout 3
-        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 23 flowey_core::pipeline::artifact::resolve 5
-        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 25 flowey_lib_common::git_checkout 3
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 25 flowey_core::pipeline::artifact::resolve 5
+        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: generate nextest command
-      run: flowey e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 23 flowey_lib_common::publish_test_results 4
-        flowey e 23 flowey_lib_common::publish_test_results 5
-        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 25 flowey_lib_common::publish_test_results 4
+        flowey e 25 flowey_lib_common::publish_test_results 5
+        flowey v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4627,12 +5213,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 23 flowey_lib_common::publish_test_results 0
-        flowey e 23 flowey_lib_common::publish_test_results 1
-        flowey e 23 flowey_lib_common::publish_test_results 2
-        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 25 flowey_lib_common::publish_test_results 0
+        flowey e 25 flowey_lib_common::publish_test_results 1
+        flowey e 25 flowey_lib_common::publish_test_results 2
+        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4642,18 +5228,18 @@ jobs:
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 23 flowey_lib_common::cache 3
+      run: flowey e 25 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 23 flowey_lib_common::cache 7
+      run: flowey e 25 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 23 flowey_lib_common::cache 11
+      run: flowey e 25 flowey_lib_common::cache 11
       shell: bash
-  job24:
+  job26:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -4665,9 +5251,10 @@ jobs:
       id-token: write
     needs:
     - job0
-    - job10
+    - job12
     - job3
-    - job6
+    - job4
+    - job8
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
@@ -4735,35 +5322,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 24 'verbose' update
+        cat <<'EOF' | flowey.exe v 26 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 24 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 26 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 0
-        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 26 flowey_lib_common::cache 0
+        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4773,17 +5360,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 26 flowey_lib_common::cache 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 24 flowey_lib_common::git_checkout 0
-        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_common::git_checkout 0
+        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4795,35 +5382,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 24 flowey_lib_common::git_checkout 3
-        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 26 flowey_lib_common::git_checkout 3
+        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 8
-        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 26 flowey_lib_common::cache 8
+        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4833,31 +5420,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 10
-        flowey.exe e 24 flowey_lib_common::download_gh_release 1
+        flowey.exe e 26 flowey_lib_common::cache 10
+        flowey.exe e 26 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 26 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 4
-        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 26 flowey_lib_common::cache 4
+        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4867,63 +5454,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 6
-        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 26 flowey_lib_common::cache 6
+        flowey.exe e 26 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 26 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 24 flowey_lib_common::publish_test_results 4
-        flowey.exe e 24 flowey_lib_common::publish_test_results 5
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 26 flowey_lib_common::publish_test_results 4
+        flowey.exe e 26 flowey_lib_common::publish_test_results 5
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4934,12 +5521,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 24 flowey_lib_common::publish_test_results 0
-        flowey.exe e 24 flowey_lib_common::publish_test_results 1
-        flowey.exe e 24 flowey_lib_common::publish_test_results 2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 26 flowey_lib_common::publish_test_results 0
+        flowey.exe e 26 flowey_lib_common::publish_test_results 1
+        flowey.exe e 26 flowey_lib_common::publish_test_results 2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4949,18 +5536,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 24 flowey_lib_common::cache 3
+      run: flowey.exe e 26 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 24 flowey_lib_common::cache 7
+      run: flowey.exe e 26 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 24 flowey_lib_common::cache 11
+      run: flowey.exe e 26 flowey_lib_common::cache 11
       shell: bash
-  job25:
+  job27:
     name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
@@ -4986,18 +5573,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 25 'verbose' update
+        cat <<'EOF' | flowey v 27 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 27 flowey_lib_common::git_checkout 0
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5009,35 +5596,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 27 flowey_lib_common::git_checkout 3
+        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 25 flowey_lib_common::install_rust 0
+      run: flowey e 27 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 25 flowey_lib_common::install_rust 1
+      run: flowey e 27 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 25 flowey_lib_common::install_rust 2
-        flowey v 25 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 27 flowey_lib_common::install_rust 2
+        flowey v 27 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 25 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      run: flowey e 27 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
-  job26:
+  job28:
     name: build openhcl (mi-secure) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job28-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5061,31 +5648,31 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 26 'verbose' update
+        cat <<'EOF' | flowey v 28 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 26 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 28 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 26 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 28 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 26 flowey_lib_common::download_gh_release 0
+      run: flowey e 28 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 26 flowey_lib_common::cache 0
-        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey e 28 flowey_lib_common::cache 0
+        flowey v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5095,31 +5682,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 26 flowey_lib_common::cache 2
-        flowey e 26 flowey_lib_common::download_gh_release 1
+        flowey e 28 flowey_lib_common::cache 2
+        flowey e 28 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 28 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 26 flowey_lib_common::install_rust 0
+      run: flowey e 28 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 26 flowey_lib_common::install_rust 1
+      run: flowey e 28 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 26 flowey_lib_common::install_rust 2
-        flowey e 26 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 28 flowey_lib_common::install_rust 2
+        flowey e 28 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 26 flowey_lib_common::git_checkout 0
-        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 28 flowey_lib_common::git_checkout 0
+        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5131,172 +5718,172 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 26 flowey_lib_common::git_checkout 3
-        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 28 flowey_lib_common::git_checkout 3
+        flowey e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 26 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 28 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 26 flowey_lib_common::resolve_protoc 0
-        flowey e 26 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 28 flowey_lib_common::resolve_protoc 0
+        flowey e 28 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 0
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 28 flowey_lib_hvlite::init_cross_build 0
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 3
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 28 flowey_lib_common::run_cargo_build 3
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 26 flowey_lib_hvlite::build_sidecar 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 1
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 28 flowey_lib_hvlite::build_sidecar 0
+        flowey e 28 flowey_lib_hvlite::init_cross_build 1
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: cargo build openhcl_boot
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 1
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 28 flowey_lib_common::run_cargo_build 1
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 28 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 3
+        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 28 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 2
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 26 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 28 flowey_lib_common::run_cargo_build 2
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 28 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 26 flowey_lib_hvlite::init_cross_build 2
+        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 28 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 0
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 28 flowey_lib_common::run_cargo_build 0
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 26 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 28 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 28 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
-        flowey e 26 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 28 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 26 flowey_lib_common::copy_to_artifact_dir 0
+      run: flowey e 28 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 26 flowey_lib_common::cache 3
+      run: flowey e 28 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -5310,21 +5897,22 @@ jobs:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
         include-hidden-files: true
-  job27:
+  job29:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job29-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job26
-    - job5
-    - job8
+    - job10
+    - job28
+    - job6
+    - job7
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -5343,39 +5931,39 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
 
-        echo '"debug"' | flowey.exe v 27 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 27 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 29 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 29 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 27 'verbose' update
+        cat <<'EOF' | flowey.exe v 29 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 27 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 27 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 27 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 27 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 27 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 27 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 27 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 27 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 29 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 29 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 29 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 29 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 29 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 29 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 29 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 29 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 29 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 27 flowey_lib_common::cache 0
-        flowey.exe v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 29 flowey_lib_common::cache 0
+        flowey.exe v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5385,17 +5973,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 27 flowey_lib_common::cache 2
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 29 flowey_lib_common::cache 2
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 27 flowey_lib_common::git_checkout 0
-        flowey.exe v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 29 flowey_lib_common::git_checkout 0
+        flowey.exe v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5407,38 +5995,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 27 flowey_lib_common::git_checkout 3
-        flowey.exe e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 29 flowey_lib_common::git_checkout 3
+        flowey.exe e 29 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 27 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 29 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 27 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 29 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 27 flowey_lib_common::cache 8
-        flowey.exe v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 29 flowey_lib_common::cache 8
+        flowey.exe v 29 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 29 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5448,31 +6036,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 29 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 27 flowey_lib_common::cache 10
-        flowey.exe e 27 flowey_lib_common::download_gh_release 1
+        flowey.exe e 29 flowey_lib_common::cache 10
+        flowey.exe e 29 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 27 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 29 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 27 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 29 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 27 flowey_lib_common::cache 4
-        flowey.exe v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 29 flowey_lib_common::cache 4
+        flowey.exe v 29 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 29 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5482,63 +6070,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 29 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 27 flowey_lib_common::cache 6
-        flowey.exe e 27 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 29 flowey_lib_common::cache 6
+        flowey.exe e 29 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 27 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 29 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 29 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 27 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 29 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 29 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 29 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 29 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 29 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 29 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 29 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 29 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 27 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 29 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 27 flowey_lib_common::publish_test_results 4
-        flowey.exe e 27 flowey_lib_common::publish_test_results 5
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 29 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 29 flowey_lib_common::publish_test_results 4
+        flowey.exe e 29 flowey_lib_common::publish_test_results 5
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5549,12 +6137,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 27 flowey_lib_common::publish_test_results 0
-        flowey.exe e 27 flowey_lib_common::publish_test_results 1
-        flowey.exe e 27 flowey_lib_common::publish_test_results 2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 29 flowey_lib_common::publish_test_results 0
+        flowey.exe e 29 flowey_lib_common::publish_test_results 1
+        flowey.exe e 29 flowey_lib_common::publish_test_results 2
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5564,19 +6152,19 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 27 flowey_lib_common::cache 3
+      run: flowey.exe e 29 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 27 flowey_lib_common::cache 7
+      run: flowey.exe e 29 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 27 flowey_lib_common::cache 11
+      run: flowey.exe e 29 flowey_lib_common::cache 11
       shell: bash
   job3:
-    name: build artifacts (for VMM tests) [aarch64-windows]
+    name: build artifacts (shared VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -5655,22 +6243,8 @@ jobs:
         cat <<'EOF' | flowey.exe v 3 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-pipette"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-pipette" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-prep_steps"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-prep_steps" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-test_igvm_agent_rpc_server" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tpm_guest_tests"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tpm_guest_tests" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 3 flowey_lib_common::install_rust 0
@@ -5713,22 +6287,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 3 flowey_lib_common::cache 4
-        flowey.exe v 3 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 3 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 3 flowey_lib_common::cache 0
+        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 3 flowey_lib_common::cache 6
+        flowey.exe e 3 flowey_lib_common::cache 2
         flowey.exe e 3 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -5739,164 +6313,26 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 4
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 6
-        flowey.exe e 3 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 4
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: cargo build prep_steps
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 2
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 3 flowey_lib_hvlite::build_prep_steps 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 5
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 6
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 10
-        flowey.exe e 3 flowey_lib_hvlite::build_vmgstool 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 6
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 3
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 7
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 5
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 9
-        flowey.exe e 3 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 7
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 3
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: cargo build test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 5
-        flowey.exe e 3 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 0
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 3 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 3 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 3 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 3 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 3 flowey_lib_common::cache 0
-        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 3 flowey_lib_common::cache 2
-        flowey.exe e 3 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey.exe e 3 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey.exe e 3 flowey_lib_common::install_cargo_nextest 0
         flowey.exe e 3 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey.exe e 3 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 3 flowey_lib_hvlite::build_openvmm 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 3 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 0
         flowey.exe e 3 flowey_lib_hvlite::build_pipette 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 3
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 3 flowey_lib_common::cache 3
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 3 flowey_lib_common::cache 7
+      run: flowey.exe e 3 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-windows-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-openvmm/
-        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-pipette
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-windows-pipette
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-pipette/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-prep_steps
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-prep_steps
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-prep_steps/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-test_igvm_agent_rpc_server
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-tmk_vmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-tpm_guest_tests
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmm-tests-archive/
-        include-hidden-files: true
   job4:
-    name: build artifacts (not for VMM tests) [x64-windows]
+    name: build artifacts (for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -5975,14 +6411,20 @@ jobs:
         cat <<'EOF' | flowey.exe v 4 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 4 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 4 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 4 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 4 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-prep_steps"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-prep_steps" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-test_igvm_agent_rpc_server" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tpm_guest_tests"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tpm_guest_tests" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 4 flowey_lib_common::install_rust 0
@@ -6025,22 +6467,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 4 flowey_lib_common::cache 0
-        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe e 4 flowey_lib_common::cache 4
+        flowey.exe v 4 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 4 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
-    - id: flowey_lib_common__cache__1
+    - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        flowey.exe v 4 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 4 flowey_lib_common::cache 2
+        flowey.exe e 4 flowey_lib_common::cache 6
         flowey.exe e 4 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -6053,71 +6495,148 @@ jobs:
         flowey.exe e 4 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey.exe e 4 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build hypestv
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 4 flowey_lib_hvlite::build_hypestv 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo build vmgs_lib
+    - name: cargo build tmk_vmm
       run: |-
         flowey.exe e 4 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 3
-        flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 5
+        flowey.exe e 4 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 5
       shell: bash
-    - name: test vmgs_lib
-      run: |-
-        flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build prep_steps
       run: |-
         flowey.exe e 4 flowey_lib_common::run_cargo_build 1
         flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 4 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 4 flowey_lib_hvlite::build_prep_steps 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 4
         flowey.exe e 4 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build ohcldiag-dev
+    - name: cargo build vmgstool
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 5
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 9
+        flowey.exe e 4 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 5
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 6
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 8
+        flowey.exe e 4 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 6
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 6
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 4 flowey_lib_common::run_cargo_build 2
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 4 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 4 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 0
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 4 flowey_lib_common::cache 0
+        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 4 flowey_lib_common::cache 2
+        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 4 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey.exe e 4 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey.exe e 4 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 4 flowey_lib_hvlite::build_openvmm 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 2
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 4 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-windows-hypestv
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 4 flowey_lib_common::cache 7
+      shell: bash
+    - name: 🌼📦 Publish aarch64-windows-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-hypestv
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-hypestv/
+        name: aarch64-windows-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-igvmfilegen
+    - name: 🌼📦 Publish aarch64-windows-prep_steps
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-igvmfilegen/
+        name: aarch64-windows-prep_steps
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-prep_steps/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-ohcldiag-dev
+    - name: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
+        name: aarch64-windows-test_igvm_agent_rpc_server
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-vmgs_lib
+    - name: 🌼📦 Publish aarch64-windows-tmk_vmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
+        name: aarch64-windows-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmm-tests-archive/
         include-hidden-files: true
   job5:
-    name: build artifacts (for VMM tests) [x64-windows]
+    name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6196,22 +6715,14 @@ jobs:
         cat <<'EOF' | flowey.exe v 5 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-openvmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-openvmm" | flowey.exe v 5 'artifact_publish_from_x64-windows-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-pipette"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 5 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-prep_steps"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-prep_steps" | flowey.exe v 5 'artifact_publish_from_x64-windows-prep_steps' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-test_igvm_agent_rpc_server"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 5 'artifact_publish_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tmk_vmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 5 'artifact_publish_from_x64-windows-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tpm_guest_tests"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 5 'artifact_publish_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmm-tests-archive"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 5 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 5 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 5 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 5 flowey_lib_common::install_rust 0
@@ -6254,22 +6765,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 5 flowey_lib_common::cache 4
-        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 5 flowey_lib_common::cache 0
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 5 flowey_lib_common::cache 6
+        flowey.exe e 5 flowey_lib_common::cache 2
         flowey.exe e 5 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -6280,79 +6791,466 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 5 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 5
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build openvmm
+    - name: cargo build hypestv
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 0
         flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 5 flowey_lib_hvlite::build_openvmm 0
+        flowey.exe e 5 flowey_lib_hvlite::build_hypestv 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 6
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
       shell: bash
-    - name: cargo build pipette
+    - name: cargo build vmgs_lib
       run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 5 flowey_lib_hvlite::build_pipette 0
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      shell: bash
+    - name: test vmgs_lib
+      run: |-
+        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 1
         flowey.exe e 5 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: cargo build tmk_vmm
+    - name: cargo build igvmfilegen
       run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 4
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 6
-        flowey.exe e 5 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 5 flowey_lib_hvlite::build_igvmfilegen 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 7
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build prep_steps
+    - name: cargo build ohcldiag-dev
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 2
         flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 5 flowey_lib_hvlite::build_prep_steps 0
+        flowey.exe e 5 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 3
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 6
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 10
-        flowey.exe e 5 flowey_lib_hvlite::build_vmgstool 0
-        flowey.exe e 5 flowey_core::pipeline::artifact::publish 4
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 3
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 7
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 8
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 5 flowey_lib_common::cache 3
       shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 5
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 9
-        flowey.exe e 5 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey.exe e 5 flowey_core::pipeline::artifact::publish 5
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 4
+    - name: 🌼📦 Publish x64-windows-hypestv
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-hypestv
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-hypestv/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-igvmfilegen
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-ohcldiag-dev
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-vmgs_lib
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
+        include-hidden-files: true
+  job6:
+    name: build artifacts (shared VMM tests) [x64-windows]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
       shell: bash
-    - name: cargo build test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 5
-        flowey.exe e 5 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
-        flowey.exe e 5 flowey_core::pipeline::artifact::publish 6
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
       shell: bash
-    - name: create cargo-nextest cache dir
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr-release.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
       run: |-
-        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 3
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-pr-release.yaml ci checkin-gates --config=pr-release
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+
+        echo '"debug"' | flowey.exe v 6 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 6 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 6 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-pipette"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 6 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey.exe e 6 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 6 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey.exe e 6 flowey_lib_common::install_rust 2
+        flowey.exe e 6 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 6 flowey_lib_common::git_checkout 0
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 6 flowey_lib_common::git_checkout 3
+        flowey.exe e 6 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey.exe e 6 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 6 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 5 flowey_lib_common::cache 0
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe e 6 flowey_lib_common::cache 0
+        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 6 flowey_lib_common::cache 2
+        flowey.exe e 6 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey.exe e 6 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 6 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey.exe e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 6 flowey_lib_hvlite::build_pipette 0
+        flowey.exe e 6 flowey_core::pipeline::artifact::publish 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 6 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish x64-windows-pipette
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-pipette
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
+        include-hidden-files: true
+  job7:
+    name: build artifacts (for VMM tests) [x64-windows]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr-release.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-pr-release.yaml ci checkin-gates --config=pr-release
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+
+        echo '"debug"' | flowey.exe v 7 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 7 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 7 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-openvmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-openvmm" | flowey.exe v 7 'artifact_publish_from_x64-windows-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-prep_steps"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-prep_steps" | flowey.exe v 7 'artifact_publish_from_x64-windows-prep_steps' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-test_igvm_agent_rpc_server"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 7 'artifact_publish_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tmk_vmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 7 'artifact_publish_from_x64-windows-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tpm_guest_tests"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 7 'artifact_publish_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool" | flowey.exe v 7 'artifact_publish_from_x64-windows-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmm-tests-archive"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 7 'artifact_publish_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey.exe e 7 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 7 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey.exe e 7 flowey_lib_common::install_rust 2
+        flowey.exe e 7 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 7 flowey_lib_common::git_checkout 0
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 7 flowey_lib_common::git_checkout 3
+        flowey.exe e 7 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey.exe e 7 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 7 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 7 flowey_lib_common::cache 4
+        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 7 flowey_lib_common::cache 6
+        flowey.exe e 7 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey.exe e 7 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 7 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey.exe e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 7 flowey_lib_hvlite::build_openvmm 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 0
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 5
+        flowey.exe e 7 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build prep_steps
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 7 flowey_lib_hvlite::build_prep_steps 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build vmgstool
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 5
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 9
+        flowey.exe e 7 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 6
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 8
+        flowey.exe e 7 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 4
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 6
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 2
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 7 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 5
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 7 flowey_lib_common::cache 0
+        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6362,43 +7260,37 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 5 flowey_lib_common::cache 2
-        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 7 flowey_lib_common::cache 2
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 5 flowey_lib_common::install_rust 3
+      run: flowey.exe e 7 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 5 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 7 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey.exe e 5 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey.exe e 5 flowey_core::pipeline::artifact::publish 7
+        flowey.exe e 7 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey.exe e 7 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 6
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 5 flowey_lib_common::cache 3
+      run: flowey.exe e 7 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 5 flowey_lib_common::cache 7
+      run: flowey.exe e 7 flowey_lib_common::cache 7
       shell: bash
     - name: 🌼📦 Publish x64-windows-openvmm
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-openvmm
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-pipette
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-pipette
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-prep_steps
       uses: actions/upload-artifact@v7
@@ -6437,526 +7329,15 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmm-tests-archive/
         include-hidden-files: true
     - name: 🌼🧼 Redact bootstrap var db
-      run: rm $AgentTempDirNormal/bootstrapped-flowey/job5.json
+      run: rm $AgentTempDirNormal/bootstrapped-flowey/job7.json
       shell: bash
     - name: 🌼🥾 Publish bootstrapped flowey
       uses: actions/upload-artifact@v7
       with:
         name: _internal-flowey-bootstrap-x86_64-windows-uid-6
         path: ${{ runner.temp }}/bootstrapped-flowey
-  job6:
-    name: build artifacts (shared VMM tests) [aarch64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 6 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 6 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 6 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 6 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests" | flowey v 6 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 6 'artifact_publish_from_aarch64-tmks' --is-raw-string update
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 6 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 6 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 6 flowey_lib_common::install_rust 2
-        flowey e 6 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 6 flowey_lib_common::git_checkout 0
-        flowey v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 6 flowey_lib_common::git_checkout 3
-        flowey e 6 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 6 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 6 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 6 flowey_lib_common::cache 0
-        flowey v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 6 flowey_lib_common::cache 2
-        flowey e 6 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 6 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 6 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 6 flowey_lib_common::resolve_protoc 0
-        flowey e 6 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build guest_test_uefi
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: build guest_test_uefi.img
-      run: |-
-        flowey e 6 flowey_lib_hvlite::build_guest_test_uefi 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: cargo build simple_tmk
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 6 flowey_lib_hvlite::build_tmks 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 1
-        flowey e 6 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 4
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 6 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 2
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 6 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 6 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 1
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::build_pipette 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 3
-        flowey e 6 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 6 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 4
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 6 flowey_lib_common::cache 3
-      shell: bash
-    - name: 🌼📦 Publish aarch64-guest_test_uefi
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-guest_test_uefi
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-pipette
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-tpm_guest_tests
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-tmks
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-tmks
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
-        include-hidden-files: true
-  job7:
-    name: build artifacts (for VMM tests) [aarch64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 7 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 7 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 7 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 7 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 7 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 7 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 7 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 7 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 7 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 7 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 7 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 7 flowey_lib_common::install_rust 2
-        flowey e 7 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 7 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 7 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 7 flowey_lib_common::git_checkout 0
-        flowey v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 7 flowey_lib_common::git_checkout 3
-        flowey e 7 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 7 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 7 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 7 flowey_lib_common::cache 0
-        flowey v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 7 flowey_lib_common::cache 2
-        flowey e 7 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 7 flowey_lib_common::resolve_protoc 0
-        flowey e 7 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 2
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 7 flowey_lib_hvlite::build_openvmm 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 4
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 7 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 1
-        flowey e 7 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 7
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 7 flowey_lib_hvlite::build_vmgstool 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 2
-        flowey e 7 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 6
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 7 flowey_core::pipeline::artifact::publish 3
-        flowey e 7 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 0
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 7 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 4
-        flowey e 7 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build ohcldiag-dev
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 1
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 5
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 7 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 7 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 7 flowey_lib_hvlite::build_openvmm 1
-        flowey e 7 flowey_core::pipeline::artifact::publish 6
-        flowey e 7 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 5
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 10
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 11
-        flowey e 7 flowey_lib_hvlite::build_openvmm_vhost 1
-        flowey e 7 flowey_core::pipeline::artifact::publish 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 7 flowey_lib_common::cache 3
-      shell: bash
-    - name: 🌼📦 Publish aarch64-linux-igvmfilegen
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-vmgs_lib
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
-        include-hidden-files: true
   job8:
-    name: build artifacts (shared VMM tests) [x64-linux]
+    name: build artifacts (shared VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6991,16 +7372,16 @@ jobs:
         cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 8 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 8 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 8 'artifact_publish_from_x64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 8 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests" | flowey v 8 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 8 'artifact_publish_from_aarch64-tmks' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 8 flowey_lib_common::install_rust 0
@@ -7118,7 +7499,7 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 8 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
         flowey e 8 flowey_lib_hvlite::init_cross_build 3
@@ -7151,38 +7532,38 @@ jobs:
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-guest_test_uefi
+    - name: 🌼📦 Publish aarch64-guest_test_uefi
       uses: actions/upload-artifact@v7
       with:
-        name: x64-guest_test_uefi
-        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
+        name: aarch64-guest_test_uefi
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-pipette
+    - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
+        name: aarch64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
+    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        name: aarch64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
+    - name: 🌼📦 Publish aarch64-linux-tpm_guest_tests
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
+        name: aarch64-linux-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-tpm_guest_tests/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-tmks
+    - name: 🌼📦 Publish aarch64-tmks
       uses: actions/upload-artifact@v7
       with:
-        name: x64-tmks
-        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
+        name: aarch64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
         include-hidden-files: true
   job9:
-    name: build artifacts (for VMM tests) [x64-linux]
+    name: build artifacts (for VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7217,26 +7598,22 @@ jobs:
         cat <<'EOF' | flowey v 9 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 9 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 9 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 9 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 9 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 9 flowey_lib_common::install_rust 0
@@ -7285,22 +7662,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 9 flowey_lib_common::cache 4
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 9 flowey_lib_common::cache 0
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 9 flowey_lib_common::cache 6
+        flowey e 9 flowey_lib_common::cache 2
         flowey e 9 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -7311,7 +7688,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7324,7 +7701,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 5
         flowey e 9 flowey_lib_hvlite::build_openvmm 0
         flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7337,7 +7714,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 9
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -7350,20 +7727,16 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 14
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_build 6
         flowey e 9 flowey_lib_hvlite::run_cargo_build 12
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      shell: bash
-    - name: test vmgs_lib
-      run: |-
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 9 flowey_core::pipeline::artifact::publish 3
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -7376,7 +7749,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -7393,10 +7766,10 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7409,7 +7782,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
         flowey e 9 flowey_lib_hvlite::build_openvmm 1
         flowey e 9 flowey_core::pipeline::artifact::publish 6
-        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7423,117 +7796,54 @@ jobs:
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 9 flowey_core::pipeline::artifact::publish 7
       shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 9 flowey_lib_common::download_cargo_nextest 0
-        flowey e 9 flowey_lib_common::download_cargo_nextest 1
-        flowey e 9 flowey_lib_common::download_cargo_nextest 2
-        flowey e 9 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 9 flowey_lib_common::cache 2
-        flowey e 9 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 9 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 9 flowey_lib_common::install_cargo_nextest 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 8
-        flowey e 9 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 1
-        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
-        flowey e 9 flowey_core::pipeline::artifact::publish 9
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
+    - name: 'validate cache entry: gh-release-download'
       run: flowey e 9 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 9 flowey_lib_common::cache 7
-      shell: bash
-    - name: 🌼📦 Publish x64-linux-igvmfilegen
+    - name: 🌼📦 Publish aarch64-linux-igvmfilegen
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        name: aarch64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        name: aarch64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
+        name: aarch64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+    - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
+        name: aarch64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
+    - name: 🌼📦 Publish aarch64-linux-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
+        name: aarch64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm
+    - name: 🌼📦 Publish aarch64-linux-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
+        name: aarch64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm_vhost
+    - name: 🌼📦 Publish aarch64-linux-vmgs_lib
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        name: aarch64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgs_lib
+    - name: 🌼📦 Publish aarch64-linux-vmgstool
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
+        name: aarch64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
         include-hidden-files: true

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -392,12 +392,584 @@ jobs:
       run: flowey.exe e 1 flowey_lib_common::cache 3
       shell: bash
   job10:
+    name: build openhcl [aarch64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 10 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 10 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 10 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 10 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 10 flowey_lib_common::cache 0
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 10 flowey_lib_common::cache 2
+        flowey e 10 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (aarch64)
+      run: flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 10 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 10 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 10 flowey_lib_common::install_rust 2
+        flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 10 flowey_lib_common::git_checkout 0
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 10 flowey_lib_common::git_checkout 3
+        flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 10 flowey_lib_common::resolve_protoc 0
+        flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 10 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 10 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish aarch64-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
+        include-hidden-files: true
+  job11:
+    name: build openhcl [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 11 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 11 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 11 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 11 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 11 flowey_lib_common::cache 0
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 11 flowey_lib_common::cache 2
+        flowey e 11 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 11 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 11 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 11 flowey_lib_common::install_rust 2
+        flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 11 flowey_lib_common::git_checkout 0
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 11 flowey_lib_common::git_checkout 3
+        flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 11 flowey_lib_common::resolve_protoc 0
+        flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build sidecar
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 11 flowey_lib_hvlite::build_sidecar 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 11 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 4
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 11 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 11 flowey_lib_common::copy_to_artifact_dir 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 11 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish x64-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
+        include-hidden-files: true
+  job12:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -465,29 +1037,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 10 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 10 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 12 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 12 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 10 'verbose' update
+        cat <<'EOF' | flowey.exe v 12 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 10 flowey_lib_common::install_rust 0
+      run: flowey.exe e 12 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 10 flowey_lib_common::install_rust 1
+      run: flowey.exe e 12 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 10 flowey_lib_common::install_rust 2
-        flowey.exe e 10 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 12 flowey_lib_common::install_rust 2
+        flowey.exe e 12 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 10 flowey_lib_common::git_checkout 0
-        flowey.exe v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 12 flowey_lib_common::git_checkout 0
+        flowey.exe v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -499,23 +1071,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 10 flowey_lib_common::git_checkout 3
-        flowey.exe e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 12 flowey_lib_common::git_checkout 3
+        flowey.exe e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 10 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 12 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 10 flowey_lib_common::cache 4
-        flowey.exe v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 12 flowey_lib_common::cache 4
+        flowey.exe v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -525,50 +1097,50 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 10 flowey_lib_common::cache 6
-        flowey.exe e 10 flowey_lib_common::download_gh_release 1
+        flowey.exe e 12 flowey_lib_common::cache 6
+        flowey.exe e 12 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 10 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 12 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 10 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 10 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 10 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 10 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 10 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 12 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 12 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 10 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 10 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 10 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 10 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 10 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 10 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 10 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 10 flowey_lib_common::cache 0
-        flowey.exe v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe e 12 flowey_lib_common::cache 0
+        flowey.exe v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -578,45 +1150,45 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 10 flowey_lib_common::cache 2
-        flowey.exe e 10 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 12 flowey_lib_common::cache 2
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 10 flowey_lib_common::install_rust 3
+      run: flowey.exe e 12 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 10 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 10 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 12 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 10 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 10 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 10 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 12 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 12 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
       run: |-
-        flowey.exe e 10 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 10 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 10 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 10 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 10 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 10 flowey_lib_common::publish_test_results 5
-        flowey.exe e 10 flowey_lib_common::publish_test_results 6
-        flowey.exe e 10 flowey_lib_common::publish_test_results 4
-        flowey.exe v 10 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 10 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 12 flowey_lib_common::publish_test_results 5
+        flowey.exe e 12 flowey_lib_common::publish_test_results 6
+        flowey.exe e 12 flowey_lib_common::publish_test_results 4
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -626,18 +1198,18 @@ jobs:
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 10 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 10 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 10 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 10 flowey_lib_common::publish_test_results 0
-        flowey.exe e 10 flowey_lib_common::publish_test_results 1
-        flowey.exe e 10 flowey_lib_common::publish_test_results 2
-        flowey.exe v 10 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 10 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 12 flowey_lib_common::publish_test_results 0
+        flowey.exe e 12 flowey_lib_common::publish_test_results 1
+        flowey.exe e 12 flowey_lib_common::publish_test_results 2
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -648,25 +1220,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 10 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 10 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
-      run: flowey.exe e 10 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 10 flowey_lib_common::cache 3
+      run: flowey.exe e 12 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 10 flowey_lib_common::cache 7
+      run: flowey.exe e 12 flowey_lib_common::cache 7
       shell: bash
-  job11:
+  job13:
     name: clippy [macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -690,35 +1262,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 11 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 11 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 13 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 13 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 11 'verbose' update
+        cat <<'EOF' | flowey v 13 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 11 flowey_lib_common::install_rust 0
+      run: flowey e 13 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 11 flowey_lib_common::install_rust 1
+      run: flowey e 13 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 11 flowey_lib_common::install_rust 2
-        flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 13 flowey_lib_common::install_rust 2
+        flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::git_checkout 0
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -730,23 +1302,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 11 flowey_lib_common::git_checkout 3
-        flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 13 flowey_lib_common::git_checkout 3
+        flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 11 flowey_lib_common::download_gh_release 0
+      run: flowey e 13 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 11 flowey_lib_common::cache 4
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey e 13 flowey_lib_common::cache 4
+        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -756,54 +1328,54 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 11 flowey_lib_common::cache 6
-        flowey e 11 flowey_lib_common::download_gh_release 1
+        flowey e 13 flowey_lib_common::cache 6
+        flowey e 13 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 11 flowey_lib_common::resolve_protoc 0
-        flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 13 flowey_lib_common::resolve_protoc 0
+        flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 0
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 13 flowey_lib_common::run_cargo_build 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 11 flowey_lib_hvlite::build_xtask 0
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 11 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 11 flowey_lib_common::download_cargo_nextest 0
-        flowey e 11 flowey_lib_common::download_cargo_nextest 1
-        flowey e 11 flowey_lib_common::download_cargo_nextest 2
-        flowey e 11 flowey_lib_common::download_cargo_nextest 3
+        flowey e 13 flowey_lib_common::download_cargo_nextest 0
+        flowey e 13 flowey_lib_common::download_cargo_nextest 1
+        flowey e 13 flowey_lib_common::download_cargo_nextest 2
+        flowey e 13 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey e 13 flowey_lib_common::cache 0
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -813,34 +1385,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 11 flowey_lib_common::cache 2
-        flowey e 11 flowey_lib_common::download_cargo_nextest 4
+        flowey e 13 flowey_lib_common::cache 2
+        flowey e 13 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 11 flowey_lib_common::install_rust 3
+      run: flowey e 13 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 11 flowey_lib_common::install_cargo_nextest 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 0
-        flowey e 11 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 13 flowey_lib_common::install_cargo_nextest 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 11 flowey_lib_common::publish_test_results 5
-        flowey e 11 flowey_lib_common::publish_test_results 6
-        flowey e 11 flowey_lib_common::publish_test_results 4
-        flowey v 11 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 11 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 13 flowey_lib_common::publish_test_results 5
+        flowey e 13 flowey_lib_common::publish_test_results 6
+        flowey e 13 flowey_lib_common::publish_test_results 4
+        flowey v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -850,18 +1422,18 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 11 flowey_lib_common::publish_test_results 8
-        flowey e 11 flowey_lib_common::publish_test_results 9
-        flowey e 11 flowey_lib_common::publish_test_results 10
-        flowey v 11 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 11 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 13 flowey_lib_common::publish_test_results 8
+        flowey e 13 flowey_lib_common::publish_test_results 9
+        flowey e 13 flowey_lib_common::publish_test_results 10
+        flowey v 13 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 13 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -872,32 +1444,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 11 flowey_lib_hvlite::init_cross_build 2
-        flowey e 11 flowey_lib_common::run_cargo_build 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 13 flowey_lib_hvlite::init_cross_build 2
+        flowey e 13 flowey_lib_common::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 11 flowey_lib_hvlite::build_xtask 1
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 13 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 11 flowey_lib_common::publish_test_results 12
-        flowey e 11 flowey_lib_common::publish_test_results 13
-        flowey e 11 flowey_lib_common::publish_test_results 14
-        flowey v 11 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 11 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 13 flowey_lib_common::publish_test_results 12
+        flowey e 13 flowey_lib_common::publish_test_results 13
+        flowey e 13 flowey_lib_common::publish_test_results 14
+        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -907,18 +1479,18 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 11 flowey_lib_common::publish_test_results 0
-        flowey e 11 flowey_lib_common::publish_test_results 1
-        flowey e 11 flowey_lib_common::publish_test_results 2
-        flowey v 11 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 11 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 13 flowey_lib_common::publish_test_results 0
+        flowey e 13 flowey_lib_common::publish_test_results 1
+        flowey e 13 flowey_lib_common::publish_test_results 2
+        flowey v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -929,25 +1501,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
-      run: flowey e 11 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 11 flowey_lib_common::cache 3
+      run: flowey e 13 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 11 flowey_lib_common::cache 7
+      run: flowey e 13 flowey_lib_common::cache 7
       shell: bash
-  job12:
+  job14:
     name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -971,29 +1543,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 12 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 14 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 14 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 12 'verbose' update
+        cat <<'EOF' | flowey v 14 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 12 flowey_lib_common::install_rust 0
+      run: flowey e 14 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 12 flowey_lib_common::install_rust 1
+      run: flowey e 14 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 12 flowey_lib_common::install_rust 2
-        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 14 flowey_lib_common::install_rust 2
+        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::git_checkout 0
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1005,27 +1577,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 12 flowey_lib_common::git_checkout 3
-        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 14 flowey_lib_common::git_checkout 3
+        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 12 flowey_lib_common::download_gh_release 0
+      run: flowey e 14 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 12 flowey_lib_common::cache 4
-        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 14 flowey_lib_common::cache 4
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1035,78 +1607,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 12 flowey_lib_common::cache 6
-        flowey e 12 flowey_lib_common::download_gh_release 1
+        flowey e 14 flowey_lib_common::cache 6
+        flowey e 14 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 12 flowey_lib_common::resolve_protoc 0
+      run: flowey e 14 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 2
+        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_clippy 5
-        flowey e 12 flowey_lib_hvlite::init_cross_build 0
+        flowey e 14 flowey_lib_common::run_cargo_clippy 5
+        flowey e 14 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 0
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 14 flowey_lib_common::run_cargo_build 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 12 flowey_lib_hvlite::build_xtask 0
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 14 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 12 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 14 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 12 flowey_lib_common::download_cargo_nextest 0
-        flowey e 12 flowey_lib_common::download_cargo_nextest 1
-        flowey e 12 flowey_lib_common::download_cargo_nextest 2
-        flowey e 12 flowey_lib_common::download_cargo_nextest 3
+        flowey e 14 flowey_lib_common::download_cargo_nextest 0
+        flowey e 14 flowey_lib_common::download_cargo_nextest 1
+        flowey e 14 flowey_lib_common::download_cargo_nextest 2
+        flowey e 14 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 14 flowey_lib_common::cache 0
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1116,34 +1688,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 12 flowey_lib_common::cache 2
-        flowey e 12 flowey_lib_common::download_cargo_nextest 4
+        flowey e 14 flowey_lib_common::cache 2
+        flowey e 14 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 12 flowey_lib_common::install_rust 3
+      run: flowey e 14 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 12 flowey_lib_common::install_cargo_nextest 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 3
-        flowey e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::install_cargo_nextest 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 3
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 12 flowey_lib_common::publish_test_results 5
-        flowey e 12 flowey_lib_common::publish_test_results 6
-        flowey e 12 flowey_lib_common::publish_test_results 4
-        flowey v 12 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 12 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 14 flowey_lib_common::publish_test_results 5
+        flowey e 14 flowey_lib_common::publish_test_results 6
+        flowey e 14 flowey_lib_common::publish_test_results 4
+        flowey v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1153,18 +1725,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 12 flowey_lib_common::publish_test_results 8
-        flowey e 12 flowey_lib_common::publish_test_results 9
-        flowey e 12 flowey_lib_common::publish_test_results 10
-        flowey v 12 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 14 flowey_lib_common::publish_test_results 8
+        flowey e 14 flowey_lib_common::publish_test_results 9
+        flowey e 14 flowey_lib_common::publish_test_results 10
+        flowey v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -1174,18 +1746,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 12 flowey_lib_common::publish_test_results 12
-        flowey e 12 flowey_lib_common::publish_test_results 13
-        flowey e 12 flowey_lib_common::publish_test_results 14
-        flowey v 12 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 12 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 14 flowey_lib_common::publish_test_results 12
+        flowey e 14 flowey_lib_common::publish_test_results 13
+        flowey e 14 flowey_lib_common::publish_test_results 14
+        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -1195,18 +1767,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 12 flowey_lib_common::publish_test_results 16
-        flowey e 12 flowey_lib_common::publish_test_results 17
-        flowey e 12 flowey_lib_common::publish_test_results 18
-        flowey v 12 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 12 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 14 flowey_lib_common::publish_test_results 16
+        flowey e 14 flowey_lib_common::publish_test_results 17
+        flowey e 14 flowey_lib_common::publish_test_results 18
+        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -1217,32 +1789,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 12 flowey_lib_hvlite::init_cross_build 1
-        flowey e 12 flowey_lib_common::run_cargo_build 1
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 14 flowey_lib_hvlite::init_cross_build 1
+        flowey e 14 flowey_lib_common::run_cargo_build 1
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 12 flowey_lib_hvlite::build_xtask 1
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 14 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 12 flowey_lib_common::publish_test_results 0
-        flowey e 12 flowey_lib_common::publish_test_results 1
-        flowey e 12 flowey_lib_common::publish_test_results 2
-        flowey v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 14 flowey_lib_common::publish_test_results 0
+        flowey e 14 flowey_lib_common::publish_test_results 1
+        flowey e 14 flowey_lib_common::publish_test_results 2
+        flowey v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1253,25 +1825,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 12 flowey_lib_common::cache 3
+      run: flowey e 14 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 12 flowey_lib_common::cache 7
+      run: flowey e 14 flowey_lib_common::cache 7
       shell: bash
-  job13:
+  job15:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=win-arm64
-    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1339,29 +1911,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 13 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 13 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 13 'verbose' update
+        cat <<'EOF' | flowey.exe v 15 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 13 flowey_lib_common::install_rust 0
+      run: flowey.exe e 15 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 13 flowey_lib_common::install_rust 1
+      run: flowey.exe e 15 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 13 flowey_lib_common::install_rust 2
-        flowey.exe e 13 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 15 flowey_lib_common::install_rust 2
+        flowey.exe e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 13 flowey_lib_common::git_checkout 0
-        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::git_checkout 0
+        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1373,23 +1945,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 13 flowey_lib_common::git_checkout 3
-        flowey.exe e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 15 flowey_lib_common::git_checkout 3
+        flowey.exe e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 13 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 15 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 13 flowey_lib_common::cache 4
-        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 15 flowey_lib_common::cache 4
+        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1399,50 +1971,50 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 13 flowey_lib_common::cache 6
-        flowey.exe e 13 flowey_lib_common::download_gh_release 1
+        flowey.exe e 15 flowey_lib_common::cache 6
+        flowey.exe e 15 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 13 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 15 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 13 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 13 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 13 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 15 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 15 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 13 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 13 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 13 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 13 flowey_lib_common::cache 0
-        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe e 15 flowey_lib_common::cache 0
+        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1452,45 +2024,45 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 13 flowey_lib_common::cache 2
-        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 15 flowey_lib_common::cache 2
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 13 flowey_lib_common::install_rust 3
+      run: flowey.exe e 15 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 13 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 15 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 13 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 13 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 13 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 15 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
       run: |-
-        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 13 flowey_lib_common::publish_test_results 5
-        flowey.exe e 13 flowey_lib_common::publish_test_results 6
-        flowey.exe e 13 flowey_lib_common::publish_test_results 4
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 15 flowey_lib_common::publish_test_results 5
+        flowey.exe e 15 flowey_lib_common::publish_test_results 6
+        flowey.exe e 15 flowey_lib_common::publish_test_results 4
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1500,18 +2072,18 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 13 flowey_lib_common::publish_test_results 0
-        flowey.exe e 13 flowey_lib_common::publish_test_results 1
-        flowey.exe e 13 flowey_lib_common::publish_test_results 2
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 15 flowey_lib_common::publish_test_results 0
+        flowey.exe e 15 flowey_lib_common::publish_test_results 1
+        flowey.exe e 15 flowey_lib_common::publish_test_results 2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1522,25 +2094,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
-      run: flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 13 flowey_lib_common::cache 3
+      run: flowey.exe e 15 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 13 flowey_lib_common::cache 7
+      run: flowey.exe e 15 flowey_lib_common::cache 7
       shell: bash
-  job14:
+  job16:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1608,35 +2180,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 14 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 14 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 14 'verbose' update
+        cat <<'EOF' | flowey v 16 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 14 flowey_lib_common::install_rust 0
+      run: flowey e 16 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 14 flowey_lib_common::install_rust 1
+      run: flowey e 16 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 14 flowey_lib_common::install_rust 2
-        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 16 flowey_lib_common::install_rust 2
+        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::git_checkout 0
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1648,23 +2220,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 14 flowey_lib_common::git_checkout 3
-        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 16 flowey_lib_common::git_checkout 3
+        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 14 flowey_lib_common::download_gh_release 0
+      run: flowey e 16 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey e 16 flowey_lib_common::cache 4
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1674,61 +2246,61 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 14 flowey_lib_common::cache 6
-        flowey e 14 flowey_lib_common::download_gh_release 1
+        flowey e 16 flowey_lib_common::cache 6
+        flowey e 16 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 14 flowey_lib_common::resolve_protoc 0
-        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 16 flowey_lib_common::resolve_protoc 0
+        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 2
+        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_build 0
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 16 flowey_lib_common::run_cargo_build 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 14 flowey_lib_hvlite::build_xtask 0
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 14 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 14 flowey_lib_common::download_cargo_nextest 0
-        flowey e 14 flowey_lib_common::download_cargo_nextest 1
-        flowey e 14 flowey_lib_common::download_cargo_nextest 2
-        flowey e 14 flowey_lib_common::download_cargo_nextest 3
+        flowey e 16 flowey_lib_common::download_cargo_nextest 0
+        flowey e 16 flowey_lib_common::download_cargo_nextest 1
+        flowey e 16 flowey_lib_common::download_cargo_nextest 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey e 16 flowey_lib_common::cache 0
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1738,34 +2310,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 14 flowey_lib_common::cache 2
-        flowey e 14 flowey_lib_common::download_cargo_nextest 4
+        flowey e 16 flowey_lib_common::cache 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 14 flowey_lib_common::install_rust 3
+      run: flowey e 16 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 14 flowey_lib_common::install_cargo_nextest 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::install_cargo_nextest 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 14 flowey_lib_common::publish_test_results 5
-        flowey e 14 flowey_lib_common::publish_test_results 6
-        flowey e 14 flowey_lib_common::publish_test_results 4
-        flowey v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 16 flowey_lib_common::publish_test_results 5
+        flowey e 16 flowey_lib_common::publish_test_results 6
+        flowey e 16 flowey_lib_common::publish_test_results 4
+        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1775,18 +2347,18 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 14 flowey_lib_common::publish_test_results 8
-        flowey e 14 flowey_lib_common::publish_test_results 9
-        flowey e 14 flowey_lib_common::publish_test_results 10
-        flowey v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 16 flowey_lib_common::publish_test_results 8
+        flowey e 16 flowey_lib_common::publish_test_results 9
+        flowey e 16 flowey_lib_common::publish_test_results 10
+        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -1797,32 +2369,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_hvlite::init_cross_build 3
-        flowey e 14 flowey_lib_common::run_cargo_build 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 16 flowey_lib_hvlite::init_cross_build 3
+        flowey e 16 flowey_lib_common::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 14 flowey_lib_hvlite::build_xtask 1
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 16 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 14 flowey_lib_common::publish_test_results 12
-        flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey e 14 flowey_lib_common::publish_test_results 14
-        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey e 16 flowey_lib_common::publish_test_results 13
+        flowey e 16 flowey_lib_common::publish_test_results 14
+        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -1832,18 +2404,18 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 14 flowey_lib_common::publish_test_results 0
-        flowey e 14 flowey_lib_common::publish_test_results 1
-        flowey e 14 flowey_lib_common::publish_test_results 2
-        flowey v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 16 flowey_lib_common::publish_test_results 0
+        flowey e 16 flowey_lib_common::publish_test_results 1
+        flowey e 16 flowey_lib_common::publish_test_results 2
+        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1854,25 +2426,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 14 flowey_lib_common::cache 3
+      run: flowey e 16 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 14 flowey_lib_common::cache 7
+      run: flowey e 16 flowey_lib_common::cache 7
       shell: bash
-  job15:
+  job17:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1940,29 +2512,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 15 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 17 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 17 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 15 'verbose' update
+        cat <<'EOF' | flowey v 17 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 15 flowey_lib_common::install_rust 0
+      run: flowey e 17 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 15 flowey_lib_common::install_rust 1
+      run: flowey e 17 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 15 flowey_lib_common::install_rust 2
-        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 17 flowey_lib_common::install_rust 2
+        flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::git_checkout 0
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1974,27 +2546,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 15 flowey_lib_common::git_checkout 3
-        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 17 flowey_lib_common::git_checkout 3
+        flowey e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 15 flowey_lib_common::download_gh_release 0
+      run: flowey e 17 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 17 flowey_lib_common::cache 4
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2004,78 +2576,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 15 flowey_lib_common::cache 6
-        flowey e 15 flowey_lib_common::download_gh_release 1
+        flowey e 17 flowey_lib_common::cache 6
+        flowey e 17 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 15 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 15 flowey_lib_common::resolve_protoc 0
+      run: flowey e 17 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 2
+        flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_clippy 5
-        flowey e 15 flowey_lib_hvlite::init_cross_build 0
+        flowey e 17 flowey_lib_common::run_cargo_clippy 5
+        flowey e 17 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_build 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 17 flowey_lib_common::run_cargo_build 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 15 flowey_lib_hvlite::build_xtask 0
+        flowey e 17 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 17 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 17 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 15 flowey_lib_common::download_cargo_nextest 0
-        flowey e 15 flowey_lib_common::download_cargo_nextest 1
-        flowey e 15 flowey_lib_common::download_cargo_nextest 2
-        flowey e 15 flowey_lib_common::download_cargo_nextest 3
+        flowey e 17 flowey_lib_common::download_cargo_nextest 0
+        flowey e 17 flowey_lib_common::download_cargo_nextest 1
+        flowey e 17 flowey_lib_common::download_cargo_nextest 2
+        flowey e 17 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 17 flowey_lib_common::cache 0
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2085,34 +2657,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 15 flowey_lib_common::cache 2
-        flowey e 15 flowey_lib_common::download_cargo_nextest 4
+        flowey e 17 flowey_lib_common::cache 2
+        flowey e 17 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 15 flowey_lib_common::install_rust 3
+      run: flowey e 17 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 15 flowey_lib_common::install_cargo_nextest 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 3
-        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::install_cargo_nextest 0
+        flowey e 17 flowey_lib_hvlite::init_cross_build 3
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 15 flowey_lib_common::publish_test_results 5
-        flowey e 15 flowey_lib_common::publish_test_results 6
-        flowey e 15 flowey_lib_common::publish_test_results 4
-        flowey v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 17 flowey_lib_common::publish_test_results 5
+        flowey e 17 flowey_lib_common::publish_test_results 6
+        flowey e 17 flowey_lib_common::publish_test_results 4
+        flowey v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2122,18 +2694,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 15 flowey_lib_common::publish_test_results 8
-        flowey e 15 flowey_lib_common::publish_test_results 9
-        flowey e 15 flowey_lib_common::publish_test_results 10
-        flowey v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 17 flowey_lib_common::publish_test_results 8
+        flowey e 17 flowey_lib_common::publish_test_results 9
+        flowey e 17 flowey_lib_common::publish_test_results 10
+        flowey v 17 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 17 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2143,18 +2715,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 15 flowey_lib_common::publish_test_results 12
-        flowey e 15 flowey_lib_common::publish_test_results 13
-        flowey e 15 flowey_lib_common::publish_test_results 14
-        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 17 flowey_lib_common::publish_test_results 12
+        flowey e 17 flowey_lib_common::publish_test_results 13
+        flowey e 17 flowey_lib_common::publish_test_results 14
+        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -2164,18 +2736,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 15 flowey_lib_common::publish_test_results 16
-        flowey e 15 flowey_lib_common::publish_test_results 17
-        flowey e 15 flowey_lib_common::publish_test_results 18
-        flowey v 15 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 17 flowey_lib_common::publish_test_results 16
+        flowey e 17 flowey_lib_common::publish_test_results 17
+        flowey e 17 flowey_lib_common::publish_test_results 18
+        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -2186,32 +2758,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 15 flowey_lib_hvlite::init_cross_build 1
-        flowey e 15 flowey_lib_common::run_cargo_build 1
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 17 flowey_lib_hvlite::init_cross_build 1
+        flowey e 17 flowey_lib_common::run_cargo_build 1
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 15 flowey_lib_hvlite::build_xtask 1
+        flowey e 17 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 17 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 15 flowey_lib_common::publish_test_results 0
-        flowey e 15 flowey_lib_common::publish_test_results 1
-        flowey e 15 flowey_lib_common::publish_test_results 2
-        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 17 flowey_lib_common::publish_test_results 0
+        flowey e 17 flowey_lib_common::publish_test_results 1
+        flowey e 17 flowey_lib_common::publish_test_results 2
+        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2222,559 +2794,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
-      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 15 flowey_lib_common::cache 3
+      run: flowey e 17 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 15 flowey_lib_common::cache 7
+      run: flowey e 17 flowey_lib_common::cache 7
       shell: bash
-  job16:
+  job18:
     name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job5
-    - job7
-    - job9
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 16 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 16 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 16 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 16 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 16 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 16 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 16 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 16 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 16 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 16 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 16 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 16 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 16 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 16 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 16 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 16 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 16 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 16 flowey_lib_common::cache 0
-        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 16 flowey_lib_common::cache 2
-        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 16 flowey_lib_common::git_checkout 0
-        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 16 flowey_lib_common::git_checkout 3
-        flowey.exe e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 16 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 16 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 16 flowey_lib_common::cache 8
-        flowey.exe v 16 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 16 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 16 flowey_lib_common::cache 10
-        flowey.exe e 16 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 16 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 16 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 16 flowey_lib_common::cache 4
-        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 16 flowey_lib_common::cache 6
-        flowey.exe e 16 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 16 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 16 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 16 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 16 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 16 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 16 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 16 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 16 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 16 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 16 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 16 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 16 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 16 flowey_lib_common::publish_test_results 4
-        flowey.exe e 16 flowey_lib_common::publish_test_results 5
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 16 flowey_lib_common::publish_test_results 0
-        flowey.exe e 16 flowey_lib_common::publish_test_results 1
-        flowey.exe e 16 flowey_lib_common::publish_test_results 2
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 16 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 16 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 16 flowey_lib_common::cache 11
-      shell: bash
-  job17:
-    name: run vmm-tests [x64-windows-intel-tdx]
-    runs-on:
-    - self-hosted
-    - Windows
-    - X64
-    - TDX
-    - Baremetal
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job5
-    - job7
-    - job9
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 17 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 17 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 17 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 17 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 17 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 17 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 17 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 17 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 17 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 17 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 17 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 17 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 17 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 17 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 17 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 17 flowey_lib_common::cache 0
-        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 17 flowey_lib_common::cache 2
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 17 flowey_lib_common::git_checkout 0
-        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 17 flowey_lib_common::git_checkout 3
-        flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 17 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 17 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 17 flowey_lib_common::cache 8
-        flowey.exe v 17 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 17 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 17 flowey_lib_common::cache 10
-        flowey.exe e 17 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 17 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 17 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 17 flowey_lib_common::cache 4
-        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 17 flowey_lib_common::cache 6
-        flowey.exe e 17 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 17 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 17 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 17 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 17 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 17 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 17 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 17 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 17 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 17 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 17 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 17 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 17 flowey_lib_common::publish_test_results 4
-        flowey.exe e 17 flowey_lib_common::publish_test_results 5
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-tdx-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 17 flowey_lib_common::publish_test_results 0
-        flowey.exe e 17 flowey_lib_common::publish_test_results 1
-        flowey.exe e 17 flowey_lib_common::publish_test_results 2
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-tdx-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 17 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 17 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 17 flowey_lib_common::cache 11
-      shell: bash
-  job18:
-    name: run vmm-tests [x64-windows-amd]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
     - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -2782,9 +2818,9 @@ jobs:
       id-token: write
     needs:
     - job0
+    - job11
     - job5
-    - job7
-    - job9
+    - job8
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -3003,9 +3039,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-logs
+        name: x64-windows-intel-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3019,9 +3055,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-junit-xml
+        name: x64-windows-intel-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -3036,28 +3072,29 @@ jobs:
       run: flowey.exe e 18 flowey_lib_common::cache 11
       shell: bash
   job19:
-    name: run vmm-tests [x64-linux-amd-kvm]
+    name: run vmm-tests [x64-windows-intel-tdx]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - Windows
+    - X64
+    - TDX
+    - Baremetal
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
+    - job11
     - job5
-    - job7
-    - job9
+    - job8
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-1,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
     - name: 🌼🛫 Initialize job
@@ -3066,139 +3103,41 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
 
-        echo '"debug"' | flowey v 19 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 19 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 19 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 19 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 19 'verbose' update
+        cat <<'EOF' | flowey.exe v 19 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 19 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 19 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 19 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 19 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 19 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 19 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      shell: bash
-    - name: creating new test content dir
-      run: |-
-        flowey e 19 flowey_core::pipeline::artifact::resolve 3
-        flowey e 19 flowey_core::pipeline::artifact::resolve 4
-        flowey e 19 flowey_core::pipeline::artifact::resolve 7
-        flowey e 19 flowey_core::pipeline::artifact::resolve 1
-        flowey e 19 flowey_core::pipeline::artifact::resolve 0
-        flowey e 19 flowey_core::pipeline::artifact::resolve 2
-        flowey e 19 flowey_core::pipeline::artifact::resolve 6
-        flowey e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 19 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 19 flowey_lib_common::cache 8
-        flowey v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey e 19 flowey_lib_common::cache 10
-        flowey e 19 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey e 19 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 19 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 19 flowey_lib_common::cache 4
-        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 19 flowey_lib_common::cache 6
-        flowey e 19 flowey_lib_common::download_gh_cli 1
-        flowey v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey e 19 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey e 19 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey e 19 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey e 19 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: flowey e 19 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 19 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 19 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 19 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 19 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 19 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 19 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 19 flowey_lib_common::download_cargo_nextest 0
-        flowey e 19 flowey_lib_common::download_cargo_nextest 1
-        flowey e 19 flowey_lib_common::download_cargo_nextest 2
-        flowey e 19 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 19 flowey_lib_common::cache 0
-        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 19 flowey_lib_common::cache 0
+        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3208,17 +3147,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 19 flowey_lib_common::cache 2
-        flowey e 19 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 19 flowey_lib_common::cache 2
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 19 flowey_lib_common::git_checkout 0
-        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 19 flowey_lib_common::git_checkout 0
+        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3230,67 +3169,178 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 19 flowey_lib_common::git_checkout 3
-        flowey e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 19 flowey_core::pipeline::artifact::resolve 5
-        flowey e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey.exe e 19 flowey_lib_common::git_checkout 3
+        flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 19 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 8
+        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 19 flowey_lib_common::cache 10
+        flowey.exe e 19 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 19 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 19 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 4
+        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 19 flowey_lib_common::cache 6
+        flowey.exe e 19 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 19 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 19 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 19 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 19 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 19 flowey_lib_common::publish_test_results 4
-        flowey e 19 flowey_lib_common::publish_test_results 5
-        flowey v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 19 flowey_lib_common::publish_test_results 4
+        flowey.exe e 19 flowey_lib_common::publish_test_results 5
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-logs
+        name: x64-windows-intel-tdx-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 19 flowey_lib_common::publish_test_results 0
-        flowey e 19 flowey_lib_common::publish_test_results 1
-        flowey e 19 flowey_lib_common::publish_test_results 2
-        flowey v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 19 flowey_lib_common::publish_test_results 0
+        flowey.exe e 19 flowey_lib_common::publish_test_results 1
+        flowey.exe e 19 flowey_lib_common::publish_test_results 2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        name: x64-windows-intel-tdx-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 19 flowey_lib_common::cache 3
+      run: flowey.exe e 19 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 19 flowey_lib_common::cache 7
+      run: flowey.exe e 19 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 19 flowey_lib_common::cache 11
+      run: flowey.exe e 19 flowey_lib_common::cache 11
       shell: bash
   job2:
     name: build artifacts (not for VMM tests) [aarch64-windows]
@@ -3510,214 +3560,71 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-linux-intel-mshv]
+    name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=azurelinux3-amd64-dom0
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
+    - job11
     - job5
-    - job7
-    - job9
+    - job8
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
-    - run: |
-        set -x
-        sudo tdnf install -y gcc glibc-devel
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr-release.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr-release.yaml ci checkin-gates --config=pr-release
-      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
 
-        echo '"debug"' | flowey v 20 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 20 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 20 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 20 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 20 'verbose' update
+        cat <<'EOF' | flowey.exe v 20 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 20 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 20 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 20 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 20 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 20 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 20 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 20 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 20 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      shell: bash
-    - name: creating new test content dir
-      run: |-
-        flowey e 20 flowey_core::pipeline::artifact::resolve 7
-        flowey e 20 flowey_core::pipeline::artifact::resolve 3
-        flowey e 20 flowey_core::pipeline::artifact::resolve 0
-        flowey e 20 flowey_core::pipeline::artifact::resolve 4
-        flowey e 20 flowey_core::pipeline::artifact::resolve 6
-        flowey e 20 flowey_core::pipeline::artifact::resolve 1
-        flowey e 20 flowey_core::pipeline::artifact::resolve 2
-        flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 20 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 20 flowey_lib_common::cache 8
-        flowey v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey e 20 flowey_lib_common::cache 10
-        flowey e 20 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey e 20 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 20 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 20 flowey_lib_common::cache 4
-        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 20 flowey_lib_common::cache 6
-        flowey e 20 flowey_lib_common::download_gh_cli 1
-        flowey v 20 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey e 20 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey e 20 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey e 20 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey e 20 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: flowey e 20 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 20 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 20 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 20 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 20 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 20 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 20 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 20 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 20 flowey_lib_common::download_cargo_nextest 0
-        flowey e 20 flowey_lib_common::download_cargo_nextest 1
-        flowey e 20 flowey_lib_common::download_cargo_nextest 2
-        flowey e 20 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 20 flowey_lib_common::cache 0
-        flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 20 flowey_lib_common::cache 0
+        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3727,17 +3634,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 20 flowey_lib_common::cache 2
-        flowey e 20 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 20 flowey_lib_common::cache 2
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 20 flowey_lib_common::git_checkout 0
-        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 20 flowey_lib_common::git_checkout 0
+        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3749,148 +3656,207 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 20 flowey_lib_common::git_checkout 3
-        flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 20 flowey_core::pipeline::artifact::resolve 5
-        flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey.exe e 20 flowey_lib_common::git_checkout 3
+        flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 20 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 20 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 20 flowey_lib_common::cache 8
+        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::cache 10
+        flowey.exe e 20 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 20 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 20 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 20 flowey_lib_common::cache 4
+        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::cache 6
+        flowey.exe e 20 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 20 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 20 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 20 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 20 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 20 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 20 flowey_lib_hvlite::install_vmm_tests_deps 0
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 20 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 20 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 20 flowey_lib_common::publish_test_results 4
-        flowey e 20 flowey_lib_common::publish_test_results 5
-        flowey v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 20 flowey_lib_common::publish_test_results 4
+        flowey.exe e 20 flowey_lib_common::publish_test_results 5
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-intel-mshv-vmm-tests-logs
+        name: x64-windows-amd-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 20 flowey_lib_common::publish_test_results 0
-        flowey e 20 flowey_lib_common::publish_test_results 1
-        flowey e 20 flowey_lib_common::publish_test_results 2
-        flowey v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 20 flowey_lib_common::publish_test_results 0
+        flowey.exe e 20 flowey_lib_common::publish_test_results 1
+        flowey.exe e 20 flowey_lib_common::publish_test_results 2
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-intel-mshv-vmm-tests-junit-xml
+        name: x64-windows-amd-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 20 flowey_lib_common::cache 3
+      run: flowey.exe e 20 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 20 flowey_lib_common::cache 7
+      run: flowey.exe e 20 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 20 flowey_lib_common::cache 11
+      run: flowey.exe e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [aarch64-windows]
+    name: run vmm-tests [x64-windows-amd-snp]
     runs-on:
     - self-hosted
     - Windows
-    - ARM64
+    - X64
+    - SNP
     - Baremetal
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job3
-    - job6
+    - job11
+    - job5
     - job8
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-pc-windows-msvc --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr-release.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/aarch64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-linux-musl-tmk_vmm,aarch64-openhcl-igvm,aarch64-tmks,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-tmk_vmm,aarch64-windows-vmgstool,aarch64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-pr-release.yaml ci checkin-gates --config=pr-release
-      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
 
         echo '"debug"' | flowey.exe v 21 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey.exe v 21 '_internal_WORKING_DIR' --is-raw-string update
@@ -3898,16 +3864,20 @@ jobs:
         cat <<'EOF' | flowey.exe v 21 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 21 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 21 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 21 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 21 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 21 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 21 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 21 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 21 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 21 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -3958,14 +3928,17 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4048,14 +4021,14 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: unpack mu_msvm package (aarch64)
+    - name: unpack mu_msvm package (x64)
       run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
         flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4065,7 +4038,12 @@ jobs:
       run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4085,9 +4063,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-vmm-tests-logs
+        name: x64-windows-amd-snp-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-windows-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4101,9 +4079,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-vmm-tests-junit-xml
+        name: x64-windows-amd-snp-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4118,20 +4096,27 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
-    name: test flowey local backend
-    runs-on: ubuntu-latest
+    name: run vmm-tests [x64-linux-amd-kvm]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
+    - job5
+    - job8
+    - job9
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-1,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
@@ -4149,11 +4134,150 @@ jobs:
         cat <<'EOF' | flowey v 22 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 22 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 22 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 22 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 22 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey e 22 flowey_core::pipeline::artifact::resolve 7
+        flowey e 22 flowey_core::pipeline::artifact::resolve 1
+        flowey e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey e 22 flowey_core::pipeline::artifact::resolve 6
+        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 22 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 22 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 22 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 22 flowey_lib_common::cache 8
+        flowey v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 22 flowey_lib_common::cache 10
+        flowey e 22 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 22 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 22 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 22 flowey_lib_common::cache 4
+        flowey v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 22 flowey_lib_common::cache 6
+        flowey e 22 flowey_lib_common::download_gh_cli 1
+        flowey v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 22 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey e 22 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure hypervisor device is accessible
+      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: ensure 2 MiB hugetlb pages are available
+      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 22 flowey_lib_common::download_cargo_nextest 0
+        flowey e 22 flowey_lib_common::download_cargo_nextest 1
+        flowey e 22 flowey_lib_common::download_cargo_nextest 2
+        flowey e 22 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 22 flowey_lib_common::cache 0
+        flowey v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 22 flowey_lib_common::cache 2
+        flowey e 22 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 22 flowey_lib_common::git_checkout 0
-        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
         flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -4161,7 +4285,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -4171,52 +4295,143 @@ jobs:
         EOF
         flowey e 22 flowey_lib_common::git_checkout 3
         flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 22 flowey_core::pipeline::artifact::resolve 5
+        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
-    - name: add default cargo home to path
-      run: flowey e 22 flowey_lib_common::install_rust 0
+    - name: generate nextest command
+      run: flowey e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: install Rust
-      run: flowey e 22 flowey_lib_common::install_rust 1
+    - name: install vmm tests deps (linux)
+      run: flowey e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
-    - name: detect active toolchain
+    - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 22 flowey_lib_common::install_rust 2
-        flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
+        flowey e 22 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 22 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 22 flowey_lib_common::publish_test_results 4
+        flowey e 22 flowey_lib_common::publish_test_results 5
+        flowey v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 22 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 22 flowey_lib_common::publish_test_results 0
+        flowey e 22 flowey_lib_common::publish_test_results 1
+        flowey e 22 flowey_lib_common::publish_test_results 2
+        flowey v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 22 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 22 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 22 flowey_lib_common::cache 11
       shell: bash
   job23:
-    name: build openhcl (mi-secure) [x64-linux]
+    name: run vmm-tests [x64-linux-intel-mshv]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=azurelinux3-amd64-dom0
     - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
+    - job5
+    - job8
+    - job9
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
+    - run: |
+        set -x
+        sudo tdnf install -y gcc glibc-devel
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr-release.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr-release.yaml ci checkin-gates --config=pr-release
+      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
         echo '"debug"' | flowey v 23 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --is-raw-string update
@@ -4224,10 +4439,25 @@ jobs:
         cat <<'EOF' | flowey v 23 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 23 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 23 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 23 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 23 flowey_core::pipeline::artifact::resolve 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey e 23 flowey_core::pipeline::artifact::resolve 6
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 23 flowey_lib_common::install_dist_pkg 0
@@ -4240,37 +4470,111 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
+        flowey e 23 flowey_lib_common::cache 8
+        flowey v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 10
+        flowey e 23 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 23 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 23 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 23 flowey_lib_common::cache 4
+        flowey v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 6
+        flowey e 23 flowey_lib_common::download_gh_cli 1
+        flowey v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 23 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey e 23 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure hypervisor device is accessible
+      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 23 flowey_lib_common::download_cargo_nextest 0
+        flowey e 23 flowey_lib_common::download_cargo_nextest 1
+        flowey e 23 flowey_lib_common::download_cargo_nextest 2
+        flowey e 23 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
         flowey e 23 flowey_lib_common::cache 0
-        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
       run: |-
         flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 23 flowey_lib_common::cache 2
-        flowey e 23 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 23 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 23 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 23 flowey_lib_common::install_rust 2
-        flowey e 23 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 23 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
@@ -4293,213 +4597,143 @@ jobs:
         EOF
         flowey e 23 flowey_lib_common::git_checkout 3
         flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 5
+        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 23 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    - name: generate nextest command
+      run: flowey e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: unpack protoc
+    - name: install vmm tests deps (linux)
+      run: flowey e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 23 flowey_lib_common::resolve_protoc 0
-        flowey e 23 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 23 flowey_lib_common::publish_test_results 4
+        flowey e 23 flowey_lib_common::publish_test_results 5
+        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: symlink protoc
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-intel-mshv-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
       run: |-
-        flowey e 23 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 23 flowey_lib_hvlite::init_cross_build 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 23 flowey_lib_common::publish_test_results 0
+        flowey e 23 flowey_lib_common::publish_test_results 1
+        flowey e 23 flowey_lib_common::publish_test_results 2
+        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: cargo build sidecar
-      run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 3
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 9
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-intel-mshv-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 23 flowey_lib_hvlite::build_sidecar 0
-        flowey e 23 flowey_lib_hvlite::init_cross_build 1
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 1
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 23 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 23 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 23 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 23 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 2
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 23 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 23 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 23 flowey_lib_common::run_cargo_build 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 23 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 23 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 23 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 23 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 23 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 23 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 23 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 23 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 23 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey e 23 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
-        include-hidden-files: true
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 23 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 23 flowey_lib_common::cache 11
+      shell: bash
   job24:
-    name: run vmm-tests [x64-windows-intel-mi-secure]
+    name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - Windows
+    - ARM64
+    - Baremetal
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job23
-    - job5
-    - job7
-    - job9
+    - job10
+    - job3
+    - job6
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-pc-windows-msvc --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr-release.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/aarch64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
+      working-directory: flowey_bootstrap
+      shell: bash
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-linux-musl-tmk_vmm,aarch64-openhcl-igvm,aarch64-tmks,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-tmk_vmm,aarch64-windows-vmgstool,aarch64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-pr-release.yaml ci checkin-gates --config=pr-release
+      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
         echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
@@ -4507,20 +4741,16 @@ jobs:
         cat <<'EOF' | flowey.exe v 24 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 24 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 24 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 24 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 24 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -4571,17 +4801,14 @@ jobs:
         flowey.exe e 24 flowey_lib_common::git_checkout 3
         flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4664,14 +4891,14 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: unpack mu_msvm package (x64)
+    - name: unpack mu_msvm package (aarch64)
       run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4701,9 +4928,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-mi-secure-vmm-tests-logs
+        name: aarch64-windows-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
+      name: 'publish test results: aarch64-windows-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4717,9 +4944,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-mi-secure-vmm-tests-junit-xml
+        name: aarch64-windows-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
+      name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4732,6 +4959,621 @@ jobs:
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey.exe e 24 flowey_lib_common::cache 11
+      shell: bash
+  job25:
+    name: test flowey local backend
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 25 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 25 flowey_lib_common::git_checkout 3
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 25 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 25 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 25 flowey_lib_common::install_rust 2
+        flowey v 25 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: test cargo xflowey build-igvm x64 --install-missing-deps
+      run: flowey e 25 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      shell: bash
+  job26:
+    name: build openhcl (mi-secure) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 26 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 26 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 26 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 26 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 26 flowey_lib_common::cache 0
+        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 26 flowey_lib_common::cache 2
+        flowey e 26 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 26 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 26 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 26 flowey_lib_common::install_rust 2
+        flowey e 26 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 26 flowey_lib_common::git_checkout 0
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 26 flowey_lib_common::git_checkout 3
+        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 26 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 26 flowey_lib_common::resolve_protoc 0
+        flowey e 26 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 26 flowey_lib_hvlite::init_cross_build 0
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build sidecar
+      run: |-
+        flowey e 26 flowey_lib_common::run_cargo_build 3
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 26 flowey_lib_hvlite::build_sidecar 0
+        flowey e 26 flowey_lib_hvlite::init_cross_build 1
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 26 flowey_lib_common::run_cargo_build 1
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 26 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 26 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 26 flowey_lib_common::run_cargo_build 2
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 26 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 26 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 26 flowey_lib_common::run_cargo_build 0
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 26 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 26 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 26 flowey_lib_common::copy_to_artifact_dir 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 26 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
+        include-hidden-files: true
+  job27:
+    name: run vmm-tests [x64-windows-intel-mi-secure]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job26
+    - job5
+    - job8
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 27 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 27 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 27 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 27 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 27 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 27 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 27 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 27 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 27 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 27 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 27 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 27 flowey_lib_common::cache 0
+        flowey.exe v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 27 flowey_lib_common::cache 2
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 27 flowey_lib_common::git_checkout 0
+        flowey.exe v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 27 flowey_lib_common::git_checkout 3
+        flowey.exe e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 27 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 27 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 27 flowey_lib_common::cache 8
+        flowey.exe v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 27 flowey_lib_common::cache 10
+        flowey.exe e 27 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 27 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 27 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 27 flowey_lib_common::cache 4
+        flowey.exe v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 27 flowey_lib_common::cache 6
+        flowey.exe e 27 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 27 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 27 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 27 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 27 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 27 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 27 flowey_lib_common::publish_test_results 4
+        flowey.exe e 27 flowey_lib_common::publish_test_results 5
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-mi-secure-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 27 flowey_lib_common::publish_test_results 0
+        flowey.exe e 27 flowey_lib_common::publish_test_results 1
+        flowey.exe e 27 flowey_lib_common::publish_test_results 2
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-mi-secure-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 27 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 27 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 27 flowey_lib_common::cache 11
       shell: bash
   job3:
     name: build artifacts (for VMM tests) [aarch64-windows]
@@ -5603,7 +6445,7 @@ jobs:
         name: _internal-flowey-bootstrap-x86_64-windows-uid-6
         path: ${{ runner.temp }}/bootstrapped-flowey
   job6:
-    name: build artifacts [aarch64-linux]
+    name: build artifacts [aarch64-linux] (shared)
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -5640,20 +6482,16 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 6 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 6 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 6 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 6 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 6 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests" | flowey v 6 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 6 'artifact_publish_from_aarch64-tmks' --is-raw-string update
       shell: bash
@@ -5667,12 +6505,6 @@ jobs:
       run: |-
         flowey e 6 flowey_lib_common::install_rust 2
         flowey e 6 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 6 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 6 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
@@ -5722,6 +6554,12 @@ jobs:
         flowey e 6 flowey_lib_common::cache 2
         flowey e 6 flowey_lib_common::download_gh_release 1
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 6 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 6 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 6 flowey_lib_common::resolve_protoc 0
@@ -5730,81 +6568,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 6 flowey_lib_hvlite::build_openvmm 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 4
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 6 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 1
         flowey e 6 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 8
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 16
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 17
-        flowey e 6 flowey_lib_hvlite::build_vmgstool 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 2
-        flowey e 6 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 7
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 15
-        flowey e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-        flowey e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 6 flowey_core::pipeline::artifact::publish 3
-        flowey e 6 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 1
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 4
-        flowey e 6 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build ohcldiag-dev
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 4
-        flowey e 6 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 5
-        flowey e 6 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -5814,23 +6578,23 @@ jobs:
     - name: build guest_test_uefi.img
       run: |-
         flowey e 6 flowey_lib_hvlite::build_guest_test_uefi 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 6
+        flowey e 6 flowey_core::pipeline::artifact::publish 0
         flowey e 6 flowey_lib_hvlite::init_cross_build 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build simple_tmk
       run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 5
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 6 flowey_lib_common::run_cargo_build 4
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 10
         flowey e 6 flowey_lib_hvlite::build_tmks 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 7
-        flowey e 6 flowey_lib_hvlite::init_cross_build 4
+        flowey e 6 flowey_core::pipeline::artifact::publish 1
+        flowey e 6 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build tpm_guest_tests
       run: |-
@@ -5842,7 +6606,66 @@ jobs:
         flowey e 6 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 6 flowey_lib_hvlite::run_cargo_build 14
         flowey e 6 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 8
+        flowey e 6 flowey_core::pipeline::artifact::publish 2
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 6 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 6 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 6 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 3
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 5
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 6 flowey_lib_hvlite::build_pipette 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 3
+        flowey e 6 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 5
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 6 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 4
+        flowey e 6 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 1
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 1
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 6 flowey_lib_hvlite::build_openvmm 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 5
+        flowey e 6 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 2
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 6 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 6
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 6 flowey_lib_common::cache 3
@@ -5853,47 +6676,35 @@ jobs:
         name: aarch64-guest_test_uefi
         path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-igvmfilegen
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
+        name: aarch64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
+        name: aarch64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-openvmm
+    - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
+        name: aarch64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-openvmm_vhost
+    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
+        name: aarch64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-tpm_guest_tests
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-tpm_guest_tests
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-vmgs_lib
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-tmks
       uses: actions/upload-artifact@v7
@@ -5902,7 +6713,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
         include-hidden-files: true
   job7:
-    name: build artifacts [x64-linux]
+    name: build artifacts [aarch64-linux] (for VMM tests)
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -5937,26 +6748,18 @@ jobs:
         cat <<'EOF' | flowey v 7 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 7 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 7 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 7 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 7 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 7 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 7 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 7 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 7 'artifact_publish_from_x64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 7 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 7 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 7 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 7 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 7 flowey_lib_common::install_rust 0
@@ -6005,22 +6808,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 7 flowey_lib_common::cache 4
-        flowey v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 7 flowey_lib_common::cache 0
+        flowey v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 7 flowey_lib_common::cache 6
+        flowey e 7 flowey_lib_common::cache 2
         flowey e 7 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -6031,233 +6834,122 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 3
+        flowey e 7 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build openvmm
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 7 flowey_lib_common::run_cargo_build 2
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 7 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 5
         flowey e 7 flowey_lib_hvlite::build_openvmm 0
         flowey e 7 flowey_core::pipeline::artifact::publish 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 4
+        flowey e 7 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 4
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 7 flowey_lib_common::run_cargo_build 3
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 7 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 7
         flowey e 7 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 7 flowey_core::pipeline::artifact::publish 1
-        flowey e 7 flowey_lib_hvlite::init_cross_build 7
+        flowey e 7 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 8
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 16
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 17
-        flowey e 7 flowey_lib_hvlite::build_vmgstool 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 2
-        flowey e 7 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 7
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 15
-        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      shell: bash
-    - name: test vmgs_lib
-      run: |-
-        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-        flowey e 7 flowey_core::pipeline::artifact::publish 3
-        flowey e 7 flowey_lib_hvlite::init_cross_build 8
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 1
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 7 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 4
-        flowey e 7 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build ohcldiag-dev
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 2
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 4
-        flowey e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 5
-        flowey e 7 flowey_lib_hvlite::init_cross_build 9
-      shell: bash
-    - name: cargo build guest_test_uefi
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 0
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: build guest_test_uefi.img
-      run: |-
-        flowey e 7 flowey_lib_hvlite::build_guest_test_uefi 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 6
-        flowey e 7 flowey_lib_hvlite::init_cross_build 0
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 10
-      shell: bash
-    - name: cargo build simple_tmk
-      run: |-
         flowey e 7 flowey_lib_common::run_cargo_build 5
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 7 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 7 flowey_lib_hvlite::build_tmks 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 7
-        flowey e 7 flowey_lib_hvlite::init_cross_build 5
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 7 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 7 flowey_core::pipeline::artifact::publish 2
+        flowey e 7 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build tpm_guest_tests
+    - name: cargo build vmgs_lib
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 6
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 7 flowey_lib_common::run_cargo_build 4
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 7 flowey_core::pipeline::artifact::publish 3
+        flowey e 7 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 7 flowey_lib_common::run_cargo_build 0
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 7 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 7 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 8
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 7 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 7 flowey_core::pipeline::artifact::publish 4
+        flowey e 7 flowey_lib_hvlite::init_cross_build 5
       shell: bash
-    - name: create cargo-nextest cache dir
+    - name: cargo build ohcldiag-dev
       run: |-
-        flowey e 7 flowey_lib_common::download_cargo_nextest 0
-        flowey e 7 flowey_lib_common::download_cargo_nextest 1
-        flowey e 7 flowey_lib_common::download_cargo_nextest 2
-        flowey e 7 flowey_lib_common::download_cargo_nextest 3
+        flowey e 7 flowey_lib_common::run_cargo_build 1
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
-    - name: Pre-processing cache vars
+    - name: split debug symbols
       run: |-
-        flowey e 7 flowey_lib_common::cache 0
-        flowey v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 7 flowey_lib_common::cache 2
-        flowey e 7 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 7 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 7 flowey_lib_common::install_cargo_nextest 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey e 7 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 9
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 7 flowey_lib_common::cache 3
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 7 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 7 flowey_lib_common::cache 7
+      run: flowey e 7 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-guest_test_uefi
+    - name: 🌼📦 Publish aarch64-linux-igvmfilegen
       uses: actions/upload-artifact@v7
       with:
-        name: x64-guest_test_uefi
-        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
+        name: aarch64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-igvmfilegen
+    - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        name: aarch64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
+    - name: 🌼📦 Publish aarch64-linux-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
+        name: aarch64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm
+    - name: 🌼📦 Publish aarch64-linux-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
+        name: aarch64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm_vhost
+    - name: 🌼📦 Publish aarch64-linux-vmgs_lib
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        name: aarch64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
+    - name: 🌼📦 Publish aarch64-linux-vmgstool
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgs_lib
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-tmks
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-tmks
-        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
+        name: aarch64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
         include-hidden-files: true
   job8:
-    name: build openhcl [aarch64-linux]
+    name: build artifacts [x64-linux] (shared)
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6292,46 +6984,20 @@ jobs:
         cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 8 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 8 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 8 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 8 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 8 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 8 flowey_lib_common::cache 0
-        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 8 flowey_lib_common::cache 2
-        flowey e 8 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (aarch64)
-      run: flowey e 8 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 8 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 8 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 8 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 8 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 8 'artifact_publish_from_x64-tmks' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 8 flowey_lib_common::install_rust 0
@@ -6347,7 +7013,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 8 flowey_lib_common::git_checkout 0
-        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
         flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -6355,7 +7021,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -6369,6 +7035,35 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 8 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 8 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 8 flowey_lib_common::cache 0
+        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 8 flowey_lib_common::cache 2
+        flowey e 8 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 8 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 8 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 8 flowey_lib_common::resolve_protoc 0
@@ -6377,170 +7072,152 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 0
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 6
       shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 1
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 8 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 8 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 8 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 8 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 8 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build guest_test_uefi
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 0
         flowey e 8 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
-    - name: split debug symbols
+    - name: build guest_test_uefi.img
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 8 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 8 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 8 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 8 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 8 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: |-
-        flowey e 8 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 8 flowey_lib_hvlite::build_pipette 0
+        flowey e 8 flowey_lib_hvlite::build_guest_test_uefi 0
         flowey e 8 flowey_core::pipeline::artifact::publish 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 0
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
-    - name: cargo build tmk_vmm
+    - name: cargo build simple_tmk
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 4
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 8 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 8 flowey_lib_hvlite::build_tmks 0
         flowey e 8 flowey_core::pipeline::artifact::publish 1
+        flowey e 8 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 8 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 2
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 8 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::build_pipette 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 1
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 1
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::build_openvmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 5
+        flowey e 8 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 6
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-linux-musl-pipette
+    - name: 🌼📦 Publish x64-guest_test_uefi
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
+        name: x64-guest_test_uefi
+        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
+    - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
+        name: x64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-tmks
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
         include-hidden-files: true
   job9:
-    name: build openhcl [x64-linux]
+    name: build artifacts [x64-linux] (for VMM tests)
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6575,52 +7252,22 @@ jobs:
         cat <<'EOF' | flowey v 9 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 9 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 9 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 9 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 9 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 9 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 9 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 9 flowey_lib_common::cache 4
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 9 flowey_lib_common::cache 6
-        flowey e 9 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 9 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 9 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 9 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 9 flowey_lib_common::install_rust 0
@@ -6633,10 +7280,16 @@ jobs:
         flowey e 9 flowey_lib_common::install_rust 2
         flowey e 9 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 9 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 9 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar5
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
         flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -6644,7 +7297,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -6658,6 +7311,29 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 9 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 9 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 9 flowey_lib_common::cache 4
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 9 flowey_lib_common::cache 6
+        flowey e 9 flowey_lib_common::download_gh_release 1
+      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 9 flowey_lib_common::resolve_protoc 0
@@ -6666,67 +7342,59 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 0
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
-      shell: bash
-    - name: cargo build sidecar
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 15
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 10
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 16
-        flowey e 9 flowey_lib_hvlite::build_sidecar 0
         flowey e 9 flowey_lib_hvlite::init_cross_build 1
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
-    - name: cargo build openhcl_boot
+    - name: cargo build openvmm
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 1
+        flowey e 9 flowey_lib_common::run_cargo_build 2
         flowey e 9 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 9 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 9 flowey_lib_hvlite::build_openvmm 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 9 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build openvmm_hcl
+    - name: cargo build openvmm_vhost
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_build 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 9 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
-    - name: building openhcl initrd
+    - name: cargo build vmgstool
       run: |-
-        flowey e 9 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 9 flowey_lib_hvlite::init_cross_build 2
+        flowey e 9 flowey_lib_common::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 9 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      shell: bash
+    - name: test vmgs_lib
+      run: |-
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey e 9 flowey_core::pipeline::artifact::publish 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -6735,189 +7403,23 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 9
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 9 flowey_core::pipeline::artifact::publish 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
-    - name: building igvm file
+    - name: cargo build ohcldiag-dev
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 9 flowey_lib_common::run_cargo_build 1
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 9 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 9 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 9 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 9 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 9 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 9 flowey_lib_hvlite::build_openhcl_initrd 3
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_igvmfilegen 3
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 9 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 9 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 9 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 9 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: |-
-        flowey e 9 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 8
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 9 flowey_lib_hvlite::build_pipette 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 8
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 7
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 17
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 11
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 18
-        flowey e 9 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 2
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 9 flowey_lib_hvlite::build_openvmm 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 4
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 7
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -6929,14 +7431,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -6952,13 +7454,27 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 9 flowey_lib_common::install_cargo_nextest 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 4
+        flowey e 9 flowey_core::pipeline::artifact::publish 6
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 1
+        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 9 flowey_lib_common::cache 3
@@ -6966,29 +7482,11 @@ jobs:
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 9 flowey_lib_common::cache 7
       shell: bash
-    - name: 🌼📦 Publish x64-linux-musl-openvmm
+    - name: 🌼📦 Publish x64-linux-igvmfilegen
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-pipette
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        name: x64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
       uses: actions/upload-artifact@v7
@@ -6996,15 +7494,39 @@ jobs:
         name: x64-linux-musl-vmm-tests-archive
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm
+    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v7
       with:
-        name: x64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
+        name: x64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-extras
+    - name: 🌼📦 Publish x64-linux-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
+        name: x64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgs_lib
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
         include-hidden-files: true

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -3795,284 +3795,12 @@ jobs:
       run: flowey.exe e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [x64-windows-amd-snp]
-    runs-on:
-    - self-hosted
-    - Windows
-    - X64
-    - SNP
-    - Baremetal
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job11
-    - job2
-    - job3
-    - job7
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 21 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 21 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 21 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 21 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 21 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 21 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 21 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 21 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 21 flowey_lib_common::cache 0
-        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 21 flowey_lib_common::cache 2
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 21 flowey_lib_common::git_checkout 3
-        flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 21 flowey_lib_common::cache 8
-        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 21 flowey_lib_common::cache 10
-        flowey.exe e 21 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 21 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 21 flowey_lib_common::cache 4
-        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 21 flowey_lib_common::cache 6
-        flowey.exe e 21 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 21 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 21 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 21 flowey_lib_common::publish_test_results 4
-        flowey.exe e 21 flowey_lib_common::publish_test_results 5
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 21 flowey_lib_common::publish_test_results 0
-        flowey.exe e 21 flowey_lib_common::publish_test_results 1
-        flowey.exe e 21 flowey_lib_common::publish_test_results 2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 21 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 21 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 21 flowey_lib_common::cache 11
-      shell: bash
-  job22:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4099,6 +3827,311 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
+        echo '"debug"' | flowey v 21 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 21 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 21 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 21 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 21 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 21 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey e 21 flowey_core::pipeline::artifact::resolve 1
+        flowey e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey e 21 flowey_core::pipeline::artifact::resolve 6
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 21 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 8
+        flowey v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 10
+        flowey e 21 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 21 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 21 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 4
+        flowey v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 6
+        flowey e 21 flowey_lib_common::download_gh_cli 1
+        flowey v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 21 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey e 21 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 21 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure hypervisor device is accessible
+      run: flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: ensure 2 MiB hugetlb pages are available
+      run: flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 21 flowey_lib_common::download_cargo_nextest 0
+        flowey e 21 flowey_lib_common::download_cargo_nextest 1
+        flowey e 21 flowey_lib_common::download_cargo_nextest 2
+        flowey e 21 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 21 flowey_lib_common::cache 0
+        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 21 flowey_lib_common::cache 2
+        flowey e 21 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 21 flowey_lib_common::git_checkout 0
+        flowey v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 21 flowey_lib_common::git_checkout 3
+        flowey e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 21 flowey_core::pipeline::artifact::resolve 5
+        flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (linux)
+      run: flowey e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 21 flowey_lib_common::publish_test_results 4
+        flowey e 21 flowey_lib_common::publish_test_results 5
+        flowey v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 21 flowey_lib_common::publish_test_results 0
+        flowey e 21 flowey_lib_common::publish_test_results 1
+        flowey e 21 flowey_lib_common::publish_test_results 2
+        flowey v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 21 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 21 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 21 flowey_lib_common::cache 11
+      shell: bash
+  job22:
+    name: run vmm-tests [x64-linux-intel-mshv]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=azurelinux3-amd64-dom0
+    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job2
+    - job3
+    - job9
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        sudo tdnf install -y gcc glibc-devel
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr-release.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr-release.yaml ci checkin-gates --config=pr-release
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
         echo '"debug"' | flowey v 22 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --is-raw-string update
 
@@ -4106,22 +4139,22 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 22 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 22 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 22 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 22 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 22 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 22 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 22 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 22 flowey_core::pipeline::artifact::resolve 3
-        flowey e 22 flowey_core::pipeline::artifact::resolve 4
-        flowey e 22 flowey_core::pipeline::artifact::resolve 7
         flowey e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey e 22 flowey_core::pipeline::artifact::resolve 0
         flowey e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey e 22 flowey_core::pipeline::artifact::resolve 7
+        flowey e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey e 22 flowey_core::pipeline::artifact::resolve 4
         flowey e 22 flowey_core::pipeline::artifact::resolve 6
         flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -4213,10 +4246,7 @@ jobs:
       run: flowey e 22 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -4267,10 +4297,9 @@ jobs:
         flowey e 22 flowey_lib_common::git_checkout 3
         flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
         flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey e 22 flowey_core::pipeline::artifact::resolve 5
-        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: generate nextest command
       run: flowey e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
@@ -4291,9 +4320,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-logs
+        name: x64-linux-intel-mshv-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4307,9 +4336,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        name: x64-linux-intel-mshv-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
@@ -4324,307 +4353,6 @@ jobs:
       run: flowey e 22 flowey_lib_common::cache 11
       shell: bash
   job23:
-    name: run vmm-tests [x64-linux-intel-mshv]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job2
-    - job3
-    - job9
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        sudo tdnf install -y gcc glibc-devel
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr-release.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr-release.yaml ci checkin-gates --config=pr-release
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 23 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 23 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 23 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      shell: bash
-    - name: creating new test content dir
-      run: |-
-        flowey e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey e 23 flowey_core::pipeline::artifact::resolve 7
-        flowey e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey e 23 flowey_core::pipeline::artifact::resolve 4
-        flowey e 23 flowey_core::pipeline::artifact::resolve 6
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 23 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 23 flowey_lib_common::cache 8
-        flowey v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey e 23 flowey_lib_common::cache 10
-        flowey e 23 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey e 23 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 23 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 23 flowey_lib_common::cache 4
-        flowey v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 23 flowey_lib_common::cache 6
-        flowey e 23 flowey_lib_common::download_gh_cli 1
-        flowey v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey e 23 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey e 23 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: flowey e 23 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 23 flowey_lib_common::download_cargo_nextest 0
-        flowey e 23 flowey_lib_common::download_cargo_nextest 1
-        flowey e 23 flowey_lib_common::download_cargo_nextest 2
-        flowey e 23 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 23 flowey_lib_common::cache 0
-        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 23 flowey_lib_common::cache 2
-        flowey e 23 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 23 flowey_lib_common::git_checkout 0
-        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 23 flowey_lib_common::git_checkout 3
-        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 23 flowey_core::pipeline::artifact::resolve 5
-        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 23 flowey_lib_common::publish_test_results 4
-        flowey e 23 flowey_lib_common::publish_test_results 5
-        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 23 flowey_lib_common::publish_test_results 0
-        flowey e 23 flowey_lib_common::publish_test_results 1
-        flowey e 23 flowey_lib_common::publish_test_results 2
-        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 23 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 23 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 23 flowey_lib_common::cache 11
-      shell: bash
-  job24:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -4707,35 +4435,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 23 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 23 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 24 'verbose' update
+        cat <<'EOF' | flowey.exe v 23 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 24 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 23 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 23 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 23 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 23 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 23 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 23 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 23 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 0
-        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 23 flowey_lib_common::cache 0
+        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4745,17 +4473,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 23 flowey_lib_common::cache 2
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 24 flowey_lib_common::git_checkout 0
-        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 23 flowey_lib_common::git_checkout 0
+        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4767,35 +4495,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 24 flowey_lib_common::git_checkout 3
-        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 23 flowey_lib_common::git_checkout 3
+        flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 8
-        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 23 flowey_lib_common::cache 8
+        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4805,31 +4533,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 10
-        flowey.exe e 24 flowey_lib_common::download_gh_release 1
+        flowey.exe e 23 flowey_lib_common::cache 10
+        flowey.exe e 23 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 23 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 23 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 4
-        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 23 flowey_lib_common::cache 4
+        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4839,63 +4567,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 6
-        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 23 flowey_lib_common::cache 6
+        flowey.exe e 23 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 23 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 23 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 24 flowey_lib_common::publish_test_results 4
-        flowey.exe e 24 flowey_lib_common::publish_test_results 5
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 23 flowey_lib_common::publish_test_results 4
+        flowey.exe e 23 flowey_lib_common::publish_test_results 5
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4906,12 +4634,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 24 flowey_lib_common::publish_test_results 0
-        flowey.exe e 24 flowey_lib_common::publish_test_results 1
-        flowey.exe e 24 flowey_lib_common::publish_test_results 2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 23 flowey_lib_common::publish_test_results 0
+        flowey.exe e 23 flowey_lib_common::publish_test_results 1
+        flowey.exe e 23 flowey_lib_common::publish_test_results 2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4921,20 +4649,95 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 24 flowey_lib_common::cache 3
+      run: flowey.exe e 23 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 24 flowey_lib_common::cache 7
+      run: flowey.exe e 23 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 24 flowey_lib_common::cache 11
+      run: flowey.exe e 23 flowey_lib_common::cache 11
       shell: bash
-  job25:
+  job24:
     name: test flowey local backend
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 24 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 24 flowey_lib_common::git_checkout 0
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 24 flowey_lib_common::git_checkout 3
+        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 24 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 24 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 24 flowey_lib_common::install_rust 2
+        flowey v 24 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: test cargo xflowey build-igvm x64 --install-missing-deps
+      run: flowey e 24 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      shell: bash
+  job25:
+    name: build openhcl (mi-secure) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4964,28 +4767,42 @@ jobs:
         cat <<'EOF' | flowey v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 25 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 25 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
-    - name: check if openvmm needs to be cloned
+    - name: checking if packages need to be installed
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 25 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::cache 0
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
       with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
+        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_common::cache 2
+        flowey e 25 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 25 flowey_lib_common::install_rust 0
@@ -4996,102 +4813,13 @@ jobs:
     - name: detect active toolchain
       run: |-
         flowey e 25 flowey_lib_common::install_rust 2
-        flowey v 25 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 25 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
-      shell: bash
-  job26:
-    name: build openhcl (mi-secure) [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 26 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 26 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 26 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 26 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 26 flowey_lib_common::cache 0
-        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 26 flowey_lib_common::cache 2
-        flowey e 26 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 26 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 26 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 26 flowey_lib_common::install_rust 2
-        flowey e 26 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 25 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 26 flowey_lib_common::git_checkout 0
-        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5103,172 +4831,172 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 26 flowey_lib_common::git_checkout 3
-        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_common::git_checkout 3
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 26 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 25 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 26 flowey_lib_common::resolve_protoc 0
-        flowey e 26 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 25 flowey_lib_common::resolve_protoc 0
+        flowey e 25 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 0
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 25 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 25 flowey_lib_hvlite::init_cross_build 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 3
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 25 flowey_lib_common::run_cargo_build 3
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 26 flowey_lib_hvlite::build_sidecar 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 1
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 25 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 25 flowey_lib_hvlite::build_sidecar 0
+        flowey e 25 flowey_lib_hvlite::init_cross_build 1
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: cargo build openhcl_boot
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 1
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 25 flowey_lib_common::run_cargo_build 1
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 25 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 25 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 25 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 3
+        flowey e 25 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 25 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 2
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 26 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 25 flowey_lib_common::run_cargo_build 2
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 25 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 25 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 26 flowey_lib_hvlite::init_cross_build 2
+        flowey e 25 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 25 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 0
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 25 flowey_lib_common::run_cargo_build 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 26 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 25 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 25 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 25 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 25 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 25 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 25 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 25 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 25 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 25 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 25 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 25 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
-        flowey e 26 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 25 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 26 flowey_lib_common::copy_to_artifact_dir 0
+      run: flowey e 25 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 26 flowey_lib_common::cache 3
+      run: flowey e 25 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -5282,20 +5010,20 @@ jobs:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
         include-hidden-files: true
-  job27:
+  job26:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
     - job2
-    - job26
+    - job25
     - job3
     - job7
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
@@ -5316,39 +5044,39 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
 
-        echo '"debug"' | flowey.exe v 27 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 27 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 27 'verbose' update
+        cat <<'EOF' | flowey.exe v 26 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 27 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 27 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 27 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 27 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 27 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 27 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 27 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 27 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 26 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 26 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 26 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 26 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 26 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 26 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 27 flowey_lib_common::cache 0
-        flowey.exe v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 26 flowey_lib_common::cache 0
+        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5358,17 +5086,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 27 flowey_lib_common::cache 2
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 26 flowey_lib_common::cache 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 27 flowey_lib_common::git_checkout 0
-        flowey.exe v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_common::git_checkout 0
+        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5380,38 +5108,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 27 flowey_lib_common::git_checkout 3
-        flowey.exe e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 26 flowey_lib_common::git_checkout 3
+        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 27 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 27 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 27 flowey_lib_common::cache 8
-        flowey.exe v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 26 flowey_lib_common::cache 8
+        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5421,31 +5149,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 27 flowey_lib_common::cache 10
-        flowey.exe e 27 flowey_lib_common::download_gh_release 1
+        flowey.exe e 26 flowey_lib_common::cache 10
+        flowey.exe e 26 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 27 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 26 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 27 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 27 flowey_lib_common::cache 4
-        flowey.exe v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 26 flowey_lib_common::cache 4
+        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5455,63 +5183,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 27 flowey_lib_common::cache 6
-        flowey.exe e 27 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 26 flowey_lib_common::cache 6
+        flowey.exe e 26 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 27 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 26 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 27 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 27 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 27 flowey_lib_common::publish_test_results 4
-        flowey.exe e 27 flowey_lib_common::publish_test_results 5
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 26 flowey_lib_common::publish_test_results 4
+        flowey.exe e 26 flowey_lib_common::publish_test_results 5
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5522,12 +5250,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 27 flowey_lib_common::publish_test_results 0
-        flowey.exe e 27 flowey_lib_common::publish_test_results 1
-        flowey.exe e 27 flowey_lib_common::publish_test_results 2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 26 flowey_lib_common::publish_test_results 0
+        flowey.exe e 26 flowey_lib_common::publish_test_results 1
+        flowey.exe e 26 flowey_lib_common::publish_test_results 2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5537,16 +5265,16 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 27 flowey_lib_common::cache 3
+      run: flowey.exe e 26 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 27 flowey_lib_common::cache 7
+      run: flowey.exe e 26 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 27 flowey_lib_common::cache 11
+      run: flowey.exe e 26 flowey_lib_common::cache 11
       shell: bash
   job3:
     name: build artifacts (shared VMM tests) [linux]

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -392,7 +392,7 @@ jobs:
       run: flowey.exe e 1 flowey_lib_common::cache 3
       shell: bash
   job10:
-    name: build artifacts (shared VMM tests) [x64-linux]
+    name: build openhcl [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -427,16 +427,42 @@ jobs:
         cat <<'EOF' | flowey v 10 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 10 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 10 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 10 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 10 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 10 'artifact_publish_from_x64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 10 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 10 flowey_lib_common::cache 0
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 10 flowey_lib_common::cache 2
+        flowey e 10 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (aarch64)
+      run: flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 10 flowey_lib_common::install_rust 0
@@ -452,7 +478,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
         flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -460,7 +486,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -474,35 +500,6 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 10 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 10 flowey_lib_common::cache 2
-        flowey e 10 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 10 flowey_lib_common::resolve_protoc 0
@@ -511,114 +508,131 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build guest_test_uefi
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 0
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: build guest_test_uefi.img
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_guest_test_uefi 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 0
         flowey e 10 flowey_lib_hvlite::init_cross_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 1
         flowey e 10 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: cargo build simple_tmk
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 10 flowey_lib_hvlite::build_tmks 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 1
-        flowey e 10 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 4
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 10 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 3
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build pipette
+    - name: cargo build openvmm_hcl
       run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 1
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::build_pipette 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 3
-        flowey e 10 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 3
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 10 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 4
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 10 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-guest_test_uefi
+    - name: 🌼📦 Publish aarch64-openhcl-igvm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-guest_test_uefi
-        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
+        name: aarch64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-pipette
+    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-tmks
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-tmks
-        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
+        name: aarch64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
         include-hidden-files: true
   job11:
-    name: build artifacts (for VMM tests) [x64-linux]
+    name: build openhcl [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -653,26 +667,42 @@ jobs:
         cat <<'EOF' | flowey v 11 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 11 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 11 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 11 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 11 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 11 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 11 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 11 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 11 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 11 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 11 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 11 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 11 flowey_lib_common::cache 0
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 11 flowey_lib_common::cache 2
+        flowey e 11 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 11 flowey_lib_common::install_rust 0
@@ -685,16 +715,10 @@ jobs:
         flowey e 11 flowey_lib_common::install_rust 2
         flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
         flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -702,7 +726,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -716,29 +740,6 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 11 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 11 flowey_lib_common::cache 4
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 11 flowey_lib_common::cache 6
-        flowey e 11 flowey_lib_common::download_gh_release 1
-      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 11 flowey_lib_common::resolve_protoc 0
@@ -747,58 +748,66 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 11 flowey_lib_hvlite::build_openvmm 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 4
+        flowey e 11 flowey_lib_hvlite::init_cross_build 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
         flowey e 11 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
-    - name: split debug symbols
+    - name: cargo build sidecar
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 11 flowey_lib_common::run_cargo_build 3
         flowey e 11 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 11 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 1
-        flowey e 11 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 7
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 13
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 11 flowey_lib_hvlite::build_vmgstool 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 2
-        flowey e 11 flowey_lib_hvlite::init_cross_build 4
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 11 flowey_lib_hvlite::build_sidecar 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
-    - name: cargo build vmgs_lib
+    - name: cargo build openhcl_boot
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 6
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey e 11 flowey_lib_common::run_cargo_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
-    - name: test vmgs_lib
+    - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-        flowey e 11 flowey_core::pipeline::artifact::publish 3
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 11 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -808,730 +817,139 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 7
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 4
-        flowey e 11 flowey_lib_hvlite::init_cross_build 6
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
-    - name: cargo build ohcldiag-dev
+    - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 4
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 11 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: extract and resolve kernel package
+      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
       shell: bash
-    - name: cargo build openvmm
+    - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 3
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 11 flowey_lib_hvlite::build_openvmm 1
-        flowey e 11 flowey_core::pipeline::artifact::publish 6
-        flowey e 11 flowey_lib_hvlite::init_cross_build 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
-    - name: cargo build openvmm_vhost
+    - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 5
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
-    - name: split debug symbols
+    - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 11
-        flowey e 11 flowey_lib_hvlite::build_openvmm_vhost 1
-        flowey e 11 flowey_core::pipeline::artifact::publish 7
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
-    - name: create cargo-nextest cache dir
+    - name: copying OpenHCL igvm files to artifact dir
       run: |-
-        flowey e 11 flowey_lib_common::download_cargo_nextest 0
-        flowey e 11 flowey_lib_common::download_cargo_nextest 1
-        flowey e 11 flowey_lib_common::download_cargo_nextest 2
-        flowey e 11 flowey_lib_common::download_cargo_nextest 3
+        flowey e 11 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 11 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 11 flowey_lib_common::cache 2
-        flowey e 11 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 11 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 11 flowey_lib_common::install_cargo_nextest 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 8
-        flowey e 11 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_archive 1
-        flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 1
-        flowey e 11 flowey_core::pipeline::artifact::publish 9
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
+    - name: 'validate cache entry: gh-release-download'
       run: flowey e 11 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 11 flowey_lib_common::cache 7
-      shell: bash
-    - name: 🌼📦 Publish x64-linux-igvmfilegen
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgs_lib
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
-        include-hidden-files: true
-  job12:
-    name: build openhcl [aarch64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 12 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 12 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 12 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 12 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 12 flowey_lib_common::cache 2
-        flowey e 12 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (aarch64)
-      run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 12 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 12 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 12 flowey_lib_common::install_rust 2
-        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 12 flowey_lib_common::git_checkout 3
-        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 12 flowey_lib_common::resolve_protoc 0
-        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 0
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 1
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 2
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 12 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 0
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 12 flowey_lib_common::cache 3
-      shell: bash
-    - name: 🌼📦 Publish aarch64-openhcl-igvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
-        include-hidden-files: true
-  job13:
-    name: build openhcl [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 13 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 13 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 13 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 13 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 13 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 13 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 13 flowey_lib_common::cache 2
-        flowey e 13 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 13 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 13 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 13 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 13 flowey_lib_common::install_rust 2
-        flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 13 flowey_lib_common::git_checkout 0
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 13 flowey_lib_common::git_checkout 3
-        flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 13 flowey_lib_common::resolve_protoc 0
-        flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: cargo build sidecar
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_build 3
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 13 flowey_lib_hvlite::build_sidecar 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 13 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 13 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_build 2
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 13 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_build 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 7
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 3
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 3
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 13 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 13 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 13 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -1545,13 +963,13 @@ jobs:
         name: x64-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
         include-hidden-files: true
-  job14:
+  job12:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1619,29 +1037,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 14 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 14 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 12 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 12 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 14 'verbose' update
+        cat <<'EOF' | flowey.exe v 12 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 14 flowey_lib_common::install_rust 0
+      run: flowey.exe e 12 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 14 flowey_lib_common::install_rust 1
+      run: flowey.exe e 12 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 14 flowey_lib_common::install_rust 2
-        flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 12 flowey_lib_common::install_rust 2
+        flowey.exe e 12 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 14 flowey_lib_common::git_checkout 0
-        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 12 flowey_lib_common::git_checkout 0
+        flowey.exe v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1653,23 +1071,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 14 flowey_lib_common::git_checkout 3
-        flowey.exe e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 12 flowey_lib_common::git_checkout 3
+        flowey.exe e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 14 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 12 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 14 flowey_lib_common::cache 4
-        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 12 flowey_lib_common::cache 4
+        flowey.exe v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1679,50 +1097,50 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 14 flowey_lib_common::cache 6
-        flowey.exe e 14 flowey_lib_common::download_gh_release 1
+        flowey.exe e 12 flowey_lib_common::cache 6
+        flowey.exe e 12 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 14 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 12 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 14 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 12 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 12 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 14 flowey_lib_common::cache 0
-        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe e 12 flowey_lib_common::cache 0
+        flowey.exe v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1732,45 +1150,45 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 14 flowey_lib_common::cache 2
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 12 flowey_lib_common::cache 2
+        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 14 flowey_lib_common::install_rust 3
+      run: flowey.exe e 12 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 14 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 12 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 14 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 12 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 12 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
       run: |-
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 14 flowey_lib_common::publish_test_results 5
-        flowey.exe e 14 flowey_lib_common::publish_test_results 6
-        flowey.exe e 14 flowey_lib_common::publish_test_results 4
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 12 flowey_lib_common::publish_test_results 5
+        flowey.exe e 12 flowey_lib_common::publish_test_results 6
+        flowey.exe e 12 flowey_lib_common::publish_test_results 4
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1780,18 +1198,18 @@ jobs:
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 14 flowey_lib_common::publish_test_results 0
-        flowey.exe e 14 flowey_lib_common::publish_test_results 1
-        flowey.exe e 14 flowey_lib_common::publish_test_results 2
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 12 flowey_lib_common::publish_test_results 0
+        flowey.exe e 12 flowey_lib_common::publish_test_results 1
+        flowey.exe e 12 flowey_lib_common::publish_test_results 2
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1802,25 +1220,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
-      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 14 flowey_lib_common::cache 3
+      run: flowey.exe e 12 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 14 flowey_lib_common::cache 7
+      run: flowey.exe e 12 flowey_lib_common::cache 7
       shell: bash
-  job15:
+  job13:
     name: clippy [macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1844,35 +1262,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 15 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 13 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 13 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 15 'verbose' update
+        cat <<'EOF' | flowey v 13 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 15 flowey_lib_common::install_rust 0
+      run: flowey e 13 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 15 flowey_lib_common::install_rust 1
+      run: flowey e 13 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 15 flowey_lib_common::install_rust 2
-        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 13 flowey_lib_common::install_rust 2
+        flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::git_checkout 0
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1884,23 +1302,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 15 flowey_lib_common::git_checkout 3
-        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 13 flowey_lib_common::git_checkout 3
+        flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 15 flowey_lib_common::download_gh_release 0
+      run: flowey e 13 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey e 13 flowey_lib_common::cache 4
+        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1910,54 +1328,54 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 15 flowey_lib_common::cache 6
-        flowey e 15 flowey_lib_common::download_gh_release 1
+        flowey e 13 flowey_lib_common::cache 6
+        flowey e 13 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 15 flowey_lib_common::resolve_protoc 0
-        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 13 flowey_lib_common::resolve_protoc 0
+        flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 1
+        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_build 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 13 flowey_lib_common::run_cargo_build 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 15 flowey_lib_hvlite::build_xtask 0
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 15 flowey_lib_common::download_cargo_nextest 0
-        flowey e 15 flowey_lib_common::download_cargo_nextest 1
-        flowey e 15 flowey_lib_common::download_cargo_nextest 2
-        flowey e 15 flowey_lib_common::download_cargo_nextest 3
+        flowey e 13 flowey_lib_common::download_cargo_nextest 0
+        flowey e 13 flowey_lib_common::download_cargo_nextest 1
+        flowey e 13 flowey_lib_common::download_cargo_nextest 2
+        flowey e 13 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey e 13 flowey_lib_common::cache 0
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1967,34 +1385,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 15 flowey_lib_common::cache 2
-        flowey e 15 flowey_lib_common::download_cargo_nextest 4
+        flowey e 13 flowey_lib_common::cache 2
+        flowey e 13 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 15 flowey_lib_common::install_rust 3
+      run: flowey e 13 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 15 flowey_lib_common::install_cargo_nextest 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 13 flowey_lib_common::install_cargo_nextest 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 15 flowey_lib_common::publish_test_results 5
-        flowey e 15 flowey_lib_common::publish_test_results 6
-        flowey e 15 flowey_lib_common::publish_test_results 4
-        flowey v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 13 flowey_lib_common::publish_test_results 5
+        flowey e 13 flowey_lib_common::publish_test_results 6
+        flowey e 13 flowey_lib_common::publish_test_results 4
+        flowey v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2004,18 +1422,18 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 15 flowey_lib_common::publish_test_results 8
-        flowey e 15 flowey_lib_common::publish_test_results 9
-        flowey e 15 flowey_lib_common::publish_test_results 10
-        flowey v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 13 flowey_lib_common::publish_test_results 8
+        flowey e 13 flowey_lib_common::publish_test_results 9
+        flowey e 13 flowey_lib_common::publish_test_results 10
+        flowey v 13 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 13 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2026,32 +1444,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 15 flowey_lib_hvlite::init_cross_build 2
-        flowey e 15 flowey_lib_common::run_cargo_build 1
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 13 flowey_lib_hvlite::init_cross_build 2
+        flowey e 13 flowey_lib_common::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 15 flowey_lib_hvlite::build_xtask 1
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 13 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 15 flowey_lib_common::publish_test_results 12
-        flowey e 15 flowey_lib_common::publish_test_results 13
-        flowey e 15 flowey_lib_common::publish_test_results 14
-        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 13 flowey_lib_common::publish_test_results 12
+        flowey e 13 flowey_lib_common::publish_test_results 13
+        flowey e 13 flowey_lib_common::publish_test_results 14
+        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -2061,18 +1479,18 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 15 flowey_lib_common::publish_test_results 0
-        flowey e 15 flowey_lib_common::publish_test_results 1
-        flowey e 15 flowey_lib_common::publish_test_results 2
-        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 13 flowey_lib_common::publish_test_results 0
+        flowey e 13 flowey_lib_common::publish_test_results 1
+        flowey e 13 flowey_lib_common::publish_test_results 2
+        flowey v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2083,25 +1501,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
-      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 15 flowey_lib_common::cache 3
+      run: flowey e 13 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 15 flowey_lib_common::cache 7
+      run: flowey e 13 flowey_lib_common::cache 7
       shell: bash
-  job16:
+  job14:
     name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2125,29 +1543,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 14 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 14 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 16 'verbose' update
+        cat <<'EOF' | flowey v 14 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 16 flowey_lib_common::install_rust 0
+      run: flowey e 14 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 16 flowey_lib_common::install_rust 1
+      run: flowey e 14 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 16 flowey_lib_common::install_rust 2
-        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 14 flowey_lib_common::install_rust 2
+        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::git_checkout 0
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2159,27 +1577,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 16 flowey_lib_common::git_checkout 3
-        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 14 flowey_lib_common::git_checkout 3
+        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 16 flowey_lib_common::download_gh_release 0
+      run: flowey e 14 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 14 flowey_lib_common::cache 4
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2189,78 +1607,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 16 flowey_lib_common::cache 6
-        flowey e 16 flowey_lib_common::download_gh_release 1
+        flowey e 14 flowey_lib_common::cache 6
+        flowey e 14 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 16 flowey_lib_common::resolve_protoc 0
+      run: flowey e 14 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 2
+        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_clippy 5
-        flowey e 16 flowey_lib_hvlite::init_cross_build 0
+        flowey e 14 flowey_lib_common::run_cargo_clippy 5
+        flowey e 14 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_build 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 14 flowey_lib_common::run_cargo_build 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::build_xtask 0
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 14 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 14 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 16 flowey_lib_common::download_cargo_nextest 0
-        flowey e 16 flowey_lib_common::download_cargo_nextest 1
-        flowey e 16 flowey_lib_common::download_cargo_nextest 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 3
+        flowey e 14 flowey_lib_common::download_cargo_nextest 0
+        flowey e 14 flowey_lib_common::download_cargo_nextest 1
+        flowey e 14 flowey_lib_common::download_cargo_nextest 2
+        flowey e 14 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 14 flowey_lib_common::cache 0
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2270,34 +1688,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 16 flowey_lib_common::cache 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 4
+        flowey e 14 flowey_lib_common::cache 2
+        flowey e 14 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 16 flowey_lib_common::install_rust 3
+      run: flowey e 14 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 16 flowey_lib_common::install_cargo_nextest 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 3
-        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::install_cargo_nextest 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 3
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 16 flowey_lib_common::publish_test_results 5
-        flowey e 16 flowey_lib_common::publish_test_results 6
-        flowey e 16 flowey_lib_common::publish_test_results 4
-        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 14 flowey_lib_common::publish_test_results 5
+        flowey e 14 flowey_lib_common::publish_test_results 6
+        flowey e 14 flowey_lib_common::publish_test_results 4
+        flowey v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2307,18 +1725,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 16 flowey_lib_common::publish_test_results 8
-        flowey e 16 flowey_lib_common::publish_test_results 9
-        flowey e 16 flowey_lib_common::publish_test_results 10
-        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 14 flowey_lib_common::publish_test_results 8
+        flowey e 14 flowey_lib_common::publish_test_results 9
+        flowey e 14 flowey_lib_common::publish_test_results 10
+        flowey v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2328,18 +1746,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 14 flowey_lib_common::publish_test_results 12
+        flowey e 14 flowey_lib_common::publish_test_results 13
+        flowey e 14 flowey_lib_common::publish_test_results 14
+        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -2349,18 +1767,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 16 flowey_lib_common::publish_test_results 16
-        flowey e 16 flowey_lib_common::publish_test_results 17
-        flowey e 16 flowey_lib_common::publish_test_results 18
-        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 14 flowey_lib_common::publish_test_results 16
+        flowey e 14 flowey_lib_common::publish_test_results 17
+        flowey e 14 flowey_lib_common::publish_test_results 18
+        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -2371,32 +1789,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_cross_build 1
-        flowey e 16 flowey_lib_common::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 14 flowey_lib_hvlite::init_cross_build 1
+        flowey e 14 flowey_lib_common::run_cargo_build 1
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 16 flowey_lib_hvlite::build_xtask 1
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 14 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 16 flowey_lib_common::publish_test_results 0
-        flowey e 16 flowey_lib_common::publish_test_results 1
-        flowey e 16 flowey_lib_common::publish_test_results 2
-        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 14 flowey_lib_common::publish_test_results 0
+        flowey e 14 flowey_lib_common::publish_test_results 1
+        flowey e 14 flowey_lib_common::publish_test_results 2
+        flowey v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2407,25 +1825,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
-      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 16 flowey_lib_common::cache 3
+      run: flowey e 14 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 16 flowey_lib_common::cache 7
+      run: flowey e 14 flowey_lib_common::cache 7
       shell: bash
-  job17:
+  job15:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=win-arm64
-    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2493,29 +1911,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 17 'verbose' update
+        cat <<'EOF' | flowey.exe v 15 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 17 flowey_lib_common::install_rust 0
+      run: flowey.exe e 15 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 17 flowey_lib_common::install_rust 1
+      run: flowey.exe e 15 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 17 flowey_lib_common::install_rust 2
-        flowey.exe e 17 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 15 flowey_lib_common::install_rust 2
+        flowey.exe e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 17 flowey_lib_common::git_checkout 0
-        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::git_checkout 0
+        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2527,23 +1945,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 17 flowey_lib_common::git_checkout 3
-        flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 15 flowey_lib_common::git_checkout 3
+        flowey.exe e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 17 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 15 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 17 flowey_lib_common::cache 4
-        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 15 flowey_lib_common::cache 4
+        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2553,50 +1971,50 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 17 flowey_lib_common::cache 6
-        flowey.exe e 17 flowey_lib_common::download_gh_release 1
+        flowey.exe e 15 flowey_lib_common::cache 6
+        flowey.exe e 15 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 17 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 15 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 17 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 15 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 15 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 17 flowey_lib_common::cache 0
-        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe e 15 flowey_lib_common::cache 0
+        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2606,45 +2024,45 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 17 flowey_lib_common::cache 2
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 15 flowey_lib_common::cache 2
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 17 flowey_lib_common::install_rust 3
+      run: flowey.exe e 15 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 17 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 15 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 17 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 15 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
       run: |-
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 17 flowey_lib_common::publish_test_results 5
-        flowey.exe e 17 flowey_lib_common::publish_test_results 6
-        flowey.exe e 17 flowey_lib_common::publish_test_results 4
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 15 flowey_lib_common::publish_test_results 5
+        flowey.exe e 15 flowey_lib_common::publish_test_results 6
+        flowey.exe e 15 flowey_lib_common::publish_test_results 4
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2654,18 +2072,18 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 17 flowey_lib_common::publish_test_results 0
-        flowey.exe e 17 flowey_lib_common::publish_test_results 1
-        flowey.exe e 17 flowey_lib_common::publish_test_results 2
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 15 flowey_lib_common::publish_test_results 0
+        flowey.exe e 15 flowey_lib_common::publish_test_results 1
+        flowey.exe e 15 flowey_lib_common::publish_test_results 2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2676,25 +2094,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 17 flowey_lib_common::cache 3
+      run: flowey.exe e 15 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 17 flowey_lib_common::cache 7
+      run: flowey.exe e 15 flowey_lib_common::cache 7
       shell: bash
-  job18:
+  job16:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2762,35 +2180,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 18 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 18 'verbose' update
+        cat <<'EOF' | flowey v 16 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 18 flowey_lib_common::install_rust 0
+      run: flowey e 16 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 18 flowey_lib_common::install_rust 1
+      run: flowey e 16 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 18 flowey_lib_common::install_rust 2
-        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 16 flowey_lib_common::install_rust 2
+        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::git_checkout 0
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2802,23 +2220,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 18 flowey_lib_common::git_checkout 3
-        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 16 flowey_lib_common::git_checkout 3
+        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 18 flowey_lib_common::download_gh_release 0
+      run: flowey e 16 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey e 16 flowey_lib_common::cache 4
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2828,61 +2246,61 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 18 flowey_lib_common::cache 6
-        flowey e 18 flowey_lib_common::download_gh_release 1
+        flowey e 16 flowey_lib_common::cache 6
+        flowey e 16 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 18 flowey_lib_common::resolve_protoc 0
-        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 16 flowey_lib_common::resolve_protoc 0
+        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 2
+        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_build 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 16 flowey_lib_common::run_cargo_build 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 18 flowey_lib_hvlite::build_xtask 0
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 18 flowey_lib_common::download_cargo_nextest 0
-        flowey e 18 flowey_lib_common::download_cargo_nextest 1
-        flowey e 18 flowey_lib_common::download_cargo_nextest 2
-        flowey e 18 flowey_lib_common::download_cargo_nextest 3
+        flowey e 16 flowey_lib_common::download_cargo_nextest 0
+        flowey e 16 flowey_lib_common::download_cargo_nextest 1
+        flowey e 16 flowey_lib_common::download_cargo_nextest 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey e 16 flowey_lib_common::cache 0
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2892,34 +2310,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 18 flowey_lib_common::cache 2
-        flowey e 18 flowey_lib_common::download_cargo_nextest 4
+        flowey e 16 flowey_lib_common::cache 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 18 flowey_lib_common::install_rust 3
+      run: flowey e 16 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 18 flowey_lib_common::install_cargo_nextest 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::install_cargo_nextest 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 18 flowey_lib_common::publish_test_results 5
-        flowey e 18 flowey_lib_common::publish_test_results 6
-        flowey e 18 flowey_lib_common::publish_test_results 4
-        flowey v 18 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 16 flowey_lib_common::publish_test_results 5
+        flowey e 16 flowey_lib_common::publish_test_results 6
+        flowey e 16 flowey_lib_common::publish_test_results 4
+        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2929,18 +2347,18 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 18 flowey_lib_common::publish_test_results 8
-        flowey e 18 flowey_lib_common::publish_test_results 9
-        flowey e 18 flowey_lib_common::publish_test_results 10
-        flowey v 18 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 16 flowey_lib_common::publish_test_results 8
+        flowey e 16 flowey_lib_common::publish_test_results 9
+        flowey e 16 flowey_lib_common::publish_test_results 10
+        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2951,32 +2369,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 18 flowey_lib_hvlite::init_cross_build 3
-        flowey e 18 flowey_lib_common::run_cargo_build 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 16 flowey_lib_hvlite::init_cross_build 3
+        flowey e 16 flowey_lib_common::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 18 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 18 flowey_lib_hvlite::build_xtask 1
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 16 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 18 flowey_lib_common::publish_test_results 12
-        flowey e 18 flowey_lib_common::publish_test_results 13
-        flowey e 18 flowey_lib_common::publish_test_results 14
-        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 18 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey e 16 flowey_lib_common::publish_test_results 13
+        flowey e 16 flowey_lib_common::publish_test_results 14
+        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -2986,18 +2404,18 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 18 flowey_lib_common::publish_test_results 0
-        flowey e 18 flowey_lib_common::publish_test_results 1
-        flowey e 18 flowey_lib_common::publish_test_results 2
-        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 16 flowey_lib_common::publish_test_results 0
+        flowey e 16 flowey_lib_common::publish_test_results 1
+        flowey e 16 flowey_lib_common::publish_test_results 2
+        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -3008,25 +2426,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 18 flowey_lib_common::cache 3
+      run: flowey e 16 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 18 flowey_lib_common::cache 7
+      run: flowey e 16 flowey_lib_common::cache 7
       shell: bash
-  job19:
+  job17:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3094,29 +2512,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 19 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 19 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 17 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 17 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 19 'verbose' update
+        cat <<'EOF' | flowey v 17 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 19 flowey_lib_common::install_rust 0
+      run: flowey e 17 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 19 flowey_lib_common::install_rust 1
+      run: flowey e 17 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 19 flowey_lib_common::install_rust 2
-        flowey e 19 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 17 flowey_lib_common::install_rust 2
+        flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 19 flowey_lib_common::git_checkout 0
-        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::git_checkout 0
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3128,27 +2546,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 19 flowey_lib_common::git_checkout 3
-        flowey e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 17 flowey_lib_common::git_checkout 3
+        flowey e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 19 flowey_lib_common::download_gh_release 0
+      run: flowey e 17 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 19 flowey_lib_common::cache 4
-        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 17 flowey_lib_common::cache 4
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3158,78 +2576,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 19 flowey_lib_common::cache 6
-        flowey e 19 flowey_lib_common::download_gh_release 1
+        flowey e 17 flowey_lib_common::cache 6
+        flowey e 17 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 19 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 19 flowey_lib_common::resolve_protoc 0
+      run: flowey e 17 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 19 flowey_lib_hvlite::init_cross_build 2
+        flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_clippy 5
-        flowey e 19 flowey_lib_hvlite::init_cross_build 0
+        flowey e 17 flowey_lib_common::run_cargo_clippy 5
+        flowey e 17 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_build 0
-        flowey e 19 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 17 flowey_lib_common::run_cargo_build 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 19 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 19 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 19 flowey_lib_hvlite::build_xtask 0
+        flowey e 17 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 17 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 19 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 17 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 19 flowey_lib_common::download_cargo_nextest 0
-        flowey e 19 flowey_lib_common::download_cargo_nextest 1
-        flowey e 19 flowey_lib_common::download_cargo_nextest 2
-        flowey e 19 flowey_lib_common::download_cargo_nextest 3
+        flowey e 17 flowey_lib_common::download_cargo_nextest 0
+        flowey e 17 flowey_lib_common::download_cargo_nextest 1
+        flowey e 17 flowey_lib_common::download_cargo_nextest 2
+        flowey e 17 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 19 flowey_lib_common::cache 0
-        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 17 flowey_lib_common::cache 0
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3239,34 +2657,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 19 flowey_lib_common::cache 2
-        flowey e 19 flowey_lib_common::download_cargo_nextest 4
+        flowey e 17 flowey_lib_common::cache 2
+        flowey e 17 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 19 flowey_lib_common::install_rust 3
+      run: flowey e 17 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 19 flowey_lib_common::install_cargo_nextest 0
-        flowey e 19 flowey_lib_hvlite::init_cross_build 3
-        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::install_cargo_nextest 0
+        flowey e 17 flowey_lib_hvlite::init_cross_build 3
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 19 flowey_lib_common::publish_test_results 5
-        flowey e 19 flowey_lib_common::publish_test_results 6
-        flowey e 19 flowey_lib_common::publish_test_results 4
-        flowey v 19 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 17 flowey_lib_common::publish_test_results 5
+        flowey e 17 flowey_lib_common::publish_test_results 6
+        flowey e 17 flowey_lib_common::publish_test_results 4
+        flowey v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -3276,18 +2694,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 19 flowey_lib_common::publish_test_results 8
-        flowey e 19 flowey_lib_common::publish_test_results 9
-        flowey e 19 flowey_lib_common::publish_test_results 10
-        flowey v 19 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 19 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 17 flowey_lib_common::publish_test_results 8
+        flowey e 17 flowey_lib_common::publish_test_results 9
+        flowey e 17 flowey_lib_common::publish_test_results 10
+        flowey v 17 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 17 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -3297,18 +2715,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 19 flowey_lib_common::publish_test_results 12
-        flowey e 19 flowey_lib_common::publish_test_results 13
-        flowey e 19 flowey_lib_common::publish_test_results 14
-        flowey v 19 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 19 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 17 flowey_lib_common::publish_test_results 12
+        flowey e 17 flowey_lib_common::publish_test_results 13
+        flowey e 17 flowey_lib_common::publish_test_results 14
+        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -3318,18 +2736,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 19 flowey_lib_common::publish_test_results 16
-        flowey e 19 flowey_lib_common::publish_test_results 17
-        flowey e 19 flowey_lib_common::publish_test_results 18
-        flowey v 19 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 19 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 17 flowey_lib_common::publish_test_results 16
+        flowey e 17 flowey_lib_common::publish_test_results 17
+        flowey e 17 flowey_lib_common::publish_test_results 18
+        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -3340,32 +2758,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 19 flowey_lib_hvlite::init_cross_build 1
-        flowey e 19 flowey_lib_common::run_cargo_build 1
-        flowey e 19 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 17 flowey_lib_hvlite::init_cross_build 1
+        flowey e 17 flowey_lib_common::run_cargo_build 1
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 19 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 19 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 19 flowey_lib_hvlite::build_xtask 1
+        flowey e 17 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 17 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 19 flowey_lib_common::publish_test_results 0
-        flowey e 19 flowey_lib_common::publish_test_results 1
-        flowey e 19 flowey_lib_common::publish_test_results 2
-        flowey v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 17 flowey_lib_common::publish_test_results 0
+        flowey e 17 flowey_lib_common::publish_test_results 1
+        flowey e 17 flowey_lib_common::publish_test_results 2
+        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -3376,20 +2794,558 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
-      run: flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 19 flowey_lib_common::cache 3
+      run: flowey e 17 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 19 flowey_lib_common::cache 7
+      run: flowey e 17 flowey_lib_common::cache 7
+      shell: bash
+  job18:
+    name: run vmm-tests [x64-windows-intel]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job11
+    - job2
+    - job3
+    - job7
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 18 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 18 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 18 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 18 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 18 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 18 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 18 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 18 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 18 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 18 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 18 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 18 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 18 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 18 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 18 flowey_lib_common::cache 0
+        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 18 flowey_lib_common::cache 2
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 18 flowey_lib_common::git_checkout 0
+        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 18 flowey_lib_common::git_checkout 3
+        flowey.exe e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 18 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 18 flowey_lib_common::cache 8
+        flowey.exe v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 18 flowey_lib_common::cache 10
+        flowey.exe e 18 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 18 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 18 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 18 flowey_lib_common::cache 4
+        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 18 flowey_lib_common::cache 6
+        flowey.exe e 18 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 18 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 18 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 18 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 18 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 18 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 18 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 18 flowey_lib_common::publish_test_results 4
+        flowey.exe e 18 flowey_lib_common::publish_test_results 5
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 18 flowey_lib_common::publish_test_results 0
+        flowey.exe e 18 flowey_lib_common::publish_test_results 1
+        flowey.exe e 18 flowey_lib_common::publish_test_results 2
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 18 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 18 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 18 flowey_lib_common::cache 11
+      shell: bash
+  job19:
+    name: run vmm-tests [x64-windows-intel-tdx]
+    runs-on:
+    - self-hosted
+    - Windows
+    - X64
+    - TDX
+    - Baremetal
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job11
+    - job2
+    - job3
+    - job7
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 19 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 19 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 19 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 19 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 19 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 19 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 19 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 19 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 19 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 0
+        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 19 flowey_lib_common::cache 2
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 19 flowey_lib_common::git_checkout 0
+        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 19 flowey_lib_common::git_checkout 3
+        flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 19 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 8
+        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 19 flowey_lib_common::cache 10
+        flowey.exe e 19 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 19 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 19 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 4
+        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 19 flowey_lib_common::cache 6
+        flowey.exe e 19 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 19 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 19 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 19 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 19 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 19 flowey_lib_common::publish_test_results 4
+        flowey.exe e 19 flowey_lib_common::publish_test_results 5
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-tdx-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 19 flowey_lib_common::publish_test_results 0
+        flowey.exe e 19 flowey_lib_common::publish_test_results 1
+        flowey.exe e 19 flowey_lib_common::publish_test_results 2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-tdx-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 19 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 19 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 19 flowey_lib_common::cache 11
       shell: bash
   job2:
-    name: build artifacts (not for VMM tests) [aarch64-windows]
+    name: build artifacts (shared VMM tests) [windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -3468,14 +3424,10 @@ jobs:
         cat <<'EOF' | flowey.exe v 2 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-hypestv"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-hypestv" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-hypestv' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-igvmfilegen"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-igvmfilegen" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-ohcldiag-dev"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-ohcldiag-dev" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgs_lib"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgs_lib" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-pipette"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-pipette" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-pipette"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 2 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 2 flowey_lib_common::install_rust 0
@@ -3544,72 +3496,43 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 2 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 0
       shell: bash
-    - name: cargo build hypestv
+    - name: cargo build pipette
       run: |-
         flowey.exe e 2 flowey_lib_common::run_cargo_build 0
         flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 2 flowey_lib_hvlite::build_hypestv 0
+        flowey.exe e 2 flowey_lib_hvlite::build_pipette 0
         flowey.exe e 2 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey.exe e 2 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 3
-        flowey.exe e 2 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-        flowey.exe e 2 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey.exe e 2 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build pipette
       run: |-
         flowey.exe e 2 flowey_lib_common::run_cargo_build 1
         flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 2 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey.exe e 2 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build ohcldiag-dev
-      run: |-
-        flowey.exe e 2 flowey_lib_common::run_cargo_build 2
-        flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 2 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey.exe e 2 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 2 flowey_lib_hvlite::build_pipette 1
+        flowey.exe e 2 flowey_core::pipeline::artifact::publish 1
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey.exe e 2 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-windows-hypestv
+    - name: 🌼📦 Publish aarch64-windows-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-hypestv
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-hypestv/
+        name: aarch64-windows-pipette
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-pipette/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-igvmfilegen
+    - name: 🌼📦 Publish x64-windows-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-igvmfilegen/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-ohcldiag-dev
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-ohcldiag-dev/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-vmgs_lib
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
+        name: x64-windows-pipette
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-windows-intel]
+    name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3617,9 +3540,9 @@ jobs:
       id-token: write
     needs:
     - job0
-    - job10
-    - job13
-    - job6
+    - job11
+    - job2
+    - job3
     - job7
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
@@ -3839,9 +3762,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-vmm-tests-logs
+        name: x64-windows-amd-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3855,9 +3778,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-vmm-tests-junit-xml
+        name: x64-windows-amd-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -3872,21 +3795,21 @@ jobs:
       run: flowey.exe e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [x64-windows-intel-tdx]
+    name: run vmm-tests [x64-windows-amd-snp]
     runs-on:
     - self-hosted
     - Windows
     - X64
-    - TDX
+    - SNP
     - Baremetal
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job10
-    - job13
-    - job6
+    - job11
+    - job2
+    - job3
     - job7
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
@@ -3976,6 +3899,10 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
@@ -3983,10 +3910,6 @@ jobs:
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4111,9 +4034,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-logs
+        name: x64-windows-amd-snp-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4127,9 +4050,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-junit-xml
+        name: x64-windows-amd-snp-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4144,558 +4067,20 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
-    name: run vmm-tests [x64-windows-amd]
+    name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job10
-    - job13
-    - job6
-    - job7
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 22 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 22 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 22 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 22 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 22 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 22 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 22 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 22 flowey_lib_common::cache 0
-        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 22 flowey_lib_common::cache 2
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 22 flowey_lib_common::git_checkout 0
-        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 22 flowey_lib_common::git_checkout 3
-        flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 22 flowey_lib_common::cache 8
-        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 22 flowey_lib_common::cache 10
-        flowey.exe e 22 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 22 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 22 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 22 flowey_lib_common::cache 4
-        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 22 flowey_lib_common::cache 6
-        flowey.exe e 22 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 22 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 22 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 22 flowey_lib_common::publish_test_results 4
-        flowey.exe e 22 flowey_lib_common::publish_test_results 5
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 22 flowey_lib_common::publish_test_results 0
-        flowey.exe e 22 flowey_lib_common::publish_test_results 1
-        flowey.exe e 22 flowey_lib_common::publish_test_results 2
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 22 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 22 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 22 flowey_lib_common::cache 11
-      shell: bash
-  job23:
-    name: run vmm-tests [x64-windows-amd-snp]
-    runs-on:
-    - self-hosted
-    - Windows
-    - X64
-    - SNP
-    - Baremetal
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job10
-    - job13
-    - job6
-    - job7
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 23 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 23 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 23 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 23 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 23 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 23 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 23 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 23 flowey_lib_common::cache 0
-        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::cache 2
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 23 flowey_lib_common::git_checkout 0
-        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::git_checkout 3
-        flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 23 flowey_lib_common::cache 8
-        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::cache 10
-        flowey.exe e 23 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 23 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 23 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 23 flowey_lib_common::cache 4
-        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::cache 6
-        flowey.exe e 23 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 23 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 23 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 23 flowey_lib_common::publish_test_results 4
-        flowey.exe e 23 flowey_lib_common::publish_test_results 5
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 23 flowey_lib_common::publish_test_results 0
-        flowey.exe e 23 flowey_lib_common::publish_test_results 1
-        flowey.exe e 23 flowey_lib_common::publish_test_results 2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 23 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 23 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 23 flowey_lib_common::cache 11
-      shell: bash
-  job24:
-    name: run vmm-tests [x64-linux-amd-kvm]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job10
-    - job11
-    - job6
+    - job2
+    - job3
+    - job9
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -4714,46 +4099,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 22 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 24 'verbose' update
+        cat <<'EOF' | flowey v 22 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 24 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 22 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 22 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 22 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 22 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey e 24 flowey_core::pipeline::artifact::resolve 7
-        flowey e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey e 22 flowey_core::pipeline::artifact::resolve 7
+        flowey e 22 flowey_core::pipeline::artifact::resolve 1
+        flowey e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey e 22 flowey_core::pipeline::artifact::resolve 6
+        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 22 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 24 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 22 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 24 flowey_lib_common::download_gh_release 0
+      run: flowey e 22 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 24 flowey_lib_common::cache 8
-        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 22 flowey_lib_common::cache 8
+        flowey v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4763,31 +4148,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 24 flowey_lib_common::cache 10
-        flowey e 24 flowey_lib_common::download_gh_release 1
+        flowey e 22 flowey_lib_common::cache 10
+        flowey e 22 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 24 flowey_lib_common::download_azcopy 0
+      run: flowey e 22 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 24 flowey_lib_common::download_gh_cli 0
+      run: flowey e 22 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 24 flowey_lib_common::cache 4
-        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 22 flowey_lib_common::cache 4
+        flowey v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4797,54 +4182,54 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 24 flowey_lib_common::cache 6
-        flowey e 24 flowey_lib_common::download_gh_cli 1
-        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 22 flowey_lib_common::cache 6
+        flowey e 22 flowey_lib_common::download_gh_cli 1
+        flowey v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 24 flowey_lib_common::use_gh_cli 0
+      run: flowey e 22 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 24 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 22 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 22 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey e 24 flowey_lib_common::download_cargo_nextest 3
+        flowey e 22 flowey_lib_common::download_cargo_nextest 0
+        flowey e 22 flowey_lib_common::download_cargo_nextest 1
+        flowey e 22 flowey_lib_common::download_cargo_nextest 2
+        flowey e 22 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 24 flowey_lib_common::cache 0
-        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 22 flowey_lib_common::cache 0
+        flowey v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4854,17 +4239,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 24 flowey_lib_common::cache 2
-        flowey e 24 flowey_lib_common::download_cargo_nextest 4
+        flowey e 22 flowey_lib_common::cache 2
+        flowey e 22 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 24 flowey_lib_common::git_checkout 0
-        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 22 flowey_lib_common::git_checkout 0
+        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4876,32 +4261,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 24 flowey_lib_common::git_checkout 3
-        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey e 22 flowey_lib_common::git_checkout 3
+        flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 22 flowey_core::pipeline::artifact::resolve 5
+        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
     - name: generate nextest command
-      run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 24 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 24 flowey_lib_common::publish_test_results 4
-        flowey e 24 flowey_lib_common::publish_test_results 5
-        flowey v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 22 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 22 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 22 flowey_lib_common::publish_test_results 4
+        flowey e 22 flowey_lib_common::publish_test_results 5
+        flowey v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4912,12 +4297,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 24 flowey_lib_common::publish_test_results 0
-        flowey e 24 flowey_lib_common::publish_test_results 1
-        flowey e 24 flowey_lib_common::publish_test_results 2
-        flowey v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 22 flowey_lib_common::publish_test_results 0
+        flowey e 22 flowey_lib_common::publish_test_results 1
+        flowey e 22 flowey_lib_common::publish_test_results 2
+        flowey v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4927,32 +4312,32 @@ jobs:
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 24 flowey_lib_common::cache 3
+      run: flowey e 22 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 24 flowey_lib_common::cache 7
+      run: flowey e 22 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 24 flowey_lib_common::cache 11
+      run: flowey e 22 flowey_lib_common::cache 11
       shell: bash
-  job25:
+  job23:
     name: run vmm-tests [x64-linux-intel-mshv]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job10
-    - job11
-    - job6
+    - job2
+    - job3
+    - job9
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
@@ -5019,46 +4404,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 23 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 25 'verbose' update
+        cat <<'EOF' | flowey v 23 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 23 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 25 flowey_core::pipeline::artifact::resolve 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 2
-        flowey e 25 flowey_core::pipeline::artifact::resolve 7
-        flowey e 25 flowey_core::pipeline::artifact::resolve 3
-        flowey e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 4
-        flowey e 25 flowey_core::pipeline::artifact::resolve 6
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 23 flowey_core::pipeline::artifact::resolve 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey e 23 flowey_core::pipeline::artifact::resolve 6
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_release 0
+      run: flowey e 23 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 8
-        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 23 flowey_lib_common::cache 8
+        flowey v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5068,31 +4453,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 10
-        flowey e 25 flowey_lib_common::download_gh_release 1
+        flowey e 23 flowey_lib_common::cache 10
+        flowey e 23 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 25 flowey_lib_common::download_azcopy 0
+      run: flowey e 23 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_cli 0
+      run: flowey e 23 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 4
-        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 23 flowey_lib_common::cache 4
+        flowey v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5102,51 +4487,51 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 6
-        flowey e 25 flowey_lib_common::download_gh_cli 1
-        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 23 flowey_lib_common::cache 6
+        flowey e 23 flowey_lib_common::download_gh_cli 1
+        flowey v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 25 flowey_lib_common::use_gh_cli 0
+      run: flowey e 23 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 25 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 23 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 23 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 25 flowey_lib_common::download_cargo_nextest 0
-        flowey e 25 flowey_lib_common::download_cargo_nextest 1
-        flowey e 25 flowey_lib_common::download_cargo_nextest 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 3
+        flowey e 23 flowey_lib_common::download_cargo_nextest 0
+        flowey e 23 flowey_lib_common::download_cargo_nextest 1
+        flowey e 23 flowey_lib_common::download_cargo_nextest 2
+        flowey e 23 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 23 flowey_lib_common::cache 0
+        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5156,17 +4541,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 4
+        flowey e 23 flowey_lib_common::cache 2
+        flowey e 23 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 23 flowey_lib_common::git_checkout 0
+        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5178,31 +4563,31 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 5
-        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 23 flowey_lib_common::git_checkout 3
+        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 5
+        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: generate nextest command
-      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 25 flowey_lib_common::publish_test_results 4
-        flowey e 25 flowey_lib_common::publish_test_results 5
-        flowey v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 23 flowey_lib_common::publish_test_results 4
+        flowey e 23 flowey_lib_common::publish_test_results 5
+        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5213,12 +4598,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 25 flowey_lib_common::publish_test_results 0
-        flowey e 25 flowey_lib_common::publish_test_results 1
-        flowey e 25 flowey_lib_common::publish_test_results 2
-        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 23 flowey_lib_common::publish_test_results 0
+        flowey e 23 flowey_lib_common::publish_test_results 1
+        flowey e 23 flowey_lib_common::publish_test_results 2
+        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5228,18 +4613,18 @@ jobs:
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 25 flowey_lib_common::cache 3
+      run: flowey e 23 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 25 flowey_lib_common::cache 7
+      run: flowey e 23 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 25 flowey_lib_common::cache 11
+      run: flowey e 23 flowey_lib_common::cache 11
       shell: bash
-  job26:
+  job24:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -5251,10 +4636,10 @@ jobs:
       id-token: write
     needs:
     - job0
-    - job12
+    - job10
+    - job2
     - job3
-    - job4
-    - job8
+    - job5
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
@@ -5322,35 +4707,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 26 'verbose' update
+        cat <<'EOF' | flowey.exe v 24 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 26 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 24 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 0
-        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 24 flowey_lib_common::cache 0
+        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5360,17 +4745,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 24 flowey_lib_common::cache 2
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 24 flowey_lib_common::git_checkout 0
+        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5382,35 +4767,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 26 flowey_lib_common::git_checkout 3
-        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 24 flowey_lib_common::git_checkout 3
+        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 8
-        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 24 flowey_lib_common::cache 8
+        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5420,31 +4805,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 10
-        flowey.exe e 26 flowey_lib_common::download_gh_release 1
+        flowey.exe e 24 flowey_lib_common::cache 10
+        flowey.exe e 24 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 26 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 4
-        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 24 flowey_lib_common::cache 4
+        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5454,63 +4839,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 6
-        flowey.exe e 26 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 24 flowey_lib_common::cache 6
+        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 26 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 26 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 26 flowey_lib_common::publish_test_results 4
-        flowey.exe e 26 flowey_lib_common::publish_test_results 5
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 24 flowey_lib_common::publish_test_results 4
+        flowey.exe e 24 flowey_lib_common::publish_test_results 5
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5521,12 +4906,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 26 flowey_lib_common::publish_test_results 0
-        flowey.exe e 26 flowey_lib_common::publish_test_results 1
-        flowey.exe e 26 flowey_lib_common::publish_test_results 2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 24 flowey_lib_common::publish_test_results 0
+        flowey.exe e 24 flowey_lib_common::publish_test_results 1
+        flowey.exe e 24 flowey_lib_common::publish_test_results 2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5536,18 +4921,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 26 flowey_lib_common::cache 3
+      run: flowey.exe e 24 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 26 flowey_lib_common::cache 7
+      run: flowey.exe e 24 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 26 flowey_lib_common::cache 11
+      run: flowey.exe e 24 flowey_lib_common::cache 11
       shell: bash
-  job27:
+  job25:
     name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
@@ -5573,18 +4958,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 27 'verbose' update
+        cat <<'EOF' | flowey v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5596,35 +4981,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 27 flowey_lib_common::git_checkout 3
-        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_common::git_checkout 3
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 27 flowey_lib_common::install_rust 0
+      run: flowey e 25 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 27 flowey_lib_common::install_rust 1
+      run: flowey e 25 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 27 flowey_lib_common::install_rust 2
-        flowey v 27 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 25 flowey_lib_common::install_rust 2
+        flowey v 25 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 27 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      run: flowey e 25 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
-  job28:
+  job26:
     name: build openhcl (mi-secure) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job28-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5648,31 +5033,31 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 28 'verbose' update
+        cat <<'EOF' | flowey v 26 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 28 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 26 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 28 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 26 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 28 flowey_lib_common::download_gh_release 0
+      run: flowey e 26 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 28 flowey_lib_common::cache 0
-        flowey v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey e 26 flowey_lib_common::cache 0
+        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5682,31 +5067,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 28 flowey_lib_common::cache 2
-        flowey e 28 flowey_lib_common::download_gh_release 1
+        flowey e 26 flowey_lib_common::cache 2
+        flowey e 26 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 28 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 28 flowey_lib_common::install_rust 0
+      run: flowey e 26 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 28 flowey_lib_common::install_rust 1
+      run: flowey e 26 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 28 flowey_lib_common::install_rust 2
-        flowey e 28 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 26 flowey_lib_common::install_rust 2
+        flowey e 26 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 28 flowey_lib_common::git_checkout 0
-        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 26 flowey_lib_common::git_checkout 0
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5718,172 +5103,172 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 28 flowey_lib_common::git_checkout 3
-        flowey e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 26 flowey_lib_common::git_checkout 3
+        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 28 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 26 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 28 flowey_lib_common::resolve_protoc 0
-        flowey e 28 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 26 flowey_lib_common::resolve_protoc 0
+        flowey e 26 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 28 flowey_lib_hvlite::init_cross_build 0
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 26 flowey_lib_hvlite::init_cross_build 0
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 3
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 26 flowey_lib_common::run_cargo_build 3
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 28 flowey_lib_hvlite::build_sidecar 0
-        flowey e 28 flowey_lib_hvlite::init_cross_build 1
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 26 flowey_lib_hvlite::build_sidecar 0
+        flowey e 26 flowey_lib_hvlite::init_cross_build 1
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: cargo build openhcl_boot
       run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 1
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 26 flowey_lib_common::run_cargo_build 1
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 28 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 26 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 28 flowey_lib_hvlite::init_cross_build 3
+        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 26 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 2
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 28 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 26 flowey_lib_common::run_cargo_build 2
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 26 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 28 flowey_lib_hvlite::init_cross_build 2
+        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 26 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 0
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 26 flowey_lib_common::run_cargo_build 0
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 28 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 26 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 26 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 28 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 26 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
-        flowey e 28 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 26 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 28 flowey_lib_common::copy_to_artifact_dir 0
+      run: flowey e 26 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 28 flowey_lib_common::cache 3
+      run: flowey e 26 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -5897,21 +5282,21 @@ jobs:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
         include-hidden-files: true
-  job29:
+  job27:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job29-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job10
-    - job28
-    - job6
+    - job2
+    - job26
+    - job3
     - job7
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
@@ -5931,39 +5316,39 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
 
-        echo '"debug"' | flowey.exe v 29 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 29 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 27 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 27 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 29 'verbose' update
+        cat <<'EOF' | flowey.exe v 27 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 29 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 29 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 29 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 29 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 29 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 29 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 29 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 29 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 29 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 27 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 27 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 27 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 27 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 27 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 27 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 27 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 27 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 29 flowey_lib_common::cache 0
-        flowey.exe v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 27 flowey_lib_common::cache 0
+        flowey.exe v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5973,17 +5358,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 29 flowey_lib_common::cache 2
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 27 flowey_lib_common::cache 2
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 29 flowey_lib_common::git_checkout 0
-        flowey.exe v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 27 flowey_lib_common::git_checkout 0
+        flowey.exe v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5995,38 +5380,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 29 flowey_lib_common::git_checkout 3
-        flowey.exe e 29 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 27 flowey_lib_common::git_checkout 3
+        flowey.exe e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 29 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 27 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 29 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 27 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 29 flowey_lib_common::cache 8
-        flowey.exe v 29 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 29 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 27 flowey_lib_common::cache 8
+        flowey.exe v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -6036,31 +5421,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 29 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 29 flowey_lib_common::cache 10
-        flowey.exe e 29 flowey_lib_common::download_gh_release 1
+        flowey.exe e 27 flowey_lib_common::cache 10
+        flowey.exe e 27 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 29 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 27 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 29 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 27 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 29 flowey_lib_common::cache 4
-        flowey.exe v 29 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 29 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 27 flowey_lib_common::cache 4
+        flowey.exe v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -6070,63 +5455,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 29 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 29 flowey_lib_common::cache 6
-        flowey.exe e 29 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 27 flowey_lib_common::cache 6
+        flowey.exe e 27 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 29 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 27 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 29 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 29 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 27 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 29 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 29 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 29 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 29 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 29 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 27 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 29 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 29 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 29 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 27 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 29 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 29 flowey_lib_common::publish_test_results 4
-        flowey.exe e 29 flowey_lib_common::publish_test_results 5
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 27 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 27 flowey_lib_common::publish_test_results 4
+        flowey.exe e 27 flowey_lib_common::publish_test_results 5
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -6137,12 +5522,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 29 flowey_lib_common::publish_test_results 0
-        flowey.exe e 29 flowey_lib_common::publish_test_results 1
-        flowey.exe e 29 flowey_lib_common::publish_test_results 2
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 27 flowey_lib_common::publish_test_results 0
+        flowey.exe e 27 flowey_lib_common::publish_test_results 1
+        flowey.exe e 27 flowey_lib_common::publish_test_results 2
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -6152,23 +5537,23 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 29 flowey_lib_common::cache 3
+      run: flowey.exe e 27 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 29 flowey_lib_common::cache 7
+      run: flowey.exe e 27 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 29 flowey_lib_common::cache 11
+      run: flowey.exe e 27 flowey_lib_common::cache 11
       shell: bash
   job3:
-    name: build artifacts (shared VMM tests) [aarch64-windows]
+    name: build artifacts (shared VMM tests) [linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6177,91 +5562,65 @@ jobs:
     - job0
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
       with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr-release.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-pr-release.yaml ci checkin-gates --config=pr-release
-      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey.exe v 3 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 3 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 3 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 3 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 3 'verbose' update
+        cat <<'EOF' | flowey v 3 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-pipette"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-pipette" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 3 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 3 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 3 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests" | flowey v 3 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 3 'artifact_publish_from_aarch64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 3 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 3 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 3 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 3 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 3 'artifact_publish_from_x64-tmks' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 3 flowey_lib_common::install_rust 0
+      run: flowey e 3 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 3 flowey_lib_common::install_rust 1
+      run: flowey e 3 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 3 flowey_lib_common::install_rust 2
-        flowey.exe e 3 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 3 flowey_lib_common::install_rust 2
+        flowey e 3 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 3 flowey_lib_common::git_checkout 0
-        flowey.exe v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 3 flowey_lib_common::git_checkout 0
+        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6273,23 +5632,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 3 flowey_lib_common::git_checkout 3
-        flowey.exe e 3 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 3 flowey_lib_common::git_checkout 3
+        flowey e 3 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 3 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 3 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 3 flowey_lib_common::download_gh_release 0
+      run: flowey e 3 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 3 flowey_lib_common::cache 0
-        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey e 3 flowey_lib_common::cache 0
+        flowey v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6299,40 +5658,232 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 3 flowey_lib_common::cache 2
-        flowey.exe e 3 flowey_lib_common::download_gh_release 1
+        flowey e 3 flowey_lib_common::cache 2
+        flowey e 3 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 3 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 3 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 3 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 3 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 3 flowey_lib_common::resolve_protoc 0
+        flowey e 3 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
+      run: flowey e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 3 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
       run: |-
-        flowey.exe e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 0
+        flowey e 3 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 1
+        flowey e 3 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 6
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 14
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 15
+        flowey e 3 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 3 flowey_core::pipeline::artifact::publish 6
+        flowey e 3 flowey_lib_hvlite::init_cross_build 9
+      shell: bash
+    - name: cargo build guest_test_uefi
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 1
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 1
+      shell: bash
+    - name: build guest_test_uefi.img
+      run: |-
+        flowey e 3 flowey_lib_hvlite::build_guest_test_uefi 0
+        flowey e 3 flowey_core::pipeline::artifact::publish 7
+        flowey e 3 flowey_lib_hvlite::init_cross_build 5
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: cargo build simple_tmk
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 4
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 12
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 3 flowey_lib_hvlite::build_tmks 0
+        flowey e 3 flowey_core::pipeline::artifact::publish 8
+        flowey e 3 flowey_lib_hvlite::init_cross_build 6
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 9
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 20
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 21
+        flowey e 3 flowey_lib_hvlite::build_tpm_guest_tests 1
+        flowey e 3 flowey_core::pipeline::artifact::publish 9
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 3 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 3 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 3 flowey_lib_hvlite::build_pipette 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 0
+        flowey e 3 flowey_lib_common::run_cargo_build 3
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 3 flowey_lib_hvlite::build_pipette 1
+        flowey e 3 flowey_core::pipeline::artifact::publish 0
+        flowey e 3 flowey_lib_hvlite::init_cross_build 8
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 7
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 16
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 17
+        flowey e 3 flowey_lib_hvlite::build_tmk_vmm 1
+        flowey e 3 flowey_core::pipeline::artifact::publish 1
+        flowey e 3 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build guest_test_uefi
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 0
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: build guest_test_uefi.img
+      run: |-
+        flowey e 3 flowey_lib_hvlite::build_guest_test_uefi 1
+        flowey e 3 flowey_core::pipeline::artifact::publish 2
+        flowey e 3 flowey_lib_hvlite::init_cross_build 0
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build simple_tmk
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 5
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 3 flowey_lib_hvlite::build_tmks 1
+        flowey e 3 flowey_core::pipeline::artifact::publish 3
+        flowey e 3 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 8
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 18
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 19
+        flowey e 3 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey e 3 flowey_core::pipeline::artifact::publish 4
+        flowey e 3 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 2
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 3 flowey_lib_hvlite::build_pipette 0
+        flowey e 3 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 3 flowey_lib_common::cache 3
+      run: flowey e 3 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-windows-pipette
+    - name: 🌼📦 Publish aarch64-guest_test_uefi
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-pipette
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-pipette/
+        name: aarch64-guest_test_uefi
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-musl-pipette
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-tmks
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-guest_test_uefi
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-guest_test_uefi
+        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-pipette
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-tmks
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
         include-hidden-files: true
   job4:
-    name: build artifacts (for VMM tests) [aarch64-windows]
+    name: build artifacts (not for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6411,20 +5962,14 @@ jobs:
         cat <<'EOF' | flowey.exe v 4 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-prep_steps"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-prep_steps" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-test_igvm_agent_rpc_server" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tpm_guest_tests"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tpm_guest_tests" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-hypestv"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-hypestv" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-hypestv' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-igvmfilegen"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-igvmfilegen" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-ohcldiag-dev"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-ohcldiag-dev" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgs_lib"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgs_lib" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-vmgs_lib' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 4 flowey_lib_common::install_rust 0
@@ -6467,22 +6012,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 4 flowey_lib_common::cache 4
-        flowey.exe v 4 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 4 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 4 flowey_lib_common::cache 0
+        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 4 flowey_lib_common::cache 6
+        flowey.exe e 4 flowey_lib_common::cache 2
         flowey.exe e 4 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -6495,148 +6040,67 @@ jobs:
         flowey.exe e 4 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey.exe e 4 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 5
-        flowey.exe e 4 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 3
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build prep_steps
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 4 flowey_lib_hvlite::build_prep_steps 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 4
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 5
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 9
-        flowey.exe e 4 flowey_lib_hvlite::build_vmgstool 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 5
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 6
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 4
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 8
-        flowey.exe e 4 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 6
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 6
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 2
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 4
-        flowey.exe e 4 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 0
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 4 flowey_lib_common::cache 0
-        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 4 flowey_lib_common::cache 2
-        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey.exe e 4 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey.exe e 4 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey.exe e 4 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build openvmm
+    - name: cargo build hypestv
       run: |-
         flowey.exe e 4 flowey_lib_common::run_cargo_build 0
         flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 4 flowey_lib_hvlite::build_openvmm 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 4 flowey_lib_hvlite::build_hypestv 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 0
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 0
       shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 4 flowey_lib_common::cache 3
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 4 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build ohcldiag-dev
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 2
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 4 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 4 flowey_lib_common::cache 7
+      run: flowey.exe e 4 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-windows-openvmm
+    - name: 🌼📦 Publish aarch64-windows-hypestv
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-openvmm/
+        name: aarch64-windows-hypestv
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-hypestv/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-prep_steps
+    - name: 🌼📦 Publish aarch64-windows-igvmfilegen
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-prep_steps
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-prep_steps/
+        name: aarch64-windows-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-igvmfilegen/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
+    - name: 🌼📦 Publish aarch64-windows-ohcldiag-dev
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-test_igvm_agent_rpc_server
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server/
+        name: aarch64-windows-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-ohcldiag-dev/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-tmk_vmm
+    - name: 🌼📦 Publish aarch64-windows-vmgs_lib
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-tpm_guest_tests
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmm-tests-archive/
+        name: aarch64-windows-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
         include-hidden-files: true
   job5:
-    name: build artifacts (not for VMM tests) [x64-windows]
+    name: build artifacts (for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6715,14 +6179,20 @@ jobs:
         cat <<'EOF' | flowey.exe v 5 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 5 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 5 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 5 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-prep_steps"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-prep_steps" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-test_igvm_agent_rpc_server" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tpm_guest_tests"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tpm_guest_tests" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 5 flowey_lib_common::install_rust 0
@@ -6765,22 +6235,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 5 flowey_lib_common::cache 0
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe e 5 flowey_lib_common::cache 4
+        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
-    - id: flowey_lib_common__cache__1
+    - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 5 flowey_lib_common::cache 2
+        flowey.exe e 5 flowey_lib_common::cache 6
         flowey.exe e 5 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -6791,73 +6261,150 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 5 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: cargo build hypestv
+    - name: cargo build openvmm
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 0
         flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 5 flowey_lib_hvlite::build_hypestv 0
+        flowey.exe e 5 flowey_lib_hvlite::build_openvmm 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build vmgs_lib
+    - name: cargo build tmk_vmm
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
-        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      shell: bash
-    - name: test vmgs_lib
-      run: |-
-        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 5
+        flowey.exe e 5 flowey_lib_hvlite::build_tmk_vmm 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 5
       shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build prep_steps
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 1
         flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 5 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey.exe e 5 flowey_lib_hvlite::build_prep_steps 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 2
         flowey.exe e 5 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build ohcldiag-dev
+    - name: cargo build vmgstool
+      run: |-
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 5
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 9
+        flowey.exe e 5 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 5 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 6
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 8
+        flowey.exe e 5 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey.exe e 5 flowey_core::pipeline::artifact::publish 4
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 6
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 2
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 5 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey.exe e 5 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 5 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
+        flowey.exe e 5 flowey_core::pipeline::artifact::publish 5
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 5 flowey_lib_common::cache 0
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 5 flowey_lib_common::cache 2
+        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 5 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey.exe e 5 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey.exe e 5 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey.exe e 5 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey.exe e 5 flowey_core::pipeline::artifact::publish 6
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 5 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-windows-hypestv
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 5 flowey_lib_common::cache 7
+      shell: bash
+    - name: 🌼📦 Publish aarch64-windows-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-hypestv
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-hypestv/
+        name: aarch64-windows-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-igvmfilegen
+    - name: 🌼📦 Publish aarch64-windows-prep_steps
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-igvmfilegen/
+        name: aarch64-windows-prep_steps
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-prep_steps/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-ohcldiag-dev
+    - name: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
+        name: aarch64-windows-test_igvm_agent_rpc_server
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-vmgs_lib
+    - name: 🌼📦 Publish aarch64-windows-tmk_vmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
+        name: aarch64-windows-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmm-tests-archive/
         include-hidden-files: true
   job6:
-    name: build artifacts (shared VMM tests) [x64-windows]
+    name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6936,8 +6483,14 @@ jobs:
         cat <<'EOF' | flowey.exe v 6 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-pipette"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 6 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 6 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 6 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 6 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 6 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 6 flowey_lib_common::install_rust 0
@@ -7006,23 +6559,70 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build pipette
+    - name: cargo build hypestv
       run: |-
         flowey.exe e 6 flowey_lib_common::run_cargo_build 0
         flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 6 flowey_lib_hvlite::build_pipette 0
+        flowey.exe e 6 flowey_lib_hvlite::build_hypestv 0
         flowey.exe e 6 flowey_core::pipeline::artifact::publish 0
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      shell: bash
+    - name: test vmgs_lib
+      run: |-
+        flowey.exe e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey.exe e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey.exe e 6 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 6 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey.exe e 6 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build ohcldiag-dev
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 2
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 6 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey.exe e 6 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey.exe e 6 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-windows-pipette
+    - name: 🌼📦 Publish x64-windows-hypestv
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-pipette
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
+        name: x64-windows-hypestv
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-hypestv/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-igvmfilegen
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-ohcldiag-dev
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-vmgs_lib
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
         include-hidden-files: true
   job7:
     name: build artifacts (for VMM tests) [x64-windows]
@@ -7337,7 +6937,7 @@ jobs:
         name: _internal-flowey-bootstrap-x86_64-windows-uid-6
         path: ${{ runner.temp }}/bootstrapped-flowey
   job8:
-    name: build artifacts (shared VMM tests) [aarch64-linux]
+    name: build artifacts (for VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7372,16 +6972,22 @@ jobs:
         cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 8 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests" | flowey v 8 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 8 'artifact_publish_from_aarch64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 8 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 8 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 8 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 8 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 8 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 8 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 8 flowey_lib_common::install_rust 0
@@ -7393,6 +6999,12 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_common::install_rust 2
         flowey e 8 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 8 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 8 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
@@ -7442,12 +7054,6 @@ jobs:
         flowey e 8 flowey_lib_common::cache 2
         flowey e 8 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 8 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 8 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 8 flowey_lib_common::resolve_protoc 0
@@ -7456,45 +7062,80 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 8 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 8 flowey_lib_hvlite::build_openvmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 0
+        flowey e 8 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 4
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 1
         flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: cargo build guest_test_uefi
+    - name: cargo build vmgstool
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 8 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 2
+        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 8 flowey_core::pipeline::artifact::publish 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build igvmfilegen
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 0
         flowey e 8 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
-    - name: build guest_test_uefi.img
+    - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::build_guest_test_uefi 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 0
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
       shell: bash
-    - name: cargo build simple_tmk
+    - name: cargo build ohcldiag-dev
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 8 flowey_lib_common::run_cargo_build 1
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::build_tmks 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 1
-        flowey e 8 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 4
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 8 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 8 flowey_lib_hvlite::resolve_openvmm_deps 0
@@ -7502,302 +7143,35 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 6
       shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 1
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::build_pipette 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 3
-        flowey e 8 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build tmk_vmm
+    - name: cargo build openvmm
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 4
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::build_openvmm 1
+        flowey e 8 flowey_core::pipeline::artifact::publish 6
+        flowey e 8 flowey_lib_hvlite::init_cross_build 7
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 10
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 1
+        flowey e 8 flowey_core::pipeline::artifact::publish 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
-      shell: bash
-    - name: 🌼📦 Publish aarch64-guest_test_uefi
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-guest_test_uefi
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-pipette
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-tpm_guest_tests
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-tmks
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-tmks
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
-        include-hidden-files: true
-  job9:
-    name: build artifacts (for VMM tests) [aarch64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 9 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 9 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 9 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 9 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 9 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 9 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 9 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 9 flowey_lib_common::install_rust 2
-        flowey e 9 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 9 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 9 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 9 flowey_lib_common::git_checkout 3
-        flowey e 9 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 9 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 9 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 9 flowey_lib_common::cache 2
-        flowey e 9 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 9 flowey_lib_common::resolve_protoc 0
-        flowey e 9 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 2
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::build_openvmm 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 4
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 7
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 9 flowey_lib_hvlite::build_vmgstool 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 9 flowey_core::pipeline::artifact::publish 3
-        flowey e 9 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 0
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build ohcldiag-dev
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 1
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 9 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 5
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 9 flowey_lib_hvlite::build_openvmm 1
-        flowey e 9 flowey_core::pipeline::artifact::publish 6
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
-        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
-        flowey e 9 flowey_core::pipeline::artifact::publish 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 9 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish aarch64-linux-igvmfilegen
       uses: actions/upload-artifact@v7
@@ -7846,4 +7220,360 @@ jobs:
       with:
         name: aarch64-linux-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
+        include-hidden-files: true
+  job9:
+    name: build artifacts (for VMM tests) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 9 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 9 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 9 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 9 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 9 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 9 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 9 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 9 flowey_lib_common::install_rust 2
+        flowey e 9 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 9 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 9 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 9 flowey_lib_common::git_checkout 0
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 9 flowey_lib_common::git_checkout 3
+        flowey e 9 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 9 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 9 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 9 flowey_lib_common::cache 4
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 9 flowey_lib_common::cache 6
+        flowey e 9 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 9 flowey_lib_common::resolve_protoc 0
+        flowey e 9 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 2
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::build_openvmm 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build vmgstool
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 9 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      shell: bash
+    - name: test vmgs_lib
+      run: |-
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey e 9 flowey_core::pipeline::artifact::publish 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 0
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+      shell: bash
+    - name: cargo build ohcldiag-dev
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 1
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 5
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::build_openvmm 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 7
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 9 flowey_lib_common::download_cargo_nextest 0
+        flowey e 9 flowey_lib_common::download_cargo_nextest 1
+        flowey e 9 flowey_lib_common::download_cargo_nextest 2
+        flowey e 9 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 9 flowey_lib_common::cache 0
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 9 flowey_lib_common::cache 2
+        flowey e 9 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 9 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 9 flowey_lib_common::install_cargo_nextest 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 8
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 1
+        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 9
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 9 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 9 flowey_lib_common::cache 7
+      shell: bash
+    - name: 🌼📦 Publish x64-linux-igvmfilegen
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgs_lib
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
         include-hidden-files: true

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -6940,10 +6940,6 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 6 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
@@ -7026,7 +7022,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 6
+        flowey e 6 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -7038,10 +7034,23 @@ jobs:
         flowey e 6 flowey_lib_hvlite::build_guest_test_uefi 0
         flowey e 6 flowey_core::pipeline::artifact::publish 0
         flowey e 6 flowey_lib_hvlite::init_cross_build 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: cargo build simple_tmk
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 2
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 5
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 6 flowey_lib_hvlite::build_tmks 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 1
+        flowey e 6 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tpm_guest_tests
       run: |-
         flowey e 6 flowey_lib_common::run_cargo_build 4
         flowey e 6 flowey_lib_hvlite::run_cargo_build 9
@@ -7050,19 +7059,6 @@ jobs:
       run: |-
         flowey e 6 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 6 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 6 flowey_lib_hvlite::build_tmks 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 1
-        flowey e 6 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 6
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 14
         flowey e 6 flowey_lib_hvlite::build_tpm_guest_tests 0
         flowey e 6 flowey_core::pipeline::artifact::publish 2
       shell: bash
@@ -7076,54 +7072,28 @@ jobs:
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 6 flowey_lib_hvlite::build_pipette 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 3
-        flowey e 6 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 5
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 11
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 6 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 4
-        flowey e 6 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
         flowey e 6 flowey_lib_common::run_cargo_build 1
         flowey e 6 flowey_lib_hvlite::run_cargo_build 1
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 6 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::build_openvmm 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 5
+        flowey e 6 flowey_lib_hvlite::build_pipette 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 3
         flowey e 6 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: cargo build openvmm_vhost
+    - name: cargo build tmk_vmm
       run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 6 flowey_lib_common::run_cargo_build 3
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 7
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 4
-        flowey e 6 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 6
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 6 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 6 flowey_lib_common::cache 3
@@ -7133,18 +7103,6 @@ jobs:
       with:
         name: aarch64-guest_test_uefi
         path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v7
@@ -7208,6 +7166,10 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 7 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 7 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
@@ -7305,42 +7267,42 @@ jobs:
         flowey e 7 flowey_lib_hvlite::run_cargo_build 5
         flowey e 7 flowey_lib_hvlite::build_openvmm 0
         flowey e 7 flowey_core::pipeline::artifact::publish 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 1
+        flowey e 7 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 7 flowey_lib_common::run_cargo_build 4
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 9
         flowey e 7 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 7 flowey_core::pipeline::artifact::publish 1
         flowey e 7 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 5
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 7 flowey_lib_common::run_cargo_build 7
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 14
         flowey e 7 flowey_lib_hvlite::build_vmgstool 0
         flowey e 7 flowey_core::pipeline::artifact::publish 2
         flowey e 7 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 4
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 7 flowey_lib_common::run_cargo_build 6
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 12
         flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
         flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 7 flowey_core::pipeline::artifact::publish 3
-        flowey e 7 flowey_lib_hvlite::init_cross_build 2
+        flowey e 7 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -7349,7 +7311,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 7 flowey_lib_hvlite::run_cargo_build 1
         flowey e 7 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 7 flowey_core::pipeline::artifact::publish 4
@@ -7367,6 +7329,39 @@ jobs:
         flowey e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey e 7 flowey_core::pipeline::artifact::publish 5
       shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 7 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 7 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 7 flowey_lib_hvlite::init_cross_build 6
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 7 flowey_lib_common::run_cargo_build 3
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 7 flowey_lib_hvlite::build_openvmm 1
+        flowey e 7 flowey_core::pipeline::artifact::publish 6
+        flowey e 7 flowey_lib_hvlite::init_cross_build 7
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 7 flowey_lib_common::run_cargo_build 5
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 10
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 7 flowey_lib_hvlite::build_openvmm_vhost 1
+        flowey e 7 flowey_core::pipeline::artifact::publish 7
+      shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 7 flowey_lib_common::cache 3
       shell: bash
@@ -7375,6 +7370,18 @@ jobs:
       with:
         name: aarch64-linux-igvmfilegen
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v7
@@ -7444,10 +7451,6 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 8 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 8 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 8 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
@@ -7530,7 +7533,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 6
+        flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -7542,10 +7545,23 @@ jobs:
         flowey e 8 flowey_lib_hvlite::build_guest_test_uefi 0
         flowey e 8 flowey_core::pipeline::artifact::publish 0
         flowey e 8 flowey_lib_hvlite::init_cross_build 0
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: cargo build simple_tmk
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::build_tmks 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 1
+        flowey e 8 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tpm_guest_tests
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 4
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
@@ -7554,19 +7570,6 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 8 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 8 flowey_lib_hvlite::build_tmks 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 1
-        flowey e 8 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
         flowey e 8 flowey_lib_hvlite::build_tpm_guest_tests 0
         flowey e 8 flowey_core::pipeline::artifact::publish 2
       shell: bash
@@ -7580,54 +7583,28 @@ jobs:
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::build_pipette 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 3
-        flowey e 8 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 5
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 11
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 4
-        flowey e 8 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 1
         flowey e 8 flowey_lib_hvlite::run_cargo_build 1
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 8 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::build_openvmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 5
+        flowey e 8 flowey_lib_hvlite::build_pipette 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 3
         flowey e 8 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: cargo build openvmm_vhost
+    - name: cargo build tmk_vmm
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 8 flowey_lib_common::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
-        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 6
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
@@ -7637,18 +7614,6 @@ jobs:
       with:
         name: x64-guest_test_uefi
         path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v7
@@ -7712,6 +7677,10 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
@@ -7813,38 +7782,38 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 5
         flowey e 9 flowey_lib_hvlite::build_openvmm 0
         flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 9 flowey_lib_common::run_cargo_build 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
         flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 9 flowey_lib_common::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
         flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 4
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 9 flowey_lib_common::run_cargo_build 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       shell: bash
     - name: test vmgs_lib
@@ -7852,7 +7821,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 9 flowey_core::pipeline::artifact::publish 3
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -7861,7 +7830,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
@@ -7878,6 +7847,39 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 3
         flowey e 9 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey e 9 flowey_core::pipeline::artifact::publish 5
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::build_openvmm 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 7
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -7918,14 +7920,14 @@ jobs:
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 6
+        flowey e 9 flowey_core::pipeline::artifact::publish 8
         flowey e 9 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 1
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
-        flowey e 9 flowey_core::pipeline::artifact::publish 7
+        flowey e 9 flowey_core::pipeline::artifact::publish 9
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 9 flowey_lib_common::cache 3
@@ -7938,6 +7940,18 @@ jobs:
       with:
         name: x64-linux-igvmfilegen
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
       uses: actions/upload-artifact@v7

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -391,7 +391,7 @@ jobs:
       run: flowey.exe e 1 flowey_lib_common::cache 3
       shell: bash
   job10:
-    name: build openhcl [aarch64-linux]
+    name: build artifacts (shared VMM tests) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -426,42 +426,16 @@ jobs:
         cat <<'EOF' | flowey v 10 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 10 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 10 flowey_lib_common::cache 2
-        flowey e 10 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (aarch64)
-      run: flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 10 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 10 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 10 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 10 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 10 'artifact_publish_from_x64-tmks' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 10 flowey_lib_common::install_rust 0
@@ -477,7 +451,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
         flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -485,7 +459,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -499,6 +473,35 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 10 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 10 flowey_lib_common::cache 0
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 10 flowey_lib_common::cache 2
+        flowey e 10 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 10 flowey_lib_common::resolve_protoc 0
@@ -507,132 +510,119 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 0
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 10 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 1
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 10 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build guest_test_uefi
       run: |-
         flowey e 10 flowey_lib_common::run_cargo_build 0
         flowey e 10 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
-    - name: split debug symbols
+    - name: build guest_test_uefi.img
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 10 flowey_lib_hvlite::build_guest_test_uefi 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
-    - name: building igvm file
+    - name: cargo build simple_tmk
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::build_tmks 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 1
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: building openhcl initrd
+    - name: cargo build tpm_guest_tests
       run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 10 flowey_lib_common::run_cargo_build 4
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
-    - name: building igvm file
+    - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 10 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 2
       shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
+    - name: unpack openvmm-deps archive
+      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
+    - name: cargo build pipette
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::build_pipette 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 3
+        flowey e 10 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 10 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-openhcl-igvm
+    - name: 🌼📦 Publish x64-guest_test_uefi
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        name: x64-guest_test_uefi
+        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
+    - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
+        name: x64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-tmks
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
         include-hidden-files: true
   job11:
-    name: verify openhcl binary size [aarch64]
-    runs-on: ubuntu-latest
+    name: build artifacts (for VMM tests) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -662,6 +652,26 @@ jobs:
         cat <<'EOF' | flowey v 11 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 11 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 11 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 11 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 11 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 11 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 11 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 11 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 11 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 11 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 11 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 11 flowey_lib_common::install_rust 0
@@ -674,10 +684,16 @@ jobs:
         flowey e 11 flowey_lib_common::install_rust 2
         flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar2
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
         flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -685,7 +701,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar2 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -695,13 +711,9 @@ jobs:
         EOF
         flowey e 11 flowey_lib_common::git_checkout 3
         flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 11 flowey_lib_common::download_gh_release 0
@@ -709,14 +721,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 4
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -726,108 +738,242 @@ jobs:
         flowey e 11 flowey_lib_common::cache 6
         flowey e 11 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
     - name: unpack protoc
-      run: flowey e 11 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 11 flowey_lib_common::resolve_protoc 0
+        flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: cargo build openvmm_hcl
+    - name: cargo build openvmm
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 11 flowey_lib_hvlite::build_openvmm 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 4
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 11 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 1
+        flowey e 11 flowey_lib_hvlite::init_cross_build 6
+      shell: bash
+    - name: cargo build vmgstool
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 7
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 11 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 2
+        flowey e 11 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 6
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      shell: bash
+    - name: test vmgs_lib
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey e 11 flowey_core::pipeline::artifact::publish 3
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build igvmfilegen
       run: |-
         flowey e 11 flowey_lib_common::run_cargo_build 0
         flowey e 11 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 4
+        flowey e 11 flowey_lib_hvlite::init_cross_build 7
       shell: bash
-    - name: collect openvmm_hcl files for analysis
+    - name: cargo build ohcldiag-dev
       run: |-
-        flowey e 11 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
-        flowey v 11 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:119:27' --is-raw-string write-to-env github floweyvar1
-      shell: bash
-    - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64_openvmm_hcl_for_size_analysis
-        path: ${{ env.floweyvar1 }}
-      name: publish openvmm_hcl for analysis
-    - name: cargo build xtask
-      run: |-
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
         flowey e 11 flowey_lib_common::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
         flowey e 11 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 11 flowey_lib_hvlite::build_xtask 0
+        flowey e 11 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 5
       shell: bash
-    - name: create gh cache dir
-      run: flowey e 11 flowey_lib_common::download_gh_cli 0
+    - name: unpack openvmm-deps archive
+      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 8
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 11 flowey_lib_hvlite::build_openvmm 1
+        flowey e 11 flowey_core::pipeline::artifact::publish 6
+        flowey e 11 flowey_lib_hvlite::init_cross_build 9
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 5
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 11 flowey_lib_hvlite::build_openvmm_vhost 1
+        flowey e 11 flowey_core::pipeline::artifact::publish 7
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 11 flowey_lib_common::download_cargo_nextest 0
+        flowey e 11 flowey_lib_common::download_cargo_nextest 1
+        flowey e 11 flowey_lib_common::download_cargo_nextest 2
+        flowey e 11 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
       run: |-
         flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 2
-        flowey e 11 flowey_lib_common::download_gh_cli 1
-        flowey v 11 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
+        flowey e 11 flowey_lib_common::download_cargo_nextest 4
       shell: bash
-    - name: setup gh cli
-      run: flowey e 11 flowey_lib_common::use_gh_cli 0
+    - name: report $CARGO_HOME
+      run: flowey e 11 flowey_lib_common::install_rust 3
       shell: bash
-    - name: get merge commit
-      run: flowey e 11 flowey_lib_common::git_merge_commit 0
-      shell: bash
-    - name: get action id by commit
+    - name: installing cargo-nextest
       run: |-
-        flowey e 11 flowey_lib_common::gh_workflow_id 0
-        flowey e 11 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 0
+        flowey e 11 flowey_lib_common::install_cargo_nextest 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 0
       shell: bash
-    - name: download artifacts from github actions run
-      run: flowey e 11 flowey_lib_common::download_gh_artifact 0
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 8
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: binary size comparison
-      run: flowey e 11 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 3
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_nextest_archive 1
+        flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 1
+        flowey e 11 flowey_core::pipeline::artifact::publish 9
       shell: bash
-    - name: 'validate cache entry: gh-cli'
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey e 11 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 11 flowey_lib_common::cache 7
       shell: bash
+    - name: 🌼📦 Publish x64-linux-igvmfilegen
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgs_lib
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
+        include-hidden-files: true
   job12:
-    name: build openhcl [x64-linux]
+    name: build openhcl [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -862,10 +1008,10 @@ jobs:
         cat <<'EOF' | flowey v 12 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 12 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 12 flowey_lib_common::install_dist_pkg 0
@@ -896,7 +1042,7 @@ jobs:
         flowey e 12 flowey_lib_common::cache 2
         flowey e 12 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack mu_msvm package (x64)
+    - name: unpack mu_msvm package (aarch64)
       run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
@@ -944,20 +1090,6 @@ jobs:
       run: |-
         flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: cargo build sidecar
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 3
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 12 flowey_lib_hvlite::build_sidecar 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 1
         flowey e 12 flowey_lib_hvlite::run_cargo_build 2
         flowey e 12 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
@@ -968,41 +1100,41 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 12 flowey_lib_hvlite::run_cargo_build 5
         flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey e 12 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
         flowey e 12 flowey_lib_common::run_cargo_build 2
         flowey e 12 flowey_lib_hvlite::run_cargo_build 6
         flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -1012,128 +1144,50 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 12 flowey_lib_hvlite::run_cargo_build 1
         flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 3
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 3
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
         flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
         flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
         flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
@@ -1146,20 +1200,20 @@ jobs:
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 12 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-openhcl-igvm
+    - name: 🌼📦 Publish aarch64-openhcl-igvm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
+        name: aarch64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-extras
+    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
-        name: x64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
+        name: aarch64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
         include-hidden-files: true
   job13:
-    name: verify openhcl binary size [x64]
+    name: verify openhcl binary size [aarch64]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1257,7 +1311,7 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 13 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract Aarch64 sysroot.tar.gz
       run: flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -1269,7 +1323,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 1
+        flowey e 13 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
@@ -1278,7 +1332,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
         flowey e 13 flowey_lib_hvlite::run_cargo_build 1
         flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 0
       shell: bash
@@ -1290,18 +1344,18 @@ jobs:
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
       uses: actions/upload-artifact@v7
       with:
-        name: x86_64_openvmm_hcl_for_size_analysis
+        name: aarch64_openvmm_hcl_for_size_analysis
         path: ${{ env.floweyvar1 }}
       name: publish openvmm_hcl for analysis
     - name: cargo build xtask
       run: |-
-        flowey e 13 flowey_lib_hvlite::init_cross_build 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 1
         flowey e 13 flowey_lib_common::run_cargo_build 1
         flowey e 13 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 13 flowey_lib_hvlite::run_cargo_build 3
         flowey e 13 flowey_lib_hvlite::build_xtask 0
       shell: bash
@@ -1355,12 +1409,540 @@ jobs:
       run: flowey e 13 flowey_lib_common::cache 7
       shell: bash
   job14:
+    name: build openhcl [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 14 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 14 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 14 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 14 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 14 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 14 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 14 flowey_lib_common::cache 0
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 14 flowey_lib_common::cache 2
+        flowey e 14 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 14 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 14 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 14 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 14 flowey_lib_common::install_rust 2
+        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 14 flowey_lib_common::git_checkout 0
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 14 flowey_lib_common::git_checkout 3
+        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 14 flowey_lib_common::resolve_protoc 0
+        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build sidecar
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_build 3
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 14 flowey_lib_hvlite::build_sidecar 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 1
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_build 1
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 14 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 14 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_build 2
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 14 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 14 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_build 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 14 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 4
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 14 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 14 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 14 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 14 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 14 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 14 flowey_lib_common::copy_to_artifact_dir 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 14 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish x64-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
+        include-hidden-files: true
+  job15:
+    name: verify openhcl binary size [x64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 15 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 15 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 15 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 15 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 15 flowey_lib_common::install_rust 2
+        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 15 flowey_lib_common::git_checkout 0
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar2
+        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar2 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 15 flowey_lib_common::git_checkout 3
+        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 15 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 15 flowey_lib_common::cache 4
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 15 flowey_lib_common::cache 6
+        flowey e 15 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 15 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: flowey e 15 flowey_lib_common::resolve_protoc 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_build 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::build_openvmm_hcl 0
+      shell: bash
+    - name: collect openvmm_hcl files for analysis
+      run: |-
+        flowey e 15 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
+        flowey v 15 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:119:27' --is-raw-string write-to-env github floweyvar1
+      shell: bash
+    - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
+      uses: actions/upload-artifact@v7
+      with:
+        name: x86_64_openvmm_hcl_for_size_analysis
+        path: ${{ env.floweyvar1 }}
+      name: publish openvmm_hcl for analysis
+    - name: cargo build xtask
+      run: |-
+        flowey e 15 flowey_lib_hvlite::init_cross_build 0
+        flowey e 15 flowey_lib_common::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 15 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 15 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 15 flowey_lib_common::cache 0
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 15 flowey_lib_common::cache 2
+        flowey e 15 flowey_lib_common::download_gh_cli 1
+        flowey v 15 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 15 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get merge commit
+      run: flowey e 15 flowey_lib_common::git_merge_commit 0
+      shell: bash
+    - name: get action id by commit
+      run: |-
+        flowey e 15 flowey_lib_common::gh_workflow_id 0
+        flowey e 15 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey e 15 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: binary size comparison
+      run: flowey e 15 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 15 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 15 flowey_lib_common::cache 7
+      shell: bash
+  job16:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1428,29 +2010,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 14 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 14 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 16 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 16 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 14 'verbose' update
+        cat <<'EOF' | flowey.exe v 16 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 14 flowey_lib_common::install_rust 0
+      run: flowey.exe e 16 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 14 flowey_lib_common::install_rust 1
+      run: flowey.exe e 16 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 14 flowey_lib_common::install_rust 2
-        flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 16 flowey_lib_common::install_rust 2
+        flowey.exe e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 14 flowey_lib_common::git_checkout 0
-        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 16 flowey_lib_common::git_checkout 0
+        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1462,23 +2044,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 14 flowey_lib_common::git_checkout 3
-        flowey.exe e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 16 flowey_lib_common::git_checkout 3
+        flowey.exe e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 14 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 16 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 14 flowey_lib_common::cache 4
-        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 16 flowey_lib_common::cache 4
+        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1488,50 +2070,50 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 14 flowey_lib_common::cache 6
-        flowey.exe e 14 flowey_lib_common::download_gh_release 1
+        flowey.exe e 16 flowey_lib_common::cache 6
+        flowey.exe e 16 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 14 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 16 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 14 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 16 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 16 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 16 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 16 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 14 flowey_lib_common::cache 0
-        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe e 16 flowey_lib_common::cache 0
+        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1541,45 +2123,45 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 14 flowey_lib_common::cache 2
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 16 flowey_lib_common::cache 2
+        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 14 flowey_lib_common::install_rust 3
+      run: flowey.exe e 16 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 14 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 16 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 14 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 16 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 16 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 16 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
       run: |-
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 14 flowey_lib_common::publish_test_results 5
-        flowey.exe e 14 flowey_lib_common::publish_test_results 6
-        flowey.exe e 14 flowey_lib_common::publish_test_results 4
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 16 flowey_lib_common::publish_test_results 5
+        flowey.exe e 16 flowey_lib_common::publish_test_results 6
+        flowey.exe e 16 flowey_lib_common::publish_test_results 4
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1589,18 +2171,18 @@ jobs:
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 14 flowey_lib_common::publish_test_results 0
-        flowey.exe e 14 flowey_lib_common::publish_test_results 1
-        flowey.exe e 14 flowey_lib_common::publish_test_results 2
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 16 flowey_lib_common::publish_test_results 0
+        flowey.exe e 16 flowey_lib_common::publish_test_results 1
+        flowey.exe e 16 flowey_lib_common::publish_test_results 2
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1611,25 +2193,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
-      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 14 flowey_lib_common::cache 3
+      run: flowey.exe e 16 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 14 flowey_lib_common::cache 7
+      run: flowey.exe e 16 flowey_lib_common::cache 7
       shell: bash
-  job15:
+  job17:
     name: clippy [macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1653,35 +2235,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 15 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 17 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 17 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 15 'verbose' update
+        cat <<'EOF' | flowey v 17 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 15 flowey_lib_common::install_rust 0
+      run: flowey e 17 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 15 flowey_lib_common::install_rust 1
+      run: flowey e 17 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 15 flowey_lib_common::install_rust 2
-        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 17 flowey_lib_common::install_rust 2
+        flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::git_checkout 0
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1693,23 +2275,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 15 flowey_lib_common::git_checkout 3
-        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 17 flowey_lib_common::git_checkout 3
+        flowey e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 15 flowey_lib_common::download_gh_release 0
+      run: flowey e 17 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey e 17 flowey_lib_common::cache 4
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1719,54 +2301,54 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 15 flowey_lib_common::cache 6
-        flowey e 15 flowey_lib_common::download_gh_release 1
+        flowey e 17 flowey_lib_common::cache 6
+        flowey e 17 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 15 flowey_lib_common::resolve_protoc 0
-        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 17 flowey_lib_common::resolve_protoc 0
+        flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 1
+        flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 17 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_build 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 17 flowey_lib_common::run_cargo_build 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 15 flowey_lib_hvlite::build_xtask 0
+        flowey e 17 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 17 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 17 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 15 flowey_lib_common::download_cargo_nextest 0
-        flowey e 15 flowey_lib_common::download_cargo_nextest 1
-        flowey e 15 flowey_lib_common::download_cargo_nextest 2
-        flowey e 15 flowey_lib_common::download_cargo_nextest 3
+        flowey e 17 flowey_lib_common::download_cargo_nextest 0
+        flowey e 17 flowey_lib_common::download_cargo_nextest 1
+        flowey e 17 flowey_lib_common::download_cargo_nextest 2
+        flowey e 17 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey e 17 flowey_lib_common::cache 0
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1776,34 +2358,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 15 flowey_lib_common::cache 2
-        flowey e 15 flowey_lib_common::download_cargo_nextest 4
+        flowey e 17 flowey_lib_common::cache 2
+        flowey e 17 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 15 flowey_lib_common::install_rust 3
+      run: flowey e 17 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 15 flowey_lib_common::install_cargo_nextest 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::install_cargo_nextest 0
+        flowey e 17 flowey_lib_hvlite::init_cross_build 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 15 flowey_lib_common::publish_test_results 5
-        flowey e 15 flowey_lib_common::publish_test_results 6
-        flowey e 15 flowey_lib_common::publish_test_results 4
-        flowey v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 17 flowey_lib_common::publish_test_results 5
+        flowey e 17 flowey_lib_common::publish_test_results 6
+        flowey e 17 flowey_lib_common::publish_test_results 4
+        flowey v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1813,18 +2395,18 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 15 flowey_lib_common::publish_test_results 8
-        flowey e 15 flowey_lib_common::publish_test_results 9
-        flowey e 15 flowey_lib_common::publish_test_results 10
-        flowey v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 17 flowey_lib_common::publish_test_results 8
+        flowey e 17 flowey_lib_common::publish_test_results 9
+        flowey e 17 flowey_lib_common::publish_test_results 10
+        flowey v 17 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 17 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -1835,32 +2417,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 15 flowey_lib_hvlite::init_cross_build 2
-        flowey e 15 flowey_lib_common::run_cargo_build 1
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 17 flowey_lib_hvlite::init_cross_build 2
+        flowey e 17 flowey_lib_common::run_cargo_build 1
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 15 flowey_lib_hvlite::build_xtask 1
+        flowey e 17 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 17 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 15 flowey_lib_common::publish_test_results 12
-        flowey e 15 flowey_lib_common::publish_test_results 13
-        flowey e 15 flowey_lib_common::publish_test_results 14
-        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 17 flowey_lib_common::publish_test_results 12
+        flowey e 17 flowey_lib_common::publish_test_results 13
+        flowey e 17 flowey_lib_common::publish_test_results 14
+        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -1870,18 +2452,18 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 15 flowey_lib_common::publish_test_results 0
-        flowey e 15 flowey_lib_common::publish_test_results 1
-        flowey e 15 flowey_lib_common::publish_test_results 2
-        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 17 flowey_lib_common::publish_test_results 0
+        flowey e 17 flowey_lib_common::publish_test_results 1
+        flowey e 17 flowey_lib_common::publish_test_results 2
+        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1892,25 +2474,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
-      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 15 flowey_lib_common::cache 3
+      run: flowey e 17 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 15 flowey_lib_common::cache 7
+      run: flowey e 17 flowey_lib_common::cache 7
       shell: bash
-  job16:
+  job18:
     name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1934,29 +2516,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 18 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 16 'verbose' update
+        cat <<'EOF' | flowey v 18 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 16 flowey_lib_common::install_rust 0
+      run: flowey e 18 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 16 flowey_lib_common::install_rust 1
+      run: flowey e 18 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 16 flowey_lib_common::install_rust 2
-        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 18 flowey_lib_common::install_rust 2
+        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::git_checkout 0
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1968,27 +2550,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 16 flowey_lib_common::git_checkout 3
-        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 18 flowey_lib_common::git_checkout 3
+        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 16 flowey_lib_common::download_gh_release 0
+      run: flowey e 18 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 18 flowey_lib_common::cache 4
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1998,78 +2580,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 16 flowey_lib_common::cache 6
-        flowey e 16 flowey_lib_common::download_gh_release 1
+        flowey e 18 flowey_lib_common::cache 6
+        flowey e 18 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 16 flowey_lib_common::resolve_protoc 0
+      run: flowey e 18 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 2
+        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_clippy 5
-        flowey e 16 flowey_lib_hvlite::init_cross_build 0
+        flowey e 18 flowey_lib_common::run_cargo_clippy 5
+        flowey e 18 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_build 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 18 flowey_lib_common::run_cargo_build 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::build_xtask 0
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 16 flowey_lib_common::download_cargo_nextest 0
-        flowey e 16 flowey_lib_common::download_cargo_nextest 1
-        flowey e 16 flowey_lib_common::download_cargo_nextest 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 3
+        flowey e 18 flowey_lib_common::download_cargo_nextest 0
+        flowey e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey e 18 flowey_lib_common::download_cargo_nextest 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 18 flowey_lib_common::cache 0
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2079,34 +2661,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 16 flowey_lib_common::cache 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 4
+        flowey e 18 flowey_lib_common::cache 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 16 flowey_lib_common::install_rust 3
+      run: flowey e 18 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 16 flowey_lib_common::install_cargo_nextest 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 3
-        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::install_cargo_nextest 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 3
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 16 flowey_lib_common::publish_test_results 5
-        flowey e 16 flowey_lib_common::publish_test_results 6
-        flowey e 16 flowey_lib_common::publish_test_results 4
-        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 18 flowey_lib_common::publish_test_results 5
+        flowey e 18 flowey_lib_common::publish_test_results 6
+        flowey e 18 flowey_lib_common::publish_test_results 4
+        flowey v 18 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2116,18 +2698,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 16 flowey_lib_common::publish_test_results 8
-        flowey e 16 flowey_lib_common::publish_test_results 9
-        flowey e 16 flowey_lib_common::publish_test_results 10
-        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 18 flowey_lib_common::publish_test_results 8
+        flowey e 18 flowey_lib_common::publish_test_results 9
+        flowey e 18 flowey_lib_common::publish_test_results 10
+        flowey v 18 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2137,18 +2719,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 18 flowey_lib_common::publish_test_results 12
+        flowey e 18 flowey_lib_common::publish_test_results 13
+        flowey e 18 flowey_lib_common::publish_test_results 14
+        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 18 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -2158,18 +2740,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 16 flowey_lib_common::publish_test_results 16
-        flowey e 16 flowey_lib_common::publish_test_results 17
-        flowey e 16 flowey_lib_common::publish_test_results 18
-        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 18 flowey_lib_common::publish_test_results 16
+        flowey e 18 flowey_lib_common::publish_test_results 17
+        flowey e 18 flowey_lib_common::publish_test_results 18
+        flowey v 18 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 18 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -2180,32 +2762,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_cross_build 1
-        flowey e 16 flowey_lib_common::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 18 flowey_lib_hvlite::init_cross_build 1
+        flowey e 18 flowey_lib_common::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 16 flowey_lib_hvlite::build_xtask 1
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 18 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 16 flowey_lib_common::publish_test_results 0
-        flowey e 16 flowey_lib_common::publish_test_results 1
-        flowey e 16 flowey_lib_common::publish_test_results 2
-        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 18 flowey_lib_common::publish_test_results 0
+        flowey e 18 flowey_lib_common::publish_test_results 1
+        flowey e 18 flowey_lib_common::publish_test_results 2
+        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2216,25 +2798,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
-      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 16 flowey_lib_common::cache 3
+      run: flowey e 18 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 16 flowey_lib_common::cache 7
+      run: flowey e 18 flowey_lib_common::cache 7
       shell: bash
-  job17:
+  job19:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=win-arm64
-    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2302,29 +2884,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 19 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 19 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 17 'verbose' update
+        cat <<'EOF' | flowey.exe v 19 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 17 flowey_lib_common::install_rust 0
+      run: flowey.exe e 19 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 17 flowey_lib_common::install_rust 1
+      run: flowey.exe e 19 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 17 flowey_lib_common::install_rust 2
-        flowey.exe e 17 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 19 flowey_lib_common::install_rust 2
+        flowey.exe e 19 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 17 flowey_lib_common::git_checkout 0
-        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 19 flowey_lib_common::git_checkout 0
+        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2336,23 +2918,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 17 flowey_lib_common::git_checkout 3
-        flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 19 flowey_lib_common::git_checkout 3
+        flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 19 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 17 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 17 flowey_lib_common::cache 4
-        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 19 flowey_lib_common::cache 4
+        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2362,50 +2944,50 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 17 flowey_lib_common::cache 6
-        flowey.exe e 17 flowey_lib_common::download_gh_release 1
+        flowey.exe e 19 flowey_lib_common::cache 6
+        flowey.exe e 19 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 17 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 19 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 19 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 19 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 17 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 19 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 19 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 19 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 19 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 17 flowey_lib_common::cache 0
-        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe e 19 flowey_lib_common::cache 0
+        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2415,45 +2997,45 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 17 flowey_lib_common::cache 2
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 19 flowey_lib_common::cache 2
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 17 flowey_lib_common::install_rust 3
+      run: flowey.exe e 19 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 17 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 19 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 19 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 17 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 19 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 19 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
       run: |-
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 19 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 17 flowey_lib_common::publish_test_results 5
-        flowey.exe e 17 flowey_lib_common::publish_test_results 6
-        flowey.exe e 17 flowey_lib_common::publish_test_results 4
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 19 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 19 flowey_lib_common::publish_test_results 5
+        flowey.exe e 19 flowey_lib_common::publish_test_results 6
+        flowey.exe e 19 flowey_lib_common::publish_test_results 4
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2463,18 +3045,18 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 17 flowey_lib_common::publish_test_results 0
-        flowey.exe e 17 flowey_lib_common::publish_test_results 1
-        flowey.exe e 17 flowey_lib_common::publish_test_results 2
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 19 flowey_lib_common::publish_test_results 0
+        flowey.exe e 19 flowey_lib_common::publish_test_results 1
+        flowey.exe e 19 flowey_lib_common::publish_test_results 2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2485,717 +3067,17 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 17 flowey_lib_common::cache 3
+      run: flowey.exe e 19 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 17 flowey_lib_common::cache 7
-      shell: bash
-  job18:
-    name: clippy [aarch64-linux], unit tests [aarch64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/aarch64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 18 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 18 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 18 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 18 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 18 flowey_lib_common::install_rust 2
-        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 18 flowey_lib_common::git_checkout 3
-        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 18 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 18 flowey_lib_common::cache 6
-        flowey e 18 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 18 flowey_lib_common::resolve_protoc 0
-        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_build 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 18 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 18 flowey_lib_common::download_cargo_nextest 0
-        flowey e 18 flowey_lib_common::download_cargo_nextest 1
-        flowey e 18 flowey_lib_common::download_cargo_nextest 2
-        flowey e 18 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 18 flowey_lib_common::cache 2
-        flowey e 18 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 18 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 18 flowey_lib_common::install_cargo_nextest 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 18 flowey_lib_common::publish_test_results 5
-        flowey e 18 flowey_lib_common::publish_test_results 6
-        flowey e 18 flowey_lib_common::publish_test_results 4
-        flowey v 18 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 18 flowey_lib_common::publish_test_results 8
-        flowey e 18 flowey_lib_common::publish_test_results 9
-        flowey e 18 flowey_lib_common::publish_test_results 10
-        flowey v 18 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: cargo build xtask
-      run: |-
-        flowey e 18 flowey_lib_hvlite::init_cross_build 3
-        flowey e 18 flowey_lib_common::run_cargo_build 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 18 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 18 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 18 flowey_lib_common::publish_test_results 12
-        flowey e 18 flowey_lib_common::publish_test_results 13
-        flowey e 18 flowey_lib_common::publish_test_results 14
-        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 18 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 18 flowey_lib_common::publish_test_results 0
-        flowey e 18 flowey_lib_common::publish_test_results 1
-        flowey e 18 flowey_lib_common::publish_test_results 2
-        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: |-
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 18 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 18 flowey_lib_common::cache 7
-      shell: bash
-  job19:
-    name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/aarch64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 19 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 19 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 19 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 19 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 19 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 19 flowey_lib_common::install_rust 2
-        flowey e 19 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 19 flowey_lib_common::git_checkout 0
-        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 19 flowey_lib_common::git_checkout 3
-        flowey e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 19 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 19 flowey_lib_common::cache 4
-        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 19 flowey_lib_common::cache 6
-        flowey e 19 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 19 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: unpack protoc
-      run: flowey e 19 flowey_lib_common::resolve_protoc 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 19 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 6
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 19 flowey_lib_common::run_cargo_clippy 5
-        flowey e 19 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 19 flowey_lib_common::run_cargo_build 0
-        flowey e 19 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 19 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 19 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 19 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 19 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 19 flowey_lib_common::download_cargo_nextest 0
-        flowey e 19 flowey_lib_common::download_cargo_nextest 1
-        flowey e 19 flowey_lib_common::download_cargo_nextest 2
-        flowey e 19 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 19 flowey_lib_common::cache 0
-        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 19 flowey_lib_common::cache 2
-        flowey e 19 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 19 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 19 flowey_lib_common::install_cargo_nextest 0
-        flowey e 19 flowey_lib_hvlite::init_cross_build 3
-        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 19 flowey_lib_common::publish_test_results 5
-        flowey e 19 flowey_lib_common::publish_test_results 6
-        flowey e 19 flowey_lib_common::publish_test_results 4
-        flowey v 19 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 19 flowey_lib_common::publish_test_results 8
-        flowey e 19 flowey_lib_common::publish_test_results 9
-        flowey e 19 flowey_lib_common::publish_test_results 10
-        flowey v 19 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 19 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
-      run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 19 flowey_lib_common::publish_test_results 12
-        flowey e 19 flowey_lib_common::publish_test_results 13
-        flowey e 19 flowey_lib_common::publish_test_results 14
-        flowey v 19 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 19 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 19 flowey_lib_common::publish_test_results 16
-        flowey e 19 flowey_lib_common::publish_test_results 17
-        flowey e 19 flowey_lib_common::publish_test_results 18
-        flowey v 19 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 19 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: cargo build xtask
-      run: |-
-        flowey e 19 flowey_lib_hvlite::init_cross_build 1
-        flowey e 19 flowey_lib_common::run_cargo_build 1
-        flowey e 19 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 19 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 19 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 19 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 4
-      shell: bash
-    - name: run 'unit-tests' nextest tests
-      run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 19 flowey_lib_common::publish_test_results 0
-        flowey e 19 flowey_lib_common::publish_test_results 1
-        flowey e 19 flowey_lib_common::publish_test_results 2
-        flowey v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: |-
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: run doctests for aarch64-unknown-linux-musl
-      run: flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 19 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 19 flowey_lib_common::cache 7
+      run: flowey.exe e 19 flowey_lib_common::cache 7
       shell: bash
   job2:
     name: build artifacts (not for VMM tests) [aarch64-windows]
@@ -3415,402 +3297,468 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-windows-intel]
+    name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job12
-    - job5
-    - job8
     if: github.event.pull_request.draft == false
     steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/aarch64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
+      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey.exe v 20 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 20 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 20 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 20 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 20 'verbose' update
+        cat <<'EOF' | flowey v 20 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 20 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 20 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 20 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 20 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 20 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 20 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 20 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 3
+    - name: add default cargo home to path
+      run: flowey e 20 flowey_lib_common::install_rust 0
       shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 20 flowey_lib_common::cache 0
-        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+    - name: install Rust
+      run: flowey e 20 flowey_lib_common::install_rust 1
       shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
+    - name: detect active toolchain
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 20 flowey_lib_common::cache 2
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 4
+        flowey e 20 flowey_lib_common::install_rust 2
+        flowey e 20 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 20 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 20 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 20 flowey_lib_common::git_checkout 0
-        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 20 flowey_lib_common::git_checkout 0
+        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 20 flowey_lib_common::git_checkout 3
-        flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
+        flowey e 20 flowey_lib_common::git_checkout 3
+        flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 20 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 20 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 20 flowey_lib_common::download_gh_release 0
+      run: flowey e 20 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 20 flowey_lib_common::cache 8
-        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 20 flowey_lib_common::cache 10
-        flowey.exe e 20 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 20 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 20 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 20 flowey_lib_common::cache 4
-        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 20 flowey_lib_common::cache 4
+        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 20 flowey_lib_common::cache 6
-        flowey.exe e 20 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 20 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
+        flowey e 20 flowey_lib_common::cache 6
+        flowey e 20 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 20 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 20 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 20 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 20 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
+    - name: unpack protoc
       run: |-
-        flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 20 flowey_lib_common::resolve_protoc 0
+        flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 20 flowey_lib_hvlite::init_cross_build 0
+        flowey e 20 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_build 0
+        flowey e 20 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 20 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 20 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 20 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 20 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 20 flowey_lib_common::download_cargo_nextest 0
+        flowey e 20 flowey_lib_common::download_cargo_nextest 1
+        flowey e 20 flowey_lib_common::download_cargo_nextest 2
+        flowey e 20 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 20 flowey_lib_common::cache 0
+        flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 20 flowey_lib_common::cache 2
+        flowey e 20 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 20 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 20 flowey_lib_common::install_cargo_nextest 0
+        flowey e 20 flowey_lib_hvlite::init_cross_build 1
+        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 20 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 20 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 20 flowey_lib_common::publish_test_results 5
+        flowey e 20 flowey_lib_common::publish_test_results 6
+        flowey e 20 flowey_lib_common::publish_test_results 4
+        flowey v 20 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 20 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 20 flowey_lib_common::publish_test_results 4
-        flowey.exe e 20 flowey_lib_common::publish_test_results 5
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-vmm-tests-logs
+        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
+    - name: generate nextest command
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 20 flowey_lib_common::publish_test_results 0
-        flowey.exe e 20 flowey_lib_common::publish_test_results 1
-        flowey.exe e 20 flowey_lib_common::publish_test_results 2
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 20 flowey_lib_common::publish_test_results 8
+        flowey e 20 flowey_lib_common::publish_test_results 9
+        flowey e 20 flowey_lib_common::publish_test_results 10
+        flowey v 20 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 20 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey e 20 flowey_lib_hvlite::init_cross_build 3
+        flowey e 20 flowey_lib_common::run_cargo_build 1
+        flowey e 20 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 20 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 20 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 20 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 20 flowey_lib_common::publish_test_results 12
+        flowey e 20 flowey_lib_common::publish_test_results 13
+        flowey e 20 flowey_lib_common::publish_test_results 14
+        flowey v 20 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 20 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 20 flowey_lib_common::publish_test_results 0
+        flowey e 20 flowey_lib_common::publish_test_results 1
+        flowey e 20 flowey_lib_common::publish_test_results 2
+        flowey v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-vmm-tests-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: |-
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 20 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for aarch64-unknown-linux-gnu
+      run: flowey e 20 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 20 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 20 flowey_lib_common::cache 7
+      run: flowey e 20 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 20 flowey_lib_common::cache 11
+      run: flowey e 20 flowey_lib_common::cache 7
       shell: bash
   job21:
-    name: run vmm-tests [x64-windows-intel-tdx]
+    name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
-    - Windows
-    - X64
-    - TDX
-    - Baremetal
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=ubuntu2404-arm64
+    - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job12
-    - job5
-    - job8
     if: github.event.pull_request.draft == false
     steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/aarch64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
+      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey.exe v 21 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 21 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 21 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 21 'verbose' update
+        cat <<'EOF' | flowey v 21 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 21 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 21 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 21 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 21 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 21 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 3
+    - name: add default cargo home to path
+      run: flowey e 21 flowey_lib_common::install_rust 0
       shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 21 flowey_lib_common::cache 0
-        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+    - name: install Rust
+      run: flowey e 21 flowey_lib_common::install_rust 1
       shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
+    - name: detect active toolchain
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 21 flowey_lib_common::cache 2
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 4
+        flowey e 21 flowey_lib_common::install_rust 2
+        flowey e 21 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 21 flowey_lib_common::git_checkout 0
+        flowey v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 21 flowey_lib_common::git_checkout 3
-        flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
+        flowey e 21 flowey_lib_common::git_checkout 3
+        flowey e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 21 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+    - name: checking if packages need to be installed
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 0
       shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+    - name: installing packages
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
+      run: flowey e 21 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 8
-        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 21 flowey_lib_common::cache 4
+        flowey v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
-    - id: flowey_lib_common__cache__9
+    - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
         key: ${{ env.floweyvar8 }}
@@ -3818,143 +3766,241 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        flowey v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 10
-        flowey.exe e 21 flowey_lib_common::download_gh_release 1
+        flowey e 21 flowey_lib_common::cache 6
+        flowey e 21 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 21 flowey_lib_common::download_azcopy 0
+    - name: unpack openvmm-deps archive
+      run: flowey e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+    - name: extract Aarch64 sysroot.tar.gz
+      run: flowey e 21 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
-    - name: downloading VMM test disk images
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 21 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: flowey e 21 flowey_lib_common::resolve_protoc 0
+      shell: bash
+    - name: symlink protoc
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 21 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 21 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_gh_cli 0
+    - name: cargo clippy
+      run: flowey e 21 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 21 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 21 flowey_lib_common::run_cargo_clippy 6
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 21 flowey_lib_common::run_cargo_clippy 5
+        flowey e 21 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 21 flowey_lib_common::run_cargo_build 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 21 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 21 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 21 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 21 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 21 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 21 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 21 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 21 flowey_lib_common::download_cargo_nextest 0
+        flowey e 21 flowey_lib_common::download_cargo_nextest 1
+        flowey e 21 flowey_lib_common::download_cargo_nextest 2
+        flowey e 21 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 4
-        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 21 flowey_lib_common::cache 0
+        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
         key: ${{ env.floweyvar6 }}
         path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 6
-        flowey.exe e 21 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
+        flowey e 21 flowey_lib_common::cache 2
+        flowey e 21 flowey_lib_common::download_cargo_nextest 4
       shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 21 flowey_lib_common::use_gh_cli 0
+    - name: report $CARGO_HOME
+      run: flowey e 21 flowey_lib_common::install_rust 3
       shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 21 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
+    - name: installing cargo-nextest
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 21 flowey_lib_common::install_cargo_nextest 0
+        flowey e 21 flowey_lib_hvlite::init_cross_build 3
+        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
+    - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 21 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 21 flowey_lib_common::publish_test_results 5
+        flowey e 21 flowey_lib_common::publish_test_results 6
+        flowey e 21 flowey_lib_common::publish_test_results 4
+        flowey v 21 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 21 flowey_lib_common::publish_test_results 4
-        flowey.exe e 21 flowey_lib_common::publish_test_results 5
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-logs
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
+    - name: generate nextest command
+      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 21 flowey_lib_common::publish_test_results 0
-        flowey.exe e 21 flowey_lib_common::publish_test_results 1
-        flowey.exe e 21 flowey_lib_common::publish_test_results 2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 21 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 21 flowey_lib_common::publish_test_results 8
+        flowey e 21 flowey_lib_common::publish_test_results 9
+        flowey e 21 flowey_lib_common::publish_test_results 10
+        flowey v 21 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 21 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+      run: |-
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 21 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 21 flowey_lib_common::publish_test_results 12
+        flowey e 21 flowey_lib_common::publish_test_results 13
+        flowey e 21 flowey_lib_common::publish_test_results 14
+        flowey v 21 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 21 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 21 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 21 flowey_lib_common::publish_test_results 16
+        flowey e 21 flowey_lib_common::publish_test_results 17
+        flowey e 21 flowey_lib_common::publish_test_results 18
+        flowey v 21 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 21 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey e 21 flowey_lib_hvlite::init_cross_build 1
+        flowey e 21 flowey_lib_common::run_cargo_build 1
+        flowey e 21 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 21 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 21 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey e 21 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 21 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 21 flowey_lib_common::publish_test_results 0
+        flowey e 21 flowey_lib_common::publish_test_results 1
+        flowey e 21 flowey_lib_common::publish_test_results 2
+        flowey v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: |-
+        flowey e 21 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 21 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for aarch64-unknown-linux-musl
+      run: flowey e 21 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 21 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 21 flowey_lib_common::cache 7
+      run: flowey e 21 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 21 flowey_lib_common::cache 11
+      run: flowey e 21 flowey_lib_common::cache 7
       shell: bash
   job22:
-    name: run vmm-tests [x64-windows-amd]
+    name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3962,9 +4008,10 @@ jobs:
       id-token: write
     needs:
     - job0
-    - job12
-    - job5
-    - job8
+    - job10
+    - job14
+    - job6
+    - job7
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -4183,9 +4230,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-logs
+        name: x64-windows-intel-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4199,9 +4246,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-junit-xml
+        name: x64-windows-intel-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4216,21 +4263,22 @@ jobs:
       run: flowey.exe e 22 flowey_lib_common::cache 11
       shell: bash
   job23:
-    name: run vmm-tests [x64-windows-amd-snp]
+    name: run vmm-tests [x64-windows-intel-tdx]
     runs-on:
     - self-hosted
     - Windows
     - X64
-    - SNP
+    - TDX
     - Baremetal
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job12
-    - job5
-    - job8
+    - job10
+    - job14
+    - job6
+    - job7
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -4319,10 +4367,6 @@ jobs:
         flowey.exe e 23 flowey_lib_common::git_checkout 3
         flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
@@ -4330,6 +4374,10 @@ jobs:
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4454,9 +4502,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-snp-vmm-tests-logs
+        name: x64-windows-intel-tdx-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4470,9 +4518,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-snp-vmm-tests-junit-xml
+        name: x64-windows-intel-tdx-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4487,20 +4535,558 @@ jobs:
       run: flowey.exe e 23 flowey_lib_common::cache 11
       shell: bash
   job24:
-    name: run vmm-tests [x64-linux-amd-kvm]
+    name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=win-amd64
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job5
-    - job8
-    - job9
+    - job10
+    - job14
+    - job6
+    - job7
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 24 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 24 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 24 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 24 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 24 flowey_lib_common::cache 0
+        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 24 flowey_lib_common::cache 2
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 24 flowey_lib_common::git_checkout 0
+        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 24 flowey_lib_common::git_checkout 3
+        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 24 flowey_lib_common::cache 8
+        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 24 flowey_lib_common::cache 10
+        flowey.exe e 24 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 24 flowey_lib_common::cache 4
+        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 24 flowey_lib_common::cache 6
+        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 24 flowey_lib_common::publish_test_results 4
+        flowey.exe e 24 flowey_lib_common::publish_test_results 5
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 24 flowey_lib_common::publish_test_results 0
+        flowey.exe e 24 flowey_lib_common::publish_test_results 1
+        flowey.exe e 24 flowey_lib_common::publish_test_results 2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 24 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 24 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 24 flowey_lib_common::cache 11
+      shell: bash
+  job25:
+    name: run vmm-tests [x64-windows-amd-snp]
+    runs-on:
+    - self-hosted
+    - Windows
+    - X64
+    - SNP
+    - Baremetal
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job10
+    - job14
+    - job6
+    - job7
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 25 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 25 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 25 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 25 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 25 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 25 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 25 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 25 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 25 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 25 flowey_lib_common::cache 0
+        flowey.exe v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 25 flowey_lib_common::cache 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 25 flowey_lib_common::git_checkout 0
+        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 25 flowey_lib_common::git_checkout 3
+        flowey.exe e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 4
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 25 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 25 flowey_lib_common::cache 8
+        flowey.exe v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 25 flowey_lib_common::cache 10
+        flowey.exe e 25 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 25 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 25 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 25 flowey_lib_common::cache 4
+        flowey.exe v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 25 flowey_lib_common::cache 6
+        flowey.exe e 25 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 25 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 25 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 25 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 25 flowey_lib_hvlite::run_prep_steps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 25 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 25 flowey_lib_common::publish_test_results 4
+        flowey.exe e 25 flowey_lib_common::publish_test_results 5
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-snp-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 25 flowey_lib_common::publish_test_results 0
+        flowey.exe e 25 flowey_lib_common::publish_test_results 1
+        flowey.exe e 25 flowey_lib_common::publish_test_results 2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-snp-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 25 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 25 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 25 flowey_lib_common::cache 11
+      shell: bash
+  job26:
+    name: run vmm-tests [x64-linux-amd-kvm]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job10
+    - job11
+    - job6
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -4519,46 +5105,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 24 'verbose' update
+        cat <<'EOF' | flowey v 26 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 24 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 26 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 26 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 26 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 26 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 26 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 26 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 26 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 26 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey e 24 flowey_core::pipeline::artifact::resolve 7
-        flowey e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 26 flowey_core::pipeline::artifact::resolve 3
+        flowey e 26 flowey_core::pipeline::artifact::resolve 4
+        flowey e 26 flowey_core::pipeline::artifact::resolve 7
+        flowey e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey e 26 flowey_core::pipeline::artifact::resolve 0
+        flowey e 26 flowey_core::pipeline::artifact::resolve 2
+        flowey e 26 flowey_core::pipeline::artifact::resolve 6
+        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 26 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 24 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 26 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 24 flowey_lib_common::download_gh_release 0
+      run: flowey e 26 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 24 flowey_lib_common::cache 8
-        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 26 flowey_lib_common::cache 8
+        flowey v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4568,31 +5154,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 24 flowey_lib_common::cache 10
-        flowey e 24 flowey_lib_common::download_gh_release 1
+        flowey e 26 flowey_lib_common::cache 10
+        flowey e 26 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 24 flowey_lib_common::download_azcopy 0
+      run: flowey e 26 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 24 flowey_lib_common::download_gh_cli 0
+      run: flowey e 26 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 24 flowey_lib_common::cache 4
-        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 26 flowey_lib_common::cache 4
+        flowey v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4602,54 +5188,54 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 24 flowey_lib_common::cache 6
-        flowey e 24 flowey_lib_common::download_gh_cli 1
-        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 26 flowey_lib_common::cache 6
+        flowey e 26 flowey_lib_common::download_gh_cli 1
+        flowey v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 24 flowey_lib_common::use_gh_cli 0
+      run: flowey e 26 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 24 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 26 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 26 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      run: flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      run: flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey e 24 flowey_lib_common::download_cargo_nextest 3
+        flowey e 26 flowey_lib_common::download_cargo_nextest 0
+        flowey e 26 flowey_lib_common::download_cargo_nextest 1
+        flowey e 26 flowey_lib_common::download_cargo_nextest 2
+        flowey e 26 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 24 flowey_lib_common::cache 0
-        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 26 flowey_lib_common::cache 0
+        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4659,17 +5245,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 24 flowey_lib_common::cache 2
-        flowey e 24 flowey_lib_common::download_cargo_nextest 4
+        flowey e 26 flowey_lib_common::cache 2
+        flowey e 26 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 24 flowey_lib_common::git_checkout 0
-        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 26 flowey_lib_common::git_checkout 0
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4681,32 +5267,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 24 flowey_lib_common::git_checkout 3
-        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey e 26 flowey_lib_common::git_checkout 3
+        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 26 flowey_core::pipeline::artifact::resolve 5
+        flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
     - name: generate nextest command
-      run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 24 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 24 flowey_lib_common::publish_test_results 4
-        flowey e 24 flowey_lib_common::publish_test_results 5
-        flowey v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 26 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 26 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 26 flowey_lib_common::publish_test_results 4
+        flowey e 26 flowey_lib_common::publish_test_results 5
+        flowey v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4717,12 +5303,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 24 flowey_lib_common::publish_test_results 0
-        flowey e 24 flowey_lib_common::publish_test_results 1
-        flowey e 24 flowey_lib_common::publish_test_results 2
-        flowey v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 26 flowey_lib_common::publish_test_results 0
+        flowey e 26 flowey_lib_common::publish_test_results 1
+        flowey e 26 flowey_lib_common::publish_test_results 2
+        flowey v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4732,32 +5318,32 @@ jobs:
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 24 flowey_lib_common::cache 3
+      run: flowey e 26 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 24 flowey_lib_common::cache 7
+      run: flowey e 26 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 24 flowey_lib_common::cache 11
+      run: flowey e 26 flowey_lib_common::cache 11
       shell: bash
-  job25:
+  job27:
     name: run vmm-tests [x64-linux-intel-mshv]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job5
-    - job8
-    - job9
+    - job10
+    - job11
+    - job6
     if: github.event.pull_request.draft == false
     steps:
     - run: |
@@ -4824,46 +5410,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 25 'verbose' update
+        cat <<'EOF' | flowey v 27 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 27 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 27 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 27 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 27 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 27 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 25 flowey_core::pipeline::artifact::resolve 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 2
-        flowey e 25 flowey_core::pipeline::artifact::resolve 7
-        flowey e 25 flowey_core::pipeline::artifact::resolve 3
-        flowey e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 4
-        flowey e 25 flowey_core::pipeline::artifact::resolve 6
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 27 flowey_core::pipeline::artifact::resolve 1
+        flowey e 27 flowey_core::pipeline::artifact::resolve 2
+        flowey e 27 flowey_core::pipeline::artifact::resolve 7
+        flowey e 27 flowey_core::pipeline::artifact::resolve 3
+        flowey e 27 flowey_core::pipeline::artifact::resolve 0
+        flowey e 27 flowey_core::pipeline::artifact::resolve 4
+        flowey e 27 flowey_core::pipeline::artifact::resolve 6
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 27 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 27 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_release 0
+      run: flowey e 27 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 8
-        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 27 flowey_lib_common::cache 8
+        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4873,31 +5459,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 10
-        flowey e 25 flowey_lib_common::download_gh_release 1
+        flowey e 27 flowey_lib_common::cache 10
+        flowey e 27 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 25 flowey_lib_common::download_azcopy 0
+      run: flowey e 27 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_cli 0
+      run: flowey e 27 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 4
-        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 27 flowey_lib_common::cache 4
+        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4907,51 +5493,51 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 6
-        flowey e 25 flowey_lib_common::download_gh_cli 1
-        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 27 flowey_lib_common::cache 6
+        flowey e 27 flowey_lib_common::download_gh_cli 1
+        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 25 flowey_lib_common::use_gh_cli 0
+      run: flowey e 27 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 25 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 27 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 27 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 25 flowey_lib_common::download_cargo_nextest 0
-        flowey e 25 flowey_lib_common::download_cargo_nextest 1
-        flowey e 25 flowey_lib_common::download_cargo_nextest 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 3
+        flowey e 27 flowey_lib_common::download_cargo_nextest 0
+        flowey e 27 flowey_lib_common::download_cargo_nextest 1
+        flowey e 27 flowey_lib_common::download_cargo_nextest 2
+        flowey e 27 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 27 flowey_lib_common::cache 0
+        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4961,17 +5547,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 4
+        flowey e 27 flowey_lib_common::cache 2
+        flowey e 27 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 27 flowey_lib_common::git_checkout 0
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4983,31 +5569,31 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 5
-        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 27 flowey_lib_common::git_checkout 3
+        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 27 flowey_core::pipeline::artifact::resolve 5
+        flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: generate nextest command
-      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 25 flowey_lib_common::publish_test_results 4
-        flowey e 25 flowey_lib_common::publish_test_results 5
-        flowey v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 27 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 27 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 27 flowey_lib_common::publish_test_results 4
+        flowey e 27 flowey_lib_common::publish_test_results 5
+        flowey v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5018,12 +5604,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 25 flowey_lib_common::publish_test_results 0
-        flowey e 25 flowey_lib_common::publish_test_results 1
-        flowey e 25 flowey_lib_common::publish_test_results 2
-        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 27 flowey_lib_common::publish_test_results 0
+        flowey e 27 flowey_lib_common::publish_test_results 1
+        flowey e 27 flowey_lib_common::publish_test_results 2
+        flowey v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5033,18 +5619,18 @@ jobs:
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 25 flowey_lib_common::cache 3
+      run: flowey e 27 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 25 flowey_lib_common::cache 7
+      run: flowey e 27 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 25 flowey_lib_common::cache 11
+      run: flowey e 27 flowey_lib_common::cache 11
       shell: bash
-  job26:
+  job28:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -5056,9 +5642,10 @@ jobs:
       id-token: write
     needs:
     - job0
-    - job10
+    - job12
     - job3
-    - job6
+    - job4
+    - job8
     if: github.event.pull_request.draft == false
     steps:
     - run: |
@@ -5126,35 +5713,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 28 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 28 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 26 'verbose' update
+        cat <<'EOF' | flowey.exe v 28 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 26 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 28 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 28 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 28 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 28 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 28 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 28 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 28 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 28 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 28 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 28 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 0
-        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 28 flowey_lib_common::cache 0
+        flowey.exe v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5164,17 +5751,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 28 flowey_lib_common::cache 2
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 28 flowey_lib_common::git_checkout 0
+        flowey.exe v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5186,35 +5773,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 26 flowey_lib_common::git_checkout 3
-        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 28 flowey_lib_common::git_checkout 3
+        flowey.exe e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 28 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 8
-        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 28 flowey_lib_common::cache 8
+        flowey.exe v 28 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 28 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5224,31 +5811,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 28 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 10
-        flowey.exe e 26 flowey_lib_common::download_gh_release 1
+        flowey.exe e 28 flowey_lib_common::cache 10
+        flowey.exe e 28 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 26 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 28 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 28 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 28 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 28 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 28 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 4
-        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 28 flowey_lib_common::cache 4
+        flowey.exe v 28 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 28 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5258,63 +5845,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 28 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 6
-        flowey.exe e 26 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 28 flowey_lib_common::cache 6
+        flowey.exe e 28 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 28 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 26 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 28 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 28 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 26 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 28 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 28 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 28 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 28 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 28 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 28 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 28 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 28 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 28 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 28 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 28 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 26 flowey_lib_common::publish_test_results 4
-        flowey.exe e 26 flowey_lib_common::publish_test_results 5
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 28 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 28 flowey_lib_common::publish_test_results 4
+        flowey.exe e 28 flowey_lib_common::publish_test_results 5
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5325,12 +5912,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 26 flowey_lib_common::publish_test_results 0
-        flowey.exe e 26 flowey_lib_common::publish_test_results 1
-        flowey.exe e 26 flowey_lib_common::publish_test_results 2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 28 flowey_lib_common::publish_test_results 0
+        flowey.exe e 28 flowey_lib_common::publish_test_results 1
+        flowey.exe e 28 flowey_lib_common::publish_test_results 2
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5340,18 +5927,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 26 flowey_lib_common::cache 3
+      run: flowey.exe e 28 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 26 flowey_lib_common::cache 7
+      run: flowey.exe e 28 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 26 flowey_lib_common::cache 11
+      run: flowey.exe e 28 flowey_lib_common::cache 11
       shell: bash
-  job27:
+  job29:
     name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
@@ -5377,18 +5964,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 29 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 29 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 27 'verbose' update
+        cat <<'EOF' | flowey v 29 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 29 flowey_lib_common::git_checkout 0
+        flowey v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5400,574 +5987,30 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 27 flowey_lib_common::git_checkout 3
-        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 29 flowey_lib_common::git_checkout 3
+        flowey e 29 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 27 flowey_lib_common::install_rust 0
+      run: flowey e 29 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 27 flowey_lib_common::install_rust 1
+      run: flowey e 29 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 27 flowey_lib_common::install_rust 2
-        flowey v 27 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 29 flowey_lib_common::install_rust 2
+        flowey v 29 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 27 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
-      shell: bash
-  job28:
-    name: build openhcl (mi-secure) [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job28-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 28 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 28 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 28 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 28 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 28 flowey_lib_common::cache 0
-        flowey v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 28 flowey_lib_common::cache 2
-        flowey e 28 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 28 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 28 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 28 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 28 flowey_lib_common::install_rust 2
-        flowey e 28 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 28 flowey_lib_common::git_checkout 0
-        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 28 flowey_lib_common::git_checkout 3
-        flowey e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 28 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 28 flowey_lib_common::resolve_protoc 0
-        flowey e 28 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 28 flowey_lib_hvlite::init_cross_build 0
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: cargo build sidecar
-      run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 3
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 28 flowey_lib_hvlite::build_sidecar 0
-        flowey e 28 flowey_lib_hvlite::init_cross_build 1
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 1
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 28 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 28 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 2
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 28 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 28 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 0
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 28 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 28 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 28 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 28 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 28 flowey_lib_common::cache 3
-      shell: bash
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
-        include-hidden-files: true
-  job29:
-    name: run vmm-tests [x64-windows-intel-mi-secure]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job29-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job28
-    - job5
-    - job8
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 29 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 29 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 29 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 29 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 29 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 29 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 29 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 29 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 29 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 29 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 29 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 29 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 29 flowey_lib_common::cache 0
-        flowey.exe v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 29 flowey_lib_common::cache 2
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 29 flowey_lib_common::git_checkout 0
-        flowey.exe v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 29 flowey_lib_common::git_checkout 3
-        flowey.exe e 29 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 29 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 29 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 29 flowey_lib_common::cache 8
-        flowey.exe v 29 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 29 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 29 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 29 flowey_lib_common::cache 10
-        flowey.exe e 29 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 29 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 29 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 29 flowey_lib_common::cache 4
-        flowey.exe v 29 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 29 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 29 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 29 flowey_lib_common::cache 6
-        flowey.exe e 29 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 29 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 29 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 29 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 29 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 29 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 29 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 29 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 29 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 29 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 29 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 29 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 29 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 29 flowey_lib_common::publish_test_results 4
-        flowey.exe e 29 flowey_lib_common::publish_test_results 5
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-mi-secure-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 29 flowey_lib_common::publish_test_results 0
-        flowey.exe e 29 flowey_lib_common::publish_test_results 1
-        flowey.exe e 29 flowey_lib_common::publish_test_results 2
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-mi-secure-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 29 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 29 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 29 flowey_lib_common::cache 11
+      run: flowey e 29 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
   job3:
-    name: build artifacts (for VMM tests) [aarch64-windows]
+    name: build artifacts (shared VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6046,22 +6089,8 @@ jobs:
         cat <<'EOF' | flowey.exe v 3 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-pipette"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-pipette" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-prep_steps"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-prep_steps" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-test_igvm_agent_rpc_server" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tpm_guest_tests"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tpm_guest_tests" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 3 flowey_lib_common::install_rust 0
@@ -6104,22 +6133,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 3 flowey_lib_common::cache 4
-        flowey.exe v 3 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 3 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 3 flowey_lib_common::cache 0
+        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 3 flowey_lib_common::cache 6
+        flowey.exe e 3 flowey_lib_common::cache 2
         flowey.exe e 3 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -6130,163 +6159,570 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 4
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 6
-        flowey.exe e 3 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 4
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: cargo build prep_steps
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 2
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 3 flowey_lib_hvlite::build_prep_steps 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 5
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 6
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 10
-        flowey.exe e 3 flowey_lib_hvlite::build_vmgstool 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 6
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 3
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 7
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 5
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 9
-        flowey.exe e 3 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 7
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 3
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: cargo build test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 5
-        flowey.exe e 3 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 0
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 3 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 3 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 3 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 3 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 3 flowey_lib_common::cache 0
-        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 3 flowey_lib_common::cache 2
-        flowey.exe e 3 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey.exe e 3 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey.exe e 3 flowey_lib_common::install_cargo_nextest 0
         flowey.exe e 3 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey.exe e 3 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 3 flowey_lib_hvlite::build_openvmm 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build pipette
       run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 3 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 0
         flowey.exe e 3 flowey_lib_hvlite::build_pipette 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 3
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 3 flowey_lib_common::cache 3
+        flowey.exe e 3 flowey_core::pipeline::artifact::publish 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 3 flowey_lib_common::cache 7
+      run: flowey.exe e 3 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-windows-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-openvmm/
-        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-pipette
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-windows-pipette
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-pipette/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-prep_steps
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-prep_steps
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-prep_steps/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-test_igvm_agent_rpc_server
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-tmk_vmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-tpm_guest_tests
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmm-tests-archive/
-        include-hidden-files: true
   job30:
+    name: build openhcl (mi-secure) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job30-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 30 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 30 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 30 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 30 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 30 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 30 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 30 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 30 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 30 flowey_lib_common::cache 0
+        flowey v 30 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 30 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 30 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 30 flowey_lib_common::cache 2
+        flowey e 30 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 30 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 30 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 30 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 30 flowey_lib_common::install_rust 2
+        flowey e 30 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 30 flowey_lib_common::git_checkout 0
+        flowey v 30 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 30 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 30 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 30 flowey_lib_common::git_checkout 3
+        flowey e 30 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 30 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 30 flowey_lib_common::resolve_protoc 0
+        flowey e 30 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 30 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 30 flowey_lib_hvlite::init_cross_build 0
+        flowey e 30 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 30 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build sidecar
+      run: |-
+        flowey e 30 flowey_lib_common::run_cargo_build 3
+        flowey e 30 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 30 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 30 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 30 flowey_lib_hvlite::build_sidecar 0
+        flowey e 30 flowey_lib_hvlite::init_cross_build 1
+        flowey e 30 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 30 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 30 flowey_lib_common::run_cargo_build 1
+        flowey e 30 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 30 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 30 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 30 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 30 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 30 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 30 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 30 flowey_lib_common::run_cargo_build 2
+        flowey e 30 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 30 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 30 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 30 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 30 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 30 flowey_lib_common::run_cargo_build 0
+        flowey e 30 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 30 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 30 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 30 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 30 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 30 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 30 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 30 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 30 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 30 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 30 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 30 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 30 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 30 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 30 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 30 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 30 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 30 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 30 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 30 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 30 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 30 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 30 flowey_lib_common::copy_to_artifact_dir 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 30 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
+        include-hidden-files: true
+  job31:
+    name: run vmm-tests [x64-windows-intel-mi-secure]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job31-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job10
+    - job30
+    - job6
+    - job7
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 31 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 31 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 31 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 31 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 31 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 31 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 31 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 31 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 31 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 31 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 31 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 31 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 31 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 31 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 31 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 31 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 31 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 31 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 31 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 31 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 31 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 31 flowey_lib_common::cache 0
+        flowey.exe v 31 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 31 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 31 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 31 flowey_lib_common::cache 2
+        flowey.exe e 31 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 31 flowey_lib_common::git_checkout 0
+        flowey.exe v 31 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 31 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 31 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 31 flowey_lib_common::git_checkout 3
+        flowey.exe e 31 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 31 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 31 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 31 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 31 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 31 flowey_lib_common::cache 8
+        flowey.exe v 31 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 31 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 31 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 31 flowey_lib_common::cache 10
+        flowey.exe e 31 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 31 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 31 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 31 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 31 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 31 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 31 flowey_lib_common::cache 4
+        flowey.exe v 31 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 31 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 31 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 31 flowey_lib_common::cache 6
+        flowey.exe e 31 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 31 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 31 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 31 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 31 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 31 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 31 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 31 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 31 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 31 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 31 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 31 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 31 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 31 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 31 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 31 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 31 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 31 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 31 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 31 flowey_lib_common::publish_test_results 4
+        flowey.exe e 31 flowey_lib_common::publish_test_results 5
+        flowey.exe v 31 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 31 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-mi-secure-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 31 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 31 flowey_lib_common::publish_test_results 0
+        flowey.exe e 31 flowey_lib_common::publish_test_results 1
+        flowey.exe e 31 flowey_lib_common::publish_test_results 2
+        flowey.exe v 31 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 31 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-mi-secure-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 31 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 31 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 31 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 31 flowey_lib_common::cache 11
+      shell: bash
+  job32:
     name: openvmm checkin gates
     runs-on: ubuntu-latest
     permissions:
@@ -6317,6 +6753,8 @@ jobs:
     - job28
     - job29
     - job3
+    - job30
+    - job31
     - job4
     - job5
     - job6
@@ -6343,18 +6781,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 30 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 30 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 32 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 32 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 30 'verbose' update
+        cat <<'EOF' | flowey v 32 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: Check if any jobs failed
-      run: flowey e 30 flowey_lib_hvlite::_jobs::all_good_job 0
+      run: flowey e 32 flowey_lib_hvlite::_jobs::all_good_job 0
       shell: bash
   job4:
-    name: build artifacts (not for VMM tests) [x64-windows]
+    name: build artifacts (for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6433,14 +6871,20 @@ jobs:
         cat <<'EOF' | flowey.exe v 4 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 4 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 4 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 4 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 4 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-prep_steps"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-prep_steps" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-test_igvm_agent_rpc_server" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tpm_guest_tests"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tpm_guest_tests" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 4 flowey_lib_common::install_rust 0
@@ -6483,22 +6927,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 4 flowey_lib_common::cache 0
-        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe e 4 flowey_lib_common::cache 4
+        flowey.exe v 4 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 4 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
-    - id: flowey_lib_common__cache__1
+    - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        flowey.exe v 4 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 4 flowey_lib_common::cache 2
+        flowey.exe e 4 flowey_lib_common::cache 6
         flowey.exe e 4 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -6511,71 +6955,148 @@ jobs:
         flowey.exe e 4 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey.exe e 4 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build hypestv
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 4 flowey_lib_hvlite::build_hypestv 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo build vmgs_lib
+    - name: cargo build tmk_vmm
       run: |-
         flowey.exe e 4 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 3
-        flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 5
+        flowey.exe e 4 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 5
       shell: bash
-    - name: test vmgs_lib
-      run: |-
-        flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build prep_steps
       run: |-
         flowey.exe e 4 flowey_lib_common::run_cargo_build 1
         flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 4 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 4 flowey_lib_hvlite::build_prep_steps 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 4
         flowey.exe e 4 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build ohcldiag-dev
+    - name: cargo build vmgstool
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 5
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 9
+        flowey.exe e 4 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 5
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 6
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 8
+        flowey.exe e 4 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 6
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 6
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 4 flowey_lib_common::run_cargo_build 2
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 4 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 4 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 0
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 4 flowey_lib_common::cache 0
+        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 4 flowey_lib_common::cache 2
+        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 4 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey.exe e 4 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey.exe e 4 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 4 flowey_lib_hvlite::build_openvmm 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 2
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 4 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-windows-hypestv
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 4 flowey_lib_common::cache 7
+      shell: bash
+    - name: 🌼📦 Publish aarch64-windows-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-hypestv
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-hypestv/
+        name: aarch64-windows-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-igvmfilegen
+    - name: 🌼📦 Publish aarch64-windows-prep_steps
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-igvmfilegen/
+        name: aarch64-windows-prep_steps
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-prep_steps/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-ohcldiag-dev
+    - name: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
+        name: aarch64-windows-test_igvm_agent_rpc_server
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-vmgs_lib
+    - name: 🌼📦 Publish aarch64-windows-tmk_vmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
+        name: aarch64-windows-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmm-tests-archive/
         include-hidden-files: true
   job5:
-    name: build artifacts (for VMM tests) [x64-windows]
+    name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6654,22 +7175,14 @@ jobs:
         cat <<'EOF' | flowey.exe v 5 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-openvmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-openvmm" | flowey.exe v 5 'artifact_publish_from_x64-windows-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-pipette"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 5 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-prep_steps"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-prep_steps" | flowey.exe v 5 'artifact_publish_from_x64-windows-prep_steps' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-test_igvm_agent_rpc_server"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 5 'artifact_publish_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tmk_vmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 5 'artifact_publish_from_x64-windows-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tpm_guest_tests"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 5 'artifact_publish_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmm-tests-archive"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 5 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 5 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 5 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 5 flowey_lib_common::install_rust 0
@@ -6712,22 +7225,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 5 flowey_lib_common::cache 4
-        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 5 flowey_lib_common::cache 0
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 5 flowey_lib_common::cache 6
+        flowey.exe e 5 flowey_lib_common::cache 2
         flowey.exe e 5 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -6738,79 +7251,466 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 5 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 5
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build openvmm
+    - name: cargo build hypestv
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 0
         flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 5 flowey_lib_hvlite::build_openvmm 0
+        flowey.exe e 5 flowey_lib_hvlite::build_hypestv 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 6
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
       shell: bash
-    - name: cargo build pipette
+    - name: cargo build vmgs_lib
       run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 5 flowey_lib_hvlite::build_pipette 0
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      shell: bash
+    - name: test vmgs_lib
+      run: |-
+        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 1
         flowey.exe e 5 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: cargo build tmk_vmm
+    - name: cargo build igvmfilegen
       run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 4
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 6
-        flowey.exe e 5 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 5 flowey_lib_hvlite::build_igvmfilegen 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 7
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build prep_steps
+    - name: cargo build ohcldiag-dev
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 2
         flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 5 flowey_lib_hvlite::build_prep_steps 0
+        flowey.exe e 5 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 3
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 6
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 10
-        flowey.exe e 5 flowey_lib_hvlite::build_vmgstool 0
-        flowey.exe e 5 flowey_core::pipeline::artifact::publish 4
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 3
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 7
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 8
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 5 flowey_lib_common::cache 3
       shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 5
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 9
-        flowey.exe e 5 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey.exe e 5 flowey_core::pipeline::artifact::publish 5
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 4
+    - name: 🌼📦 Publish x64-windows-hypestv
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-hypestv
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-hypestv/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-igvmfilegen
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-ohcldiag-dev
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-vmgs_lib
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
+        include-hidden-files: true
+  job6:
+    name: build artifacts (shared VMM tests) [x64-windows]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
       shell: bash
-    - name: cargo build test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 5
-        flowey.exe e 5 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
-        flowey.exe e 5 flowey_core::pipeline::artifact::publish 6
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
       shell: bash
-    - name: create cargo-nextest cache dir
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
       run: |-
-        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 3
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+
+        echo '"debug"' | flowey.exe v 6 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 6 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 6 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-pipette"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 6 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey.exe e 6 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 6 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey.exe e 6 flowey_lib_common::install_rust 2
+        flowey.exe e 6 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 6 flowey_lib_common::git_checkout 0
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 6 flowey_lib_common::git_checkout 3
+        flowey.exe e 6 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey.exe e 6 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 6 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 5 flowey_lib_common::cache 0
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe e 6 flowey_lib_common::cache 0
+        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 6 flowey_lib_common::cache 2
+        flowey.exe e 6 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey.exe e 6 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 6 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey.exe e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 6 flowey_lib_hvlite::build_pipette 0
+        flowey.exe e 6 flowey_core::pipeline::artifact::publish 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 6 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish x64-windows-pipette
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-pipette
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
+        include-hidden-files: true
+  job7:
+    name: build artifacts (for VMM tests) [x64-windows]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+
+        echo '"debug"' | flowey.exe v 7 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 7 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 7 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-openvmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-openvmm" | flowey.exe v 7 'artifact_publish_from_x64-windows-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-prep_steps"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-prep_steps" | flowey.exe v 7 'artifact_publish_from_x64-windows-prep_steps' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-test_igvm_agent_rpc_server"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 7 'artifact_publish_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tmk_vmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 7 'artifact_publish_from_x64-windows-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tpm_guest_tests"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 7 'artifact_publish_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool" | flowey.exe v 7 'artifact_publish_from_x64-windows-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmm-tests-archive"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 7 'artifact_publish_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey.exe e 7 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 7 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey.exe e 7 flowey_lib_common::install_rust 2
+        flowey.exe e 7 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 7 flowey_lib_common::git_checkout 0
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 7 flowey_lib_common::git_checkout 3
+        flowey.exe e 7 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey.exe e 7 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 7 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 7 flowey_lib_common::cache 4
+        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 7 flowey_lib_common::cache 6
+        flowey.exe e 7 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey.exe e 7 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 7 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey.exe e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 7 flowey_lib_hvlite::build_openvmm 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 0
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 5
+        flowey.exe e 7 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build prep_steps
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 7 flowey_lib_hvlite::build_prep_steps 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build vmgstool
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 5
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 9
+        flowey.exe e 7 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 6
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 8
+        flowey.exe e 7 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 4
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 6
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 2
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 7 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 5
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 7 flowey_lib_common::cache 0
+        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6820,43 +7720,37 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 5 flowey_lib_common::cache 2
-        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 7 flowey_lib_common::cache 2
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 5 flowey_lib_common::install_rust 3
+      run: flowey.exe e 7 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 5 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 7 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey.exe e 5 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey.exe e 5 flowey_core::pipeline::artifact::publish 7
+        flowey.exe e 7 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey.exe e 7 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 6
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 5 flowey_lib_common::cache 3
+      run: flowey.exe e 7 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 5 flowey_lib_common::cache 7
+      run: flowey.exe e 7 flowey_lib_common::cache 7
       shell: bash
     - name: 🌼📦 Publish x64-windows-openvmm
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-openvmm
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-pipette
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-pipette
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-prep_steps
       uses: actions/upload-artifact@v7
@@ -6895,526 +7789,15 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmm-tests-archive/
         include-hidden-files: true
     - name: 🌼🧼 Redact bootstrap var db
-      run: rm $AgentTempDirNormal/bootstrapped-flowey/job5.json
+      run: rm $AgentTempDirNormal/bootstrapped-flowey/job7.json
       shell: bash
     - name: 🌼🥾 Publish bootstrapped flowey
       uses: actions/upload-artifact@v7
       with:
         name: _internal-flowey-bootstrap-x86_64-windows-uid-6
         path: ${{ runner.temp }}/bootstrapped-flowey
-  job6:
-    name: build artifacts (shared VMM tests) [aarch64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 6 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 6 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 6 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 6 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests" | flowey v 6 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 6 'artifact_publish_from_aarch64-tmks' --is-raw-string update
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 6 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 6 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 6 flowey_lib_common::install_rust 2
-        flowey e 6 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 6 flowey_lib_common::git_checkout 0
-        flowey v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 6 flowey_lib_common::git_checkout 3
-        flowey e 6 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 6 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 6 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 6 flowey_lib_common::cache 0
-        flowey v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 6 flowey_lib_common::cache 2
-        flowey e 6 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 6 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 6 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 6 flowey_lib_common::resolve_protoc 0
-        flowey e 6 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build guest_test_uefi
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: build guest_test_uefi.img
-      run: |-
-        flowey e 6 flowey_lib_hvlite::build_guest_test_uefi 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: cargo build simple_tmk
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 6 flowey_lib_hvlite::build_tmks 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 1
-        flowey e 6 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 4
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 6 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 2
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 6 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 6 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 1
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::build_pipette 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 3
-        flowey e 6 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 6 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 4
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 6 flowey_lib_common::cache 3
-      shell: bash
-    - name: 🌼📦 Publish aarch64-guest_test_uefi
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-guest_test_uefi
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-pipette
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-tpm_guest_tests
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-tmks
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-tmks
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
-        include-hidden-files: true
-  job7:
-    name: build artifacts (for VMM tests) [aarch64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 7 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 7 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 7 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 7 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 7 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 7 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 7 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 7 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 7 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 7 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 7 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 7 flowey_lib_common::install_rust 2
-        flowey e 7 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 7 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 7 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 7 flowey_lib_common::git_checkout 0
-        flowey v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 7 flowey_lib_common::git_checkout 3
-        flowey e 7 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 7 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 7 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 7 flowey_lib_common::cache 0
-        flowey v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 7 flowey_lib_common::cache 2
-        flowey e 7 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 7 flowey_lib_common::resolve_protoc 0
-        flowey e 7 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 2
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 7 flowey_lib_hvlite::build_openvmm 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 4
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 7 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 1
-        flowey e 7 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 7
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 7 flowey_lib_hvlite::build_vmgstool 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 2
-        flowey e 7 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 6
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 7 flowey_core::pipeline::artifact::publish 3
-        flowey e 7 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 0
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 7 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 4
-        flowey e 7 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build ohcldiag-dev
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 1
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 5
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 7 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 7 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 7 flowey_lib_hvlite::build_openvmm 1
-        flowey e 7 flowey_core::pipeline::artifact::publish 6
-        flowey e 7 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 5
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 10
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 11
-        flowey e 7 flowey_lib_hvlite::build_openvmm_vhost 1
-        flowey e 7 flowey_core::pipeline::artifact::publish 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 7 flowey_lib_common::cache 3
-      shell: bash
-    - name: 🌼📦 Publish aarch64-linux-igvmfilegen
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-vmgs_lib
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
-        include-hidden-files: true
   job8:
-    name: build artifacts (shared VMM tests) [x64-linux]
+    name: build artifacts (shared VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7449,16 +7832,16 @@ jobs:
         cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 8 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 8 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 8 'artifact_publish_from_x64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 8 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests" | flowey v 8 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 8 'artifact_publish_from_aarch64-tmks' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 8 flowey_lib_common::install_rust 0
@@ -7576,7 +7959,7 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 8 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
         flowey e 8 flowey_lib_hvlite::init_cross_build 3
@@ -7609,38 +7992,38 @@ jobs:
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-guest_test_uefi
+    - name: 🌼📦 Publish aarch64-guest_test_uefi
       uses: actions/upload-artifact@v7
       with:
-        name: x64-guest_test_uefi
-        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
+        name: aarch64-guest_test_uefi
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-pipette
+    - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
+        name: aarch64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
+    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        name: aarch64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
+    - name: 🌼📦 Publish aarch64-linux-tpm_guest_tests
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
+        name: aarch64-linux-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-tpm_guest_tests/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-tmks
+    - name: 🌼📦 Publish aarch64-tmks
       uses: actions/upload-artifact@v7
       with:
-        name: x64-tmks
-        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
+        name: aarch64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
         include-hidden-files: true
   job9:
-    name: build artifacts (for VMM tests) [x64-linux]
+    name: build artifacts (for VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7675,26 +8058,22 @@ jobs:
         cat <<'EOF' | flowey v 9 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 9 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 9 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 9 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 9 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 9 flowey_lib_common::install_rust 0
@@ -7743,22 +8122,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 9 flowey_lib_common::cache 4
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 9 flowey_lib_common::cache 0
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 9 flowey_lib_common::cache 6
+        flowey e 9 flowey_lib_common::cache 2
         flowey e 9 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -7769,7 +8148,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7782,7 +8161,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 5
         flowey e 9 flowey_lib_hvlite::build_openvmm 0
         flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7795,7 +8174,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 9
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -7808,20 +8187,16 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 14
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_build 6
         flowey e 9 flowey_lib_hvlite::run_cargo_build 12
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      shell: bash
-    - name: test vmgs_lib
-      run: |-
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 9 flowey_core::pipeline::artifact::publish 3
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -7834,7 +8209,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -7851,10 +8226,10 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7867,7 +8242,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
         flowey e 9 flowey_lib_hvlite::build_openvmm 1
         flowey e 9 flowey_core::pipeline::artifact::publish 6
-        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7881,117 +8256,54 @@ jobs:
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 9 flowey_core::pipeline::artifact::publish 7
       shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 9 flowey_lib_common::download_cargo_nextest 0
-        flowey e 9 flowey_lib_common::download_cargo_nextest 1
-        flowey e 9 flowey_lib_common::download_cargo_nextest 2
-        flowey e 9 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 9 flowey_lib_common::cache 2
-        flowey e 9 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 9 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 9 flowey_lib_common::install_cargo_nextest 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 8
-        flowey e 9 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 1
-        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
-        flowey e 9 flowey_core::pipeline::artifact::publish 9
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
+    - name: 'validate cache entry: gh-release-download'
       run: flowey e 9 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 9 flowey_lib_common::cache 7
-      shell: bash
-    - name: 🌼📦 Publish x64-linux-igvmfilegen
+    - name: 🌼📦 Publish aarch64-linux-igvmfilegen
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        name: aarch64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        name: aarch64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
+        name: aarch64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+    - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
+        name: aarch64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
+    - name: 🌼📦 Publish aarch64-linux-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
+        name: aarch64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm
+    - name: 🌼📦 Publish aarch64-linux-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
+        name: aarch64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm_vhost
+    - name: 🌼📦 Publish aarch64-linux-vmgs_lib
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        name: aarch64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgs_lib
+    - name: 🌼📦 Publish aarch64-linux-vmgstool
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
+        name: aarch64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
         include-hidden-files: true

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -6903,7 +6903,7 @@ jobs:
         name: _internal-flowey-bootstrap-x86_64-windows-uid-6
         path: ${{ runner.temp }}/bootstrapped-flowey
   job6:
-    name: build artifacts [aarch64-linux] (shared)
+    name: build artifacts (shared VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7171,7 +7171,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
         include-hidden-files: true
   job7:
-    name: build artifacts [aarch64-linux] (for VMM tests)
+    name: build artifacts (for VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7407,7 +7407,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
         include-hidden-files: true
   job8:
-    name: build artifacts [x64-linux] (shared)
+    name: build artifacts (shared VMM tests) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7675,7 +7675,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
         include-hidden-files: true
   job9:
-    name: build artifacts [x64-linux] (for VMM tests)
+    name: build artifacts (for VMM tests) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7800,7 +7800,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7813,7 +7813,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 5
         flowey e 9 flowey_lib_hvlite::build_openvmm 0
         flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7826,7 +7826,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -7839,7 +7839,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 10
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
@@ -7852,7 +7852,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 9 flowey_core::pipeline::artifact::publish 3
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -7865,7 +7865,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -7919,14 +7919,7 @@ jobs:
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
         flowey e 9 flowey_core::pipeline::artifact::publish 6
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+        flowey e 9 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -746,7 +746,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 2
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -759,7 +759,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_build 5
         flowey e 11 flowey_lib_hvlite::build_openvmm 0
         flowey e 11 flowey_core::pipeline::artifact::publish 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 4
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -772,7 +772,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_build 9
         flowey e 11 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 11 flowey_core::pipeline::artifact::publish 1
-        flowey e 11 flowey_lib_hvlite::init_cross_build 6
+        flowey e 11 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -785,7 +785,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_build 14
         flowey e 11 flowey_lib_hvlite::build_vmgstool 0
         flowey e 11 flowey_core::pipeline::artifact::publish 2
-        flowey e 11 flowey_lib_hvlite::init_cross_build 5
+        flowey e 11 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
@@ -798,7 +798,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 11 flowey_core::pipeline::artifact::publish 3
-        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+        flowey e 11 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -811,7 +811,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 11 flowey_core::pipeline::artifact::publish 4
-        flowey e 11 flowey_lib_hvlite::init_cross_build 7
+        flowey e 11 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -898,7 +898,7 @@ jobs:
         flowey e 11 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 0
         flowey e 11 flowey_core::pipeline::artifact::publish 8
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+        flowey e 11 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -4186,284 +4186,12 @@ jobs:
       run: flowey.exe e 22 flowey_lib_common::cache 11
       shell: bash
   job23:
-    name: run vmm-tests [x64-windows-amd-snp]
-    runs-on:
-    - self-hosted
-    - Windows
-    - X64
-    - SNP
-    - Baremetal
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job12
-    - job2
-    - job3
-    - job7
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 23 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 23 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 23 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 23 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 23 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 23 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 23 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 23 flowey_lib_common::cache 0
-        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::cache 2
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 23 flowey_lib_common::git_checkout 0
-        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::git_checkout 3
-        flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 23 flowey_lib_common::cache 8
-        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::cache 10
-        flowey.exe e 23 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 23 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 23 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 23 flowey_lib_common::cache 4
-        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::cache 6
-        flowey.exe e 23 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 23 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 23 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 23 flowey_lib_common::publish_test_results 4
-        flowey.exe e 23 flowey_lib_common::publish_test_results 5
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 23 flowey_lib_common::publish_test_results 0
-        flowey.exe e 23 flowey_lib_common::publish_test_results 1
-        flowey.exe e 23 flowey_lib_common::publish_test_results 2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 23 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 23 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 23 flowey_lib_common::cache 11
-      shell: bash
-  job24:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4490,6 +4218,311 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
+        echo '"debug"' | flowey v 23 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 23 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 23 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 23 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey e 23 flowey_core::pipeline::artifact::resolve 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey e 23 flowey_core::pipeline::artifact::resolve 6
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 23 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 23 flowey_lib_common::cache 8
+        flowey v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 10
+        flowey e 23 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 23 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 23 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 23 flowey_lib_common::cache 4
+        flowey v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 6
+        flowey e 23 flowey_lib_common::download_gh_cli 1
+        flowey v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 23 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey e 23 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure hypervisor device is accessible
+      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: ensure 2 MiB hugetlb pages are available
+      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 23 flowey_lib_common::download_cargo_nextest 0
+        flowey e 23 flowey_lib_common::download_cargo_nextest 1
+        flowey e 23 flowey_lib_common::download_cargo_nextest 2
+        flowey e 23 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 23 flowey_lib_common::cache 0
+        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 2
+        flowey e 23 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 23 flowey_lib_common::git_checkout 0
+        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 23 flowey_lib_common::git_checkout 3
+        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 5
+        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (linux)
+      run: flowey e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 23 flowey_lib_common::publish_test_results 4
+        flowey e 23 flowey_lib_common::publish_test_results 5
+        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 23 flowey_lib_common::publish_test_results 0
+        flowey e 23 flowey_lib_common::publish_test_results 1
+        flowey e 23 flowey_lib_common::publish_test_results 2
+        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 23 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 23 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 23 flowey_lib_common::cache 11
+      shell: bash
+  job24:
+    name: run vmm-tests [x64-linux-intel-mshv]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=azurelinux3-amd64-dom0
+    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job2
+    - job3
+    - job9
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        sudo tdnf install -y gcc glibc-devel
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
         echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
 
@@ -4497,22 +4530,22 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 24 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 24 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey e 24 flowey_core::pipeline::artifact::resolve 7
         flowey e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey e 24 flowey_core::pipeline::artifact::resolve 0
         flowey e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey e 24 flowey_core::pipeline::artifact::resolve 3
+        flowey e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 4
         flowey e 24 flowey_core::pipeline::artifact::resolve 6
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -4604,10 +4637,7 @@ jobs:
       run: flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -4658,10 +4688,9 @@ jobs:
         flowey e 24 flowey_lib_common::git_checkout 3
         flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
         flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: generate nextest command
       run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
@@ -4682,9 +4711,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-logs
+        name: x64-linux-intel-mshv-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4698,9 +4727,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        name: x64-linux-intel-mshv-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
@@ -4715,307 +4744,6 @@ jobs:
       run: flowey e 24 flowey_lib_common::cache 11
       shell: bash
   job25:
-    name: run vmm-tests [x64-linux-intel-mshv]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job2
-    - job3
-    - job9
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        sudo tdnf install -y gcc glibc-devel
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 25 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      shell: bash
-    - name: creating new test content dir
-      run: |-
-        flowey e 25 flowey_core::pipeline::artifact::resolve 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 2
-        flowey e 25 flowey_core::pipeline::artifact::resolve 7
-        flowey e 25 flowey_core::pipeline::artifact::resolve 3
-        flowey e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 4
-        flowey e 25 flowey_core::pipeline::artifact::resolve 6
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 25 flowey_lib_common::cache 8
-        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey e 25 flowey_lib_common::cache 10
-        flowey e 25 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey e 25 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 25 flowey_lib_common::cache 4
-        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 25 flowey_lib_common::cache 6
-        flowey e 25 flowey_lib_common::download_gh_cli 1
-        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey e 25 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey e 25 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 25 flowey_lib_common::download_cargo_nextest 0
-        flowey e 25 flowey_lib_common::download_cargo_nextest 1
-        flowey e 25 flowey_lib_common::download_cargo_nextest 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 25 flowey_lib_common::cache 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 5
-        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 25 flowey_lib_common::publish_test_results 4
-        flowey e 25 flowey_lib_common::publish_test_results 5
-        flowey v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 25 flowey_lib_common::publish_test_results 0
-        flowey e 25 flowey_lib_common::publish_test_results 1
-        flowey e 25 flowey_lib_common::publish_test_results 2
-        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 25 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 25 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 25 flowey_lib_common::cache 11
-      shell: bash
-  job26:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -5098,35 +4826,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 25 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 26 'verbose' update
+        cat <<'EOF' | flowey.exe v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 26 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 25 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 25 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 25 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 25 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 25 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 25 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 25 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 25 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 25 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 25 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 0
-        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 25 flowey_lib_common::cache 0
+        flowey.exe v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5136,17 +4864,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 25 flowey_lib_common::cache 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_common::git_checkout 0
+        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5158,35 +4886,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 26 flowey_lib_common::git_checkout 3
-        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 25 flowey_lib_common::git_checkout 3
+        flowey.exe e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 8
-        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 25 flowey_lib_common::cache 8
+        flowey.exe v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5196,31 +4924,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 10
-        flowey.exe e 26 flowey_lib_common::download_gh_release 1
+        flowey.exe e 25 flowey_lib_common::cache 10
+        flowey.exe e 25 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 26 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 25 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 4
-        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 25 flowey_lib_common::cache 4
+        flowey.exe v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5230,63 +4958,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 6
-        flowey.exe e 26 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 25 flowey_lib_common::cache 6
+        flowey.exe e 25 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 26 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 25 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 26 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 25 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 26 flowey_lib_common::publish_test_results 4
-        flowey.exe e 26 flowey_lib_common::publish_test_results 5
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 25 flowey_lib_common::publish_test_results 4
+        flowey.exe e 25 flowey_lib_common::publish_test_results 5
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5297,12 +5025,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 26 flowey_lib_common::publish_test_results 0
-        flowey.exe e 26 flowey_lib_common::publish_test_results 1
-        flowey.exe e 26 flowey_lib_common::publish_test_results 2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 25 flowey_lib_common::publish_test_results 0
+        flowey.exe e 25 flowey_lib_common::publish_test_results 1
+        flowey.exe e 25 flowey_lib_common::publish_test_results 2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5312,20 +5040,95 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 26 flowey_lib_common::cache 3
+      run: flowey.exe e 25 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 26 flowey_lib_common::cache 7
+      run: flowey.exe e 25 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 26 flowey_lib_common::cache 11
+      run: flowey.exe e 25 flowey_lib_common::cache 11
       shell: bash
-  job27:
+  job26:
     name: test flowey local backend
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 26 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 26 flowey_lib_common::git_checkout 0
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 26 flowey_lib_common::git_checkout 3
+        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 26 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 26 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 26 flowey_lib_common::install_rust 2
+        flowey v 26 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: test cargo xflowey build-igvm x64 --install-missing-deps
+      run: flowey e 26 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      shell: bash
+  job27:
+    name: build openhcl (mi-secure) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5355,28 +5158,42 @@ jobs:
         cat <<'EOF' | flowey v 27 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 27 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 27 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
-    - name: check if openvmm needs to be cloned
+    - name: checking if packages need to be installed
+      run: flowey e 27 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 27 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 27 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
       run: |-
-        flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 27 flowey_lib_common::cache 0
+        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
       with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
       run: |-
-        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
+        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 27 flowey_lib_common::git_checkout 3
-        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 27 flowey_lib_common::cache 2
+        flowey e 27 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 27 flowey_lib_common::install_rust 0
@@ -5387,102 +5204,13 @@ jobs:
     - name: detect active toolchain
       run: |-
         flowey e 27 flowey_lib_common::install_rust 2
-        flowey v 27 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 27 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
-      shell: bash
-  job28:
-    name: build openhcl (mi-secure) [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job28-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 28 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 28 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 28 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 28 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 28 flowey_lib_common::cache 0
-        flowey v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 28 flowey_lib_common::cache 2
-        flowey e 28 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 28 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 28 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 28 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 28 flowey_lib_common::install_rust 2
-        flowey e 28 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 27 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 28 flowey_lib_common::git_checkout 0
-        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 27 flowey_lib_common::git_checkout 0
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5494,172 +5222,172 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 28 flowey_lib_common::git_checkout 3
-        flowey e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 27 flowey_lib_common::git_checkout 3
+        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 28 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 27 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 28 flowey_lib_common::resolve_protoc 0
-        flowey e 28 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 27 flowey_lib_common::resolve_protoc 0
+        flowey e 27 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 28 flowey_lib_hvlite::init_cross_build 0
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 27 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 27 flowey_lib_hvlite::init_cross_build 0
+        flowey e 27 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 27 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 3
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 27 flowey_lib_common::run_cargo_build 3
+        flowey e 27 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 28 flowey_lib_hvlite::build_sidecar 0
-        flowey e 28 flowey_lib_hvlite::init_cross_build 1
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 27 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 27 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 27 flowey_lib_hvlite::build_sidecar 0
+        flowey e 27 flowey_lib_hvlite::init_cross_build 1
+        flowey e 27 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 27 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: cargo build openhcl_boot
       run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 1
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 27 flowey_lib_common::run_cargo_build 1
+        flowey e 27 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 28 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 27 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 27 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 27 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 27 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 28 flowey_lib_hvlite::init_cross_build 3
+        flowey e 27 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 27 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 2
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 28 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 27 flowey_lib_common::run_cargo_build 2
+        flowey e 27 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 27 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 27 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 28 flowey_lib_hvlite::init_cross_build 2
+        flowey e 27 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 27 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 0
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 27 flowey_lib_common::run_cargo_build 0
+        flowey e 27 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 28 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 27 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 27 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 27 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 27 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 27 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 28 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 27 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 27 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 27 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 27 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 27 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 27 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 27 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 27 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 27 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 27 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
-        flowey e 28 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 27 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 27 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 27 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 27 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 27 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 27 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 28 flowey_lib_common::copy_to_artifact_dir 0
+      run: flowey e 27 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 28 flowey_lib_common::cache 3
+      run: flowey e 27 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -5673,20 +5401,20 @@ jobs:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
         include-hidden-files: true
-  job29:
+  job28:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job29-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job28-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
     - job2
-    - job28
+    - job27
     - job3
     - job7
     if: github.event.pull_request.draft == false
@@ -5707,39 +5435,39 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
 
-        echo '"debug"' | flowey.exe v 29 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 29 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 28 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 28 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 29 'verbose' update
+        cat <<'EOF' | flowey.exe v 28 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 29 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 29 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 29 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 29 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 29 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 29 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 29 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 29 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 29 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 28 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 28 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 28 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 28 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 28 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 28 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 28 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 28 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 28 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 28 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 28 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 28 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 28 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 28 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 29 flowey_lib_common::cache 0
-        flowey.exe v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 28 flowey_lib_common::cache 0
+        flowey.exe v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5749,17 +5477,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 29 flowey_lib_common::cache 2
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 28 flowey_lib_common::cache 2
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 29 flowey_lib_common::git_checkout 0
-        flowey.exe v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 28 flowey_lib_common::git_checkout 0
+        flowey.exe v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5771,38 +5499,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 29 flowey_lib_common::git_checkout 3
-        flowey.exe e 29 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 28 flowey_lib_common::git_checkout 3
+        flowey.exe e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 29 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 29 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 28 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 29 flowey_lib_common::cache 8
-        flowey.exe v 29 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 29 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 28 flowey_lib_common::cache 8
+        flowey.exe v 28 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 28 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5812,31 +5540,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 29 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 28 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 29 flowey_lib_common::cache 10
-        flowey.exe e 29 flowey_lib_common::download_gh_release 1
+        flowey.exe e 28 flowey_lib_common::cache 10
+        flowey.exe e 28 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 29 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 28 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 28 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 28 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 28 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 29 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 28 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 29 flowey_lib_common::cache 4
-        flowey.exe v 29 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 29 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 28 flowey_lib_common::cache 4
+        flowey.exe v 28 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 28 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5846,63 +5574,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 29 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 28 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 29 flowey_lib_common::cache 6
-        flowey.exe e 29 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 28 flowey_lib_common::cache 6
+        flowey.exe e 28 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 28 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 29 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 28 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 29 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 28 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 29 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 28 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 29 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 28 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 29 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 28 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 29 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 28 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 29 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 29 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 28 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 28 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 29 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 28 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 29 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 28 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 29 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 28 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 28 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 28 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 29 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 29 flowey_lib_common::publish_test_results 4
-        flowey.exe e 29 flowey_lib_common::publish_test_results 5
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 28 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 28 flowey_lib_common::publish_test_results 4
+        flowey.exe e 28 flowey_lib_common::publish_test_results 5
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5913,12 +5641,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 29 flowey_lib_common::publish_test_results 0
-        flowey.exe e 29 flowey_lib_common::publish_test_results 1
-        flowey.exe e 29 flowey_lib_common::publish_test_results 2
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 28 flowey_lib_common::publish_test_results 0
+        flowey.exe e 28 flowey_lib_common::publish_test_results 1
+        flowey.exe e 28 flowey_lib_common::publish_test_results 2
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5928,16 +5656,82 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 29 flowey_lib_common::cache 3
+      run: flowey.exe e 28 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 29 flowey_lib_common::cache 7
+      run: flowey.exe e 28 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 29 flowey_lib_common::cache 11
+      run: flowey.exe e 28 flowey_lib_common::cache 11
+      shell: bash
+  job29:
+    name: openvmm checkin gates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job1
+    - job10
+    - job11
+    - job12
+    - job13
+    - job14
+    - job15
+    - job16
+    - job17
+    - job18
+    - job19
+    - job2
+    - job20
+    - job21
+    - job22
+    - job23
+    - job24
+    - job25
+    - job26
+    - job27
+    - job28
+    - job3
+    - job4
+    - job5
+    - job6
+    - job7
+    - job8
+    - job9
+    if: always() && github.event.pull_request.draft == false
+    env:
+      ANY_JOBS_FAILED: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 29 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 29 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 29 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: Check if any jobs failed
+      run: flowey e 29 flowey_lib_hvlite::_jobs::all_good_job 0
       shell: bash
   job3:
     name: build artifacts (shared VMM tests) [linux]
@@ -6273,73 +6067,6 @@ jobs:
         name: x64-tmks
         path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
         include-hidden-files: true
-  job30:
-    name: openvmm checkin gates
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job1
-    - job10
-    - job11
-    - job12
-    - job13
-    - job14
-    - job15
-    - job16
-    - job17
-    - job18
-    - job19
-    - job2
-    - job20
-    - job21
-    - job22
-    - job23
-    - job24
-    - job25
-    - job26
-    - job27
-    - job28
-    - job29
-    - job3
-    - job4
-    - job5
-    - job6
-    - job7
-    - job8
-    - job9
-    if: always() && github.event.pull_request.draft == false
-    env:
-      ANY_JOBS_FAILED: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 30 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 30 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 30 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: Check if any jobs failed
-      run: flowey e 30 flowey_lib_hvlite::_jobs::all_good_job 0
-      shell: bash
   job4:
     name: build artifacts (not for VMM tests) [aarch64-windows]
     runs-on:

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -391,7 +391,7 @@ jobs:
       run: flowey.exe e 1 flowey_lib_common::cache 3
       shell: bash
   job10:
-    name: build openhcl [x64-linux]
+    name: build openhcl [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -426,20 +426,10 @@ jobs:
         cat <<'EOF' | flowey v 10 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 10 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 10 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 10 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 10 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 10 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 10 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 10 flowey_lib_common::install_dist_pkg 0
@@ -452,25 +442,25 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 10 flowey_lib_common::cache 4
-        flowey v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey e 10 flowey_lib_common::cache 0
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 10 flowey_lib_common::cache 6
+        flowey e 10 flowey_lib_common::cache 2
         flowey e 10 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack mu_msvm package (x64)
+    - name: unpack mu_msvm package (aarch64)
       run: flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
@@ -487,7 +477,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar5
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
         flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -495,7 +485,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -518,20 +508,6 @@ jobs:
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 10 flowey_lib_hvlite::init_cross_build 0
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 13
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 14
-      shell: bash
-    - name: cargo build sidecar
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 6
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 15
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 10
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 16
-        flowey e 10 flowey_lib_hvlite::build_sidecar 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 1
         flowey e 10 flowey_lib_hvlite::run_cargo_build 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
@@ -542,41 +518,41 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 5
         flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 5
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 3
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
         flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 10 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -586,128 +562,50 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 9
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 10 flowey_lib_hvlite::run_cargo_build 1
         flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 3
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
         flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
         flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
         flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
@@ -715,152 +613,25 @@ jobs:
         flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: |-
-        flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 5
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 11
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 8
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 10 flowey_lib_hvlite::build_pipette 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 8
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 7
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 17
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 11
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 18
-        flowey e 10 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 1
-        flowey e 10 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 10 flowey_lib_hvlite::build_openvmm 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 2
-        flowey e 10 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 4
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 7
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 10 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 3
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 10 flowey_lib_common::download_cargo_nextest 0
-        flowey e 10 flowey_lib_common::download_cargo_nextest 1
-        flowey e 10 flowey_lib_common::download_cargo_nextest 2
-        flowey e 10 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 10 flowey_lib_common::cache 2
-        flowey e 10 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 10 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 10 flowey_lib_common::install_cargo_nextest 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey e 10 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 10 flowey_lib_common::cache 3
+      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 10 flowey_lib_common::cache 7
+      run: flowey e 10 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-linux-musl-openvmm
+    - name: 🌼📦 Publish aarch64-openhcl-igvm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        name: aarch64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-pipette
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
+        name: aarch64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
         include-hidden-files: true
   job11:
-    name: verify openhcl binary size [x64]
+    name: verify openhcl binary size [aarch64]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -958,7 +729,7 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract Aarch64 sysroot.tar.gz
       run: flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -970,7 +741,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+        flowey e 11 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
@@ -979,7 +750,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
       shell: bash
@@ -991,18 +762,18 @@ jobs:
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
       uses: actions/upload-artifact@v7
       with:
-        name: x86_64_openvmm_hcl_for_size_analysis
+        name: aarch64_openvmm_hcl_for_size_analysis
         path: ${{ env.floweyvar1 }}
       name: publish openvmm_hcl for analysis
     - name: cargo build xtask
       run: |-
-        flowey e 11 flowey_lib_hvlite::init_cross_build 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
         flowey e 11 flowey_lib_common::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 11 flowey_lib_hvlite::run_cargo_build 3
         flowey e 11 flowey_lib_hvlite::build_xtask 0
       shell: bash
@@ -1056,12 +827,540 @@ jobs:
       run: flowey e 11 flowey_lib_common::cache 7
       shell: bash
   job12:
+    name: build openhcl [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 12 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 12 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 12 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 12 flowey_lib_common::cache 0
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 12 flowey_lib_common::cache 2
+        flowey e 12 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 12 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 12 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 12 flowey_lib_common::install_rust 2
+        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 12 flowey_lib_common::git_checkout 0
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 12 flowey_lib_common::git_checkout 3
+        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 12 flowey_lib_common::resolve_protoc 0
+        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 0
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build sidecar
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 12 flowey_lib_hvlite::build_sidecar 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 1
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 1
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 12 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 0
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 4
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 12 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish x64-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
+        include-hidden-files: true
+  job13:
+    name: verify openhcl binary size [x64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 13 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 13 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 13 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 13 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 13 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 13 flowey_lib_common::install_rust 2
+        flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 13 flowey_lib_common::git_checkout 0
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar2
+        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar2 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 13 flowey_lib_common::git_checkout 3
+        flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 13 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 13 flowey_lib_common::cache 4
+        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 13 flowey_lib_common::cache 6
+        flowey e 13 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 13 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: flowey e 13 flowey_lib_common::resolve_protoc 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 0
+      shell: bash
+    - name: collect openvmm_hcl files for analysis
+      run: |-
+        flowey e 13 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
+        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:119:27' --is-raw-string write-to-env github floweyvar1
+      shell: bash
+    - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
+      uses: actions/upload-artifact@v7
+      with:
+        name: x86_64_openvmm_hcl_for_size_analysis
+        path: ${{ env.floweyvar1 }}
+      name: publish openvmm_hcl for analysis
+    - name: cargo build xtask
+      run: |-
+        flowey e 13 flowey_lib_hvlite::init_cross_build 0
+        flowey e 13 flowey_lib_common::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 13 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 13 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 13 flowey_lib_common::cache 0
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 13 flowey_lib_common::cache 2
+        flowey e 13 flowey_lib_common::download_gh_cli 1
+        flowey v 13 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 13 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get merge commit
+      run: flowey e 13 flowey_lib_common::git_merge_commit 0
+      shell: bash
+    - name: get action id by commit
+      run: |-
+        flowey e 13 flowey_lib_common::gh_workflow_id 0
+        flowey e 13 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey e 13 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: binary size comparison
+      run: flowey e 13 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 13 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 13 flowey_lib_common::cache 7
+      shell: bash
+  job14:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1129,29 +1428,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 12 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 12 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 14 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 14 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 12 'verbose' update
+        cat <<'EOF' | flowey.exe v 14 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 12 flowey_lib_common::install_rust 0
+      run: flowey.exe e 14 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 12 flowey_lib_common::install_rust 1
+      run: flowey.exe e 14 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 12 flowey_lib_common::install_rust 2
-        flowey.exe e 12 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 14 flowey_lib_common::install_rust 2
+        flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 12 flowey_lib_common::git_checkout 0
-        flowey.exe v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 14 flowey_lib_common::git_checkout 0
+        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1163,23 +1462,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 12 flowey_lib_common::git_checkout 3
-        flowey.exe e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 14 flowey_lib_common::git_checkout 3
+        flowey.exe e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 12 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 14 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 12 flowey_lib_common::cache 4
-        flowey.exe v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 14 flowey_lib_common::cache 4
+        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1189,50 +1488,50 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 12 flowey_lib_common::cache 6
-        flowey.exe e 12 flowey_lib_common::download_gh_release 1
+        flowey.exe e 14 flowey_lib_common::cache 6
+        flowey.exe e 14 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 12 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 14 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 12 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 14 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 14 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 12 flowey_lib_common::cache 0
-        flowey.exe v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe e 14 flowey_lib_common::cache 0
+        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1242,45 +1541,45 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 12 flowey_lib_common::cache 2
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 14 flowey_lib_common::cache 2
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 12 flowey_lib_common::install_rust 3
+      run: flowey.exe e 14 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 12 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 14 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 12 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 14 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 14 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 12 flowey_lib_common::publish_test_results 5
-        flowey.exe e 12 flowey_lib_common::publish_test_results 6
-        flowey.exe e 12 flowey_lib_common::publish_test_results 4
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 14 flowey_lib_common::publish_test_results 5
+        flowey.exe e 14 flowey_lib_common::publish_test_results 6
+        flowey.exe e 14 flowey_lib_common::publish_test_results 4
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1290,18 +1589,18 @@ jobs:
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 12 flowey_lib_common::publish_test_results 0
-        flowey.exe e 12 flowey_lib_common::publish_test_results 1
-        flowey.exe e 12 flowey_lib_common::publish_test_results 2
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 14 flowey_lib_common::publish_test_results 0
+        flowey.exe e 14 flowey_lib_common::publish_test_results 1
+        flowey.exe e 14 flowey_lib_common::publish_test_results 2
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1312,25 +1611,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
-      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 12 flowey_lib_common::cache 3
+      run: flowey.exe e 14 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 12 flowey_lib_common::cache 7
+      run: flowey.exe e 14 flowey_lib_common::cache 7
       shell: bash
-  job13:
+  job15:
     name: clippy [macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1354,35 +1653,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 13 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 13 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 15 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 13 'verbose' update
+        cat <<'EOF' | flowey v 15 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 13 flowey_lib_common::install_rust 0
+      run: flowey e 15 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 13 flowey_lib_common::install_rust 1
+      run: flowey e 15 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 13 flowey_lib_common::install_rust 2
-        flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 15 flowey_lib_common::install_rust 2
+        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 13 flowey_lib_common::git_checkout 0
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::git_checkout 0
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1394,23 +1693,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 13 flowey_lib_common::git_checkout 3
-        flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 15 flowey_lib_common::git_checkout 3
+        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 13 flowey_lib_common::download_gh_release 0
+      run: flowey e 15 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 13 flowey_lib_common::cache 4
-        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey e 15 flowey_lib_common::cache 4
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1420,54 +1719,54 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 13 flowey_lib_common::cache 6
-        flowey e 13 flowey_lib_common::download_gh_release 1
+        flowey e 15 flowey_lib_common::cache 6
+        flowey e 15 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 13 flowey_lib_common::resolve_protoc 0
-        flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 15 flowey_lib_common::resolve_protoc 0
+        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 1
+        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_build 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 15 flowey_lib_common::run_cargo_build 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::build_xtask 0
+        flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 13 flowey_lib_common::download_cargo_nextest 0
-        flowey e 13 flowey_lib_common::download_cargo_nextest 1
-        flowey e 13 flowey_lib_common::download_cargo_nextest 2
-        flowey e 13 flowey_lib_common::download_cargo_nextest 3
+        flowey e 15 flowey_lib_common::download_cargo_nextest 0
+        flowey e 15 flowey_lib_common::download_cargo_nextest 1
+        flowey e 15 flowey_lib_common::download_cargo_nextest 2
+        flowey e 15 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey e 15 flowey_lib_common::cache 0
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1477,34 +1776,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 13 flowey_lib_common::cache 2
-        flowey e 13 flowey_lib_common::download_cargo_nextest 4
+        flowey e 15 flowey_lib_common::cache 2
+        flowey e 15 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 13 flowey_lib_common::install_rust 3
+      run: flowey e 15 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 13 flowey_lib_common::install_cargo_nextest 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::install_cargo_nextest 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 13 flowey_lib_common::publish_test_results 5
-        flowey e 13 flowey_lib_common::publish_test_results 6
-        flowey e 13 flowey_lib_common::publish_test_results 4
-        flowey v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 15 flowey_lib_common::publish_test_results 5
+        flowey e 15 flowey_lib_common::publish_test_results 6
+        flowey e 15 flowey_lib_common::publish_test_results 4
+        flowey v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1514,18 +1813,18 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 13 flowey_lib_common::publish_test_results 8
-        flowey e 13 flowey_lib_common::publish_test_results 9
-        flowey e 13 flowey_lib_common::publish_test_results 10
-        flowey v 13 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 13 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 15 flowey_lib_common::publish_test_results 8
+        flowey e 15 flowey_lib_common::publish_test_results 9
+        flowey e 15 flowey_lib_common::publish_test_results 10
+        flowey v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -1536,32 +1835,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 13 flowey_lib_hvlite::init_cross_build 2
-        flowey e 13 flowey_lib_common::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 15 flowey_lib_hvlite::init_cross_build 2
+        flowey e 15 flowey_lib_common::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 13 flowey_lib_hvlite::build_xtask 1
+        flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 15 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 13 flowey_lib_common::publish_test_results 12
-        flowey e 13 flowey_lib_common::publish_test_results 13
-        flowey e 13 flowey_lib_common::publish_test_results 14
-        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 15 flowey_lib_common::publish_test_results 12
+        flowey e 15 flowey_lib_common::publish_test_results 13
+        flowey e 15 flowey_lib_common::publish_test_results 14
+        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -1571,18 +1870,18 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 13 flowey_lib_common::publish_test_results 0
-        flowey e 13 flowey_lib_common::publish_test_results 1
-        flowey e 13 flowey_lib_common::publish_test_results 2
-        flowey v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 15 flowey_lib_common::publish_test_results 0
+        flowey e 15 flowey_lib_common::publish_test_results 1
+        flowey e 15 flowey_lib_common::publish_test_results 2
+        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1593,25 +1892,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 13 flowey_lib_common::cache 3
+      run: flowey e 15 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 13 flowey_lib_common::cache 7
+      run: flowey e 15 flowey_lib_common::cache 7
       shell: bash
-  job14:
+  job16:
     name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1635,29 +1934,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 14 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 14 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 14 'verbose' update
+        cat <<'EOF' | flowey v 16 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 14 flowey_lib_common::install_rust 0
+      run: flowey e 16 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 14 flowey_lib_common::install_rust 1
+      run: flowey e 16 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 14 flowey_lib_common::install_rust 2
-        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 16 flowey_lib_common::install_rust 2
+        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::git_checkout 0
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1669,27 +1968,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 14 flowey_lib_common::git_checkout 3
-        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 16 flowey_lib_common::git_checkout 3
+        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 14 flowey_lib_common::download_gh_release 0
+      run: flowey e 16 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 16 flowey_lib_common::cache 4
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1699,78 +1998,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 14 flowey_lib_common::cache 6
-        flowey e 14 flowey_lib_common::download_gh_release 1
+        flowey e 16 flowey_lib_common::cache 6
+        flowey e 16 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 14 flowey_lib_common::resolve_protoc 0
+      run: flowey e 16 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 2
+        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_clippy 5
-        flowey e 14 flowey_lib_hvlite::init_cross_build 0
+        flowey e 16 flowey_lib_common::run_cargo_clippy 5
+        flowey e 16 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_build 0
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 16 flowey_lib_common::run_cargo_build 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 14 flowey_lib_hvlite::build_xtask 0
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 14 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 14 flowey_lib_common::download_cargo_nextest 0
-        flowey e 14 flowey_lib_common::download_cargo_nextest 1
-        flowey e 14 flowey_lib_common::download_cargo_nextest 2
-        flowey e 14 flowey_lib_common::download_cargo_nextest 3
+        flowey e 16 flowey_lib_common::download_cargo_nextest 0
+        flowey e 16 flowey_lib_common::download_cargo_nextest 1
+        flowey e 16 flowey_lib_common::download_cargo_nextest 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 16 flowey_lib_common::cache 0
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1780,34 +2079,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 14 flowey_lib_common::cache 2
-        flowey e 14 flowey_lib_common::download_cargo_nextest 4
+        flowey e 16 flowey_lib_common::cache 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 14 flowey_lib_common::install_rust 3
+      run: flowey e 16 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 14 flowey_lib_common::install_cargo_nextest 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 3
-        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::install_cargo_nextest 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 3
+        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 14 flowey_lib_common::publish_test_results 5
-        flowey e 14 flowey_lib_common::publish_test_results 6
-        flowey e 14 flowey_lib_common::publish_test_results 4
-        flowey v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 16 flowey_lib_common::publish_test_results 5
+        flowey e 16 flowey_lib_common::publish_test_results 6
+        flowey e 16 flowey_lib_common::publish_test_results 4
+        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1817,18 +2116,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 14 flowey_lib_common::publish_test_results 8
-        flowey e 14 flowey_lib_common::publish_test_results 9
-        flowey e 14 flowey_lib_common::publish_test_results 10
-        flowey v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 16 flowey_lib_common::publish_test_results 8
+        flowey e 16 flowey_lib_common::publish_test_results 9
+        flowey e 16 flowey_lib_common::publish_test_results 10
+        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -1838,18 +2137,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 14 flowey_lib_common::publish_test_results 12
-        flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey e 14 flowey_lib_common::publish_test_results 14
-        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey e 16 flowey_lib_common::publish_test_results 13
+        flowey e 16 flowey_lib_common::publish_test_results 14
+        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -1859,18 +2158,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 14 flowey_lib_common::publish_test_results 16
-        flowey e 14 flowey_lib_common::publish_test_results 17
-        flowey e 14 flowey_lib_common::publish_test_results 18
-        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 16 flowey_lib_common::publish_test_results 16
+        flowey e 16 flowey_lib_common::publish_test_results 17
+        flowey e 16 flowey_lib_common::publish_test_results 18
+        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -1881,32 +2180,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_hvlite::init_cross_build 1
-        flowey e 14 flowey_lib_common::run_cargo_build 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 16 flowey_lib_hvlite::init_cross_build 1
+        flowey e 16 flowey_lib_common::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 14 flowey_lib_hvlite::build_xtask 1
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 16 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 14 flowey_lib_common::publish_test_results 0
-        flowey e 14 flowey_lib_common::publish_test_results 1
-        flowey e 14 flowey_lib_common::publish_test_results 2
-        flowey v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 16 flowey_lib_common::publish_test_results 0
+        flowey e 16 flowey_lib_common::publish_test_results 1
+        flowey e 16 flowey_lib_common::publish_test_results 2
+        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1917,25 +2216,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
-      run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 14 flowey_lib_common::cache 3
+      run: flowey e 16 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 14 flowey_lib_common::cache 7
+      run: flowey e 16 flowey_lib_common::cache 7
       shell: bash
-  job15:
+  job17:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=win-arm64
-    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2003,29 +2302,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 15 'verbose' update
+        cat <<'EOF' | flowey.exe v 17 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 15 flowey_lib_common::install_rust 0
+      run: flowey.exe e 17 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 15 flowey_lib_common::install_rust 1
+      run: flowey.exe e 17 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 15 flowey_lib_common::install_rust 2
-        flowey.exe e 15 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 17 flowey_lib_common::install_rust 2
+        flowey.exe e 17 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 15 flowey_lib_common::git_checkout 0
-        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 17 flowey_lib_common::git_checkout 0
+        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2037,23 +2336,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 15 flowey_lib_common::git_checkout 3
-        flowey.exe e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 17 flowey_lib_common::git_checkout 3
+        flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 15 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 17 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 15 flowey_lib_common::cache 4
-        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 17 flowey_lib_common::cache 4
+        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2063,50 +2362,50 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 15 flowey_lib_common::cache 6
-        flowey.exe e 15 flowey_lib_common::download_gh_release 1
+        flowey.exe e 17 flowey_lib_common::cache 6
+        flowey.exe e 17 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 15 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 17 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 15 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 17 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 17 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 15 flowey_lib_common::cache 0
-        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe e 17 flowey_lib_common::cache 0
+        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2116,45 +2415,45 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 15 flowey_lib_common::cache 2
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 17 flowey_lib_common::cache 2
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 15 flowey_lib_common::install_rust 3
+      run: flowey.exe e 17 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 15 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 17 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 17 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 17 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 15 flowey_lib_common::publish_test_results 5
-        flowey.exe e 15 flowey_lib_common::publish_test_results 6
-        flowey.exe e 15 flowey_lib_common::publish_test_results 4
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 17 flowey_lib_common::publish_test_results 5
+        flowey.exe e 17 flowey_lib_common::publish_test_results 6
+        flowey.exe e 17 flowey_lib_common::publish_test_results 4
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2164,18 +2463,18 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 15 flowey_lib_common::publish_test_results 0
-        flowey.exe e 15 flowey_lib_common::publish_test_results 1
-        flowey.exe e 15 flowey_lib_common::publish_test_results 2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 17 flowey_lib_common::publish_test_results 0
+        flowey.exe e 17 flowey_lib_common::publish_test_results 1
+        flowey.exe e 17 flowey_lib_common::publish_test_results 2
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2186,25 +2485,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
-      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 15 flowey_lib_common::cache 3
+      run: flowey.exe e 17 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 15 flowey_lib_common::cache 7
+      run: flowey.exe e 17 flowey_lib_common::cache 7
       shell: bash
-  job16:
+  job18:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2272,35 +2571,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 18 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 16 'verbose' update
+        cat <<'EOF' | flowey v 18 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 16 flowey_lib_common::install_rust 0
+      run: flowey e 18 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 16 flowey_lib_common::install_rust 1
+      run: flowey e 18 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 16 flowey_lib_common::install_rust 2
-        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 18 flowey_lib_common::install_rust 2
+        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::git_checkout 0
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2312,23 +2611,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 16 flowey_lib_common::git_checkout 3
-        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 18 flowey_lib_common::git_checkout 3
+        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 16 flowey_lib_common::download_gh_release 0
+      run: flowey e 18 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey e 18 flowey_lib_common::cache 4
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2338,61 +2637,61 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 16 flowey_lib_common::cache 6
-        flowey e 16 flowey_lib_common::download_gh_release 1
+        flowey e 18 flowey_lib_common::cache 6
+        flowey e 18 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 16 flowey_lib_common::resolve_protoc 0
-        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 18 flowey_lib_common::resolve_protoc 0
+        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 2
+        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_build 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 18 flowey_lib_common::run_cargo_build 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::build_xtask 0
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 16 flowey_lib_common::download_cargo_nextest 0
-        flowey e 16 flowey_lib_common::download_cargo_nextest 1
-        flowey e 16 flowey_lib_common::download_cargo_nextest 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 3
+        flowey e 18 flowey_lib_common::download_cargo_nextest 0
+        flowey e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey e 18 flowey_lib_common::download_cargo_nextest 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey e 18 flowey_lib_common::cache 0
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2402,34 +2701,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 16 flowey_lib_common::cache 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 4
+        flowey e 18 flowey_lib_common::cache 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 16 flowey_lib_common::install_rust 3
+      run: flowey e 18 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 16 flowey_lib_common::install_cargo_nextest 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::install_cargo_nextest 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 16 flowey_lib_common::publish_test_results 5
-        flowey e 16 flowey_lib_common::publish_test_results 6
-        flowey e 16 flowey_lib_common::publish_test_results 4
-        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 18 flowey_lib_common::publish_test_results 5
+        flowey e 18 flowey_lib_common::publish_test_results 6
+        flowey e 18 flowey_lib_common::publish_test_results 4
+        flowey v 18 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2439,18 +2738,18 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 16 flowey_lib_common::publish_test_results 8
-        flowey e 16 flowey_lib_common::publish_test_results 9
-        flowey e 16 flowey_lib_common::publish_test_results 10
-        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 18 flowey_lib_common::publish_test_results 8
+        flowey e 18 flowey_lib_common::publish_test_results 9
+        flowey e 18 flowey_lib_common::publish_test_results 10
+        flowey v 18 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2461,32 +2760,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_cross_build 3
-        flowey e 16 flowey_lib_common::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 18 flowey_lib_hvlite::init_cross_build 3
+        flowey e 18 flowey_lib_common::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 16 flowey_lib_hvlite::build_xtask 1
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 18 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 18 flowey_lib_common::publish_test_results 12
+        flowey e 18 flowey_lib_common::publish_test_results 13
+        flowey e 18 flowey_lib_common::publish_test_results 14
+        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 18 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -2496,18 +2795,18 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 16 flowey_lib_common::publish_test_results 0
-        flowey e 16 flowey_lib_common::publish_test_results 1
-        flowey e 16 flowey_lib_common::publish_test_results 2
-        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 18 flowey_lib_common::publish_test_results 0
+        flowey e 18 flowey_lib_common::publish_test_results 1
+        flowey e 18 flowey_lib_common::publish_test_results 2
+        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2518,25 +2817,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 16 flowey_lib_common::cache 3
+      run: flowey e 18 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 16 flowey_lib_common::cache 7
+      run: flowey e 18 flowey_lib_common::cache 7
       shell: bash
-  job17:
+  job19:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2604,29 +2903,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 17 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 17 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 19 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 19 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 17 'verbose' update
+        cat <<'EOF' | flowey v 19 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 17 flowey_lib_common::install_rust 0
+      run: flowey e 19 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 17 flowey_lib_common::install_rust 1
+      run: flowey e 19 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 17 flowey_lib_common::install_rust 2
-        flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 19 flowey_lib_common::install_rust 2
+        flowey e 19 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::git_checkout 0
+        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2638,27 +2937,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 17 flowey_lib_common::git_checkout 3
-        flowey e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 19 flowey_lib_common::git_checkout 3
+        flowey e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 19 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 19 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 17 flowey_lib_common::download_gh_release 0
+      run: flowey e 19 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 19 flowey_lib_common::cache 4
+        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2668,78 +2967,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 17 flowey_lib_common::cache 6
-        flowey e 17 flowey_lib_common::download_gh_release 1
+        flowey e 19 flowey_lib_common::cache 6
+        flowey e 19 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 19 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 17 flowey_lib_common::resolve_protoc 0
+      run: flowey e 19 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 17 flowey_lib_hvlite::init_cross_build 2
+        flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 19 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_clippy 5
-        flowey e 17 flowey_lib_hvlite::init_cross_build 0
+        flowey e 19 flowey_lib_common::run_cargo_clippy 5
+        flowey e 19 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_build 0
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 19 flowey_lib_common::run_cargo_build 0
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 17 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 17 flowey_lib_hvlite::build_xtask 0
+        flowey e 19 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 19 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 17 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 19 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 17 flowey_lib_common::download_cargo_nextest 0
-        flowey e 17 flowey_lib_common::download_cargo_nextest 1
-        flowey e 17 flowey_lib_common::download_cargo_nextest 2
-        flowey e 17 flowey_lib_common::download_cargo_nextest 3
+        flowey e 19 flowey_lib_common::download_cargo_nextest 0
+        flowey e 19 flowey_lib_common::download_cargo_nextest 1
+        flowey e 19 flowey_lib_common::download_cargo_nextest 2
+        flowey e 19 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 19 flowey_lib_common::cache 0
+        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2749,34 +3048,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 17 flowey_lib_common::cache 2
-        flowey e 17 flowey_lib_common::download_cargo_nextest 4
+        flowey e 19 flowey_lib_common::cache 2
+        flowey e 19 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 17 flowey_lib_common::install_rust 3
+      run: flowey e 19 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 17 flowey_lib_common::install_cargo_nextest 0
-        flowey e 17 flowey_lib_hvlite::init_cross_build 3
-        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 19 flowey_lib_common::install_cargo_nextest 0
+        flowey e 19 flowey_lib_hvlite::init_cross_build 3
+        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 17 flowey_lib_common::publish_test_results 5
-        flowey e 17 flowey_lib_common::publish_test_results 6
-        flowey e 17 flowey_lib_common::publish_test_results 4
-        flowey v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 19 flowey_lib_common::publish_test_results 5
+        flowey e 19 flowey_lib_common::publish_test_results 6
+        flowey e 19 flowey_lib_common::publish_test_results 4
+        flowey v 19 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2786,18 +3085,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 17 flowey_lib_common::publish_test_results 8
-        flowey e 17 flowey_lib_common::publish_test_results 9
-        flowey e 17 flowey_lib_common::publish_test_results 10
-        flowey v 17 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 17 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 19 flowey_lib_common::publish_test_results 8
+        flowey e 19 flowey_lib_common::publish_test_results 9
+        flowey e 19 flowey_lib_common::publish_test_results 10
+        flowey v 19 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 19 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2807,18 +3106,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 17 flowey_lib_common::publish_test_results 12
-        flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey e 17 flowey_lib_common::publish_test_results 14
-        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 19 flowey_lib_common::publish_test_results 12
+        flowey e 19 flowey_lib_common::publish_test_results 13
+        flowey e 19 flowey_lib_common::publish_test_results 14
+        flowey v 19 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 19 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -2828,18 +3127,18 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 17 flowey_lib_common::publish_test_results 16
-        flowey e 17 flowey_lib_common::publish_test_results 17
-        flowey e 17 flowey_lib_common::publish_test_results 18
-        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 19 flowey_lib_common::publish_test_results 16
+        flowey e 19 flowey_lib_common::publish_test_results 17
+        flowey e 19 flowey_lib_common::publish_test_results 18
+        flowey v 19 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 19 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -2850,32 +3149,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 17 flowey_lib_hvlite::init_cross_build 1
-        flowey e 17 flowey_lib_common::run_cargo_build 1
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 19 flowey_lib_hvlite::init_cross_build 1
+        flowey e 19 flowey_lib_common::run_cargo_build 1
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 17 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 17 flowey_lib_hvlite::build_xtask 1
+        flowey e 19 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 19 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 17 flowey_lib_common::publish_test_results 0
-        flowey e 17 flowey_lib_common::publish_test_results 1
-        flowey e 17 flowey_lib_common::publish_test_results 2
-        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 19 flowey_lib_common::publish_test_results 0
+        flowey e 19 flowey_lib_common::publish_test_results 1
+        flowey e 19 flowey_lib_common::publish_test_results 2
+        flowey v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2886,553 +3185,17 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
-      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 17 flowey_lib_common::cache 3
+      run: flowey e 19 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 17 flowey_lib_common::cache 7
-      shell: bash
-  job18:
-    name: run vmm-tests [x64-windows-intel]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job10
-    - job5
-    - job7
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 18 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 18 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 18 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 18 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 18 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 18 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 18 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 18 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 18 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 18 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 18 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 18 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 18 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 18 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 18 flowey_lib_common::cache 0
-        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::cache 2
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 18 flowey_lib_common::git_checkout 0
-        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::git_checkout 3
-        flowey.exe e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 18 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 18 flowey_lib_common::cache 8
-        flowey.exe v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::cache 10
-        flowey.exe e 18 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 18 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 18 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 18 flowey_lib_common::cache 4
-        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::cache 6
-        flowey.exe e 18 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 18 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 18 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 18 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 18 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 18 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 18 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 18 flowey_lib_common::publish_test_results 4
-        flowey.exe e 18 flowey_lib_common::publish_test_results 5
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 18 flowey_lib_common::publish_test_results 0
-        flowey.exe e 18 flowey_lib_common::publish_test_results 1
-        flowey.exe e 18 flowey_lib_common::publish_test_results 2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 18 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 18 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 18 flowey_lib_common::cache 11
-      shell: bash
-  job19:
-    name: run vmm-tests [x64-windows-intel-tdx]
-    runs-on:
-    - self-hosted
-    - Windows
-    - X64
-    - TDX
-    - Baremetal
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job10
-    - job5
-    - job7
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 19 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 19 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 19 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 19 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 19 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 19 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 19 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 19 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 19 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 19 flowey_lib_common::cache 0
-        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 19 flowey_lib_common::cache 2
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 19 flowey_lib_common::git_checkout 0
-        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 19 flowey_lib_common::git_checkout 3
-        flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 19 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 19 flowey_lib_common::cache 8
-        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 19 flowey_lib_common::cache 10
-        flowey.exe e 19 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 19 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 19 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 19 flowey_lib_common::cache 4
-        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 19 flowey_lib_common::cache 6
-        flowey.exe e 19 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 19 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 19 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 19 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 19 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 19 flowey_lib_common::publish_test_results 4
-        flowey.exe e 19 flowey_lib_common::publish_test_results 5
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-tdx-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 19 flowey_lib_common::publish_test_results 0
-        flowey.exe e 19 flowey_lib_common::publish_test_results 1
-        flowey.exe e 19 flowey_lib_common::publish_test_results 2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-tdx-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 19 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 19 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 19 flowey_lib_common::cache 11
+      run: flowey e 19 flowey_lib_common::cache 7
       shell: bash
   job2:
     name: build artifacts (not for VMM tests) [aarch64-windows]
@@ -3652,10 +3415,10 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-windows-amd]
+    name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3663,9 +3426,9 @@ jobs:
       id-token: write
     needs:
     - job0
-    - job10
+    - job12
     - job5
-    - job7
+    - job8
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -3884,9 +3647,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-logs
+        name: x64-windows-intel-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3900,9 +3663,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-junit-xml
+        name: x64-windows-intel-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -3917,644 +3680,574 @@ jobs:
       run: flowey.exe e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [x64-linux-amd-kvm]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job10
-    - job5
-    - job7
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-1,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 21 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 21 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 21 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 21 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 21 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 21 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      shell: bash
-    - name: creating new test content dir
-      run: |-
-        flowey e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey e 21 flowey_core::pipeline::artifact::resolve 4
-        flowey e 21 flowey_core::pipeline::artifact::resolve 7
-        flowey e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey e 21 flowey_core::pipeline::artifact::resolve 2
-        flowey e 21 flowey_core::pipeline::artifact::resolve 6
-        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 21 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 21 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 21 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 21 flowey_lib_common::cache 8
-        flowey v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey e 21 flowey_lib_common::cache 10
-        flowey e 21 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey e 21 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 21 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 21 flowey_lib_common::cache 4
-        flowey v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 21 flowey_lib_common::cache 6
-        flowey e 21 flowey_lib_common::download_gh_cli 1
-        flowey v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey e 21 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey e 21 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: flowey e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 21 flowey_lib_common::download_cargo_nextest 0
-        flowey e 21 flowey_lib_common::download_cargo_nextest 1
-        flowey e 21 flowey_lib_common::download_cargo_nextest 2
-        flowey e 21 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 21 flowey_lib_common::cache 0
-        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 21 flowey_lib_common::cache 2
-        flowey e 21 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 21 flowey_lib_common::git_checkout 0
-        flowey v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 21 flowey_lib_common::git_checkout 3
-        flowey e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 21 flowey_core::pipeline::artifact::resolve 5
-        flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey e 21 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 21 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 21 flowey_lib_common::publish_test_results 4
-        flowey e 21 flowey_lib_common::publish_test_results 5
-        flowey v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-amd-kvm-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 21 flowey_lib_common::publish_test_results 0
-        flowey e 21 flowey_lib_common::publish_test_results 1
-        flowey e 21 flowey_lib_common::publish_test_results 2
-        flowey v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-amd-kvm-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 21 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 21 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 21 flowey_lib_common::cache 11
-      shell: bash
-  job22:
-    name: run vmm-tests [x64-linux-intel-mshv]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job10
-    - job5
-    - job7
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        sudo tdnf install -y gcc glibc-devel
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 22 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 22 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 22 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 22 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 22 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 22 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      shell: bash
-    - name: creating new test content dir
-      run: |-
-        flowey e 22 flowey_core::pipeline::artifact::resolve 7
-        flowey e 22 flowey_core::pipeline::artifact::resolve 3
-        flowey e 22 flowey_core::pipeline::artifact::resolve 0
-        flowey e 22 flowey_core::pipeline::artifact::resolve 4
-        flowey e 22 flowey_core::pipeline::artifact::resolve 6
-        flowey e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey e 22 flowey_core::pipeline::artifact::resolve 2
-        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 22 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 22 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 22 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 22 flowey_lib_common::cache 8
-        flowey v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey e 22 flowey_lib_common::cache 10
-        flowey e 22 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey e 22 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 22 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 22 flowey_lib_common::cache 4
-        flowey v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 22 flowey_lib_common::cache 6
-        flowey e 22 flowey_lib_common::download_gh_cli 1
-        flowey v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey e 22 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey e 22 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: flowey e 22 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 22 flowey_lib_common::download_cargo_nextest 0
-        flowey e 22 flowey_lib_common::download_cargo_nextest 1
-        flowey e 22 flowey_lib_common::download_cargo_nextest 2
-        flowey e 22 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 22 flowey_lib_common::cache 0
-        flowey v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 22 flowey_lib_common::cache 2
-        flowey e 22 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 22 flowey_lib_common::git_checkout 0
-        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 22 flowey_lib_common::git_checkout 3
-        flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 22 flowey_core::pipeline::artifact::resolve 5
-        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey e 22 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 22 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 22 flowey_lib_common::publish_test_results 4
-        flowey e 22 flowey_lib_common::publish_test_results 5
-        flowey v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 22 flowey_lib_common::publish_test_results 0
-        flowey e 22 flowey_lib_common::publish_test_results 1
-        flowey e 22 flowey_lib_common::publish_test_results 2
-        flowey v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 22 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 22 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 22 flowey_lib_common::cache 11
-      shell: bash
-  job23:
-    name: run vmm-tests [aarch64-windows]
+    name: run vmm-tests [x64-windows-intel-tdx]
     runs-on:
     - self-hosted
     - Windows
-    - ARM64
+    - X64
+    - TDX
     - Baremetal
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job3
-    - job6
+    - job12
+    - job5
     - job8
     if: github.event.pull_request.draft == false
     steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-pc-windows-msvc --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/aarch64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-linux-musl-tmk_vmm,aarch64-openhcl-igvm,aarch64-tmks,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-tmk_vmm,aarch64-windows-vmgstool,aarch64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
-      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 21 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 21 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 21 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 21 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 21 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 21 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 21 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 21 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 21 flowey_lib_common::cache 0
+        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 21 flowey_lib_common::cache 2
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 21 flowey_lib_common::git_checkout 0
+        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 21 flowey_lib_common::git_checkout 3
+        flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 21 flowey_lib_common::cache 8
+        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 21 flowey_lib_common::cache 10
+        flowey.exe e 21 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 21 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 21 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 21 flowey_lib_common::cache 4
+        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 21 flowey_lib_common::cache 6
+        flowey.exe e 21 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 21 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 21 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 21 flowey_lib_common::publish_test_results 4
+        flowey.exe e 21 flowey_lib_common::publish_test_results 5
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-tdx-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 21 flowey_lib_common::publish_test_results 0
+        flowey.exe e 21 flowey_lib_common::publish_test_results 1
+        flowey.exe e 21 flowey_lib_common::publish_test_results 2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-tdx-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 21 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 21 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 21 flowey_lib_common::cache 11
+      shell: bash
+  job22:
+    name: run vmm-tests [x64-windows-amd]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job12
+    - job5
+    - job8
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 22 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 22 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 22 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 22 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 22 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 22 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 22 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 0
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 22 flowey_lib_common::git_checkout 0
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::git_checkout 3
+        flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 8
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 10
+        flowey.exe e 22 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 22 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 22 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 4
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 6
+        flowey.exe e 22 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 22 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 22 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 22 flowey_lib_common::publish_test_results 4
+        flowey.exe e 22 flowey_lib_common::publish_test_results 5
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 22 flowey_lib_common::publish_test_results 0
+        flowey.exe e 22 flowey_lib_common::publish_test_results 1
+        flowey.exe e 22 flowey_lib_common::publish_test_results 2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 22 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 22 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 22 flowey_lib_common::cache 11
+      shell: bash
+  job23:
+    name: run vmm-tests [x64-windows-amd-snp]
+    runs-on:
+    - self-hosted
+    - Windows
+    - X64
+    - SNP
+    - Baremetal
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job12
+    - job5
+    - job8
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
 
         echo '"debug"' | flowey.exe v 23 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey.exe v 23 '_internal_WORKING_DIR' --is-raw-string update
@@ -4562,16 +4255,20 @@ jobs:
         cat <<'EOF' | flowey.exe v 23 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 23 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 23 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 23 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 23 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 23 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 23 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 23 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 23 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 23 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 23 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 23 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -4622,14 +4319,17 @@ jobs:
         flowey.exe e 23 flowey_lib_common::git_checkout 3
         flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4712,14 +4412,14 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: unpack mu_msvm package (aarch64)
+    - name: unpack mu_msvm package (x64)
       run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
         flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4729,7 +4429,12 @@ jobs:
       run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4749,9 +4454,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-vmm-tests-logs
+        name: x64-windows-amd-snp-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-windows-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4765,9 +4470,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-vmm-tests-junit-xml
+        name: x64-windows-amd-snp-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4782,20 +4487,27 @@ jobs:
       run: flowey.exe e 23 flowey_lib_common::cache 11
       shell: bash
   job24:
-    name: test flowey local backend
-    runs-on: ubuntu-latest
+    name: run vmm-tests [x64-linux-amd-kvm]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
+    - job5
+    - job8
+    - job9
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-1,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
@@ -4813,11 +4525,150 @@ jobs:
         cat <<'EOF' | flowey v 24 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 24 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 24 flowey_core::pipeline::artifact::resolve 3
+        flowey e 24 flowey_core::pipeline::artifact::resolve 4
+        flowey e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey e 24 flowey_core::pipeline::artifact::resolve 1
+        flowey e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey e 24 flowey_core::pipeline::artifact::resolve 6
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 24 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 24 flowey_lib_common::cache 8
+        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 24 flowey_lib_common::cache 10
+        flowey e 24 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 24 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 24 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 24 flowey_lib_common::cache 4
+        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 24 flowey_lib_common::cache 6
+        flowey e 24 flowey_lib_common::download_gh_cli 1
+        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 24 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey e 24 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure hypervisor device is accessible
+      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: ensure 2 MiB hugetlb pages are available
+      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 24 flowey_lib_common::download_cargo_nextest 0
+        flowey e 24 flowey_lib_common::download_cargo_nextest 1
+        flowey e 24 flowey_lib_common::download_cargo_nextest 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 24 flowey_lib_common::cache 0
+        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 24 flowey_lib_common::cache 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 24 flowey_lib_common::git_checkout 0
-        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
         flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -4825,7 +4676,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -4835,52 +4686,143 @@ jobs:
         EOF
         flowey e 24 flowey_lib_common::git_checkout 3
         flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
-    - name: add default cargo home to path
-      run: flowey e 24 flowey_lib_common::install_rust 0
+    - name: generate nextest command
+      run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: install Rust
-      run: flowey e 24 flowey_lib_common::install_rust 1
+    - name: install vmm tests deps (linux)
+      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
-    - name: detect active toolchain
+    - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 24 flowey_lib_common::install_rust 2
-        flowey v 24 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
+        flowey e 24 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 24 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 24 flowey_lib_common::publish_test_results 4
+        flowey e 24 flowey_lib_common::publish_test_results 5
+        flowey v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 24 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 24 flowey_lib_common::publish_test_results 0
+        flowey e 24 flowey_lib_common::publish_test_results 1
+        flowey e 24 flowey_lib_common::publish_test_results 2
+        flowey v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 24 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 24 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 24 flowey_lib_common::cache 11
       shell: bash
   job25:
-    name: build openhcl (mi-secure) [x64-linux]
+    name: run vmm-tests [x64-linux-intel-mshv]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=azurelinux3-amd64-dom0
     - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
+    - job5
+    - job8
+    - job9
     if: github.event.pull_request.draft == false
     steps:
+    - run: |
+        set -x
+        sudo tdnf install -y gcc glibc-devel
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
+      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
         echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
@@ -4888,10 +4830,25 @@ jobs:
         cat <<'EOF' | flowey v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 25 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 25 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey e 25 flowey_core::pipeline::artifact::resolve 7
+        flowey e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 4
+        flowey e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 25 flowey_lib_common::install_dist_pkg 0
@@ -4904,37 +4861,111 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
+        flowey e 25 flowey_lib_common::cache 8
+        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 25 flowey_lib_common::cache 10
+        flowey e 25 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 25 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 25 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 25 flowey_lib_common::cache 4
+        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 25 flowey_lib_common::cache 6
+        flowey e 25 flowey_lib_common::download_gh_cli 1
+        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 25 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey e 25 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure hypervisor device is accessible
+      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
         flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
       run: |-
         flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 25 flowey_lib_common::cache 2
-        flowey e 25 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 25 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 25 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 25 flowey_lib_common::install_rust 2
-        flowey e 25 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 25 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
@@ -4957,213 +4988,143 @@ jobs:
         EOF
         flowey e 25 flowey_lib_common::git_checkout 3
         flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 25 flowey_core::pipeline::artifact::resolve 5
+        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 25 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    - name: generate nextest command
+      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: unpack protoc
+    - name: install vmm tests deps (linux)
+      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 25 flowey_lib_common::resolve_protoc 0
-        flowey e 25 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 25 flowey_lib_common::publish_test_results 4
+        flowey e 25 flowey_lib_common::publish_test_results 5
+        flowey v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: symlink protoc
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-intel-mshv-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
       run: |-
-        flowey e 25 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 25 flowey_lib_hvlite::init_cross_build 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 25 flowey_lib_common::publish_test_results 0
+        flowey e 25 flowey_lib_common::publish_test_results 1
+        flowey e 25 flowey_lib_common::publish_test_results 2
+        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: cargo build sidecar
-      run: |-
-        flowey e 25 flowey_lib_common::run_cargo_build 3
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 9
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-intel-mshv-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 25 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 25 flowey_lib_hvlite::build_sidecar 0
-        flowey e 25 flowey_lib_hvlite::init_cross_build 1
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 25 flowey_lib_common::run_cargo_build 1
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 25 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 25 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 25 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 25 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 25 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 25 flowey_lib_common::run_cargo_build 2
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 25 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 25 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 25 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 25 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 25 flowey_lib_common::run_cargo_build 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 25 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 25 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 25 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 25 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 25 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 25 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 25 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 25 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 25 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 25 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 25 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 25 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 25 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 25 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 25 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey e 25 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
-        include-hidden-files: true
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 25 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 25 flowey_lib_common::cache 11
+      shell: bash
   job26:
-    name: run vmm-tests [x64-windows-intel-mi-secure]
+    name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - Windows
+    - ARM64
+    - Baremetal
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
     - job10
-    - job25
-    - job5
-    - job7
+    - job3
+    - job6
     if: github.event.pull_request.draft == false
     steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-pc-windows-msvc --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/aarch64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
+      working-directory: flowey_bootstrap
+      shell: bash
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-linux-musl-tmk_vmm,aarch64-openhcl-igvm,aarch64-tmks,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-tmk_vmm,aarch64-windows-vmgstool,aarch64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
+      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
         echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
@@ -5171,20 +5132,16 @@ jobs:
         cat <<'EOF' | flowey.exe v 26 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 26 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 26 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 26 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 26 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 26 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 26 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 26 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -5235,17 +5192,14 @@ jobs:
         flowey.exe e 26 flowey_lib_common::git_checkout 3
         flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -5328,14 +5282,14 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: unpack mu_msvm package (x64)
+    - name: unpack mu_msvm package (aarch64)
       run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -5365,9 +5319,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-mi-secure-vmm-tests-logs
+        name: aarch64-windows-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
+      name: 'publish test results: aarch64-windows-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -5381,9 +5335,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-mi-secure-vmm-tests-junit-xml
+        name: aarch64-windows-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
+      name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -5398,42 +5352,14 @@ jobs:
       run: flowey.exe e 26 flowey_lib_common::cache 11
       shell: bash
   job27:
-    name: openvmm checkin gates
+    name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job1
-    - job10
-    - job11
-    - job12
-    - job13
-    - job14
-    - job15
-    - job16
-    - job17
-    - job18
-    - job19
-    - job2
-    - job20
-    - job21
-    - job22
-    - job23
-    - job24
-    - job25
-    - job26
-    - job3
-    - job4
-    - job5
-    - job6
-    - job7
-    - job8
-    - job9
-    if: always() && github.event.pull_request.draft == false
-    env:
-      ANY_JOBS_FAILED: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
+    if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
@@ -5458,8 +5384,587 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: Check if any jobs failed
-      run: flowey e 27 flowey_lib_hvlite::_jobs::all_good_job 0
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 27 flowey_lib_common::git_checkout 0
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 27 flowey_lib_common::git_checkout 3
+        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 27 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 27 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 27 flowey_lib_common::install_rust 2
+        flowey v 27 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: test cargo xflowey build-igvm x64 --install-missing-deps
+      run: flowey e 27 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      shell: bash
+  job28:
+    name: build openhcl (mi-secure) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job28-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 28 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 28 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 28 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 28 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 28 flowey_lib_common::cache 0
+        flowey v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 28 flowey_lib_common::cache 2
+        flowey e 28 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 28 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 28 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 28 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 28 flowey_lib_common::install_rust 2
+        flowey e 28 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 28 flowey_lib_common::git_checkout 0
+        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 28 flowey_lib_common::git_checkout 3
+        flowey e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 28 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 28 flowey_lib_common::resolve_protoc 0
+        flowey e 28 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 28 flowey_lib_hvlite::init_cross_build 0
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build sidecar
+      run: |-
+        flowey e 28 flowey_lib_common::run_cargo_build 3
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 28 flowey_lib_hvlite::build_sidecar 0
+        flowey e 28 flowey_lib_hvlite::init_cross_build 1
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 28 flowey_lib_common::run_cargo_build 1
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 28 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 28 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 28 flowey_lib_common::run_cargo_build 2
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 28 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 28 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 28 flowey_lib_common::run_cargo_build 0
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 28 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 28 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 28 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 28 flowey_lib_common::copy_to_artifact_dir 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 28 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
+        include-hidden-files: true
+  job29:
+    name: run vmm-tests [x64-windows-intel-mi-secure]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job29-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job28
+    - job5
+    - job8
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 29 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 29 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 29 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 29 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 29 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 29 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 29 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 29 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 29 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 29 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 29 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 29 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 29 flowey_lib_common::cache 0
+        flowey.exe v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 29 flowey_lib_common::cache 2
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 29 flowey_lib_common::git_checkout 0
+        flowey.exe v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 29 flowey_lib_common::git_checkout 3
+        flowey.exe e 29 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 29 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 29 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 29 flowey_lib_common::cache 8
+        flowey.exe v 29 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 29 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 29 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 29 flowey_lib_common::cache 10
+        flowey.exe e 29 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 29 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 29 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 29 flowey_lib_common::cache 4
+        flowey.exe v 29 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 29 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 29 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 29 flowey_lib_common::cache 6
+        flowey.exe e 29 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 29 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 29 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 29 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 29 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 29 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 29 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 29 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 29 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 29 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 29 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 29 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 29 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 29 flowey_lib_common::publish_test_results 4
+        flowey.exe e 29 flowey_lib_common::publish_test_results 5
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-mi-secure-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 29 flowey_lib_common::publish_test_results 0
+        flowey.exe e 29 flowey_lib_common::publish_test_results 1
+        flowey.exe e 29 flowey_lib_common::publish_test_results 2
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-mi-secure-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 29 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 29 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 29 flowey_lib_common::cache 11
       shell: bash
   job3:
     name: build artifacts (for VMM tests) [aarch64-windows]
@@ -5781,6 +6286,73 @@ jobs:
         name: aarch64-windows-vmm-tests-archive
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmm-tests-archive/
         include-hidden-files: true
+  job30:
+    name: openvmm checkin gates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job1
+    - job10
+    - job11
+    - job12
+    - job13
+    - job14
+    - job15
+    - job16
+    - job17
+    - job18
+    - job19
+    - job2
+    - job20
+    - job21
+    - job22
+    - job23
+    - job24
+    - job25
+    - job26
+    - job27
+    - job28
+    - job29
+    - job3
+    - job4
+    - job5
+    - job6
+    - job7
+    - job8
+    - job9
+    if: always() && github.event.pull_request.draft == false
+    env:
+      ANY_JOBS_FAILED: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 30 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 30 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 30 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: Check if any jobs failed
+      run: flowey e 30 flowey_lib_hvlite::_jobs::all_good_job 0
+      shell: bash
   job4:
     name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
@@ -6331,7 +6903,7 @@ jobs:
         name: _internal-flowey-bootstrap-x86_64-windows-uid-6
         path: ${{ runner.temp }}/bootstrapped-flowey
   job6:
-    name: build artifacts [aarch64-linux]
+    name: build artifacts [aarch64-linux] (shared)
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6368,20 +6940,16 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 6 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 6 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 6 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 6 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 6 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 6 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests" | flowey v 6 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 6 'artifact_publish_from_aarch64-tmks' --is-raw-string update
       shell: bash
@@ -6395,12 +6963,6 @@ jobs:
       run: |-
         flowey e 6 flowey_lib_common::install_rust 2
         flowey e 6 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 6 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 6 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
@@ -6450,6 +7012,12 @@ jobs:
         flowey e 6 flowey_lib_common::cache 2
         flowey e 6 flowey_lib_common::download_gh_release 1
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 6 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 6 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 6 flowey_lib_common::resolve_protoc 0
@@ -6458,81 +7026,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 6 flowey_lib_hvlite::build_openvmm 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 0
-        flowey e 6 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 4
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 6 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 1
         flowey e 6 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 8
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 16
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 17
-        flowey e 6 flowey_lib_hvlite::build_vmgstool 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 2
-        flowey e 6 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 7
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 15
-        flowey e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-        flowey e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 6 flowey_core::pipeline::artifact::publish 3
-        flowey e 6 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 1
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 4
-        flowey e 6 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build ohcldiag-dev
-      run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 2
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 4
-        flowey e 6 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 5
-        flowey e 6 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -6542,23 +7036,23 @@ jobs:
     - name: build guest_test_uefi.img
       run: |-
         flowey e 6 flowey_lib_hvlite::build_guest_test_uefi 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 6
+        flowey e 6 flowey_core::pipeline::artifact::publish 0
         flowey e 6 flowey_lib_hvlite::init_cross_build 0
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build simple_tmk
       run: |-
-        flowey e 6 flowey_lib_common::run_cargo_build 5
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 6 flowey_lib_common::run_cargo_build 4
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 6 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 6 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 10
         flowey e 6 flowey_lib_hvlite::build_tmks 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 7
-        flowey e 6 flowey_lib_hvlite::init_cross_build 4
+        flowey e 6 flowey_core::pipeline::artifact::publish 1
+        flowey e 6 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build tpm_guest_tests
       run: |-
@@ -6570,7 +7064,66 @@ jobs:
         flowey e 6 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 6 flowey_lib_hvlite::run_cargo_build 14
         flowey e 6 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey e 6 flowey_core::pipeline::artifact::publish 8
+        flowey e 6 flowey_core::pipeline::artifact::publish 2
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 6 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 6 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 6 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 3
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 5
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 6 flowey_lib_hvlite::build_pipette 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 3
+        flowey e 6 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 5
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 6 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 4
+        flowey e 6 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 1
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 1
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 6 flowey_lib_hvlite::build_openvmm 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 5
+        flowey e 6 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 6 flowey_lib_common::run_cargo_build 2
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 6 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 6 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 6 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 6 flowey_core::pipeline::artifact::publish 6
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 6 flowey_lib_common::cache 3
@@ -6581,47 +7134,35 @@ jobs:
         name: aarch64-guest_test_uefi
         path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-igvmfilegen
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
+        name: aarch64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
+    - name: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
+        name: aarch64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-openvmm
+    - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
+        name: aarch64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-openvmm_vhost
+    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
+        name: aarch64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-tpm_guest_tests
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-tpm_guest_tests
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-vmgs_lib
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-tmks
       uses: actions/upload-artifact@v7
@@ -6630,7 +7171,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
         include-hidden-files: true
   job7:
-    name: build artifacts [x64-linux]
+    name: build artifacts [aarch64-linux] (for VMM tests)
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6665,26 +7206,18 @@ jobs:
         cat <<'EOF' | flowey v 7 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 7 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 7 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 7 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 7 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 7 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 7 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 7 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 7 'artifact_publish_from_x64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 7 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 7 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 7 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 7 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 7 flowey_lib_common::install_rust 0
@@ -6733,22 +7266,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 7 flowey_lib_common::cache 4
-        flowey v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 7 flowey_lib_common::cache 0
+        flowey v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 7 flowey_lib_common::cache 6
+        flowey e 7 flowey_lib_common::cache 2
         flowey e 7 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -6759,233 +7292,122 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 3
+        flowey e 7 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build openvmm
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 7 flowey_lib_common::run_cargo_build 2
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 7 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 5
         flowey e 7 flowey_lib_hvlite::build_openvmm 0
         flowey e 7 flowey_core::pipeline::artifact::publish 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 4
+        flowey e 7 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 4
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 7 flowey_lib_common::run_cargo_build 3
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 7 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 7
         flowey e 7 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 7 flowey_core::pipeline::artifact::publish 1
-        flowey e 7 flowey_lib_hvlite::init_cross_build 7
+        flowey e 7 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 8
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 16
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 17
-        flowey e 7 flowey_lib_hvlite::build_vmgstool 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 2
-        flowey e 7 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 7
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 15
-        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      shell: bash
-    - name: test vmgs_lib
-      run: |-
-        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-        flowey e 7 flowey_core::pipeline::artifact::publish 3
-        flowey e 7 flowey_lib_hvlite::init_cross_build 8
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 1
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 7 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 4
-        flowey e 7 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build ohcldiag-dev
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 2
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 7 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 4
-        flowey e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 5
-        flowey e 7 flowey_lib_hvlite::init_cross_build 9
-      shell: bash
-    - name: cargo build guest_test_uefi
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 0
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: build guest_test_uefi.img
-      run: |-
-        flowey e 7 flowey_lib_hvlite::build_guest_test_uefi 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 6
-        flowey e 7 flowey_lib_hvlite::init_cross_build 0
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 10
-      shell: bash
-    - name: cargo build simple_tmk
-      run: |-
         flowey e 7 flowey_lib_common::run_cargo_build 5
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 7 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 7 flowey_lib_hvlite::build_tmks 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 7
-        flowey e 7 flowey_lib_hvlite::init_cross_build 5
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 7 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 7 flowey_core::pipeline::artifact::publish 2
+        flowey e 7 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build tpm_guest_tests
+    - name: cargo build vmgs_lib
       run: |-
-        flowey e 7 flowey_lib_common::run_cargo_build 6
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 7 flowey_lib_common::run_cargo_build 4
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 7 flowey_core::pipeline::artifact::publish 3
+        flowey e 7 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 7 flowey_lib_common::run_cargo_build 0
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 7 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 7 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 7 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 8
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 7 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 7 flowey_core::pipeline::artifact::publish 4
+        flowey e 7 flowey_lib_hvlite::init_cross_build 5
       shell: bash
-    - name: create cargo-nextest cache dir
+    - name: cargo build ohcldiag-dev
       run: |-
-        flowey e 7 flowey_lib_common::download_cargo_nextest 0
-        flowey e 7 flowey_lib_common::download_cargo_nextest 1
-        flowey e 7 flowey_lib_common::download_cargo_nextest 2
-        flowey e 7 flowey_lib_common::download_cargo_nextest 3
+        flowey e 7 flowey_lib_common::run_cargo_build 1
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
-    - name: Pre-processing cache vars
+    - name: split debug symbols
       run: |-
-        flowey e 7 flowey_lib_common::cache 0
-        flowey v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 7 flowey_lib_common::cache 2
-        flowey e 7 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 7 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 7 flowey_lib_common::install_cargo_nextest 0
-        flowey e 7 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 7 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey e 7 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 7 flowey_core::pipeline::artifact::publish 9
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 7 flowey_lib_common::cache 3
+        flowey e 7 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 7 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 7 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 7 flowey_lib_common::cache 7
+      run: flowey e 7 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-guest_test_uefi
+    - name: 🌼📦 Publish aarch64-linux-igvmfilegen
       uses: actions/upload-artifact@v7
       with:
-        name: x64-guest_test_uefi
-        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
+        name: aarch64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-igvmfilegen
+    - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        name: aarch64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
+    - name: 🌼📦 Publish aarch64-linux-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
+        name: aarch64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm
+    - name: 🌼📦 Publish aarch64-linux-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
+        name: aarch64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm_vhost
+    - name: 🌼📦 Publish aarch64-linux-vmgs_lib
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        name: aarch64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
+    - name: 🌼📦 Publish aarch64-linux-vmgstool
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgs_lib
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-tmks
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-tmks
-        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
+        name: aarch64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
         include-hidden-files: true
   job8:
-    name: build openhcl [aarch64-linux]
+    name: build artifacts [x64-linux] (shared)
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7020,46 +7442,20 @@ jobs:
         cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 8 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 8 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 8 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 8 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 8 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 8 flowey_lib_common::cache 0
-        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 8 flowey_lib_common::cache 2
-        flowey e 8 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (aarch64)
-      run: flowey e 8 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 8 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 8 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 8 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 8 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 8 'artifact_publish_from_x64-tmks' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 8 flowey_lib_common::install_rust 0
@@ -7075,7 +7471,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 8 flowey_lib_common::git_checkout 0
-        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
         flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -7083,7 +7479,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -7097,6 +7493,35 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 8 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 8 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 8 flowey_lib_common::cache 0
+        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 8 flowey_lib_common::cache 2
+        flowey e 8 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 8 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 8 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 8 flowey_lib_common::resolve_protoc 0
@@ -7105,171 +7530,157 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 0
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 6
       shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 1
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 8 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 8 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 8 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 8 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 8 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build guest_test_uefi
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 0
         flowey e 8 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
-    - name: split debug symbols
+    - name: build guest_test_uefi.img
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 8 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 8 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 8 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 8 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 8 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: |-
-        flowey e 8 flowey_lib_common::copy_to_artifact_dir 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 8 flowey_lib_hvlite::build_pipette 0
+        flowey e 8 flowey_lib_hvlite::build_guest_test_uefi 0
         flowey e 8 flowey_core::pipeline::artifact::publish 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 0
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
-    - name: cargo build tmk_vmm
+    - name: cargo build simple_tmk
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 4
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 8 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 8 flowey_lib_hvlite::build_tmks 0
         flowey e 8 flowey_core::pipeline::artifact::publish 1
+        flowey e 8 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 8 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 2
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 8 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::build_pipette 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 1
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 1
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::build_openvmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 5
+        flowey e 8 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 6
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-linux-musl-pipette
+    - name: 🌼📦 Publish x64-guest_test_uefi
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
+        name: x64-guest_test_uefi
+        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
+    - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
+        name: x64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-tmks
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
         include-hidden-files: true
   job9:
-    name: verify openhcl binary size [aarch64]
-    runs-on: ubuntu-latest
+    name: build artifacts [x64-linux] (for VMM tests)
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -7299,6 +7710,22 @@ jobs:
         cat <<'EOF' | flowey v 9 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 9 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 9 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 9 flowey_lib_common::install_rust 0
@@ -7311,10 +7738,16 @@ jobs:
         flowey e 9 flowey_lib_common::install_rust 2
         flowey e 9 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 9 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 9 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
         flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -7322,7 +7755,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar2 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -7332,13 +7765,9 @@ jobs:
         EOF
         flowey e 9 flowey_lib_common::git_checkout 3
         flowey e 9 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 9 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 9 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 9 flowey_lib_common::install_dist_pkg 1
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 9 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 9 flowey_lib_common::download_gh_release 0
@@ -7346,14 +7775,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 4
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -7363,103 +7792,199 @@ jobs:
         flowey e 9 flowey_lib_common::cache 6
         flowey e 9 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 9 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
     - name: unpack protoc
-      run: flowey e 9 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 9 flowey_lib_common::resolve_protoc 0
+        flowey e 9 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build openvmm_hcl
+    - name: cargo build openvmm
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 2
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::build_openvmm 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build vmgstool
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 9 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      shell: bash
+    - name: test vmgs_lib
+      run: |-
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey e 9 flowey_core::pipeline::artifact::publish 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build igvmfilegen
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_build 0
         flowey e 9 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 9 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
-    - name: collect openvmm_hcl files for analysis
+    - name: cargo build ohcldiag-dev
       run: |-
-        flowey e 9 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
-        flowey v 9 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:119:27' --is-raw-string write-to-env github floweyvar1
-      shell: bash
-    - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64_openvmm_hcl_for_size_analysis
-        path: ${{ env.floweyvar1 }}
-      name: publish openvmm_hcl for analysis
-    - name: cargo build xtask
-      run: |-
-        flowey e 9 flowey_lib_hvlite::init_cross_build 1
         flowey e 9 flowey_lib_common::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 0
         flowey e 9 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 9 flowey_lib_hvlite::build_xtask 0
+        flowey e 9 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 5
       shell: bash
-    - name: create gh cache dir
-      run: flowey e 9 flowey_lib_common::download_gh_cli 0
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 9 flowey_lib_common::download_cargo_nextest 0
+        flowey e 9 flowey_lib_common::download_cargo_nextest 1
+        flowey e 9 flowey_lib_common::download_cargo_nextest 2
+        flowey e 9 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
       run: |-
         flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 2
-        flowey e 9 flowey_lib_common::download_gh_cli 1
-        flowey v 9 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
+        flowey e 9 flowey_lib_common::download_cargo_nextest 4
       shell: bash
-    - name: setup gh cli
-      run: flowey e 9 flowey_lib_common::use_gh_cli 0
+    - name: report $CARGO_HOME
+      run: flowey e 9 flowey_lib_common::install_rust 3
       shell: bash
-    - name: get merge commit
-      run: flowey e 9 flowey_lib_common::git_merge_commit 0
-      shell: bash
-    - name: get action id by commit
+    - name: installing cargo-nextest
       run: |-
-        flowey e 9 flowey_lib_common::gh_workflow_id 0
-        flowey e 9 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 0
+        flowey e 9 flowey_lib_common::install_cargo_nextest 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 0
       shell: bash
-    - name: download artifacts from github actions run
-      run: flowey e 9 flowey_lib_common::download_gh_artifact 0
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 6
       shell: bash
-    - name: binary size comparison
-      run: flowey e 9 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 3
+    - name: unpack openvmm-deps archive
+      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: 'validate cache entry: gh-cli'
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 1
+        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 7
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey e 9 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 9 flowey_lib_common::cache 7
       shell: bash
+    - name: 🌼📦 Publish x64-linux-igvmfilegen
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgs_lib
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
+        include-hidden-files: true

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -391,7 +391,7 @@ jobs:
       run: flowey.exe e 1 flowey_lib_common::cache 3
       shell: bash
   job10:
-    name: build artifacts (shared VMM tests) [x64-linux]
+    name: build openhcl [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -426,16 +426,42 @@ jobs:
         cat <<'EOF' | flowey v 10 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 10 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 10 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 10 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 10 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 10 'artifact_publish_from_x64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 10 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 10 flowey_lib_common::cache 0
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 10 flowey_lib_common::cache 2
+        flowey e 10 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (aarch64)
+      run: flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 10 flowey_lib_common::install_rust 0
@@ -451,7 +477,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
         flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -459,7 +485,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -473,35 +499,6 @@ jobs:
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 10 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 10 flowey_lib_common::cache 2
-        flowey e 10 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 10 flowey_lib_common::resolve_protoc 0
@@ -510,119 +507,132 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build guest_test_uefi
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 0
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: build guest_test_uefi.img
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_guest_test_uefi 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 0
         flowey e 10 flowey_lib_hvlite::init_cross_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 1
         flowey e 10 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: cargo build simple_tmk
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 10 flowey_lib_hvlite::build_tmks 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 1
-        flowey e 10 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 4
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 10 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
+    - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 3
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build pipette
+    - name: cargo build openvmm_hcl
       run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 1
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::build_pipette 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 3
-        flowey e 10 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 3
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 10 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 4
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 10 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-guest_test_uefi
+    - name: 🌼📦 Publish aarch64-openhcl-igvm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-guest_test_uefi
-        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
+        name: aarch64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-pipette
+    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-tmks
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-tmks
-        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
+        name: aarch64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
         include-hidden-files: true
   job11:
-    name: build artifacts (for VMM tests) [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    name: verify openhcl binary size [aarch64]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
@@ -652,26 +662,6 @@ jobs:
         cat <<'EOF' | flowey v 11 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 11 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 11 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 11 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 11 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 11 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 11 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 11 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 11 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 11 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 11 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 11 flowey_lib_common::install_rust 0
@@ -684,16 +674,10 @@ jobs:
         flowey e 11 flowey_lib_common::install_rust 2
         flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar2
         flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -701,7 +685,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
+        persist-credentials: ${{ env.floweyvar2 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -711,9 +695,13 @@ jobs:
         EOF
         flowey e 11 flowey_lib_common::git_checkout 3
         flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    - name: checking if packages need to be installed
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 11 flowey_lib_common::download_gh_release 0
@@ -721,14 +709,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 4
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -738,242 +726,108 @@ jobs:
         flowey e 11 flowey_lib_common::cache 6
         flowey e 11 flowey_lib_common::download_gh_release 1
       shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
     - name: unpack protoc
-      run: |-
-        flowey e 11 flowey_lib_common::resolve_protoc 0
-        flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: flowey e 11 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+        flowey e 11 flowey_lib_hvlite::init_cross_build 0
       shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 11 flowey_lib_hvlite::build_openvmm 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 4
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 11 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 1
-        flowey e 11 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 7
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 11 flowey_lib_hvlite::build_vmgstool 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 2
-        flowey e 11 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 6
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      shell: bash
-    - name: test vmgs_lib
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-        flowey e 11 flowey_core::pipeline::artifact::publish 3
-        flowey e 11 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build openvmm_hcl
       run: |-
         flowey e 11 flowey_lib_common::run_cargo_build 0
         flowey e 11 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 4
-        flowey e 11 flowey_lib_hvlite::init_cross_build 6
+        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
       shell: bash
-    - name: cargo build ohcldiag-dev
+    - name: collect openvmm_hcl files for analysis
       run: |-
+        flowey e 11 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
+        flowey v 11 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:119:27' --is-raw-string write-to-env github floweyvar1
+      shell: bash
+    - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64_openvmm_hcl_for_size_analysis
+        path: ${{ env.floweyvar1 }}
+      name: publish openvmm_hcl for analysis
+    - name: cargo build xtask
+      run: |-
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
         flowey e 11 flowey_lib_common::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 11 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 11 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 5
+        flowey e 11 flowey_lib_hvlite::build_xtask 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 8
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 3
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 11 flowey_lib_hvlite::build_openvmm 1
-        flowey e 11 flowey_core::pipeline::artifact::publish 6
-        flowey e 11 flowey_lib_hvlite::init_cross_build 9
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 5
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 11
-        flowey e 11 flowey_lib_hvlite::build_openvmm_vhost 1
-        flowey e 11 flowey_core::pipeline::artifact::publish 7
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 11 flowey_lib_common::download_cargo_nextest 0
-        flowey e 11 flowey_lib_common::download_cargo_nextest 1
-        flowey e 11 flowey_lib_common::download_cargo_nextest 2
-        flowey e 11 flowey_lib_common::download_cargo_nextest 3
+    - name: create gh cache dir
+      run: flowey e 11 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
       run: |-
         flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 2
-        flowey e 11 flowey_lib_common::download_cargo_nextest 4
+        flowey e 11 flowey_lib_common::download_gh_cli 1
+        flowey v 11 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
       shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 11 flowey_lib_common::install_rust 3
+    - name: setup gh cli
+      run: flowey e 11 flowey_lib_common::use_gh_cli 0
       shell: bash
-    - name: installing cargo-nextest
+    - name: get merge commit
+      run: flowey e 11 flowey_lib_common::git_merge_commit 0
+      shell: bash
+    - name: get action id by commit
       run: |-
-        flowey e 11 flowey_lib_common::install_cargo_nextest 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 0
+        flowey e 11 flowey_lib_common::gh_workflow_id 0
+        flowey e 11 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 0
       shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 8
-        flowey e 11 flowey_lib_hvlite::init_cross_build 7
+    - name: download artifacts from github actions run
+      run: flowey e 11 flowey_lib_common::download_gh_artifact 0
       shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_archive 1
-        flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 1
-        flowey e 11 flowey_core::pipeline::artifact::publish 9
+    - name: binary size comparison
+      run: flowey e 11 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 3
       shell: bash
-    - name: 'validate cache entry: cargo-nextest'
+    - name: 'validate cache entry: gh-cli'
       run: flowey e 11 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 11 flowey_lib_common::cache 7
       shell: bash
-    - name: 🌼📦 Publish x64-linux-igvmfilegen
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-openvmm_vhost
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-openvmm_vhost
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgs_lib
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
-        include-hidden-files: true
   job12:
-    name: build openhcl [aarch64-linux]
+    name: build openhcl [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -1008,10 +862,10 @@ jobs:
         cat <<'EOF' | flowey v 12 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 12 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 12 flowey_lib_common::install_dist_pkg 0
@@ -1042,7 +896,7 @@ jobs:
         flowey e 12 flowey_lib_common::cache 2
         flowey e 12 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack mu_msvm package (aarch64)
+    - name: unpack mu_msvm package (x64)
       run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
@@ -1090,6 +944,20 @@ jobs:
       run: |-
         flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build sidecar
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 12 flowey_lib_hvlite::build_sidecar 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 1
         flowey e 12 flowey_lib_hvlite::run_cargo_build 2
         flowey e 12 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
@@ -1100,41 +968,41 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 12 flowey_lib_hvlite::run_cargo_build 5
         flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
+    - name: extract X86_64 sysroot.tar.gz
       run: |-
         flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 1
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
         flowey e 12 flowey_lib_common::run_cargo_build 2
         flowey e 12 flowey_lib_hvlite::run_cargo_build 6
         flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -1144,50 +1012,128 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 7
         flowey e 12 flowey_lib_hvlite::run_cargo_build 1
         flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 4
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
         flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
         flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
         flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
@@ -1200,20 +1146,20 @@ jobs:
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 12 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-openhcl-igvm
+    - name: 🌼📦 Publish x64-openhcl-igvm
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        name: x64-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
+    - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
+        name: x64-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
         include-hidden-files: true
   job13:
-    name: verify openhcl binary size [aarch64]
+    name: verify openhcl binary size [x64]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1311,7 +1257,7 @@ jobs:
     - name: unpack openvmm-deps archive
       run: flowey e 13 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
+    - name: extract X86_64 sysroot.tar.gz
       run: flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -1323,7 +1269,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
@@ -1332,7 +1278,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 13 flowey_lib_hvlite::run_cargo_build 1
         flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 0
       shell: bash
@@ -1344,18 +1290,18 @@ jobs:
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64_openvmm_hcl_for_size_analysis
+        name: x86_64_openvmm_hcl_for_size_analysis
         path: ${{ env.floweyvar1 }}
       name: publish openvmm_hcl for analysis
     - name: cargo build xtask
       run: |-
-        flowey e 13 flowey_lib_hvlite::init_cross_build 1
+        flowey e 13 flowey_lib_hvlite::init_cross_build 0
         flowey e 13 flowey_lib_common::run_cargo_build 1
         flowey e 13 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
         flowey e 13 flowey_lib_hvlite::run_cargo_build 3
         flowey e 13 flowey_lib_hvlite::build_xtask 0
       shell: bash
@@ -1409,540 +1355,12 @@ jobs:
       run: flowey e 13 flowey_lib_common::cache 7
       shell: bash
   job14:
-    name: build openhcl [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 14 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 14 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 14 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 14 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 14 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 14 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 14 flowey_lib_common::cache 2
-        flowey e 14 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 14 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 14 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 14 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 14 flowey_lib_common::install_rust 2
-        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 14 flowey_lib_common::git_checkout 3
-        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 14 flowey_lib_common::resolve_protoc 0
-        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 0
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: cargo build sidecar
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_build 3
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 14 flowey_lib_hvlite::build_sidecar 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_build 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 14 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 14 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_build 2
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 14 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 14 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_build 0
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 7
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 14 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 14 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 14 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 3
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 3
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 14 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 14 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 14 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 14 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 14 flowey_lib_common::cache 3
-      shell: bash
-    - name: 🌼📦 Publish x64-openhcl-igvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
-        include-hidden-files: true
-  job15:
-    name: verify openhcl binary size [x64]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 15 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 15 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 15 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 15 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 15 flowey_lib_common::install_rust 2
-        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar2
-        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar2 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 15 flowey_lib_common::git_checkout 3
-        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 15 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 15 flowey_lib_common::cache 6
-        flowey e 15 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 15 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: unpack protoc
-      run: flowey e 15 flowey_lib_common::resolve_protoc 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_build 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 15 flowey_lib_hvlite::build_openvmm_hcl 0
-      shell: bash
-    - name: collect openvmm_hcl files for analysis
-      run: |-
-        flowey e 15 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
-        flowey v 15 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:119:27' --is-raw-string write-to-env github floweyvar1
-      shell: bash
-    - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
-      uses: actions/upload-artifact@v7
-      with:
-        name: x86_64_openvmm_hcl_for_size_analysis
-        path: ${{ env.floweyvar1 }}
-      name: publish openvmm_hcl for analysis
-    - name: cargo build xtask
-      run: |-
-        flowey e 15 flowey_lib_hvlite::init_cross_build 0
-        flowey e 15 flowey_lib_common::run_cargo_build 1
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 15 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 15 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 15 flowey_lib_common::cache 2
-        flowey e 15 flowey_lib_common::download_gh_cli 1
-        flowey v 15 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey e 15 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get merge commit
-      run: flowey e 15 flowey_lib_common::git_merge_commit 0
-      shell: bash
-    - name: get action id by commit
-      run: |-
-        flowey e 15 flowey_lib_common::gh_workflow_id 0
-        flowey e 15 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey e 15 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: binary size comparison
-      run: flowey e 15 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 15 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 15 flowey_lib_common::cache 7
-      shell: bash
-  job16:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2010,29 +1428,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 16 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 16 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 14 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 14 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 16 'verbose' update
+        cat <<'EOF' | flowey.exe v 14 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 16 flowey_lib_common::install_rust 0
+      run: flowey.exe e 14 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 16 flowey_lib_common::install_rust 1
+      run: flowey.exe e 14 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 16 flowey_lib_common::install_rust 2
-        flowey.exe e 16 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 14 flowey_lib_common::install_rust 2
+        flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 16 flowey_lib_common::git_checkout 0
-        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 14 flowey_lib_common::git_checkout 0
+        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2044,23 +1462,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 16 flowey_lib_common::git_checkout 3
-        flowey.exe e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 14 flowey_lib_common::git_checkout 3
+        flowey.exe e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 16 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 14 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 16 flowey_lib_common::cache 4
-        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 14 flowey_lib_common::cache 4
+        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2070,50 +1488,50 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 16 flowey_lib_common::cache 6
-        flowey.exe e 16 flowey_lib_common::download_gh_release 1
+        flowey.exe e 14 flowey_lib_common::cache 6
+        flowey.exe e 14 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 16 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 14 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 16 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 16 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 16 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 14 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 14 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 16 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 16 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 16 flowey_lib_common::cache 0
-        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe e 14 flowey_lib_common::cache 0
+        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2123,45 +1541,45 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 16 flowey_lib_common::cache 2
-        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 14 flowey_lib_common::cache 2
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 16 flowey_lib_common::install_rust 3
+      run: flowey.exe e 14 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 16 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 14 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 16 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 16 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 16 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 14 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 14 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
       run: |-
-        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 16 flowey_lib_common::publish_test_results 5
-        flowey.exe e 16 flowey_lib_common::publish_test_results 6
-        flowey.exe e 16 flowey_lib_common::publish_test_results 4
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 14 flowey_lib_common::publish_test_results 5
+        flowey.exe e 14 flowey_lib_common::publish_test_results 6
+        flowey.exe e 14 flowey_lib_common::publish_test_results 4
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2171,18 +1589,18 @@ jobs:
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 16 flowey_lib_common::publish_test_results 0
-        flowey.exe e 16 flowey_lib_common::publish_test_results 1
-        flowey.exe e 16 flowey_lib_common::publish_test_results 2
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 14 flowey_lib_common::publish_test_results 0
+        flowey.exe e 14 flowey_lib_common::publish_test_results 1
+        flowey.exe e 14 flowey_lib_common::publish_test_results 2
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2193,25 +1611,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
-      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 16 flowey_lib_common::cache 3
+      run: flowey.exe e 14 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 16 flowey_lib_common::cache 7
+      run: flowey.exe e 14 flowey_lib_common::cache 7
       shell: bash
-  job17:
+  job15:
     name: clippy [macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2235,35 +1653,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 17 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 17 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 15 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 17 'verbose' update
+        cat <<'EOF' | flowey v 15 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 17 flowey_lib_common::install_rust 0
+      run: flowey e 15 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 17 flowey_lib_common::install_rust 1
+      run: flowey e 15 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 17 flowey_lib_common::install_rust 2
-        flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 15 flowey_lib_common::install_rust 2
+        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::git_checkout 0
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2275,23 +1693,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 17 flowey_lib_common::git_checkout 3
-        flowey e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 15 flowey_lib_common::git_checkout 3
+        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 17 flowey_lib_common::download_gh_release 0
+      run: flowey e 15 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey e 15 flowey_lib_common::cache 4
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2301,54 +1719,54 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 17 flowey_lib_common::cache 6
-        flowey e 17 flowey_lib_common::download_gh_release 1
+        flowey e 15 flowey_lib_common::cache 6
+        flowey e 15 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 17 flowey_lib_common::resolve_protoc 0
-        flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 15 flowey_lib_common::resolve_protoc 0
+        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 17 flowey_lib_hvlite::init_cross_build 1
+        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_build 0
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 15 flowey_lib_common::run_cargo_build 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 17 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 17 flowey_lib_hvlite::build_xtask 0
+        flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 17 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 17 flowey_lib_common::download_cargo_nextest 0
-        flowey e 17 flowey_lib_common::download_cargo_nextest 1
-        flowey e 17 flowey_lib_common::download_cargo_nextest 2
-        flowey e 17 flowey_lib_common::download_cargo_nextest 3
+        flowey e 15 flowey_lib_common::download_cargo_nextest 0
+        flowey e 15 flowey_lib_common::download_cargo_nextest 1
+        flowey e 15 flowey_lib_common::download_cargo_nextest 2
+        flowey e 15 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey e 15 flowey_lib_common::cache 0
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2358,34 +1776,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 17 flowey_lib_common::cache 2
-        flowey e 17 flowey_lib_common::download_cargo_nextest 4
+        flowey e 15 flowey_lib_common::cache 2
+        flowey e 15 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 17 flowey_lib_common::install_rust 3
+      run: flowey e 15 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 17 flowey_lib_common::install_cargo_nextest 0
-        flowey e 17 flowey_lib_hvlite::init_cross_build 0
-        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::install_cargo_nextest 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 17 flowey_lib_common::publish_test_results 5
-        flowey e 17 flowey_lib_common::publish_test_results 6
-        flowey e 17 flowey_lib_common::publish_test_results 4
-        flowey v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 15 flowey_lib_common::publish_test_results 5
+        flowey e 15 flowey_lib_common::publish_test_results 6
+        flowey e 15 flowey_lib_common::publish_test_results 4
+        flowey v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2395,18 +1813,18 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 17 flowey_lib_common::publish_test_results 8
-        flowey e 17 flowey_lib_common::publish_test_results 9
-        flowey e 17 flowey_lib_common::publish_test_results 10
-        flowey v 17 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 17 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 15 flowey_lib_common::publish_test_results 8
+        flowey e 15 flowey_lib_common::publish_test_results 9
+        flowey e 15 flowey_lib_common::publish_test_results 10
+        flowey v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2417,32 +1835,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 17 flowey_lib_hvlite::init_cross_build 2
-        flowey e 17 flowey_lib_common::run_cargo_build 1
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 15 flowey_lib_hvlite::init_cross_build 2
+        flowey e 15 flowey_lib_common::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 17 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 17 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 17 flowey_lib_hvlite::build_xtask 1
+        flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 15 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 17 flowey_lib_common::publish_test_results 12
-        flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey e 17 flowey_lib_common::publish_test_results 14
-        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 15 flowey_lib_common::publish_test_results 12
+        flowey e 15 flowey_lib_common::publish_test_results 13
+        flowey e 15 flowey_lib_common::publish_test_results 14
+        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -2452,18 +1870,18 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 17 flowey_lib_common::publish_test_results 0
-        flowey e 17 flowey_lib_common::publish_test_results 1
-        flowey e 17 flowey_lib_common::publish_test_results 2
-        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 15 flowey_lib_common::publish_test_results 0
+        flowey e 15 flowey_lib_common::publish_test_results 1
+        flowey e 15 flowey_lib_common::publish_test_results 2
+        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2474,25 +1892,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
-      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 17 flowey_lib_common::cache 3
+      run: flowey e 15 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 17 flowey_lib_common::cache 7
+      run: flowey e 15 flowey_lib_common::cache 7
       shell: bash
-  job18:
+  job16:
     name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2516,29 +1934,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 18 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 18 'verbose' update
+        cat <<'EOF' | flowey v 16 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 18 flowey_lib_common::install_rust 0
+      run: flowey e 16 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 18 flowey_lib_common::install_rust 1
+      run: flowey e 16 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 18 flowey_lib_common::install_rust 2
-        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 16 flowey_lib_common::install_rust 2
+        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::git_checkout 0
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2550,27 +1968,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 18 flowey_lib_common::git_checkout 3
-        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 16 flowey_lib_common::git_checkout 3
+        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 18 flowey_lib_common::download_gh_release 0
+      run: flowey e 16 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 16 flowey_lib_common::cache 4
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2580,78 +1998,78 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 18 flowey_lib_common::cache 6
-        flowey e 18 flowey_lib_common::download_gh_release 1
+        flowey e 16 flowey_lib_common::cache 6
+        flowey e 16 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      run: flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 18 flowey_lib_common::resolve_protoc 0
+      run: flowey e 16 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 2
+        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_clippy 5
-        flowey e 18 flowey_lib_hvlite::init_cross_build 0
+        flowey e 16 flowey_lib_common::run_cargo_clippy 5
+        flowey e 16 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_build 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 16 flowey_lib_common::run_cargo_build 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 18 flowey_lib_hvlite::build_xtask 0
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 18 flowey_lib_common::download_cargo_nextest 0
-        flowey e 18 flowey_lib_common::download_cargo_nextest 1
-        flowey e 18 flowey_lib_common::download_cargo_nextest 2
-        flowey e 18 flowey_lib_common::download_cargo_nextest 3
+        flowey e 16 flowey_lib_common::download_cargo_nextest 0
+        flowey e 16 flowey_lib_common::download_cargo_nextest 1
+        flowey e 16 flowey_lib_common::download_cargo_nextest 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 16 flowey_lib_common::cache 0
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2661,34 +2079,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 18 flowey_lib_common::cache 2
-        flowey e 18 flowey_lib_common::download_cargo_nextest 4
+        flowey e 16 flowey_lib_common::cache 2
+        flowey e 16 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 18 flowey_lib_common::install_rust 3
+      run: flowey e 16 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 18 flowey_lib_common::install_cargo_nextest 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 3
-        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::install_cargo_nextest 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 3
+        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 18 flowey_lib_common::publish_test_results 5
-        flowey e 18 flowey_lib_common::publish_test_results 6
-        flowey e 18 flowey_lib_common::publish_test_results 4
-        flowey v 18 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 16 flowey_lib_common::publish_test_results 5
+        flowey e 16 flowey_lib_common::publish_test_results 6
+        flowey e 16 flowey_lib_common::publish_test_results 4
+        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2698,18 +2116,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 18 flowey_lib_common::publish_test_results 8
-        flowey e 18 flowey_lib_common::publish_test_results 9
-        flowey e 18 flowey_lib_common::publish_test_results 10
-        flowey v 18 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 16 flowey_lib_common::publish_test_results 8
+        flowey e 16 flowey_lib_common::publish_test_results 9
+        flowey e 16 flowey_lib_common::publish_test_results 10
+        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2719,18 +2137,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 18 flowey_lib_common::publish_test_results 12
-        flowey e 18 flowey_lib_common::publish_test_results 13
-        flowey e 18 flowey_lib_common::publish_test_results 14
-        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 18 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey e 16 flowey_lib_common::publish_test_results 13
+        flowey e 16 flowey_lib_common::publish_test_results 14
+        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
@@ -2740,18 +2158,18 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 18 flowey_lib_common::publish_test_results 16
-        flowey e 18 flowey_lib_common::publish_test_results 17
-        flowey e 18 flowey_lib_common::publish_test_results 18
-        flowey v 18 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 18 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 16 flowey_lib_common::publish_test_results 16
+        flowey e 16 flowey_lib_common::publish_test_results 17
+        flowey e 16 flowey_lib_common::publish_test_results 18
+        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
@@ -2762,32 +2180,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 18 flowey_lib_hvlite::init_cross_build 1
-        flowey e 18 flowey_lib_common::run_cargo_build 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 16 flowey_lib_hvlite::init_cross_build 1
+        flowey e 16 flowey_lib_common::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 18 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 18 flowey_lib_hvlite::build_xtask 1
+        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 16 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 18 flowey_lib_common::publish_test_results 0
-        flowey e 18 flowey_lib_common::publish_test_results 1
-        flowey e 18 flowey_lib_common::publish_test_results 2
-        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 16 flowey_lib_common::publish_test_results 0
+        flowey e 16 flowey_lib_common::publish_test_results 1
+        flowey e 16 flowey_lib_common::publish_test_results 2
+        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2798,25 +2216,25 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
-      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 18 flowey_lib_common::cache 3
+      run: flowey e 16 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 18 flowey_lib_common::cache 7
+      run: flowey e 16 flowey_lib_common::cache 7
       shell: bash
-  job19:
+  job17:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=win-arm64
-    - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2884,29 +2302,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 19 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 19 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 19 'verbose' update
+        cat <<'EOF' | flowey.exe v 17 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 19 flowey_lib_common::install_rust 0
+      run: flowey.exe e 17 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 19 flowey_lib_common::install_rust 1
+      run: flowey.exe e 17 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 19 flowey_lib_common::install_rust 2
-        flowey.exe e 19 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 17 flowey_lib_common::install_rust 2
+        flowey.exe e 17 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 19 flowey_lib_common::git_checkout 0
-        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
-        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 17 flowey_lib_common::git_checkout 0
+        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2918,23 +2336,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 19 flowey_lib_common::git_checkout 3
-        flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 17 flowey_lib_common::git_checkout 3
+        flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 19 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 17 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 19 flowey_lib_common::cache 4
-        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 17 flowey_lib_common::cache 4
+        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2944,50 +2362,50 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 19 flowey_lib_common::cache 6
-        flowey.exe e 19 flowey_lib_common::download_gh_release 1
+        flowey.exe e 17 flowey_lib_common::cache 6
+        flowey.exe e 17 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 19 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 17 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 19 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 19 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 19 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 19 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 19 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 17 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 17 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 19 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 19 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 19 flowey_lib_common::cache 0
-        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe e 17 flowey_lib_common::cache 0
+        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2997,45 +2415,45 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 19 flowey_lib_common::cache 2
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 17 flowey_lib_common::cache 2
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 19 flowey_lib_common::install_rust 3
+      run: flowey.exe e 17 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 19 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 19 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 17 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 19 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 19 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 19 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 17 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 17 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
       run: |-
-        flowey.exe e 19 flowey_lib_hvlite::build_nextest_unit_tests 0
-        flowey.exe e 19 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 19 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 19 flowey_lib_common::publish_test_results 5
-        flowey.exe e 19 flowey_lib_common::publish_test_results 6
-        flowey.exe e 19 flowey_lib_common::publish_test_results 4
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 17 flowey_lib_common::publish_test_results 5
+        flowey.exe e 17 flowey_lib_common::publish_test_results 6
+        flowey.exe e 17 flowey_lib_common::publish_test_results 4
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -3045,18 +2463,18 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 19 flowey_lib_common::publish_test_results 0
-        flowey.exe e 19 flowey_lib_common::publish_test_results 1
-        flowey.exe e 19 flowey_lib_common::publish_test_results 2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 17 flowey_lib_common::publish_test_results 0
+        flowey.exe e 17 flowey_lib_common::publish_test_results 1
+        flowey.exe e 17 flowey_lib_common::publish_test_results 2
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -3067,20 +2485,720 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 19 flowey_lib_common::cache 3
+      run: flowey.exe e 17 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 19 flowey_lib_common::cache 7
+      run: flowey.exe e 17 flowey_lib_common::cache 7
+      shell: bash
+  job18:
+    name: clippy [aarch64-linux], unit tests [aarch64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=ubuntu2404-arm64
+    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/aarch64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
+        echo '"debug"' | flowey v 18 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 18 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 18 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 18 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 18 flowey_lib_common::install_rust 2
+        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 18 flowey_lib_common::git_checkout 0
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar9 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 18 flowey_lib_common::git_checkout 3
+        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 18 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 18 flowey_lib_common::cache 4
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 18 flowey_lib_common::cache 6
+        flowey e 18 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 18 flowey_lib_common::resolve_protoc 0
+        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_build 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 18 flowey_lib_common::download_cargo_nextest 0
+        flowey e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey e 18 flowey_lib_common::download_cargo_nextest 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 18 flowey_lib_common::cache 0
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 18 flowey_lib_common::cache 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 18 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 18 flowey_lib_common::install_cargo_nextest 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 18 flowey_lib_common::publish_test_results 5
+        flowey e 18 flowey_lib_common::publish_test_results 6
+        flowey e 18 flowey_lib_common::publish_test_results 4
+        flowey v 18 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__7
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 18 flowey_lib_common::publish_test_results 8
+        flowey e 18 flowey_lib_common::publish_test_results 9
+        flowey e 18 flowey_lib_common::publish_test_results 10
+        flowey v 18 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey e 18 flowey_lib_hvlite::init_cross_build 3
+        flowey e 18 flowey_lib_common::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 18 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 18 flowey_lib_common::publish_test_results 12
+        flowey e 18 flowey_lib_common::publish_test_results 13
+        flowey e 18 flowey_lib_common::publish_test_results 14
+        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 18 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 18 flowey_lib_common::publish_test_results 0
+        flowey e 18 flowey_lib_common::publish_test_results 1
+        flowey e 18 flowey_lib_common::publish_test_results 2
+        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: |-
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for aarch64-unknown-linux-gnu
+      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 18 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 18 flowey_lib_common::cache 7
+      shell: bash
+  job19:
+    name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=ubuntu2404-arm64
+    - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/aarch64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
+        echo '"debug"' | flowey v 19 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 19 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 19 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 19 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 19 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 19 flowey_lib_common::install_rust 2
+        flowey e 19 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 19 flowey_lib_common::git_checkout 0
+        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar10 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 19 flowey_lib_common::git_checkout 3
+        flowey e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 19 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 19 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 19 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 19 flowey_lib_common::cache 4
+        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 19 flowey_lib_common::cache 6
+        flowey e 19 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 19 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: flowey e 19 flowey_lib_common::resolve_protoc 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 19 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 6
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 19 flowey_lib_common::run_cargo_clippy 5
+        flowey e 19 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 19 flowey_lib_common::run_cargo_build 0
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 19 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 19 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 19 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 19 flowey_lib_common::download_cargo_nextest 0
+        flowey e 19 flowey_lib_common::download_cargo_nextest 1
+        flowey e 19 flowey_lib_common::download_cargo_nextest 2
+        flowey e 19 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 19 flowey_lib_common::cache 0
+        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 19 flowey_lib_common::cache 2
+        flowey e 19 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 19 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 19 flowey_lib_common::install_cargo_nextest 0
+        flowey e 19 flowey_lib_hvlite::init_cross_build 3
+        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 19 flowey_lib_common::publish_test_results 5
+        flowey e 19 flowey_lib_common::publish_test_results 6
+        flowey e 19 flowey_lib_common::publish_test_results 4
+        flowey v 19 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__7
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 19 flowey_lib_common::publish_test_results 8
+        flowey e 19 flowey_lib_common::publish_test_results 9
+        flowey e 19 flowey_lib_common::publish_test_results 10
+        flowey v 19 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 19 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+      run: |-
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 19 flowey_lib_common::publish_test_results 12
+        flowey e 19 flowey_lib_common::publish_test_results 13
+        flowey e 19 flowey_lib_common::publish_test_results 14
+        flowey v 19 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 19 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 19 flowey_lib_common::publish_test_results 16
+        flowey e 19 flowey_lib_common::publish_test_results 17
+        flowey e 19 flowey_lib_common::publish_test_results 18
+        flowey v 19 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 19 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey e 19 flowey_lib_hvlite::init_cross_build 1
+        flowey e 19 flowey_lib_common::run_cargo_build 1
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 19 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 19 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 19 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 19 flowey_lib_common::publish_test_results 0
+        flowey e 19 flowey_lib_common::publish_test_results 1
+        flowey e 19 flowey_lib_common::publish_test_results 2
+        flowey v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: |-
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for aarch64-unknown-linux-musl
+      run: flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 19 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 19 flowey_lib_common::cache 7
       shell: bash
   job2:
-    name: build artifacts (not for VMM tests) [aarch64-windows]
+    name: build artifacts (shared VMM tests) [windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -3159,14 +3277,10 @@ jobs:
         cat <<'EOF' | flowey.exe v 2 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-hypestv"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-hypestv" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-hypestv' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-igvmfilegen"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-igvmfilegen" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-ohcldiag-dev"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-ohcldiag-dev" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgs_lib"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgs_lib" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-pipette"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-pipette" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-pipette"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 2 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 2 flowey_lib_common::install_rust 0
@@ -3235,530 +3349,170 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 2 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 0
       shell: bash
-    - name: cargo build hypestv
+    - name: cargo build pipette
       run: |-
         flowey.exe e 2 flowey_lib_common::run_cargo_build 0
         flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 2 flowey_lib_hvlite::build_hypestv 0
+        flowey.exe e 2 flowey_lib_hvlite::build_pipette 0
         flowey.exe e 2 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey.exe e 2 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 3
-        flowey.exe e 2 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-        flowey.exe e 2 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey.exe e 2 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build pipette
       run: |-
         flowey.exe e 2 flowey_lib_common::run_cargo_build 1
         flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 2 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey.exe e 2 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 2 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build ohcldiag-dev
-      run: |-
-        flowey.exe e 2 flowey_lib_common::run_cargo_build 2
-        flowey.exe e 2 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 2 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey.exe e 2 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 2 flowey_lib_hvlite::build_pipette 1
+        flowey.exe e 2 flowey_core::pipeline::artifact::publish 1
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey.exe e 2 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-windows-hypestv
+    - name: 🌼📦 Publish aarch64-windows-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-hypestv
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-hypestv/
+        name: aarch64-windows-pipette
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-pipette/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-igvmfilegen
+    - name: 🌼📦 Publish x64-windows-pipette
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-igvmfilegen/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-ohcldiag-dev
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-ohcldiag-dev/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-vmgs_lib
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
+        name: x64-windows-pipette
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
         include-hidden-files: true
   job20:
-    name: clippy [aarch64-linux], unit tests [aarch64-linux]
+    name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=ubuntu2404-arm64
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=win-amd64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
+    - job12
+    - job2
+    - job3
+    - job7
     if: github.event.pull_request.draft == false
     steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
       with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/aarch64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
-      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
 
-        echo '"debug"' | flowey v 20 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 20 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 20 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 20 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 20 'verbose' update
+        cat <<'EOF' | flowey.exe v 20 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 20 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 20 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 20 flowey_lib_common::install_rust 2
-        flowey e 20 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 20 flowey_lib_common::git_checkout 0
-        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
-        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 20 flowey_lib_common::git_checkout 3
-        flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 20 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 20 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 20 flowey_lib_common::cache 4
-        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 20 flowey_lib_common::cache 6
-        flowey e 20 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 20 flowey_lib_common::resolve_protoc 0
-        flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 20 flowey_lib_hvlite::init_cross_build 0
-        flowey e 20 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 20 flowey_lib_common::run_cargo_build 0
-        flowey e 20 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 20 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 20 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 20 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 20 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 1
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 20 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 20 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 20 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 20 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 20 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 20 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 20 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 20 flowey_lib_common::download_cargo_nextest 0
-        flowey e 20 flowey_lib_common::download_cargo_nextest 1
-        flowey e 20 flowey_lib_common::download_cargo_nextest 2
-        flowey e 20 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 20 flowey_lib_common::cache 0
-        flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe e 20 flowey_lib_common::cache 0
+        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 20 flowey_lib_common::cache 2
-        flowey e 20 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 20 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 20 flowey_lib_common::install_cargo_nextest 0
-        flowey e 20 flowey_lib_hvlite::init_cross_build 1
-        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 20 flowey_lib_common::publish_test_results 5
-        flowey e 20 flowey_lib_common::publish_test_results 6
-        flowey e 20 flowey_lib_common::publish_test_results 4
-        flowey v 20 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 20 flowey_lib_common::publish_test_results 8
-        flowey e 20 flowey_lib_common::publish_test_results 9
-        flowey e 20 flowey_lib_common::publish_test_results 10
-        flowey v 20 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 20 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: cargo build xtask
-      run: |-
-        flowey e 20 flowey_lib_hvlite::init_cross_build 3
-        flowey e 20 flowey_lib_common::run_cargo_build 1
-        flowey e 20 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 20 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 20 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 20 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests' nextest tests
-      run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 20 flowey_lib_common::publish_test_results 12
-        flowey e 20 flowey_lib_common::publish_test_results 13
-        flowey e 20 flowey_lib_common::publish_test_results 14
-        flowey v 20 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 20 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 20 flowey_lib_common::publish_test_results 0
-        flowey e 20 flowey_lib_common::publish_test_results 1
-        flowey e 20 flowey_lib_common::publish_test_results 2
-        flowey v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: |-
-        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 20 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 20 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 20 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 20 flowey_lib_common::cache 7
-      shell: bash
-  job21:
-    name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/aarch64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 21 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 21 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 21 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 21 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 21 flowey_lib_common::install_rust 2
-        flowey e 21 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 20 flowey_lib_common::cache 2
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 21 flowey_lib_common::git_checkout 0
-        flowey v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 20 flowey_lib_common::git_checkout 0
+        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 21 flowey_lib_common::git_checkout 3
-        flowey e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 21 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 20 flowey_lib_common::git_checkout 3
+        flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 21 flowey_lib_common::install_dist_pkg 0
+    - name: creating new test content dir
+      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
-    - name: installing packages
-      run: flowey e 21 flowey_lib_common::install_dist_pkg 1
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 20 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 21 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 20 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 21 flowey_lib_common::cache 4
-        flowey v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 20 flowey_lib_common::cache 8
+        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
       with:
         key: ${{ env.floweyvar8 }}
@@ -3766,241 +3520,410 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 21 flowey_lib_common::cache 6
-        flowey e 21 flowey_lib_common::download_gh_release 1
+        flowey.exe e 20 flowey_lib_common::cache 10
+        flowey.exe e 20 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: extract azcopy from archive
+      run: flowey.exe e 20 flowey_lib_common::download_azcopy 0
       shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 21 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 21 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: unpack protoc
-      run: flowey e 21 flowey_lib_common::resolve_protoc 0
-      shell: bash
-    - name: symlink protoc
+    - name: downloading VMM test disk images
       run: |-
-        flowey e 21 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 21 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
-    - name: cargo clippy
-      run: flowey e 21 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 21 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 21 flowey_lib_common::run_cargo_clippy 6
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 21 flowey_lib_common::run_cargo_clippy 5
-        flowey e 21 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 21 flowey_lib_common::run_cargo_build 0
-        flowey e 21 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 21 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 21 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 21 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 21 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 21 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 21 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 21 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 21 flowey_lib_common::download_cargo_nextest 0
-        flowey e 21 flowey_lib_common::download_cargo_nextest 1
-        flowey e 21 flowey_lib_common::download_cargo_nextest 2
-        flowey e 21 flowey_lib_common::download_cargo_nextest 3
+    - name: create gh cache dir
+      run: flowey.exe e 20 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 21 flowey_lib_common::cache 0
-        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 20 flowey_lib_common::cache 4
+        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
-    - id: flowey_lib_common__cache__1
+    - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
         key: ${{ env.floweyvar6 }}
         path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
       run: |-
-        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 21 flowey_lib_common::cache 2
-        flowey e 21 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 20 flowey_lib_common::cache 6
+        flowey.exe e 20 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 20 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
       shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 21 flowey_lib_common::install_rust 3
+    - name: setup gh cli
+      run: flowey.exe e 20 flowey_lib_common::use_gh_cli 0
       shell: bash
-    - name: installing cargo-nextest
+    - name: get latest completed action id
+      run: flowey.exe e 20 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 20 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 20 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
       run: |-
-        flowey e 21 flowey_lib_common::install_cargo_nextest 0
-        flowey e 21 flowey_lib_hvlite::init_cross_build 3
-        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 20 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 20 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 21 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 21 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 21 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 21 flowey_lib_common::publish_test_results 5
-        flowey e 21 flowey_lib_common::publish_test_results 6
-        flowey e 21 flowey_lib_common::publish_test_results 4
-        flowey v 21 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 20 flowey_lib_common::publish_test_results 4
+        flowey.exe e 20 flowey_lib_common::publish_test_results 5
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-windows-intel-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: 🦀 flowey rust steps
       run: |-
-        flowey e 21 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 21 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 21 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 21 flowey_lib_common::publish_test_results 8
-        flowey e 21 flowey_lib_common::publish_test_results 9
-        flowey e 21 flowey_lib_common::publish_test_results 10
-        flowey v 21 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 21 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
-      run: |-
-        flowey e 21 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 21 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 21 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 21 flowey_lib_common::publish_test_results 12
-        flowey e 21 flowey_lib_common::publish_test_results 13
-        flowey e 21 flowey_lib_common::publish_test_results 14
-        flowey v 21 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 21 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 21 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 21 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 21 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 21 flowey_lib_common::publish_test_results 16
-        flowey e 21 flowey_lib_common::publish_test_results 17
-        flowey e 21 flowey_lib_common::publish_test_results 18
-        flowey v 21 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 21 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: cargo build xtask
-      run: |-
-        flowey e 21 flowey_lib_hvlite::init_cross_build 1
-        flowey e 21 flowey_lib_common::run_cargo_build 1
-        flowey e 21 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 21 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 21 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 21 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: flowey e 21 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 4
-      shell: bash
-    - name: run 'unit-tests' nextest tests
-      run: |-
-        flowey e 21 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 21 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 21 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 21 flowey_lib_common::publish_test_results 0
-        flowey e 21 flowey_lib_common::publish_test_results 1
-        flowey e 21 flowey_lib_common::publish_test_results 2
-        flowey v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 20 flowey_lib_common::publish_test_results 0
+        flowey.exe e 20 flowey_lib_common::publish_test_results 1
+        flowey.exe e 20 flowey_lib_common::publish_test_results 2
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests-junit-xml
+        name: x64-windows-intel-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: |-
-        flowey e 21 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 21 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: run doctests for aarch64-unknown-linux-musl
-      run: flowey e 21 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 21 flowey_lib_common::cache 3
+      run: flowey.exe e 20 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 20 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 21 flowey_lib_common::cache 7
+      run: flowey.exe e 20 flowey_lib_common::cache 11
       shell: bash
-  job22:
-    name: run vmm-tests [x64-windows-intel]
+  job21:
+    name: run vmm-tests [x64-windows-intel-tdx]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
+    - Windows
+    - X64
+    - TDX
+    - Baremetal
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job12
+    - job2
+    - job3
+    - job7
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 21 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 21 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 21 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 21 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 21 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 21 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 21 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 21 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 21 flowey_lib_common::cache 0
+        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 21 flowey_lib_common::cache 2
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 21 flowey_lib_common::git_checkout 0
+        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 21 flowey_lib_common::git_checkout 3
+        flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 21 flowey_lib_common::cache 8
+        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 21 flowey_lib_common::cache 10
+        flowey.exe e 21 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 21 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 21 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 21 flowey_lib_common::cache 4
+        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 21 flowey_lib_common::cache 6
+        flowey.exe e 21 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 21 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 21 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 21 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 21 flowey_lib_common::publish_test_results 4
+        flowey.exe e 21 flowey_lib_common::publish_test_results 5
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-tdx-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 21 flowey_lib_common::publish_test_results 0
+        flowey.exe e 21 flowey_lib_common::publish_test_results 1
+        flowey.exe e 21 flowey_lib_common::publish_test_results 2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-intel-tdx-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 21 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 21 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 21 flowey_lib_common::cache 11
+      shell: bash
+  job22:
+    name: run vmm-tests [x64-windows-amd]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -4008,9 +3931,9 @@ jobs:
       id-token: write
     needs:
     - job0
-    - job10
-    - job14
-    - job6
+    - job12
+    - job2
+    - job3
     - job7
     if: github.event.pull_request.draft == false
     steps:
@@ -4230,9 +4153,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-vmm-tests-logs
+        name: x64-windows-amd-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4246,9 +4169,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-vmm-tests-junit-xml
+        name: x64-windows-amd-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4263,21 +4186,21 @@ jobs:
       run: flowey.exe e 22 flowey_lib_common::cache 11
       shell: bash
   job23:
-    name: run vmm-tests [x64-windows-intel-tdx]
+    name: run vmm-tests [x64-windows-amd-snp]
     runs-on:
     - self-hosted
     - Windows
     - X64
-    - TDX
+    - SNP
     - Baremetal
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job10
-    - job14
-    - job6
+    - job12
+    - job2
+    - job3
     - job7
     if: github.event.pull_request.draft == false
     steps:
@@ -4367,6 +4290,10 @@ jobs:
         flowey.exe e 23 flowey_lib_common::git_checkout 3
         flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
@@ -4374,10 +4301,6 @@ jobs:
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4502,9 +4425,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-logs
+        name: x64-windows-amd-snp-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4518,9 +4441,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-junit-xml
+        name: x64-windows-amd-snp-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4535,558 +4458,20 @@ jobs:
       run: flowey.exe e 23 flowey_lib_common::cache 11
       shell: bash
   job24:
-    name: run vmm-tests [x64-windows-amd]
+    name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job10
-    - job14
-    - job6
-    - job7
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 24 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 24 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 24 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 24 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 24 flowey_lib_common::cache 0
-        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 24 flowey_lib_common::cache 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 24 flowey_lib_common::git_checkout 0
-        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 24 flowey_lib_common::git_checkout 3
-        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 24 flowey_lib_common::cache 8
-        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 24 flowey_lib_common::cache 10
-        flowey.exe e 24 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 24 flowey_lib_common::cache 4
-        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 24 flowey_lib_common::cache 6
-        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 24 flowey_lib_common::publish_test_results 4
-        flowey.exe e 24 flowey_lib_common::publish_test_results 5
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 24 flowey_lib_common::publish_test_results 0
-        flowey.exe e 24 flowey_lib_common::publish_test_results 1
-        flowey.exe e 24 flowey_lib_common::publish_test_results 2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 24 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 24 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 24 flowey_lib_common::cache 11
-      shell: bash
-  job25:
-    name: run vmm-tests [x64-windows-amd-snp]
-    runs-on:
-    - self-hosted
-    - Windows
-    - X64
-    - SNP
-    - Baremetal
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job10
-    - job14
-    - job6
-    - job7
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 25 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 25 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 25 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 25 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 25 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 25 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 25 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 25 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 25 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 25 flowey_lib_common::cache 0
-        flowey.exe v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 25 flowey_lib_common::cache 2
-        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 25 flowey_lib_common::git_checkout 0
-        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 25 flowey_lib_common::git_checkout 3
-        flowey.exe e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 4
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 25 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 25 flowey_lib_common::cache 8
-        flowey.exe v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 25 flowey_lib_common::cache 10
-        flowey.exe e 25 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 25 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 25 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 25 flowey_lib_common::cache 4
-        flowey.exe v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 25 flowey_lib_common::cache 6
-        flowey.exe e 25 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 25 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 25 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 25 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 25 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 25 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 25 flowey_lib_common::publish_test_results 4
-        flowey.exe e 25 flowey_lib_common::publish_test_results 5
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 25 flowey_lib_common::publish_test_results 0
-        flowey.exe e 25 flowey_lib_common::publish_test_results 1
-        flowey.exe e 25 flowey_lib_common::publish_test_results 2
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 25 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 25 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 25 flowey_lib_common::cache 11
-      shell: bash
-  job26:
-    name: run vmm-tests [x64-linux-amd-kvm]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job10
-    - job11
-    - job6
+    - job2
+    - job3
+    - job9
     if: github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
@@ -5105,46 +4490,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 26 'verbose' update
+        cat <<'EOF' | flowey v 24 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 26 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 26 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 26 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 26 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 26 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 26 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 26 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 26 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 24 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 26 flowey_core::pipeline::artifact::resolve 3
-        flowey e 26 flowey_core::pipeline::artifact::resolve 4
-        flowey e 26 flowey_core::pipeline::artifact::resolve 7
-        flowey e 26 flowey_core::pipeline::artifact::resolve 1
-        flowey e 26 flowey_core::pipeline::artifact::resolve 0
-        flowey e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey e 26 flowey_core::pipeline::artifact::resolve 6
-        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 3
+        flowey e 24 flowey_core::pipeline::artifact::resolve 4
+        flowey e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey e 24 flowey_core::pipeline::artifact::resolve 1
+        flowey e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey e 24 flowey_core::pipeline::artifact::resolve 6
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 26 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 26 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 26 flowey_lib_common::download_gh_release 0
+      run: flowey e 24 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 26 flowey_lib_common::cache 8
-        flowey v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 24 flowey_lib_common::cache 8
+        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5154,31 +4539,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 26 flowey_lib_common::cache 10
-        flowey e 26 flowey_lib_common::download_gh_release 1
+        flowey e 24 flowey_lib_common::cache 10
+        flowey e 24 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 26 flowey_lib_common::download_azcopy 0
+      run: flowey e 24 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 26 flowey_lib_common::download_gh_cli 0
+      run: flowey e 24 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 26 flowey_lib_common::cache 4
-        flowey v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 24 flowey_lib_common::cache 4
+        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5188,54 +4573,54 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 26 flowey_lib_common::cache 6
-        flowey e 26 flowey_lib_common::download_gh_cli 1
-        flowey v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 24 flowey_lib_common::cache 6
+        flowey e 24 flowey_lib_common::download_gh_cli 1
+        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 26 flowey_lib_common::use_gh_cli 0
+      run: flowey e 24 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 26 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 24 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 26 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 26 flowey_lib_common::download_cargo_nextest 0
-        flowey e 26 flowey_lib_common::download_cargo_nextest 1
-        flowey e 26 flowey_lib_common::download_cargo_nextest 2
-        flowey e 26 flowey_lib_common::download_cargo_nextest 3
+        flowey e 24 flowey_lib_common::download_cargo_nextest 0
+        flowey e 24 flowey_lib_common::download_cargo_nextest 1
+        flowey e 24 flowey_lib_common::download_cargo_nextest 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 26 flowey_lib_common::cache 0
-        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 24 flowey_lib_common::cache 0
+        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5245,17 +4630,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 26 flowey_lib_common::cache 2
-        flowey e 26 flowey_lib_common::download_cargo_nextest 4
+        flowey e 24 flowey_lib_common::cache 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 26 flowey_lib_common::git_checkout 0
-        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_common::git_checkout 0
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5267,32 +4652,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 26 flowey_lib_common::git_checkout 3
-        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-        flowey e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 26 flowey_core::pipeline::artifact::resolve 5
-        flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey e 24 flowey_lib_common::git_checkout 3
+        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
     - name: generate nextest command
-      run: flowey e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 26 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 26 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 26 flowey_lib_common::publish_test_results 4
-        flowey e 26 flowey_lib_common::publish_test_results 5
-        flowey v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 24 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 24 flowey_lib_common::publish_test_results 4
+        flowey e 24 flowey_lib_common::publish_test_results 5
+        flowey v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5303,12 +4688,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 26 flowey_lib_common::publish_test_results 0
-        flowey e 26 flowey_lib_common::publish_test_results 1
-        flowey e 26 flowey_lib_common::publish_test_results 2
-        flowey v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 24 flowey_lib_common::publish_test_results 0
+        flowey e 24 flowey_lib_common::publish_test_results 1
+        flowey e 24 flowey_lib_common::publish_test_results 2
+        flowey v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5318,32 +4703,32 @@ jobs:
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 26 flowey_lib_common::cache 3
+      run: flowey e 24 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 26 flowey_lib_common::cache 7
+      run: flowey e 24 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 26 flowey_lib_common::cache 11
+      run: flowey e 24 flowey_lib_common::cache 11
       shell: bash
-  job27:
+  job25:
     name: run vmm-tests [x64-linux-intel-mshv]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job10
-    - job11
-    - job6
+    - job2
+    - job3
+    - job9
     if: github.event.pull_request.draft == false
     steps:
     - run: |
@@ -5410,46 +4795,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 27 'verbose' update
+        cat <<'EOF' | flowey v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 27 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 27 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 27 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 27 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 27 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 27 flowey_core::pipeline::artifact::resolve 1
-        flowey e 27 flowey_core::pipeline::artifact::resolve 2
-        flowey e 27 flowey_core::pipeline::artifact::resolve 7
-        flowey e 27 flowey_core::pipeline::artifact::resolve 3
-        flowey e 27 flowey_core::pipeline::artifact::resolve 0
-        flowey e 27 flowey_core::pipeline::artifact::resolve 4
-        flowey e 27 flowey_core::pipeline::artifact::resolve 6
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey e 25 flowey_core::pipeline::artifact::resolve 7
+        flowey e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 4
+        flowey e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 27 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 27 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 27 flowey_lib_common::download_gh_release 0
+      run: flowey e 25 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 27 flowey_lib_common::cache 8
-        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 25 flowey_lib_common::cache 8
+        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5459,31 +4844,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 27 flowey_lib_common::cache 10
-        flowey e 27 flowey_lib_common::download_gh_release 1
+        flowey e 25 flowey_lib_common::cache 10
+        flowey e 25 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 27 flowey_lib_common::download_azcopy 0
+      run: flowey e 25 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 27 flowey_lib_common::download_gh_cli 0
+      run: flowey e 25 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 27 flowey_lib_common::cache 4
-        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 25 flowey_lib_common::cache 4
+        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5493,51 +4878,51 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 27 flowey_lib_common::cache 6
-        flowey e 27 flowey_lib_common::download_gh_cli 1
-        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 25 flowey_lib_common::cache 6
+        flowey e 25 flowey_lib_common::download_gh_cli 1
+        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 27 flowey_lib_common::use_gh_cli 0
+      run: flowey e 25 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 27 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 25 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 27 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 27 flowey_lib_common::download_cargo_nextest 0
-        flowey e 27 flowey_lib_common::download_cargo_nextest 1
-        flowey e 27 flowey_lib_common::download_cargo_nextest 2
-        flowey e 27 flowey_lib_common::download_cargo_nextest 3
+        flowey e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 27 flowey_lib_common::cache 0
-        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 25 flowey_lib_common::cache 0
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5547,17 +4932,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 27 flowey_lib_common::cache 2
-        flowey e 27 flowey_lib_common::download_cargo_nextest 4
+        flowey e 25 flowey_lib_common::cache 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5569,31 +4954,31 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 27 flowey_lib_common::git_checkout 3
-        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 27 flowey_core::pipeline::artifact::resolve 5
-        flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 25 flowey_lib_common::git_checkout 3
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 25 flowey_core::pipeline::artifact::resolve 5
+        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: generate nextest command
-      run: flowey e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 27 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 27 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 27 flowey_lib_common::publish_test_results 4
-        flowey e 27 flowey_lib_common::publish_test_results 5
-        flowey v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 25 flowey_lib_common::publish_test_results 4
+        flowey e 25 flowey_lib_common::publish_test_results 5
+        flowey v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5604,12 +4989,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 27 flowey_lib_common::publish_test_results 0
-        flowey e 27 flowey_lib_common::publish_test_results 1
-        flowey e 27 flowey_lib_common::publish_test_results 2
-        flowey v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 25 flowey_lib_common::publish_test_results 0
+        flowey e 25 flowey_lib_common::publish_test_results 1
+        flowey e 25 flowey_lib_common::publish_test_results 2
+        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5619,18 +5004,18 @@ jobs:
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 27 flowey_lib_common::cache 3
+      run: flowey e 25 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 27 flowey_lib_common::cache 7
+      run: flowey e 25 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 27 flowey_lib_common::cache 11
+      run: flowey e 25 flowey_lib_common::cache 11
       shell: bash
-  job28:
+  job26:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -5642,10 +5027,10 @@ jobs:
       id-token: write
     needs:
     - job0
-    - job12
+    - job10
+    - job2
     - job3
-    - job4
-    - job8
+    - job5
     if: github.event.pull_request.draft == false
     steps:
     - run: |
@@ -5713,35 +5098,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 28 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 28 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 28 'verbose' update
+        cat <<'EOF' | flowey.exe v 26 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 28 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 28 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 28 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 28 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 28 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 28 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 28 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 28 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 28 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 28 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 26 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 28 flowey_lib_common::cache 0
-        flowey.exe v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 26 flowey_lib_common::cache 0
+        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5751,17 +5136,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 28 flowey_lib_common::cache 2
-        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 26 flowey_lib_common::cache 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 28 flowey_lib_common::git_checkout 0
-        flowey.exe v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_common::git_checkout 0
+        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5773,35 +5158,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 28 flowey_lib_common::git_checkout 3
-        flowey.exe e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 26 flowey_lib_common::git_checkout 3
+        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 28 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 28 flowey_lib_common::cache 8
-        flowey.exe v 28 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 28 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 26 flowey_lib_common::cache 8
+        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5811,31 +5196,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 28 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 28 flowey_lib_common::cache 10
-        flowey.exe e 28 flowey_lib_common::download_gh_release 1
+        flowey.exe e 26 flowey_lib_common::cache 10
+        flowey.exe e 26 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 28 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 26 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 28 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 28 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 28 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 28 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 28 flowey_lib_common::cache 4
-        flowey.exe v 28 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 28 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 26 flowey_lib_common::cache 4
+        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5845,63 +5230,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 28 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 28 flowey_lib_common::cache 6
-        flowey.exe e 28 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 28 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 26 flowey_lib_common::cache 6
+        flowey.exe e 26 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 28 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 26 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 28 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 28 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 28 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 28 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 28 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 28 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 28 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 28 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 28 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 28 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 28 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 28 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 28 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 28 flowey_lib_common::publish_test_results 4
-        flowey.exe e 28 flowey_lib_common::publish_test_results 5
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 26 flowey_lib_common::publish_test_results 4
+        flowey.exe e 26 flowey_lib_common::publish_test_results 5
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5912,12 +5297,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 28 flowey_lib_common::publish_test_results 0
-        flowey.exe e 28 flowey_lib_common::publish_test_results 1
-        flowey.exe e 28 flowey_lib_common::publish_test_results 2
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 26 flowey_lib_common::publish_test_results 0
+        flowey.exe e 26 flowey_lib_common::publish_test_results 1
+        flowey.exe e 26 flowey_lib_common::publish_test_results 2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5927,18 +5312,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 28 flowey_lib_common::cache 3
+      run: flowey.exe e 26 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 28 flowey_lib_common::cache 7
+      run: flowey.exe e 26 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 28 flowey_lib_common::cache 11
+      run: flowey.exe e 26 flowey_lib_common::cache 11
       shell: bash
-  job29:
+  job27:
     name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
@@ -5964,18 +5349,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 29 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 29 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 29 'verbose' update
+        cat <<'EOF' | flowey v 27 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 29 flowey_lib_common::git_checkout 0
-        flowey v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 27 flowey_lib_common::git_checkout 0
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5987,203 +5372,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 29 flowey_lib_common::git_checkout 3
-        flowey e 29 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 27 flowey_lib_common::git_checkout 3
+        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 29 flowey_lib_common::install_rust 0
+      run: flowey e 27 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 29 flowey_lib_common::install_rust 1
+      run: flowey e 27 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 29 flowey_lib_common::install_rust 2
-        flowey v 29 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 27 flowey_lib_common::install_rust 2
+        flowey v 27 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 29 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      run: flowey e 27 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
-  job3:
-    name: build artifacts (shared VMM tests) [aarch64-windows]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
-
-        echo '"debug"' | flowey.exe v 3 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 3 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 3 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-pipette"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-pipette" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-pipette' --is-raw-string update
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey.exe e 3 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey.exe e 3 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey.exe e 3 flowey_lib_common::install_rust 2
-        flowey.exe e 3 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 3 flowey_lib_common::git_checkout 0
-        flowey.exe v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 3 flowey_lib_common::git_checkout 3
-        flowey.exe e 3 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 3 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 3 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 3 flowey_lib_common::cache 0
-        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 3 flowey_lib_common::cache 2
-        flowey.exe e 3 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey.exe e 3 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 3 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey.exe e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey.exe e 3 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 3 flowey_lib_hvlite::build_pipette 0
-        flowey.exe e 3 flowey_core::pipeline::artifact::publish 0
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 3 flowey_lib_common::cache 3
-      shell: bash
-    - name: 🌼📦 Publish aarch64-windows-pipette
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-pipette
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-pipette/
-        include-hidden-files: true
-  job30:
+  job28:
     name: build openhcl (mi-secure) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job30-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job28-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -6207,31 +5424,31 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 30 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 30 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 30 'verbose' update
+        cat <<'EOF' | flowey v 28 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 30 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 30 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 30 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 28 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 30 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 28 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 30 flowey_lib_common::download_gh_release 0
+      run: flowey e 28 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 30 flowey_lib_common::cache 0
-        flowey v 30 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 30 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey e 28 flowey_lib_common::cache 0
+        flowey v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6241,31 +5458,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 30 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 30 flowey_lib_common::cache 2
-        flowey e 30 flowey_lib_common::download_gh_release 1
+        flowey e 28 flowey_lib_common::cache 2
+        flowey e 28 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 30 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 28 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 30 flowey_lib_common::install_rust 0
+      run: flowey e 28 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 30 flowey_lib_common::install_rust 1
+      run: flowey e 28 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 30 flowey_lib_common::install_rust 2
-        flowey e 30 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 28 flowey_lib_common::install_rust 2
+        flowey e 28 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 30 flowey_lib_common::git_checkout 0
-        flowey v 30 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 30 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 28 flowey_lib_common::git_checkout 0
+        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6277,172 +5494,172 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 30 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 30 flowey_lib_common::git_checkout 3
-        flowey e 30 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 28 flowey_lib_common::git_checkout 3
+        flowey e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 30 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 28 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 30 flowey_lib_common::resolve_protoc 0
-        flowey e 30 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 28 flowey_lib_common::resolve_protoc 0
+        flowey e 28 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 30 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 30 flowey_lib_hvlite::init_cross_build 0
-        flowey e 30 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 30 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 28 flowey_lib_hvlite::init_cross_build 0
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: cargo build sidecar
       run: |-
-        flowey e 30 flowey_lib_common::run_cargo_build 3
-        flowey e 30 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 28 flowey_lib_common::run_cargo_build 3
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 30 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 30 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 30 flowey_lib_hvlite::build_sidecar 0
-        flowey e 30 flowey_lib_hvlite::init_cross_build 1
-        flowey e 30 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 30 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 28 flowey_lib_hvlite::build_sidecar 0
+        flowey e 28 flowey_lib_hvlite::init_cross_build 1
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: cargo build openhcl_boot
       run: |-
-        flowey e 30 flowey_lib_common::run_cargo_build 1
-        flowey e 30 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 28 flowey_lib_common::run_cargo_build 1
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 30 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 30 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 30 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 28 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 30 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: |-
-        flowey e 30 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 30 flowey_lib_hvlite::init_cross_build 3
+        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 28 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
-        flowey e 30 flowey_lib_common::run_cargo_build 2
-        flowey e 30 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 30 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 28 flowey_lib_common::run_cargo_build 2
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 28 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 30 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 30 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 30 flowey_lib_hvlite::init_cross_build 2
+        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 28 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
-        flowey e 30 flowey_lib_common::run_cargo_build 0
-        flowey e 30 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 28 flowey_lib_common::run_cargo_build 0
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 30 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 30 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 30 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 28 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 28 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 30 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 30 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 30 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 28 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
-        flowey e 30 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 30 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 30 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 30 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 30 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 30 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 28 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 30 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 30 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 30 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 30 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
       run: |-
-        flowey e 30 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 30 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 30 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 30 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 30 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 30 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 28 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 30 flowey_lib_common::copy_to_artifact_dir 0
+      run: flowey e 28 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 30 flowey_lib_common::cache 3
+      run: flowey e 28 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
       uses: actions/upload-artifact@v7
@@ -6456,21 +5673,21 @@ jobs:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
         include-hidden-files: true
-  job31:
+  job29:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job31-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job29-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job10
-    - job30
-    - job6
+    - job2
+    - job28
+    - job3
     - job7
     if: github.event.pull_request.draft == false
     steps:
@@ -6490,39 +5707,39 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
 
-        echo '"debug"' | flowey.exe v 31 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 31 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 29 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 29 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 31 'verbose' update
+        cat <<'EOF' | flowey.exe v 29 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 31 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 31 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 31 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 31 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 31 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 31 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 31 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 31 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 31 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 31 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 31 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 31 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 31 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 31 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 29 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 29 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 29 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 29 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 29 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 29 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 29 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 29 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 29 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 31 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 31 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 31 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 31 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 31 flowey_lib_common::cache 0
-        flowey.exe v 31 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 31 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 29 flowey_lib_common::cache 0
+        flowey.exe v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6532,17 +5749,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 31 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 31 flowey_lib_common::cache 2
-        flowey.exe e 31 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 29 flowey_lib_common::cache 2
+        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 31 flowey_lib_common::git_checkout 0
-        flowey.exe v 31 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 31 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 29 flowey_lib_common::git_checkout 0
+        flowey.exe v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6554,38 +5771,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 31 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 31 flowey_lib_common::git_checkout 3
-        flowey.exe e 31 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 31 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 29 flowey_lib_common::git_checkout 3
+        flowey.exe e 29 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 31 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 31 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 29 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 31 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 29 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 31 flowey_lib_common::cache 8
-        flowey.exe v 31 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 31 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 29 flowey_lib_common::cache 8
+        flowey.exe v 29 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 29 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -6595,31 +5812,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 31 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 29 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 31 flowey_lib_common::cache 10
-        flowey.exe e 31 flowey_lib_common::download_gh_release 1
+        flowey.exe e 29 flowey_lib_common::cache 10
+        flowey.exe e 29 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 31 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 29 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 31 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 31 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 31 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 31 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 29 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 31 flowey_lib_common::cache 4
-        flowey.exe v 31 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 31 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 29 flowey_lib_common::cache 4
+        flowey.exe v 29 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 29 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -6629,63 +5846,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 31 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 29 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 31 flowey_lib_common::cache 6
-        flowey.exe e 31 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 31 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 29 flowey_lib_common::cache 6
+        flowey.exe e 29 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 31 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 29 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 31 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 29 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 31 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 29 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 31 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 29 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 31 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 29 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 31 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 29 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 31 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 31 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 31 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 31 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 29 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 29 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 31 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 29 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 31 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 29 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 31 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 29 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 31 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 31 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 31 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 31 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 31 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 31 flowey_lib_common::publish_test_results 4
-        flowey.exe e 31 flowey_lib_common::publish_test_results 5
-        flowey.exe v 31 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 31 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 29 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 29 flowey_lib_common::publish_test_results 4
+        flowey.exe e 29 flowey_lib_common::publish_test_results 5
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -6696,12 +5913,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 31 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 31 flowey_lib_common::publish_test_results 0
-        flowey.exe e 31 flowey_lib_common::publish_test_results 1
-        flowey.exe e 31 flowey_lib_common::publish_test_results 2
-        flowey.exe v 31 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 31 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 29 flowey_lib_common::publish_test_results 0
+        flowey.exe e 29 flowey_lib_common::publish_test_results 1
+        flowey.exe e 29 flowey_lib_common::publish_test_results 2
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -6711,18 +5928,352 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 31 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 31 flowey_lib_common::cache 3
+      run: flowey.exe e 29 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 31 flowey_lib_common::cache 7
+      run: flowey.exe e 29 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 31 flowey_lib_common::cache 11
+      run: flowey.exe e 29 flowey_lib_common::cache 11
       shell: bash
-  job32:
+  job3:
+    name: build artifacts (shared VMM tests) [linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 3 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 3 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 3 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 3 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 3 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 3 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests" | flowey v 3 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 3 'artifact_publish_from_aarch64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 3 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 3 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 3 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-tpm_guest_tests" | flowey v 3 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 3 'artifact_publish_from_x64-tmks' --is-raw-string update
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 3 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 3 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 3 flowey_lib_common::install_rust 2
+        flowey e 3 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 3 flowey_lib_common::git_checkout 0
+        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 3 flowey_lib_common::git_checkout 3
+        flowey e 3 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 3 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 3 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 3 flowey_lib_common::cache 0
+        flowey v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 3 flowey_lib_common::cache 2
+        flowey e 3 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 3 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 3 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 3 flowey_lib_common::resolve_protoc 0
+        flowey e 3 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: flowey e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 3 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 3 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 1
+        flowey e 3 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 6
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 14
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 15
+        flowey e 3 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 3 flowey_core::pipeline::artifact::publish 6
+        flowey e 3 flowey_lib_hvlite::init_cross_build 9
+      shell: bash
+    - name: cargo build guest_test_uefi
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 1
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 1
+      shell: bash
+    - name: build guest_test_uefi.img
+      run: |-
+        flowey e 3 flowey_lib_hvlite::build_guest_test_uefi 0
+        flowey e 3 flowey_core::pipeline::artifact::publish 7
+        flowey e 3 flowey_lib_hvlite::init_cross_build 5
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: cargo build simple_tmk
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 4
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 12
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 3 flowey_lib_hvlite::build_tmks 0
+        flowey e 3 flowey_core::pipeline::artifact::publish 8
+        flowey e 3 flowey_lib_hvlite::init_cross_build 6
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 9
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 20
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 21
+        flowey e 3 flowey_lib_hvlite::build_tpm_guest_tests 1
+        flowey e 3 flowey_core::pipeline::artifact::publish 9
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 3 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 3 flowey_lib_hvlite::init_cross_build 7
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 3
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 3 flowey_lib_hvlite::build_pipette 1
+        flowey e 3 flowey_core::pipeline::artifact::publish 0
+        flowey e 3 flowey_lib_hvlite::init_cross_build 8
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 7
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 16
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 17
+        flowey e 3 flowey_lib_hvlite::build_tmk_vmm 1
+        flowey e 3 flowey_core::pipeline::artifact::publish 1
+        flowey e 3 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build guest_test_uefi
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 0
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: build guest_test_uefi.img
+      run: |-
+        flowey e 3 flowey_lib_hvlite::build_guest_test_uefi 1
+        flowey e 3 flowey_core::pipeline::artifact::publish 2
+        flowey e 3 flowey_lib_hvlite::init_cross_build 0
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build simple_tmk
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 5
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 3 flowey_lib_hvlite::build_tmks 1
+        flowey e 3 flowey_core::pipeline::artifact::publish 3
+        flowey e 3 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 8
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 18
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 19
+        flowey e 3 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey e 3 flowey_core::pipeline::artifact::publish 4
+        flowey e 3 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build pipette
+      run: |-
+        flowey e 3 flowey_lib_common::run_cargo_build 2
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 3 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 3 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 3 flowey_lib_hvlite::build_pipette 0
+        flowey e 3 flowey_core::pipeline::artifact::publish 5
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 3 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish aarch64-guest_test_uefi
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-guest_test_uefi
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-musl-pipette
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-tmks
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-guest_test_uefi
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-guest_test_uefi
+        path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-pipette
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-pipette
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-tmks
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
+        include-hidden-files: true
+  job30:
     name: openvmm checkin gates
     runs-on: ubuntu-latest
     permissions:
@@ -6753,8 +6304,6 @@ jobs:
     - job28
     - job29
     - job3
-    - job30
-    - job31
     - job4
     - job5
     - job6
@@ -6781,18 +6330,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 32 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 32 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 30 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 30 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 32 'verbose' update
+        cat <<'EOF' | flowey v 30 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: Check if any jobs failed
-      run: flowey e 32 flowey_lib_hvlite::_jobs::all_good_job 0
+      run: flowey e 30 flowey_lib_hvlite::_jobs::all_good_job 0
       shell: bash
   job4:
-    name: build artifacts (for VMM tests) [aarch64-windows]
+    name: build artifacts (not for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -6871,20 +6420,14 @@ jobs:
         cat <<'EOF' | flowey.exe v 4 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-prep_steps"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-prep_steps" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-test_igvm_agent_rpc_server" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tpm_guest_tests"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tpm_guest_tests" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-hypestv"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-hypestv" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-hypestv' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-igvmfilegen"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-igvmfilegen" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-ohcldiag-dev"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-ohcldiag-dev" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgs_lib"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgs_lib" | flowey.exe v 4 'artifact_publish_from_aarch64-windows-vmgs_lib' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 4 flowey_lib_common::install_rust 0
@@ -6927,22 +6470,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 4 flowey_lib_common::cache 4
-        flowey.exe v 4 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 4 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 4 flowey_lib_common::cache 0
+        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
-    - id: flowey_lib_common__cache__5
+    - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 4 flowey_lib_common::cache 6
+        flowey.exe e 4 flowey_lib_common::cache 2
         flowey.exe e 4 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -6955,148 +6498,67 @@ jobs:
         flowey.exe e 4 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey.exe e 4 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build tmk_vmm
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 5
-        flowey.exe e 4 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 3
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build prep_steps
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 4 flowey_lib_hvlite::build_prep_steps 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 4
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 5
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 9
-        flowey.exe e 4 flowey_lib_hvlite::build_vmgstool 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 5
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 6
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 4
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 8
-        flowey.exe e 4 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 6
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 6
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_build 2
-        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 4
-        flowey.exe e 4 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 0
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 4 flowey_lib_common::cache 0
-        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 4 flowey_lib_common::cache 2
-        flowey.exe e 4 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey.exe e 4 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey.exe e 4 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: build + archive 'vmm_tests' nextests
-      run: |-
-        flowey.exe e 4 flowey_lib_common::run_cargo_nextest_archive 0
-        flowey.exe e 4 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build openvmm
+    - name: cargo build hypestv
       run: |-
         flowey.exe e 4 flowey_lib_common::run_cargo_build 0
         flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 4 flowey_lib_hvlite::build_openvmm 0
-        flowey.exe e 4 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 4 flowey_lib_hvlite::build_hypestv 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 0
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 0
       shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 4 flowey_lib_common::cache 3
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey.exe e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 4 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build ohcldiag-dev
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 2
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 4 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey.exe e 4 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 4 flowey_lib_common::cache 7
+      run: flowey.exe e 4 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish aarch64-windows-openvmm
+    - name: 🌼📦 Publish aarch64-windows-hypestv
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-openvmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-openvmm/
+        name: aarch64-windows-hypestv
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-hypestv/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-prep_steps
+    - name: 🌼📦 Publish aarch64-windows-igvmfilegen
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-prep_steps
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-prep_steps/
+        name: aarch64-windows-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-igvmfilegen/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
+    - name: 🌼📦 Publish aarch64-windows-ohcldiag-dev
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-test_igvm_agent_rpc_server
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server/
+        name: aarch64-windows-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-ohcldiag-dev/
         include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-tmk_vmm
+    - name: 🌼📦 Publish aarch64-windows-vmgs_lib
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-tpm_guest_tests
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-vmgstool
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-vmgstool
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-windows-vmm-tests-archive
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-windows-vmm-tests-archive
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmm-tests-archive/
+        name: aarch64-windows-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
         include-hidden-files: true
   job5:
-    name: build artifacts (not for VMM tests) [x64-windows]
+    name: build artifacts (for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7175,14 +6637,20 @@ jobs:
         cat <<'EOF' | flowey.exe v 5 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 5 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 5 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 5 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-prep_steps"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-prep_steps" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-test_igvm_agent_rpc_server" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tpm_guest_tests"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tpm_guest_tests" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 5 flowey_lib_common::install_rust 0
@@ -7225,22 +6693,22 @@ jobs:
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 5 flowey_lib_common::cache 0
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe e 5 flowey_lib_common::cache 4
+        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
-    - id: flowey_lib_common__cache__1
+    - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 5 flowey_lib_common::cache 2
+        flowey.exe e 5 flowey_lib_common::cache 6
         flowey.exe e 5 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
@@ -7251,73 +6719,150 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 5 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: cargo build hypestv
+    - name: cargo build openvmm
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 0
         flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 5 flowey_lib_hvlite::build_hypestv 0
+        flowey.exe e 5 flowey_lib_hvlite::build_openvmm 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build vmgs_lib
+    - name: cargo build tmk_vmm
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
-        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      shell: bash
-    - name: test vmgs_lib
-      run: |-
-        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 5
+        flowey.exe e 5 flowey_lib_hvlite::build_tmk_vmm 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 5
       shell: bash
-    - name: cargo build igvmfilegen
+    - name: cargo build prep_steps
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 1
         flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 5 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey.exe e 5 flowey_lib_hvlite::build_prep_steps 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 2
         flowey.exe e 5 flowey_lib_hvlite::init_cross_build 3
       shell: bash
-    - name: cargo build ohcldiag-dev
+    - name: cargo build vmgstool
+      run: |-
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 5
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 9
+        flowey.exe e 5 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 5 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 6
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build tpm_guest_tests
+      run: |-
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 8
+        flowey.exe e 5 flowey_lib_hvlite::build_tpm_guest_tests 0
+        flowey.exe e 5 flowey_core::pipeline::artifact::publish 4
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 6
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 5 flowey_lib_common::run_cargo_build 2
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 2
-        flowey.exe e 5 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey.exe e 5 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 5 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
+        flowey.exe e 5 flowey_core::pipeline::artifact::publish 5
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 5 flowey_lib_common::cache 0
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 5 flowey_lib_common::cache 2
+        flowey.exe e 5 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 5 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey.exe e 5 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey.exe e 5 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey.exe e 5 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey.exe e 5 flowey_core::pipeline::artifact::publish 6
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 5 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-windows-hypestv
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 5 flowey_lib_common::cache 7
+      shell: bash
+    - name: 🌼📦 Publish aarch64-windows-openvmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-hypestv
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-hypestv/
+        name: aarch64-windows-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-openvmm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-igvmfilegen
+    - name: 🌼📦 Publish aarch64-windows-prep_steps
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-igvmfilegen
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-igvmfilegen/
+        name: aarch64-windows-prep_steps
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-prep_steps/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-ohcldiag-dev
+    - name: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-ohcldiag-dev
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
+        name: aarch64-windows-test_igvm_agent_rpc_server
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-windows-vmgs_lib
+    - name: 🌼📦 Publish aarch64-windows-tmk_vmm
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-vmgs_lib
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
+        name: aarch64-windows-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-tpm_guest_tests
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-tpm_guest_tests
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tpm_guest_tests/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-windows-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmm-tests-archive/
         include-hidden-files: true
   job6:
-    name: build artifacts (shared VMM tests) [x64-windows]
+    name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7396,8 +6941,14 @@ jobs:
         cat <<'EOF' | flowey.exe v 6 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-pipette"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 6 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 6 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 6 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 6 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 6 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 6 flowey_lib_common::install_rust 0
@@ -7466,23 +7017,70 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 1
       shell: bash
-    - name: cargo build pipette
+    - name: cargo build hypestv
       run: |-
         flowey.exe e 6 flowey_lib_common::run_cargo_build 0
         flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 6 flowey_lib_hvlite::build_pipette 0
+        flowey.exe e 6 flowey_lib_hvlite::build_hypestv 0
         flowey.exe e 6 flowey_core::pipeline::artifact::publish 0
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      shell: bash
+    - name: test vmgs_lib
+      run: |-
+        flowey.exe e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey.exe e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey.exe e 6 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 6 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey.exe e 6 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build ohcldiag-dev
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 2
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 6 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey.exe e 6 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey.exe e 6 flowey_lib_common::cache 3
       shell: bash
-    - name: 🌼📦 Publish x64-windows-pipette
+    - name: 🌼📦 Publish x64-windows-hypestv
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-pipette
-        path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
+        name: x64-windows-hypestv
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-hypestv/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-igvmfilegen
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-ohcldiag-dev
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-windows-vmgs_lib
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
         include-hidden-files: true
   job7:
     name: build artifacts (for VMM tests) [x64-windows]
@@ -7797,7 +7395,7 @@ jobs:
         name: _internal-flowey-bootstrap-x86_64-windows-uid-6
         path: ${{ runner.temp }}/bootstrapped-flowey
   job8:
-    name: build artifacts (shared VMM tests) [aarch64-linux]
+    name: build artifacts (for VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -7832,16 +7430,22 @@ jobs:
         cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 8 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-tpm_guest_tests" | flowey v 8 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 8 'artifact_publish_from_aarch64-tmks' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 8 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 8 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 8 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 8 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 8 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 8 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 8 flowey_lib_common::install_rust 0
@@ -7853,6 +7457,12 @@ jobs:
       run: |-
         flowey e 8 flowey_lib_common::install_rust 2
         flowey e 8 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 8 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 8 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
@@ -7902,12 +7512,6 @@ jobs:
         flowey e 8 flowey_lib_common::cache 2
         flowey e 8 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 8 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 8 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 8 flowey_lib_common::resolve_protoc 0
@@ -7916,45 +7520,80 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 8 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 8 flowey_lib_hvlite::build_openvmm 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 0
+        flowey e 8 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 4
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 1
         flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
-    - name: cargo build guest_test_uefi
+    - name: cargo build vmgstool
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 8 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 2
+        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 8 flowey_core::pipeline::artifact::publish 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build igvmfilegen
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 0
         flowey e 8 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
-    - name: build guest_test_uefi.img
+    - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::build_guest_test_uefi 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 0
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
       shell: bash
-    - name: cargo build simple_tmk
+    - name: cargo build ohcldiag-dev
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 8 flowey_lib_common::run_cargo_build 1
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 8 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::build_tmks 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 1
-        flowey e 8 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build tpm_guest_tests
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 4
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 8 flowey_lib_hvlite::build_tpm_guest_tests 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 8 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 8 flowey_lib_hvlite::resolve_openvmm_deps 0
@@ -7962,302 +7601,35 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 6
       shell: bash
-    - name: cargo build pipette
-      run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 1
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 8 flowey_lib_hvlite::build_pipette 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 3
-        flowey e 8 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build tmk_vmm
+    - name: cargo build openvmm
       run: |-
         flowey e 8 flowey_lib_common::run_cargo_build 3
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 8 flowey_lib_hvlite::build_tmk_vmm 0
-        flowey e 8 flowey_core::pipeline::artifact::publish 4
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::build_openvmm 1
+        flowey e 8 flowey_core::pipeline::artifact::publish 6
+        flowey e 8 flowey_lib_hvlite::init_cross_build 7
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 10
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 1
+        flowey e 8 flowey_core::pipeline::artifact::publish 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
-      shell: bash
-    - name: 🌼📦 Publish aarch64-guest_test_uefi
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-guest_test_uefi
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-pipette
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-pipette
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-tmk_vmm
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-linux-tpm_guest_tests
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-tpm_guest_tests
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-tpm_guest_tests/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-tmks
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-tmks
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
-        include-hidden-files: true
-  job9:
-    name: build artifacts (for VMM tests) [aarch64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 9 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 9 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 9 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 9 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 9 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 9 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 9 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 9 flowey_lib_common::install_rust 2
-        flowey e 9 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 9 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 9 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 9 flowey_lib_common::git_checkout 3
-        flowey e 9 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 9 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 9 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 9 flowey_lib_common::cache 2
-        flowey e 9 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 9 flowey_lib_common::resolve_protoc 0
-        flowey e 9 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 2
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::build_openvmm 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 4
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build vmgstool
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 7
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
-        flowey e 9 flowey_lib_hvlite::build_vmgstool 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build vmgs_lib
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-        flowey e 9 flowey_core::pipeline::artifact::publish 3
-        flowey e 9 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 0
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: cargo build ohcldiag-dev
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 1
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 9 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 5
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
-      shell: bash
-    - name: cargo build openvmm
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 3
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 9 flowey_lib_hvlite::build_openvmm 1
-        flowey e 9 flowey_core::pipeline::artifact::publish 6
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
-      shell: bash
-    - name: cargo build openvmm_vhost
-      run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
-        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
-        flowey e 9 flowey_core::pipeline::artifact::publish 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 9 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish aarch64-linux-igvmfilegen
       uses: actions/upload-artifact@v7
@@ -8306,4 +7678,360 @@ jobs:
       with:
         name: aarch64-linux-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
+        include-hidden-files: true
+  job9:
+    name: build artifacts (for VMM tests) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 9 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 9 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 9 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 9 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 9 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 9 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 9 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 9 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 9 flowey_lib_common::install_rust 2
+        flowey e 9 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 9 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 9 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 9 flowey_lib_common::git_checkout 0
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 9 flowey_lib_common::git_checkout 3
+        flowey e 9 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 9 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 9 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 9 flowey_lib_common::cache 4
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 9 flowey_lib_common::cache 6
+        flowey e 9 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 9 flowey_lib_common::resolve_protoc 0
+        flowey e 9 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 2
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::build_openvmm 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+      shell: bash
+    - name: cargo build vmgstool
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 9 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build vmgs_lib
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      shell: bash
+    - name: test vmgs_lib
+      run: |-
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey e 9 flowey_core::pipeline::artifact::publish 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 0
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+      shell: bash
+    - name: cargo build ohcldiag-dev
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 1
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 5
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+      shell: bash
+    - name: cargo build openvmm
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::build_openvmm 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+      shell: bash
+    - name: cargo build openvmm_vhost
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 7
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 9 flowey_lib_common::download_cargo_nextest 0
+        flowey e 9 flowey_lib_common::download_cargo_nextest 1
+        flowey e 9 flowey_lib_common::download_cargo_nextest 2
+        flowey e 9 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 9 flowey_lib_common::cache 0
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 9 flowey_lib_common::cache 2
+        flowey e 9 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 9 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 9 flowey_lib_common::install_cargo_nextest 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 8
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+      shell: bash
+    - name: build + archive 'vmm_tests' nextests
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_nextest_archive 1
+        flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
+        flowey e 9 flowey_core::pipeline::artifact::publish 9
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 9 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 9 flowey_lib_common::cache 7
+      shell: bash
+    - name: 🌼📦 Publish x64-linux-igvmfilegen
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-igvmfilegen
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-vmm-tests-archive/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-ohcldiag-dev
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-ohcldiag-dev
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-openvmm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-openvmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-openvmm_vhost
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-openvmm_vhost
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgs_lib
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgs_lib
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmgstool
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmgstool
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-vmm-tests-archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-vmm-tests-archive
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
         include-hidden-files: true

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -212,7 +212,7 @@ jobs:
   - publish: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
     displayName: 🌼🥾 Publish bootstrapped flowey
     artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
-- job: job18
+- job: job20
   displayName: build openhcl (mi-secure) [x64-linux]
   pool:
     demands:
@@ -242,28 +242,28 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 18 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 18 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 20 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 20 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 18 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 20 'verbose' update
       ${{ parameters.verbose }}
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 18 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 20 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | $FLOWEY_BIN v 18 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | $FLOWEY_BIN v 20 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::install_dist_pkg 0
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::install_dist_pkg 0
     displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::install_dist_pkg 1
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::install_dist_pkg 1
     displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+      $(FLOWEY_BIN) e 20 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -273,27 +273,27 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 20 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::install_rust 0
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 18 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 20 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 20 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 20 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -305,165 +305,165 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 20 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      $(FLOWEY_BIN) e 20 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 8
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 20 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 9
     displayName: cargo build sidecar
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 10
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_sidecar 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_sidecar 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 3
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 4
+      $(FLOWEY_BIN) e 20 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 4
     displayName: cargo build openhcl_boot
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 5
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_boot 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_boot 0
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
     displayName: extract and resolve kernel package
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::init_cross_build 3
     displayName: extract X86_64 sysroot.tar.gz
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      $(FLOWEY_BIN) e 20 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
     displayName: cargo build openvmm_hcl
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_initrd 2
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_initrd 2
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::init_cross_build 2
     displayName: building openhcl initrd
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 20 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 0
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 5
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_igvmfilegen 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_igvmfilegen 2
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_igvmfilegen 2
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
     displayName: building igvm file
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
     displayName: unpack mu_msvm package (x64)
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
     displayName: extract and resolve kernel package
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_initrd 1
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
     displayName: building openhcl initrd
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_igvmfilegen 1
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
     displayName: building igvm file
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_initrd 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_initrd 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
     displayName: building openhcl initrd
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_igvmfilegen 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
     displayName: building igvm file
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::copy_to_artifact_dir 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      $(FLOWEY_BIN) e 20 flowey_lib_common::copy_to_artifact_dir 1
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
     displayName: copying OpenHCL igvm files to artifact dir
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::copy_to_artifact_dir 0
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::copy_to_artifact_dir 0
     displayName: copying OpenHCL igvm extras to artifact dir
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm
     displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm
@@ -471,7 +471,7 @@ jobs:
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras
     displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
     artifact: x64-mi-secure-openhcl-igvm-extras
-- job: job14
+- job: job16
   displayName: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
   pool:
     demands:
@@ -501,25 +501,25 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 14 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 14 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 16 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 16 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 14 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 16 'verbose' update
       ${{ parameters.verbose }}
       EOF
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 14 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 16 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 16 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
+      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -531,21 +531,21 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_dist_pkg 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::install_dist_pkg 0
     displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_dist_pkg 1
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::install_dist_pkg 1
     displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
+      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -555,68 +555,68 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
     displayName: extract X86_64 sysroot.tar.gz
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::resolve_protoc 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::resolve_protoc 0
     displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_cross_build 2
     displayName: symlink protoc
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 4
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_clippy 4
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 1
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 6
-    displayName: cargo clippy
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 5
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_clippy 6
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_clippy 5
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_cross_build 0
+    displayName: cargo clippy
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 0
     displayName: cargo build xtask
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_xtask 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_xtask 0
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::check_clippy 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::check_clippy 0
     displayName: determine clippy exclusions
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_clippy 0
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 2
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_clippy 2
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 3
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_clippy 3
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
+      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -626,33 +626,33 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 2
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::install_rust 2
     displayName: report $CARGO_HOME
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 3
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 16 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 4
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 5
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 5
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 6
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 4
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 6
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 4
+      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (openssl)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -661,18 +661,18 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (openssl)
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 6
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 7
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 7
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 8
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 6
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 7
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 7
+      $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 8
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 6
+      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
+      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (symcrypt)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -681,18 +681,18 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 9
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 8
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 9
+      $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 2
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 8
+      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (all)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -703,30 +703,30 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 2
     displayName: cargo build xtask
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_xtask 1
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_xtask 1
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 8
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 9
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 8
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 9
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -735,18 +735,18 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-unit-tests
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 3
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 4
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 3
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 4
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 2
+      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (none)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -757,16 +757,16 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
     displayName: run doctests for x86_64-unknown-linux-musl
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job13
+- job: job15
   displayName: clippy [macos], unit tests [x64-linux]
   pool:
     demands:
@@ -796,29 +796,29 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 13 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 13 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 15 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 15 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 13 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 15 'verbose' update
       ${{ parameters.verbose }}
       EOF
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_dist_pkg 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_dist_pkg 0
     displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_dist_pkg 1
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_dist_pkg 1
     displayName: installing packages
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar9
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar9
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -830,18 +830,18 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -851,52 +851,52 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 1
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_build 0
     displayName: cargo build xtask
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_xtask 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_xtask 0
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::check_clippy 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::check_clippy 0
     displayName: determine clippy exclusions
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_clippy 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 0
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_clippy 1
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -906,33 +906,33 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 2
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_rust 2
     displayName: report $CARGO_HOME
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 5
-      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 4
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (all)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -943,30 +943,30 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 2
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_build 2
     displayName: cargo build xtask
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_xtask 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_xtask 1
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 6
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 7
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 7
-      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 6
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 7
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 7
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 6
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -975,18 +975,18 @@ jobs:
       testRunTitle: x64-linux-unit-tests-unit-tests
     displayName: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 2
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 3
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 4
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 3
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 4
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (none)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -995,18 +995,18 @@ jobs:
       testRunTitle: x64-linux-unit-tests-unit-tests crypto (none)
     displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 4
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 5
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 6
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 4
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 6
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 2
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (openssl)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1017,16 +1017,16 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
     displayName: run doctests for x86_64-unknown-linux-gnu
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job12
+- job: job14
   displayName: clippy [x64-windows], unit tests [x64-windows]
   pool:
     demands:
@@ -1101,25 +1101,25 @@ jobs:
     displayName: 🌼🔎 Self-check YAML
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 12 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 12 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 14 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 14 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 12 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 14 'verbose' update
       ${{ parameters.verbose }}
       EOF
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar7
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar7
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -1131,18 +1131,18 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1152,48 +1152,48 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 2
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_xtask 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_xtask 0
     displayName: cargo build xtask
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::check_clippy 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::check_clippy 0
     displayName: determine clippy exclusions
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 0
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 1
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1203,33 +1203,33 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 2
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 2
     displayName: report $CARGO_HOME
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (none)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1240,25 +1240,25 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 3
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_xtask 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_xtask 1
     displayName: cargo build xtask
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 2
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 3
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 3
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 2
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1269,17 +1269,548 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
     displayName: run doctests for x86_64-pc-windows-msvc
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job11
+- job: job13
   displayName: build openhcl [x64-linux]
+  pool:
+    demands:
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
+  dependsOn:
+  - job0
+  condition: and(succeeded(), not(canceled()))
+  variables:
+  - name: FLOWEY_TEMP_DIR
+    value: $(Build.StagingDirectory)/.flowey-internal
+  steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼🥾 Download bootstrapped flowey
+    inputs:
+      artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
+      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - bash: |
+      set -e
+      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
+      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
+
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey"
+      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
+    displayName: Set flowey path
+  - bash: |
+      set -e
+      echo '"debug"' | $FLOWEY_BIN v 13 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 13 '_internal_WORKING_DIR' --is-raw-string update
+
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 13 'verbose' update
+      ${{ parameters.verbose }}
+      EOF
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 13 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-extras"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras" | $FLOWEY_BIN v 13 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+    displayName: 🌼🛫 Initialize job
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar2)
+      path: $(floweyvar1)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (x64)
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar3)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    displayName: unpack protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 8
+    displayName: symlink protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 9
+    displayName: cargo build sidecar
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 6
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_sidecar 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 3
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 4
+    displayName: cargo build openhcl_boot
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_boot 0
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+    displayName: extract and resolve kernel package
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 3
+    displayName: extract X86_64 sysroot.tar.gz
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+    displayName: cargo build openvmm_hcl
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_initrd 4
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 2
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 0
+    displayName: cargo build igvmfilegen
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 7
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_igvmfilegen 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_igvmfilegen 4
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+    displayName: split debug symbols
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+    displayName: extract and resolve kernel package
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_initrd 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_igvmfilegen 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_initrd 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_igvmfilegen 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+    displayName: extract and resolve kernel package
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_initrd 3
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_igvmfilegen 3
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_initrd 2
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_igvmfilegen 2
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_common::copy_to_artifact_dir 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+    displayName: copying OpenHCL igvm files to artifact dir
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::copy_to_artifact_dir 0
+    displayName: copying OpenHCL igvm extras to artifact dir
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: gh-release-download'
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm
+    displayName: 🌼📦 Publish x64-openhcl-igvm
+    artifact: x64-openhcl-igvm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras
+    displayName: 🌼📦 Publish x64-openhcl-igvm-extras
+    artifact: x64-openhcl-igvm-extras
+- job: job12
+  displayName: build openhcl [aarch64-linux]
+  pool:
+    demands:
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
+  dependsOn:
+  - job0
+  condition: and(succeeded(), not(canceled()))
+  variables:
+  - name: FLOWEY_TEMP_DIR
+    value: $(Build.StagingDirectory)/.flowey-internal
+  steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼🥾 Download bootstrapped flowey
+    inputs:
+      artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
+      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - bash: |
+      set -e
+      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
+      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
+
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey"
+      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
+    displayName: Set flowey path
+  - bash: |
+      set -e
+      echo '"debug"' | $FLOWEY_BIN v 12 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 12 '_internal_WORKING_DIR' --is-raw-string update
+
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 12 'verbose' update
+      ${{ parameters.verbose }}
+      EOF
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm" | $FLOWEY_BIN v 12 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-extras"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras" | $FLOWEY_BIN v 12 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
+    displayName: 🌼🛫 Initialize job
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar2)
+      path: $(floweyvar1)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (aarch64)
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar3)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    displayName: unpack protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 3
+    displayName: symlink protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 4
+    displayName: cargo build openhcl_boot
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_boot 0
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+    displayName: extract and resolve kernel package
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 1
+    displayName: extract Aarch64 sysroot.tar.gz
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+    displayName: cargo build openvmm_hcl
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 2
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 0
+    displayName: cargo build igvmfilegen
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_igvmfilegen 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+    displayName: extract and resolve kernel package
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::copy_to_artifact_dir 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+    displayName: copying OpenHCL igvm files to artifact dir
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::copy_to_artifact_dir 0
+    displayName: copying OpenHCL igvm extras to artifact dir
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: gh-release-download'
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm
+    displayName: 🌼📦 Publish aarch64-openhcl-igvm
+    artifact: aarch64-openhcl-igvm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras
+    displayName: 🌼📦 Publish aarch64-openhcl-igvm-extras
+    artifact: aarch64-openhcl-igvm-extras
+- job: job11
+  displayName: build artifacts (for VMM tests) [x64-linux]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -1314,40 +1845,27 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 11 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-igvmfilegen"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-igvmfilegen" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-vmm-tests-archive"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-vmm-tests-archive" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-ohcldiag-dev"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-ohcldiag-dev" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmgs_lib"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgs_lib" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmgstool"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgstool" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmm-tests-archive"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmm-tests-archive" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar2)
-      path: $(floweyvar1)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (x64)
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
@@ -1355,17 +1873,21 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 1
       $(FLOWEY_BIN) e 11 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
       $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar3)
+    persistCredentials: $(floweyvar1)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
@@ -1376,6 +1898,29 @@ jobs:
     displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar5)
+      path: $(floweyvar4)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 6
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::resolve_protoc 0
@@ -1384,67 +1929,60 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 2
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 4
+    displayName: cargo build openvmm
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm 0
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 4
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 8
+    displayName: cargo build openvmm_vhost
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 3
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 9
-    displayName: cargo build sidecar
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm_vhost 0
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 6
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 13
+    displayName: cargo build vmgstool
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 6
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 10
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_sidecar 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 14
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_vmgstool 0
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 5
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 4
-    displayName: cargo build openhcl_boot
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 12
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+    displayName: cargo build vmgs_lib
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 5
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 5
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_boot 0
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-    displayName: extract and resolve kernel package
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 3
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 3
-    displayName: extract X86_64 sysroot.tar.gz
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-    displayName: cargo build openvmm_hcl
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 2
-    displayName: building openhcl initrd
+    displayName: test vmgs_lib
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 0
@@ -1452,145 +1990,140 @@ jobs:
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 5
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 7
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-    displayName: building igvm file
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 2
+    displayName: cargo build ohcldiag-dev
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_ohcldiag_dev 0
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 5
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-    displayName: extract and resolve kernel package
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-    displayName: building openhcl initrd
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 8
+    displayName: extract X86_64 sysroot.tar.gz
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-    displayName: building igvm file
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 6
+    displayName: cargo build openvmm
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm 1
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 9
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-    displayName: building openhcl initrd
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 10
+    displayName: cargo build openvmm_vhost
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-    displayName: building igvm file
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 11
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm_vhost 1
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 7
+    displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::copy_to_artifact_dir 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-    displayName: copying OpenHCL igvm files to artifact dir
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::copy_to_artifact_dir 0
-    displayName: copying OpenHCL igvm extras to artifact dir
+      $(FLOWEY_BIN) e 11 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 11 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 11 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 11 flowey_lib_common::download_cargo_nextest 3
+    displayName: create cargo-nextest cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar3)
+      path: $(floweyvar2)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: cargo-nextest'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_cargo_nextest 4
+    displayName: downloading cargo-nextest
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 2
+    displayName: report $CARGO_HOME
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 0
+    displayName: installing cargo-nextest
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_archive 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_vmm_tests 0
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 8
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 1
+    displayName: build + archive 'vmm_tests' nextests
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_archive 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_vmm_tests 1
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 9
+    displayName: build + archive 'vmm_tests' nextests
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: cargo-nextest'
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm
-    displayName: 🌼📦 Publish x64-openhcl-igvm
-    artifact: x64-openhcl-igvm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras
-    displayName: 🌼📦 Publish x64-openhcl-igvm-extras
-    artifact: x64-openhcl-igvm-extras
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-igvmfilegen
+    displayName: 🌼📦 Publish x64-linux-igvmfilegen
+    artifact: x64-linux-igvmfilegen
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm
+    displayName: 🌼📦 Publish x64-linux-musl-openvmm
+    artifact: x64-linux-musl-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost
+    displayName: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+    artifact: x64-linux-musl-openvmm_vhost
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-vmm-tests-archive
+    displayName: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+    artifact: x64-linux-musl-vmm-tests-archive
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-ohcldiag-dev
+    displayName: 🌼📦 Publish x64-linux-ohcldiag-dev
+    artifact: x64-linux-ohcldiag-dev
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm
+    displayName: 🌼📦 Publish x64-linux-openvmm
+    artifact: x64-linux-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm_vhost
+    displayName: 🌼📦 Publish x64-linux-openvmm_vhost
+    artifact: x64-linux-openvmm_vhost
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgs_lib
+    displayName: 🌼📦 Publish x64-linux-vmgs_lib
+    artifact: x64-linux-vmgs_lib
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgstool
+    displayName: 🌼📦 Publish x64-linux-vmgstool
+    artifact: x64-linux-vmgstool
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmm-tests-archive
+    displayName: 🌼📦 Publish x64-linux-vmm-tests-archive
+    artifact: x64-linux-vmm-tests-archive
 - job: job10
-  displayName: build openhcl [aarch64-linux]
+  displayName: build artifacts (shared VMM tests) [x64-linux]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -1625,27 +2158,57 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 10 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-guest_test_uefi"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 10 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-pipette"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 10 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-tmk_vmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 10 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-tpm_guest_tests"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 10 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-tmks"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-tmks" | $FLOWEY_BIN v 10 'artifact_publish_from_x64-tmks' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 10 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar1)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar2)
-      path: $(floweyvar1)
+      key: $(floweyvar3)
+      path: $(floweyvar2)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
@@ -1657,36 +2220,10 @@ jobs:
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (aarch64)
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 10 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar3)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_common::resolve_protoc 0
@@ -1695,122 +2232,97 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 4
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 4
-    displayName: cargo build openhcl_boot
+      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 0
+    displayName: cargo build guest_test_uefi
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_guest_test_uefi 0
+      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 4
+    displayName: build guest_test_uefi.img
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 2
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 5
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_boot 0
+    displayName: cargo build simple_tmk
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_tmks 0
+      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 1
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-    displayName: extract and resolve kernel package
+      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 4
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 9
+    displayName: cargo build tpm_guest_tests
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_tpm_guest_tests 0
+      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 2
+    displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 1
-    displayName: extract Aarch64 sysroot.tar.gz
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 3
+    displayName: extract X86_64 sysroot.tar.gz
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-    displayName: cargo build openvmm_hcl
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 2
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 0
-    displayName: cargo build igvmfilegen
+      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 1
+    displayName: cargo build pipette
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_pipette 0
+      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 2
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-    displayName: building igvm file
+      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 7
+    displayName: cargo build tmk_vmm
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_tmk_vmm 0
+      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 4
     displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::copy_to_artifact_dir 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-    displayName: copying OpenHCL igvm files to artifact dir
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::copy_to_artifact_dir 0
-    displayName: copying OpenHCL igvm extras to artifact dir
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm
-    displayName: 🌼📦 Publish aarch64-openhcl-igvm
-    artifact: aarch64-openhcl-igvm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras
-    displayName: 🌼📦 Publish aarch64-openhcl-igvm-extras
-    artifact: aarch64-openhcl-igvm-extras
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-guest_test_uefi
+    displayName: 🌼📦 Publish x64-guest_test_uefi
+    artifact: x64-guest_test_uefi
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette
+    displayName: 🌼📦 Publish x64-linux-musl-pipette
+    artifact: x64-linux-musl-pipette
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-tmk_vmm
+    displayName: 🌼📦 Publish x64-linux-musl-tmk_vmm
+    artifact: x64-linux-musl-tmk_vmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-tpm_guest_tests
+    displayName: 🌼📦 Publish x64-linux-tpm_guest_tests
+    artifact: x64-linux-tpm_guest_tests
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-tmks
+    displayName: 🌼📦 Publish x64-tmks
+    artifact: x64-tmks
 - job: job9
-  displayName: build artifacts (for VMM tests) [x64-linux]
+  displayName: build artifacts (for VMM tests) [aarch64-linux]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -1845,26 +2357,22 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 9 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-igvmfilegen"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-igvmfilegen" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm_vhost"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-vmm-tests-archive"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-vmm-tests-archive" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-ohcldiag-dev"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-ohcldiag-dev" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-openvmm_vhost"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmgs_lib"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgs_lib" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmgstool"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgstool" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmm-tests-archive"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmm-tests-archive" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-igvmfilegen"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-igvmfilegen" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-ohcldiag-dev"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-ohcldiag-dev" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm_vhost" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-vmgs_lib"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgs_lib" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-vmgstool"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgstool" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::install_rust 0
     displayName: install Rust
@@ -1902,22 +2410,22 @@ jobs:
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
+      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar5)
-      path: $(floweyvar4)
+      key: $(floweyvar3)
+      path: $(floweyvar2)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
@@ -1929,7 +2437,7 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 0
     displayName: symlink protoc
   - bash: |-
       set -e
@@ -1942,7 +2450,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 2
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -1955,7 +2463,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 9
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_vhost 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -1968,21 +2476,17 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 14
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_vmgstool 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 5
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 3
     displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 6
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 12
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-    displayName: cargo build vmgs_lib
-  - bash: |-
-      set -e
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 3
-    displayName: test vmgs_lib
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 1
+    displayName: cargo build vmgs_lib
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 0
@@ -1994,7 +2498,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 7
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 5
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2013,8 +2517,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 8
-    displayName: extract X86_64 sysroot.tar.gz
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 6
+    displayName: extract Aarch64 sysroot.tar.gz
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 3
@@ -2026,7 +2530,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 7
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm 1
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 6
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 9
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 7
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2040,90 +2544,34 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_vhost 1
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 7
     displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 9 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 9 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 9 flowey_lib_common::download_cargo_nextest 3
-    displayName: create cargo-nextest cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar3)
-      path: $(floweyvar2)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: cargo-nextest'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::download_cargo_nextest 4
-    displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::install_rust 2
-    displayName: report $CARGO_HOME
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 0
-    displayName: installing cargo-nextest
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_nextest_archive 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 8
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 1
-    displayName: build + archive 'vmm_tests' nextests
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_nextest_archive 1
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
-      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 9
-    displayName: build + archive 'vmm_tests' nextests
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-igvmfilegen
-    displayName: 🌼📦 Publish x64-linux-igvmfilegen
-    artifact: x64-linux-igvmfilegen
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm
-    displayName: 🌼📦 Publish x64-linux-musl-openvmm
-    artifact: x64-linux-musl-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost
-    displayName: 🌼📦 Publish x64-linux-musl-openvmm_vhost
-    artifact: x64-linux-musl-openvmm_vhost
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-vmm-tests-archive
-    displayName: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
-    artifact: x64-linux-musl-vmm-tests-archive
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-ohcldiag-dev
-    displayName: 🌼📦 Publish x64-linux-ohcldiag-dev
-    artifact: x64-linux-ohcldiag-dev
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm
-    displayName: 🌼📦 Publish x64-linux-openvmm
-    artifact: x64-linux-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm_vhost
-    displayName: 🌼📦 Publish x64-linux-openvmm_vhost
-    artifact: x64-linux-openvmm_vhost
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgs_lib
-    displayName: 🌼📦 Publish x64-linux-vmgs_lib
-    artifact: x64-linux-vmgs_lib
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgstool
-    displayName: 🌼📦 Publish x64-linux-vmgstool
-    artifact: x64-linux-vmgstool
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmm-tests-archive
-    displayName: 🌼📦 Publish x64-linux-vmm-tests-archive
-    artifact: x64-linux-vmm-tests-archive
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-igvmfilegen
+    displayName: 🌼📦 Publish aarch64-linux-igvmfilegen
+    artifact: aarch64-linux-igvmfilegen
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm
+    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm
+    artifact: aarch64-linux-musl-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost
+    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
+    artifact: aarch64-linux-musl-openvmm_vhost
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-ohcldiag-dev
+    displayName: 🌼📦 Publish aarch64-linux-ohcldiag-dev
+    artifact: aarch64-linux-ohcldiag-dev
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm
+    displayName: 🌼📦 Publish aarch64-linux-openvmm
+    artifact: aarch64-linux-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm_vhost
+    displayName: 🌼📦 Publish aarch64-linux-openvmm_vhost
+    artifact: aarch64-linux-openvmm_vhost
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgs_lib
+    displayName: 🌼📦 Publish aarch64-linux-vmgs_lib
+    artifact: aarch64-linux-vmgs_lib
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgstool
+    displayName: 🌼📦 Publish aarch64-linux-vmgstool
+    artifact: aarch64-linux-vmgstool
 - job: job8
-  displayName: build artifacts (shared VMM tests) [x64-linux]
+  displayName: build artifacts (shared VMM tests) [aarch64-linux]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -2158,16 +2606,16 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 8 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-guest_test_uefi"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-pipette"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-tmk_vmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-tpm_guest_tests"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-tmks"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-tmks" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-tmks' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-guest_test_uefi"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-guest_test_uefi" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-pipette"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-tmk_vmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-tpm_guest_tests"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-tpm_guest_tests" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-tmks"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-tmks" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-tmks' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::install_rust 0
     displayName: install Rust
@@ -2278,7 +2726,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 3
-    displayName: extract X86_64 sysroot.tar.gz
+    displayName: extract Aarch64 sysroot.tar.gz
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 1
@@ -2306,454 +2754,6 @@ jobs:
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-guest_test_uefi
-    displayName: 🌼📦 Publish x64-guest_test_uefi
-    artifact: x64-guest_test_uefi
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette
-    displayName: 🌼📦 Publish x64-linux-musl-pipette
-    artifact: x64-linux-musl-pipette
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-tmk_vmm
-    displayName: 🌼📦 Publish x64-linux-musl-tmk_vmm
-    artifact: x64-linux-musl-tmk_vmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-tpm_guest_tests
-    displayName: 🌼📦 Publish x64-linux-tpm_guest_tests
-    artifact: x64-linux-tpm_guest_tests
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-tmks
-    displayName: 🌼📦 Publish x64-tmks
-    artifact: x64-tmks
-- job: job7
-  displayName: build artifacts (for VMM tests) [aarch64-linux]
-  pool:
-    demands:
-    - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
-  dependsOn:
-  - job0
-  condition: and(succeeded(), not(canceled()))
-  variables:
-  - name: FLOWEY_TEMP_DIR
-    value: $(Build.StagingDirectory)/.flowey-internal
-  steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼🥾 Download bootstrapped flowey
-    inputs:
-      artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
-      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
-  - bash: |
-      set -e
-      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
-      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
-
-      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey"
-      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
-    displayName: Set flowey path
-  - bash: |
-      set -e
-      echo '"debug"' | $FLOWEY_BIN v 7 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 7 '_internal_WORKING_DIR' --is-raw-string update
-
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 7 'verbose' update
-      ${{ parameters.verbose }}
-      EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-igvmfilegen"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-igvmfilegen" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-ohcldiag-dev"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-ohcldiag-dev" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-openvmm_vhost"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm_vhost" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-vmgs_lib"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgs_lib" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-vmgstool"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgstool" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
-    displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 7 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar1)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-    displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar3)
-      path: $(floweyvar2)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 7 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-    displayName: unpack protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 0
-    displayName: symlink protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 4
-    displayName: cargo build openvmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 5
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_openvmm 0
-      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 2
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 8
-    displayName: cargo build openvmm_vhost
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 9
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_openvmm_vhost 0
-      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 4
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 7
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 13
-    displayName: cargo build vmgstool
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 6
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 14
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_vmgstool 0
-      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 3
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 6
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 12
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 1
-    displayName: cargo build vmgs_lib
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 0
-    displayName: cargo build igvmfilegen
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 5
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 5
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 2
-    displayName: cargo build ohcldiag-dev
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
-      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 5
-    displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 7 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 6
-    displayName: extract Aarch64 sysroot.tar.gz
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 6
-    displayName: cargo build openvmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_openvmm 1
-      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 6
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 7
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 5
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 10
-    displayName: cargo build openvmm_vhost
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 11
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_openvmm_vhost 1
-      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 7
-    displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-igvmfilegen
-    displayName: 🌼📦 Publish aarch64-linux-igvmfilegen
-    artifact: aarch64-linux-igvmfilegen
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm
-    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm
-    artifact: aarch64-linux-musl-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost
-    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
-    artifact: aarch64-linux-musl-openvmm_vhost
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-ohcldiag-dev
-    displayName: 🌼📦 Publish aarch64-linux-ohcldiag-dev
-    artifact: aarch64-linux-ohcldiag-dev
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm
-    displayName: 🌼📦 Publish aarch64-linux-openvmm
-    artifact: aarch64-linux-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm_vhost
-    displayName: 🌼📦 Publish aarch64-linux-openvmm_vhost
-    artifact: aarch64-linux-openvmm_vhost
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgs_lib
-    displayName: 🌼📦 Publish aarch64-linux-vmgs_lib
-    artifact: aarch64-linux-vmgs_lib
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgstool
-    displayName: 🌼📦 Publish aarch64-linux-vmgstool
-    artifact: aarch64-linux-vmgstool
-- job: job6
-  displayName: build artifacts (shared VMM tests) [aarch64-linux]
-  pool:
-    demands:
-    - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
-  dependsOn:
-  - job0
-  condition: and(succeeded(), not(canceled()))
-  variables:
-  - name: FLOWEY_TEMP_DIR
-    value: $(Build.StagingDirectory)/.flowey-internal
-  steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼🥾 Download bootstrapped flowey
-    inputs:
-      artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
-      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
-  - bash: |
-      set -e
-      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
-      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
-
-      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey"
-      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
-    displayName: Set flowey path
-  - bash: |
-      set -e
-      echo '"debug"' | $FLOWEY_BIN v 6 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 6 '_internal_WORKING_DIR' --is-raw-string update
-
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 6 'verbose' update
-      ${{ parameters.verbose }}
-      EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-guest_test_uefi"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-guest_test_uefi" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-pipette"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-tmk_vmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-tpm_guest_tests"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-tpm_guest_tests" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-tmks"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-tmks" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-tmks' --is-raw-string update
-    displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 6 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar1)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-    displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar3)
-      path: $(floweyvar2)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 6 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-    displayName: unpack protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 4
-    displayName: symlink protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 0
-    displayName: cargo build guest_test_uefi
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_guest_test_uefi 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 4
-    displayName: build guest_test_uefi.img
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 5
-    displayName: cargo build simple_tmk
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_tmks 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 1
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 9
-    displayName: cargo build tpm_guest_tests
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 10
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_tpm_guest_tests 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 2
-    displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 6 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 3
-    displayName: extract Aarch64 sysroot.tar.gz
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 1
-    displayName: cargo build pipette
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_pipette 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 2
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 7
-    displayName: cargo build tmk_vmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 8
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_tmk_vmm 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 4
-    displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-guest_test_uefi
     displayName: 🌼📦 Publish aarch64-guest_test_uefi
     artifact: aarch64-guest_test_uefi
@@ -2769,7 +2769,7 @@ jobs:
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-tmks
     displayName: 🌼📦 Publish aarch64-tmks
     artifact: aarch64-tmks
-- job: job5
+- job: job7
   displayName: build artifacts (for VMM tests) [x64-windows]
   pool:
     demands:
@@ -2844,41 +2844,39 @@ jobs:
     displayName: 🌼🔎 Self-check YAML
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 5 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 5 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 7 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 7 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 5 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 7 'verbose' update
       ${{ parameters.verbose }}
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-pipette"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-windows-openvmm' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-prep_steps"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-prep_steps' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-windows-prep_steps' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-test_igvm_agent_rpc_server"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-tmk_vmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-windows-tmk_vmm' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-tpm_guest_tests"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-windows-tpm_guest_tests' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-vmgstool"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-vmgstool' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-windows-vmgstool' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-vmm-tests-archive"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-windows-vmm-tests-archive' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::install_rust 0
+  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 5 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 7 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 7 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 7 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -2890,18 +2888,18 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 7 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::git_checkout_openvmm_repo 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+  - bash: $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
+      $(FLOWEY_BIN) e 7 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -2911,94 +2909,86 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 5 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 7 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      $(FLOWEY_BIN) e 7 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 5
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 4
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 0
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_openvmm 0
-      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_openvmm 0
+      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 0
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 1
     displayName: cargo build openvmm
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_pipette 0
-      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 2
-    displayName: cargo build pipette
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_tmk_vmm 0
-      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 7
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_tmk_vmm 0
+      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 5
     displayName: cargo build tmk_vmm
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_prep_steps 0
-      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_prep_steps 0
+      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 3
     displayName: cargo build prep_steps
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 6
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 10
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_vmgstool 0
-      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 3
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 5
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_vmgstool 0
+      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 7
     displayName: cargo build vmgstool
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 5
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 9
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_tpm_guest_tests 0
-      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 5
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 4
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 4
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_tpm_guest_tests 0
+      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 4
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 3
     displayName: cargo build tpm_guest_tests
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 5
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 6
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 4
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 5
     displayName: cargo build test_igvm_agent_rpc_server
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 5 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 5 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 5 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 7 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 7 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 7 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 7 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+      $(FLOWEY_BIN) e 7 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3008,36 +2998,33 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 5 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 7 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::install_rust 2
+  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::install_rust 2
     displayName: report $CARGO_HOME
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 7 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 0
     displayName: installing cargo-nextest
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_nextest_archive 0
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_nextest_vmm_tests 0
-      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 7
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_nextest_archive 0
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_nextest_vmm_tests 0
+      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 6
     displayName: build + archive 'vmm_tests' nextests
-  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-openvmm
     displayName: 🌼📦 Publish x64-windows-openvmm
     artifact: x64-windows-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-pipette
-    displayName: 🌼📦 Publish x64-windows-pipette
-    artifact: x64-windows-pipette
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-prep_steps
     displayName: 🌼📦 Publish x64-windows-prep_steps
     artifact: x64-windows-prep_steps
@@ -3056,242 +3043,169 @@ jobs:
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-vmm-tests-archive
     displayName: 🌼📦 Publish x64-windows-vmm-tests-archive
     artifact: x64-windows-vmm-tests-archive
-  - bash: rm $(AgentTempDirNormal)/bootstrapped-flowey/job5.json
+  - bash: rm $(AgentTempDirNormal)/bootstrapped-flowey/job7.json
     displayName: 🌼🧼 Redact bootstrap var db
   - publish: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
     displayName: 🌼🥾 Publish bootstrapped flowey
     artifact: _internal-flowey-bootstrap-x86_64-windows-uid-3
-- job: job17
-  displayName: run vmm-tests [x64-linux-amd-kvm]
+- job: job6
+  displayName: build artifacts (shared VMM tests) [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64
+    - ImageOverride -equals win-amd64
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
-  - job5
-  - job8
-  - job9
   condition: and(succeeded(), not(canceled()))
   variables:
   - name: FLOWEY_TEMP_DIR
     value: $(Build.StagingDirectory)/.flowey-internal
   steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼🥾 Download bootstrapped flowey
+  - bash: |
+      set -x
+      i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+      sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+      . "$HOME/.cargo/env"
+      echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
+    condition: eq(variables['Agent.OS'], 'Linux')
+    displayName: rustup (Linux)
+  - bash: |
+      set -x
+      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+      ./rustup-init.exe -y --default-toolchain=1.95.0
+      echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+    displayName: rustup (Windows X64)
+  - bash: |
+      set -x
+      rustup show
+    displayName: Verify rustup installation
+  - checkout: self
+    fetchTags: false
+    fetchDepth: 1
+    path: flowey_bootstrap
+  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+    workingDirectory: ../flowey_bootstrap
+    displayName: Build flowey
+  - bash: |
+      mkdir ./flowey_bootstrap_temp
+      mv ./ci-flowey/openvmm-pr.yaml ./flowey_bootstrap_temp/pipeline.yaml
+      mv ./ci-flowey/openvmm-pr.json ./flowey_bootstrap_temp/pipeline.json
+      mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe ./flowey_bootstrap_temp/flowey.exe
+    workingDirectory: ../flowey_bootstrap
+    displayName: Stage flowey artifact
+  - task: CopyFiles@2
+    displayName: Copy flowey artifact
     inputs:
-      artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
-      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-guest_test_uefi
-    inputs:
-      artifact: x64-guest_test_uefi
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-musl-pipette
-    inputs:
-      artifact: x64-linux-musl-pipette
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-musl-tmk_vmm
-    inputs:
-      artifact: x64-linux-musl-tmk_vmm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-openvmm
-    inputs:
-      artifact: x64-linux-openvmm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-openvmm_vhost
-    inputs:
-      artifact: x64-linux-openvmm_vhost
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm_vhost
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-vmm-tests-archive
-    inputs:
-      artifact: x64-linux-vmm-tests-archive
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-vmm-tests-archive
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-tmks
-    inputs:
-      artifact: x64-tmks
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-pipette
-    inputs:
-      artifact: x64-windows-pipette
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette
+      SourceFolder: ../flowey_bootstrap/flowey_bootstrap_temp
+      TargetFolder: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - bash: rm -rf ./flowey_bootstrap_temp
+    workingDirectory: ../flowey_bootstrap
+    displayName: Cleanup staged flowey artifact
   - bash: |
       set -e
       AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
       AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
       echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
 
-      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey"
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey.exe"
       echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
     displayName: Set flowey path
+  - bash: |-
+      ESCAPED_AGENT_TEMPDIR=$(
+      cat <<'EOF' | sed 's/\\/\\\\/g'
+      $(FLOWEY_TEMP_DIR)
+      EOF
+      )
+      $(FLOWEY_BIN) pipeline ado --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out ci-flowey/openvmm-pr.yaml ci checkin-gates --config=pr
+    displayName: 🌼🔎 Self-check YAML
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 17 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 17 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 6 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 6 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 17 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 6 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 17 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-vmm-tests-archive" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 17 'artifact_use_from_x64-tmks' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-pipette"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 6 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-    displayName: ensure hypervisor device is accessible
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
-    displayName: ensure 2 MiB hugetlb pages are available
+  - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::install_rust 0
+    displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 3
-    displayName: create cargo-nextest cache dir
+      $(FLOWEY_BIN) e 6 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 6 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar4)
-      path: $(floweyvar3)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: cargo-nextest'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 4
-    displayName: downloading cargo-nextest
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 6 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar2)
+    persistCredentials: $(floweyvar1)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 7
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 6 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::git_checkout_openvmm_repo 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-    displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $(FLOWEY_BIN) e 6 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar6)
-      path: $(floweyvar5)
+      key: $(floweyvar3)
+      path: $(floweyvar2)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 6 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_azcopy 0
-    displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-    displayName: calculating required VMM tests disk images
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-    displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (x64)
+      $(FLOWEY_BIN) e 6 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::init_vmm_tests_env 0
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
-    displayName: setting up vmm_tests env
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-    displayName: generate nextest command
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::install_vmm_tests_deps 0
-    displayName: install vmm tests deps (linux)
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 0
+    displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 17 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 17 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'vmm_tests' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar1)
-      testRunTitle: x64-linux-amd-kvm-vmm-tests
-    displayName: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 2
-      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-    displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 7
+      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_pipette 0
+      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 0
+    displayName: cargo build pipette
+  - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
-- job: job19
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-pipette
+    displayName: 🌼📦 Publish x64-windows-pipette
+    artifact: x64-windows-pipette
+- job: job21
   displayName: run vmm-tests [x64-windows-intel-mi-secure]
   pool:
     demands:
@@ -3299,9 +3213,10 @@ jobs:
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
-  - job18
-  - job5
-  - job8
+  - job10
+  - job20
+  - job6
+  - job7
   condition: and(succeeded(), not(canceled()))
   variables:
   - name: FLOWEY_TEMP_DIR
@@ -3394,6 +3309,246 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
+      echo '"debug"' | $FLOWEY_BIN v 21 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 21 '_internal_WORKING_DIR' --is-raw-string update
+
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 21 'verbose' update
+      ${{ parameters.verbose }}
+      EOF
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 21 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 21 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 21 'artifact_use_from_x64-tmks' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+    displayName: 🌼🛫 Initialize job
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 21 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 21 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 21 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 21 flowey_lib_common::download_cargo_nextest 3
+    displayName: create cargo-nextest cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 21 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar4)
+      path: $(floweyvar3)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: cargo-nextest'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 21 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 21 flowey_lib_common::download_cargo_nextest 4
+    displayName: downloading cargo-nextest
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 21 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar2)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 21 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 8
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+    displayName: creating new test content dir
+  - bash: $(FLOWEY_BIN) e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+    displayName: resolve OpenHCL igvm artifact
+  - bash: $(FLOWEY_BIN) e 21 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 21 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 21 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar6)
+      path: $(floweyvar5)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 21 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 21 flowey_lib_common::cache 6
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 21 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 21 flowey_lib_common::download_azcopy 0
+    displayName: extract azcopy from archive
+  - bash: $(FLOWEY_BIN) e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+    displayName: calculating required VMM tests disk images
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+    displayName: downloading VMM test disk images
+  - bash: $(FLOWEY_BIN) e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (x64)
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::init_vmm_tests_env 0
+      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+    displayName: setting up vmm_tests env
+  - bash: $(FLOWEY_BIN) e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+    displayName: generate nextest command
+  - bash: $(FLOWEY_BIN) e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+    displayName: install vmm tests deps (windows)
+  - bash: $(FLOWEY_BIN) e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+    displayName: starting test_igvm_agent_rpc_server
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 21 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 21 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+    displayName: run 'vmm_tests' nextest tests
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 21 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 21 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 21 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 21 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: stopping test_igvm_agent_rpc_server
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar1)
+      testRunTitle: x64-windows-intel-mi-secure-vmm-tests
+    displayName: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 21 flowey_lib_common::publish_test_results 2
+      $(FLOWEY_BIN) e 21 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+    displayName: report test results to overall pipeline status
+  - bash: $(FLOWEY_BIN) e 21 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: cargo-nextest'
+  - bash: $(FLOWEY_BIN) e 21 flowey_lib_common::cache 7
+    displayName: 'validate cache entry: gh-release-download'
+- job: job19
+  displayName: run vmm-tests [x64-linux-amd-kvm]
+  pool:
+    demands:
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
+  dependsOn:
+  - job0
+  - job10
+  - job11
+  - job6
+  condition: and(succeeded(), not(canceled()))
+  variables:
+  - name: FLOWEY_TEMP_DIR
+    value: $(Build.StagingDirectory)/.flowey-internal
+  steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼🥾 Download bootstrapped flowey
+    inputs:
+      artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
+      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-guest_test_uefi
+    inputs:
+      artifact: x64-guest_test_uefi
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-musl-pipette
+    inputs:
+      artifact: x64-linux-musl-pipette
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-musl-tmk_vmm
+    inputs:
+      artifact: x64-linux-musl-tmk_vmm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-openvmm
+    inputs:
+      artifact: x64-linux-openvmm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-openvmm_vhost
+    inputs:
+      artifact: x64-linux-openvmm_vhost
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm_vhost
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-vmm-tests-archive
+    inputs:
+      artifact: x64-linux-vmm-tests-archive
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-vmm-tests-archive
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-tmks
+    inputs:
+      artifact: x64-tmks
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-pipette
+    inputs:
+      artifact: x64-windows-pipette
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette
+  - bash: |
+      set -e
+      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
+      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
+
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey"
+      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
+    displayName: Set flowey path
+  - bash: |
+      set -e
       echo '"debug"' | $FLOWEY_BIN v 19 'FLOWEY_LOG' update
       echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 19 '_internal_WORKING_DIR' --is-raw-string update
 
@@ -3403,18 +3558,16 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 19 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-vmm-tests-archive" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 19 'artifact_use_from_x64-tmks' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
     displayName: 🌼🛫 Initialize job
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+    displayName: ensure hypervisor device is accessible
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+    displayName: ensure 2 MiB hugetlb pages are available
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 0
@@ -3462,22 +3615,20 @@ jobs:
       $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 2
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 7
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 1
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 9
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 10
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 6
     displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-    displayName: resolve OpenHCL igvm artifact
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
   - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -3517,51 +3668,45 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::init_vmm_tests_env 0
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 12
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
     displayName: setting up vmm_tests env
   - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
-    displayName: install vmm tests deps (windows)
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-    displayName: starting test_igvm_agent_rpc_server
+    displayName: install vmm tests deps (linux)
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-    displayName: run 'vmm_tests' nextest tests
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 19 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 0
       $FLOWEY_BIN v 19 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
       $FLOWEY_BIN v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: stopping test_igvm_agent_rpc_server
+    displayName: run 'vmm_tests' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar1)
-      testRunTitle: x64-windows-intel-mi-secure-vmm-tests
-    displayName: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
+      testRunTitle: x64-linux-amd-kvm-vmm-tests
+    displayName: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 2
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
   - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job16
+- job: job18
   displayName: run vmm-tests [x64-windows-amd]
   pool:
     demands:
@@ -3569,9 +3714,10 @@ jobs:
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
-  - job11
-  - job5
-  - job8
+  - job10
+  - job13
+  - job6
+  - job7
   condition: and(succeeded(), not(canceled()))
   variables:
   - name: FLOWEY_TEMP_DIR
@@ -3664,39 +3810,39 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 16 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 16 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 18 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 18 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 16 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 18 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 16 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 16 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 16 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 16 'artifact_use_from_x64-tmks' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 18 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 18 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 18 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 18 'artifact_use_from_x64-tmks' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3706,18 +3852,18 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -3729,32 +3875,32 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 6
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 9
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 10
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 8
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
     displayName: resolve OpenHCL igvm artifact
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3764,54 +3910,54 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_azcopy 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_azcopy 0
     displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
     displayName: calculating required VMM tests disk images
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
     displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_uefi_mu_msvm 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
     displayName: unpack mu_msvm package (x64)
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_vmm_tests_env 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_vmm_tests_env 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
     displayName: setting up vmm_tests env
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::install_vmm_tests_deps 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::install_vmm_tests_deps 0
     displayName: install vmm tests deps (windows)
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
     displayName: starting test_igvm_agent_rpc_server
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
     displayName: run 'vmm_tests' nextest tests
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 18 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 18 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: stopping test_igvm_agent_rpc_server
   - task: PublishTestResults@2
     inputs:
@@ -3822,16 +3968,16 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 2
-      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 2
+      $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job15
+- job: job17
   displayName: run vmm-tests [x64-windows-intel]
   pool:
     demands:
@@ -3839,9 +3985,10 @@ jobs:
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
-  - job11
-  - job5
-  - job8
+  - job10
+  - job13
+  - job6
+  - job7
   condition: and(succeeded(), not(canceled()))
   variables:
   - name: FLOWEY_TEMP_DIR
@@ -3934,39 +4081,39 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 15 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 15 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 17 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 17 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 15 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 17 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 15 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 15 'artifact_use_from_x64-tmks' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 17 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 17 'artifact_use_from_x64-tmks' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3976,18 +4123,18 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -3999,32 +4146,32 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 6
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 9
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 10
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 8
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
     displayName: resolve OpenHCL igvm artifact
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -4034,54 +4181,54 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_azcopy 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_azcopy 0
     displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
     displayName: calculating required VMM tests disk images
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
     displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::resolve_openvmm_deps 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_uefi_mu_msvm 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_uefi_mu_msvm 0
     displayName: unpack mu_msvm package (x64)
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_vmm_tests_env 0
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::init_vmm_tests_env 0
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
     displayName: setting up vmm_tests env
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::install_vmm_tests_deps 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::install_vmm_tests_deps 0
     displayName: install vmm tests deps (windows)
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
     displayName: starting test_igvm_agent_rpc_server
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
     displayName: run 'vmm_tests' nextest tests
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 17 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 17 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: stopping test_igvm_agent_rpc_server
   - task: PublishTestResults@2
     inputs:
@@ -4092,17 +4239,218 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 2
+      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job4
+- job: job5
   displayName: build artifacts (not for VMM tests) [x64-windows]
+  pool:
+    demands:
+    - ImageOverride -equals win-amd64
+    name: openvmm-ado-amd-westus2
+  dependsOn:
+  - job0
+  condition: and(succeeded(), not(canceled()))
+  variables:
+  - name: FLOWEY_TEMP_DIR
+    value: $(Build.StagingDirectory)/.flowey-internal
+  steps:
+  - bash: |
+      set -x
+      i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+      sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+      . "$HOME/.cargo/env"
+      echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
+    condition: eq(variables['Agent.OS'], 'Linux')
+    displayName: rustup (Linux)
+  - bash: |
+      set -x
+      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+      ./rustup-init.exe -y --default-toolchain=1.95.0
+      echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+    displayName: rustup (Windows X64)
+  - bash: |
+      set -x
+      rustup show
+    displayName: Verify rustup installation
+  - checkout: self
+    fetchTags: false
+    fetchDepth: 1
+    path: flowey_bootstrap
+  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+    workingDirectory: ../flowey_bootstrap
+    displayName: Build flowey
+  - bash: |
+      mkdir ./flowey_bootstrap_temp
+      mv ./ci-flowey/openvmm-pr.yaml ./flowey_bootstrap_temp/pipeline.yaml
+      mv ./ci-flowey/openvmm-pr.json ./flowey_bootstrap_temp/pipeline.json
+      mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe ./flowey_bootstrap_temp/flowey.exe
+    workingDirectory: ../flowey_bootstrap
+    displayName: Stage flowey artifact
+  - task: CopyFiles@2
+    displayName: Copy flowey artifact
+    inputs:
+      SourceFolder: ../flowey_bootstrap/flowey_bootstrap_temp
+      TargetFolder: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - bash: rm -rf ./flowey_bootstrap_temp
+    workingDirectory: ../flowey_bootstrap
+    displayName: Cleanup staged flowey artifact
+  - bash: |
+      set -e
+      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
+      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
+
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey.exe"
+      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
+    displayName: Set flowey path
+  - bash: |-
+      ESCAPED_AGENT_TEMPDIR=$(
+      cat <<'EOF' | sed 's/\\/\\\\/g'
+      $(FLOWEY_TEMP_DIR)
+      EOF
+      )
+      $(FLOWEY_BIN) pipeline ado --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out ci-flowey/openvmm-pr.yaml ci checkin-gates --config=pr
+    displayName: 🌼🔎 Self-check YAML
+  - bash: |
+      set -e
+      echo '"debug"' | $FLOWEY_BIN v 5 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 5 '_internal_WORKING_DIR' --is-raw-string update
+
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 5 'verbose' update
+      ${{ parameters.verbose }}
+      EOF
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-hypestv"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-hypestv" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-igvmfilegen"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-igvmfilegen" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-ohcldiag-dev"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-ohcldiag-dev" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-vmgs_lib"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-vmgs_lib" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
+    displayName: 🌼🛫 Initialize job
+  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 5 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar1)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar3)
+      path: $(floweyvar2)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 5 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    displayName: unpack protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 1
+    displayName: symlink protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_hypestv 0
+      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 0
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 0
+    displayName: cargo build hypestv
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+    displayName: cargo build vmgs_lib
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 2
+    displayName: test vmgs_lib
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_igvmfilegen 0
+      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 3
+    displayName: cargo build igvmfilegen
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_ohcldiag_dev 0
+      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 3
+    displayName: cargo build ohcldiag-dev
+  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: gh-release-download'
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-hypestv
+    displayName: 🌼📦 Publish x64-windows-hypestv
+    artifact: x64-windows-hypestv
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-igvmfilegen
+    displayName: 🌼📦 Publish x64-windows-igvmfilegen
+    artifact: x64-windows-igvmfilegen
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-ohcldiag-dev
+    displayName: 🌼📦 Publish x64-windows-ohcldiag-dev
+    artifact: x64-windows-ohcldiag-dev
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-vmgs_lib
+    displayName: 🌼📦 Publish x64-windows-vmgs_lib
+    artifact: x64-windows-vmgs_lib
+- job: job4
+  displayName: build artifacts (for VMM tests) [aarch64-windows]
   pool:
     demands:
     - ImageOverride -equals win-amd64
@@ -4182,14 +4530,20 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 4 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-hypestv"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-hypestv" | $FLOWEY_BIN v 4 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-igvmfilegen"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-igvmfilegen" | $FLOWEY_BIN v 4 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-ohcldiag-dev"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-ohcldiag-dev" | $FLOWEY_BIN v 4 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-vmgs_lib"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-vmgs_lib" | $FLOWEY_BIN v 4 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-openvmm" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-prep_steps"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-prep_steps" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-tmk_vmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tmk_vmm" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-tpm_guest_tests"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tpm_guest_tests" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-vmgstool"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmgstool" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-vmm-tests-archive"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmm-tests-archive" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::install_rust 0
     displayName: install Rust
@@ -4223,22 +4577,22 @@ jobs:
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+      $(FLOWEY_BIN) e 4 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 4 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 4 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar3)
-      path: $(floweyvar2)
+      key: $(floweyvar5)
+      path: $(floweyvar4)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 4 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 4 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 4 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
@@ -4254,56 +4608,123 @@ jobs:
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 0
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_hypestv 0
-      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 0
-    displayName: cargo build hypestv
-  - bash: |-
-      set -e
       $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-    displayName: cargo build vmgs_lib
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 2
-    displayName: test vmgs_lib
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_tmk_vmm 0
+      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 5
+    displayName: cargo build tmk_vmm
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 1
       $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_prep_steps 0
+      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 4
       $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 3
-    displayName: cargo build igvmfilegen
+    displayName: cargo build prep_steps
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 5
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_vmgstool 0
+      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 5
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 7
+    displayName: cargo build vmgstool
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 4
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_tpm_guest_tests 0
+      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 6
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 3
+    displayName: cargo build tpm_guest_tests
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_ohcldiag_dev 0
-      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 3
-    displayName: cargo build ohcldiag-dev
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 4
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 0
+    displayName: cargo build test_igvm_agent_rpc_server
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 4 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 4 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 4 flowey_lib_common::download_cargo_nextest 3
+    displayName: create cargo-nextest cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar3)
+      path: $(floweyvar2)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: cargo-nextest'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 4 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::download_cargo_nextest 4
+    displayName: downloading cargo-nextest
+  - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::install_rust 2
+    displayName: report $CARGO_HOME
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 0
+    displayName: installing cargo-nextest
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_nextest_archive 0
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_nextest_vmm_tests 0
+      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 4
+    displayName: build + archive 'vmm_tests' nextests
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_openvmm 0
+      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 2
+    displayName: cargo build openvmm
   - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: cargo-nextest'
+  - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-hypestv
-    displayName: 🌼📦 Publish x64-windows-hypestv
-    artifact: x64-windows-hypestv
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-igvmfilegen
-    displayName: 🌼📦 Publish x64-windows-igvmfilegen
-    artifact: x64-windows-igvmfilegen
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-ohcldiag-dev
-    displayName: 🌼📦 Publish x64-windows-ohcldiag-dev
-    artifact: x64-windows-ohcldiag-dev
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-vmgs_lib
-    displayName: 🌼📦 Publish x64-windows-vmgs_lib
-    artifact: x64-windows-vmgs_lib
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-openvmm
+    displayName: 🌼📦 Publish aarch64-windows-openvmm
+    artifact: aarch64-windows-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-prep_steps
+    displayName: 🌼📦 Publish aarch64-windows-prep_steps
+    artifact: aarch64-windows-prep_steps
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server
+    displayName: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
+    artifact: aarch64-windows-test_igvm_agent_rpc_server
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tmk_vmm
+    displayName: 🌼📦 Publish aarch64-windows-tmk_vmm
+    artifact: aarch64-windows-tmk_vmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tpm_guest_tests
+    displayName: 🌼📦 Publish aarch64-windows-tpm_guest_tests
+    artifact: aarch64-windows-tpm_guest_tests
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmgstool
+    displayName: 🌼📦 Publish aarch64-windows-vmgstool
+    artifact: aarch64-windows-vmgstool
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmm-tests-archive
+    displayName: 🌼📦 Publish aarch64-windows-vmm-tests-archive
+    artifact: aarch64-windows-vmm-tests-archive
 - job: job3
-  displayName: build artifacts (for VMM tests) [aarch64-windows]
+  displayName: build artifacts (shared VMM tests) [aarch64-windows]
   pool:
     demands:
     - ImageOverride -equals win-amd64
@@ -4383,22 +4804,8 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 3 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-openvmm" | $FLOWEY_BIN v 3 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-pipette"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-pipette" | $FLOWEY_BIN v 3 'artifact_publish_from_aarch64-windows-pipette' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-prep_steps"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-prep_steps" | $FLOWEY_BIN v 3 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 3 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-tmk_vmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tmk_vmm" | $FLOWEY_BIN v 3 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-tpm_guest_tests"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tpm_guest_tests" | $FLOWEY_BIN v 3 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-vmgstool"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmgstool" | $FLOWEY_BIN v 3 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-vmm-tests-archive"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmm-tests-archive" | $FLOWEY_BIN v 3 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::install_rust 0
     displayName: install Rust
@@ -4432,22 +4839,22 @@ jobs:
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 3 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 3 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
+      $(FLOWEY_BIN) e 3 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar5)
-      path: $(floweyvar4)
+      key: $(floweyvar3)
+      path: $(floweyvar2)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 3 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 3 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 3 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
@@ -4459,136 +4866,20 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 2
-    displayName: symlink protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_tmk_vmm 0
-      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 7
-    displayName: cargo build tmk_vmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_prep_steps 0
-      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 5
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 4
-    displayName: cargo build prep_steps
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 6
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 10
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_vmgstool 0
-      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 6
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 3
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 8
-    displayName: cargo build vmgstool
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 5
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 9
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_tpm_guest_tests 0
-      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 7
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 4
-    displayName: cargo build tpm_guest_tests
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 5
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 0
-    displayName: cargo build test_igvm_agent_rpc_server
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 3 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 3 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 3 flowey_lib_common::download_cargo_nextest 3
-    displayName: create cargo-nextest cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar3)
-      path: $(floweyvar2)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: cargo-nextest'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 3 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::download_cargo_nextest 4
-    displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::install_rust 2
-    displayName: report $CARGO_HOME
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::install_cargo_nextest 0
       $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 0
-    displayName: installing cargo-nextest
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_nextest_archive 0
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_nextest_vmm_tests 0
-      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 5
-    displayName: build + archive 'vmm_tests' nextests
+    displayName: symlink protoc
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 0
       $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 0
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_openvmm 0
-      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 6
-    displayName: cargo build openvmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_pipette 0
-      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 0
     displayName: cargo build pipette
   - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-openvmm
-    displayName: 🌼📦 Publish aarch64-windows-openvmm
-    artifact: aarch64-windows-openvmm
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-pipette
     displayName: 🌼📦 Publish aarch64-windows-pipette
     artifact: aarch64-windows-pipette
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-prep_steps
-    displayName: 🌼📦 Publish aarch64-windows-prep_steps
-    artifact: aarch64-windows-prep_steps
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server
-    displayName: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
-    artifact: aarch64-windows-test_igvm_agent_rpc_server
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tmk_vmm
-    displayName: 🌼📦 Publish aarch64-windows-tmk_vmm
-    artifact: aarch64-windows-tmk_vmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tpm_guest_tests
-    displayName: 🌼📦 Publish aarch64-windows-tpm_guest_tests
-    artifact: aarch64-windows-tpm_guest_tests
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmgstool
-    displayName: 🌼📦 Publish aarch64-windows-vmgstool
-    artifact: aarch64-windows-vmgstool
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmm-tests-archive
-    displayName: 🌼📦 Publish aarch64-windows-vmm-tests-archive
-    artifact: aarch64-windows-vmm-tests-archive
 - job: job2
   displayName: build artifacts (not for VMM tests) [aarch64-windows]
   pool:

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -1847,6 +1847,10 @@ jobs:
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-igvmfilegen"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-igvmfilegen" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-vmm-tests-archive"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-vmm-tests-archive" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-ohcldiag-dev"
@@ -1938,38 +1942,38 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 4
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 8
     displayName: cargo build openvmm_vhost
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 9
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_vhost 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 1
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 6
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 5
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 7
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 13
     displayName: cargo build vmgstool
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 6
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 14
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_vmgstool 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 2
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 5
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 6
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 12
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
     displayName: cargo build vmgs_lib
   - bash: |-
@@ -1977,7 +1981,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 3
     displayName: test vmgs_lib
   - bash: |-
       set -e
@@ -1986,7 +1990,7 @@ jobs:
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 5
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 4
@@ -2003,6 +2007,38 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 3
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_ohcldiag_dev 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 5
+    displayName: split debug symbols
+  - bash: $(FLOWEY_BIN) e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 8
+    displayName: extract X86_64 sysroot.tar.gz
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 6
+    displayName: cargo build openvmm
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm 1
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 6
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 9
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 5
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 10
+    displayName: cargo build openvmm_vhost
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 11
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_vhost 1
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 7
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2043,14 +2079,14 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_nextest_archive 0
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 6
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 8
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 1
     displayName: build + archive 'vmm_tests' nextests
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_nextest_archive 1
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
-      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 7
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 9
     displayName: build + archive 'vmm_tests' nextests
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
@@ -2059,6 +2095,12 @@ jobs:
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-igvmfilegen
     displayName: 🌼📦 Publish x64-linux-igvmfilegen
     artifact: x64-linux-igvmfilegen
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm
+    displayName: 🌼📦 Publish x64-linux-musl-openvmm
+    artifact: x64-linux-musl-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost
+    displayName: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+    artifact: x64-linux-musl-openvmm_vhost
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-vmm-tests-archive
     displayName: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
     artifact: x64-linux-musl-vmm-tests-archive
@@ -2118,10 +2160,6 @@ jobs:
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-guest_test_uefi"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm_vhost"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-pipette"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-tmk_vmm"
@@ -2194,7 +2232,7 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 4
     displayName: symlink protoc
   - bash: |-
       set -e
@@ -2206,31 +2244,31 @@ jobs:
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_guest_test_uefi 0
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 0
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 4
     displayName: build guest_test_uefi.img
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 5
     displayName: cargo build simple_tmk
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 6
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_tmks 0
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 1
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 1
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 6
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 13
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 4
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 9
     displayName: cargo build tpm_guest_tests
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 14
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 10
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_tpm_guest_tests 0
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 2
     displayName: split debug symbols
@@ -2243,66 +2281,34 @@ jobs:
     displayName: extract X86_64 sysroot.tar.gz
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 1
     displayName: cargo build pipette
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 2
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_pipette 0
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 4
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 5
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 11
-    displayName: cargo build tmk_vmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 12
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_tmk_vmm 0
-      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 5
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 1
-    displayName: cargo build openvmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 5
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm 0
-      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 5
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 2
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 3
-    displayName: cargo build openvmm_vhost
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 7
+    displayName: cargo build tmk_vmm
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 4
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm_vhost 0
-      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 6
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_tmk_vmm 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 4
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-guest_test_uefi
     displayName: 🌼📦 Publish x64-guest_test_uefi
     artifact: x64-guest_test_uefi
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm
-    displayName: 🌼📦 Publish x64-linux-musl-openvmm
-    artifact: x64-linux-musl-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost
-    displayName: 🌼📦 Publish x64-linux-musl-openvmm_vhost
-    artifact: x64-linux-musl-openvmm_vhost
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette
     displayName: 🌼📦 Publish x64-linux-musl-pipette
     artifact: x64-linux-musl-pipette
@@ -2353,6 +2359,10 @@ jobs:
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-igvmfilegen"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-igvmfilegen" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-ohcldiag-dev"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-ohcldiag-dev" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-openvmm"
@@ -2440,42 +2450,42 @@ jobs:
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_openvmm 0
       $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 2
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 4
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 8
     displayName: cargo build openvmm_vhost
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 9
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_openvmm_vhost 0
       $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 1
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 4
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 5
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 7
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 13
     displayName: cargo build vmgstool
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 6
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 14
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_vmgstool 0
       $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 2
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 3
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 6
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 12
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
       $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 1
     displayName: cargo build vmgs_lib
   - bash: |-
       set -e
@@ -2484,7 +2494,7 @@ jobs:
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 5
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 4
@@ -2502,11 +2512,49 @@ jobs:
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
       $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 5
     displayName: split debug symbols
+  - bash: $(FLOWEY_BIN) e 7 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 6
+    displayName: extract Aarch64 sysroot.tar.gz
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 6
+    displayName: cargo build openvmm
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_openvmm 1
+      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 6
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 7
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 5
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 10
+    displayName: cargo build openvmm_vhost
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 11
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_openvmm_vhost 1
+      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 7
+    displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-igvmfilegen
     displayName: 🌼📦 Publish aarch64-linux-igvmfilegen
     artifact: aarch64-linux-igvmfilegen
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm
+    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm
+    artifact: aarch64-linux-musl-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost
+    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
+    artifact: aarch64-linux-musl-openvmm_vhost
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-ohcldiag-dev
     displayName: 🌼📦 Publish aarch64-linux-ohcldiag-dev
     artifact: aarch64-linux-ohcldiag-dev
@@ -2560,10 +2608,6 @@ jobs:
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-guest_test_uefi"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-guest_test_uefi" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-pipette"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-tmk_vmm"
@@ -2636,7 +2680,7 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 4
     displayName: symlink protoc
   - bash: |-
       set -e
@@ -2648,31 +2692,31 @@ jobs:
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_guest_test_uefi 0
       $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 0
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 4
     displayName: build guest_test_uefi.img
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 5
     displayName: cargo build simple_tmk
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 6
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_tmks 0
       $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 1
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 1
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 6
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 13
+      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 4
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 9
     displayName: cargo build tpm_guest_tests
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 14
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 10
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_tpm_guest_tests 0
       $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 2
     displayName: split debug symbols
@@ -2685,66 +2729,34 @@ jobs:
     displayName: extract Aarch64 sysroot.tar.gz
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 1
     displayName: cargo build pipette
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 2
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_pipette 0
       $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 4
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 5
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 11
-    displayName: cargo build tmk_vmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 12
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_tmk_vmm 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 5
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 1
-    displayName: cargo build openvmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 5
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_openvmm 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 5
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 2
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 3
-    displayName: cargo build openvmm_vhost
+      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 7
+    displayName: cargo build tmk_vmm
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 4
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_openvmm_vhost 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 6
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_tmk_vmm 0
+      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 4
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-guest_test_uefi
     displayName: 🌼📦 Publish aarch64-guest_test_uefi
     artifact: aarch64-guest_test_uefi
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm
-    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm
-    artifact: aarch64-linux-musl-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost
-    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
-    artifact: aarch64-linux-musl-openvmm_vhost
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette
     displayName: 🌼📦 Publish aarch64-linux-musl-pipette
     artifact: aarch64-linux-musl-pipette

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -212,7 +212,7 @@ jobs:
   - publish: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
     displayName: 🌼🥾 Publish bootstrapped flowey
     artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
-- job: job16
+- job: job18
   displayName: build openhcl (mi-secure) [x64-linux]
   pool:
     demands:
@@ -242,28 +242,28 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 16 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 16 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 18 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 18 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 16 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 18 'verbose' update
       ${{ parameters.verbose }}
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 16 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 18 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | $FLOWEY_BIN v 16 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | $FLOWEY_BIN v 18 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::install_dist_pkg 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::install_dist_pkg 0
     displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::install_dist_pkg 1
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::install_dist_pkg 1
     displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -273,27 +273,27 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::install_rust 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 16 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -305,165 +305,165 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 8
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 9
     displayName: cargo build sidecar
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 10
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_sidecar 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_sidecar 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 3
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 4
+      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 4
     displayName: cargo build openhcl_boot
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 5
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_boot 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_boot 0
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
     displayName: extract and resolve kernel package
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 3
     displayName: extract X86_64 sysroot.tar.gz
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
     displayName: cargo build openvmm_hcl
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_initrd 2
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_initrd 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 2
     displayName: building openhcl initrd
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 0
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_split_debug_info 5
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_igvmfilegen 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_igvmfilegen 2
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_igvmfilegen 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
     displayName: building igvm file
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_uefi_mu_msvm 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
     displayName: unpack mu_msvm package (x64)
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
     displayName: extract and resolve kernel package
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_initrd 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
     displayName: building openhcl initrd
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_igvmfilegen 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
     displayName: building igvm file
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_initrd 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_initrd 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
     displayName: building openhcl initrd
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_igvmfilegen 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
     displayName: building igvm file
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::copy_to_artifact_dir 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::copy_to_artifact_dir 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
     displayName: copying OpenHCL igvm files to artifact dir
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::copy_to_artifact_dir 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::copy_to_artifact_dir 0
     displayName: copying OpenHCL igvm extras to artifact dir
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm
     displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm
@@ -471,7 +471,7 @@ jobs:
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras
     displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
     artifact: x64-mi-secure-openhcl-igvm-extras
-- job: job12
+- job: job14
   displayName: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
   pool:
     demands:
@@ -501,25 +501,25 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 12 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 12 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 14 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 14 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 12 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 14 'verbose' update
       ${{ parameters.verbose }}
       EOF
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -531,21 +531,21 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_dist_pkg 0
     displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 1
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_dist_pkg 1
     displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
+      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -555,68 +555,68 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
     displayName: extract X86_64 sysroot.tar.gz
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::resolve_protoc 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::resolve_protoc 0
     displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 2
     displayName: symlink protoc
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 4
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 4
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 1
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 6
-    displayName: cargo clippy
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 5
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 6
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 5
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 0
+    displayName: cargo clippy
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 0
     displayName: cargo build xtask
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_xtask 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_xtask 0
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::check_clippy 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::check_clippy 0
     displayName: determine clippy exclusions
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 0
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 2
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 2
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 3
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 3
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
+      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -626,33 +626,33 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 2
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 2
     displayName: report $CARGO_HOME
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 3
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 4
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 5
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 5
-      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 6
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
-      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 4
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 6
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 4
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (openssl)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -661,18 +661,18 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (openssl)
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 6
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 7
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 7
-      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 8
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
-      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 6
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 7
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 7
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 8
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 6
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (symcrypt)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -681,18 +681,18 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 9
-      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 8
-      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 9
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 8
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (all)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -703,30 +703,30 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 2
     displayName: cargo build xtask
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_xtask 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_xtask 1
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 8
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 9
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 8
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 9
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -735,18 +735,18 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-unit-tests
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 2
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 3
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 4
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 3
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 4
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 2
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (none)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -757,16 +757,16 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 6
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
     displayName: run doctests for x86_64-unknown-linux-musl
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job11
+- job: job13
   displayName: clippy [macos], unit tests [x64-linux]
   pool:
     demands:
@@ -796,29 +796,29 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 11 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 11 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 13 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 13 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 11 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 13 'verbose' update
       ${{ parameters.verbose }}
       EOF
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 11 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_dist_pkg 0
     displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 1
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_dist_pkg 1
     displayName: installing packages
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar9
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar9
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -830,18 +830,18 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -851,52 +851,52 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 1
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 0
     displayName: cargo build xtask
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_xtask 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_xtask 0
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::check_clippy 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::check_clippy 0
     displayName: determine clippy exclusions
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_clippy 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_clippy 0
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_clippy 1
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 11 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 11 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 11 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -906,33 +906,33 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 2
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 2
     displayName: report $CARGO_HOME
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 4
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 5
-      $(FLOWEY_BIN) e 11 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 11 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 11 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 4
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (all)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -943,30 +943,30 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 2
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 2
     displayName: cargo build xtask
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_xtask 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_xtask 1
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 6
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 7
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 1
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 7
-      $(FLOWEY_BIN) e 11 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 11 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 11 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 6
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 7
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 7
+      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 6
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -975,18 +975,18 @@ jobs:
       testRunTitle: x64-linux-unit-tests-unit-tests
     displayName: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 2
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 2
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 11 flowey_lib_common::ado_task_publish_test_results 4
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 11 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 3
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 4
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (none)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -995,18 +995,18 @@ jobs:
       testRunTitle: x64-linux-unit-tests-unit-tests crypto (none)
     displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 4
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 5
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 11 flowey_lib_common::ado_task_publish_test_results 6
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 11 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
-      $FLOWEY_BIN v 11 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 4
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 6
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 2
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (openssl)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1017,16 +1017,16 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 5
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
     displayName: run doctests for x86_64-unknown-linux-gnu
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job10
+- job: job12
   displayName: clippy [x64-windows], unit tests [x64-windows]
   pool:
     demands:
@@ -1101,25 +1101,25 @@ jobs:
     displayName: 🌼🔎 Self-check YAML
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 10 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 10 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 12 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 12 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 10 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 12 'verbose' update
       ${{ parameters.verbose }}
       EOF
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 10 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar7
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar7
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -1131,18 +1131,18 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1152,48 +1152,48 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 10 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 2
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_xtask 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_xtask 0
     displayName: cargo build xtask
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::check_clippy 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::check_clippy 0
     displayName: determine clippy exclusions
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_clippy 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 0
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_clippy 1
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 10 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 10 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 10 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1203,33 +1203,33 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 10 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 2
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 2
     displayName: report $CARGO_HOME
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_nextest_unit_tests 2
-      $(FLOWEY_BIN) e 10 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 10 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 10 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 10 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 10 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 2
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (none)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1240,25 +1240,25 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 3
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_xtask 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_xtask 1
     displayName: cargo build xtask
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_nextest_unit_tests 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_nextest_run 2
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_nextest_run 3
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_nextest_unit_tests 1
-      $(FLOWEY_BIN) e 10 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 10 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 10 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 10 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 10 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 2
+      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1269,17 +1269,548 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
     displayName: run doctests for x86_64-pc-windows-msvc
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job9
+- job: job11
   displayName: build openhcl [x64-linux]
+  pool:
+    demands:
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
+  dependsOn:
+  - job0
+  condition: and(succeeded(), not(canceled()))
+  variables:
+  - name: FLOWEY_TEMP_DIR
+    value: $(Build.StagingDirectory)/.flowey-internal
+  steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼🥾 Download bootstrapped flowey
+    inputs:
+      artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
+      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - bash: |
+      set -e
+      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
+      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
+
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey"
+      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
+    displayName: Set flowey path
+  - bash: |
+      set -e
+      echo '"debug"' | $FLOWEY_BIN v 11 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 11 '_internal_WORKING_DIR' --is-raw-string update
+
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 11 'verbose' update
+      ${{ parameters.verbose }}
+      EOF
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-extras"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+    displayName: 🌼🛫 Initialize job
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar2)
+      path: $(floweyvar1)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (x64)
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 11 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar3)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    displayName: unpack protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 8
+    displayName: symlink protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 9
+    displayName: cargo build sidecar
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_sidecar 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 3
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 4
+    displayName: cargo build openhcl_boot
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_boot 0
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+    displayName: extract and resolve kernel package
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 3
+    displayName: extract X86_64 sysroot.tar.gz
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+    displayName: cargo build openvmm_hcl
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 2
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 0
+    displayName: cargo build igvmfilegen
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_igvmfilegen 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+    displayName: split debug symbols
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+    displayName: extract and resolve kernel package
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+    displayName: extract and resolve kernel package
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::copy_to_artifact_dir 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+    displayName: copying OpenHCL igvm files to artifact dir
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::copy_to_artifact_dir 0
+    displayName: copying OpenHCL igvm extras to artifact dir
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: gh-release-download'
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm
+    displayName: 🌼📦 Publish x64-openhcl-igvm
+    artifact: x64-openhcl-igvm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras
+    displayName: 🌼📦 Publish x64-openhcl-igvm-extras
+    artifact: x64-openhcl-igvm-extras
+- job: job10
+  displayName: build openhcl [aarch64-linux]
+  pool:
+    demands:
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
+  dependsOn:
+  - job0
+  condition: and(succeeded(), not(canceled()))
+  variables:
+  - name: FLOWEY_TEMP_DIR
+    value: $(Build.StagingDirectory)/.flowey-internal
+  steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼🥾 Download bootstrapped flowey
+    inputs:
+      artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
+      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - bash: |
+      set -e
+      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
+      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
+
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey"
+      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
+    displayName: Set flowey path
+  - bash: |
+      set -e
+      echo '"debug"' | $FLOWEY_BIN v 10 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 10 '_internal_WORKING_DIR' --is-raw-string update
+
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 10 'verbose' update
+      ${{ parameters.verbose }}
+      EOF
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-extras"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
+    displayName: 🌼🛫 Initialize job
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar2)
+      path: $(floweyvar1)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 10 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (aarch64)
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 10 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar3)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    displayName: unpack protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 3
+    displayName: symlink protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 4
+    displayName: cargo build openhcl_boot
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_boot 0
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+    displayName: extract and resolve kernel package
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 1
+    displayName: extract Aarch64 sysroot.tar.gz
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+    displayName: cargo build openvmm_hcl
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 2
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 0
+    displayName: cargo build igvmfilegen
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_igvmfilegen 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_igvmfilegen 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+    displayName: extract and resolve kernel package
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_igvmfilegen 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::copy_to_artifact_dir 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+    displayName: copying OpenHCL igvm files to artifact dir
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::copy_to_artifact_dir 0
+    displayName: copying OpenHCL igvm extras to artifact dir
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: gh-release-download'
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm
+    displayName: 🌼📦 Publish aarch64-openhcl-igvm
+    artifact: aarch64-openhcl-igvm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras
+    displayName: 🌼📦 Publish aarch64-openhcl-igvm-extras
+    artifact: aarch64-openhcl-igvm-extras
+- job: job9
+  displayName: build artifacts [x64-linux] (for VMM tests)
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -1314,37 +1845,67 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 9 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm_vhost"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-pipette"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-tmk_vmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-igvmfilegen"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-igvmfilegen" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-vmm-tests-archive"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-vmm-tests-archive" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-ohcldiag-dev"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-ohcldiag-dev" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmgs_lib"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgs_lib" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmgstool"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgstool" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmm-tests-archive"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmm-tests-archive" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
     displayName: 🌼🛫 Initialize job
+  - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 9 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::install_dist_pkg 0
     displayName: checking if packages need to be installed
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::install_dist_pkg 1
     displayName: installing packages
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar1)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar4)
-      path: $(floweyvar3)
+      key: $(floweyvar5)
+      path: $(floweyvar4)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
@@ -1356,36 +1917,6 @@ jobs:
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 9 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (x64)
-  - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 9 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar5
-      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar5)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-    displayName: set '-Dwarnings' in .cargo/config.toml
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::resolve_protoc 0
@@ -1394,67 +1925,60 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 13
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 14
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 1
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 6
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 15
-    displayName: cargo build sidecar
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 10
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 16
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_sidecar 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 3
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 2
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 4
-    displayName: cargo build openhcl_boot
+    displayName: cargo build openvmm
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 1
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 5
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_boot 0
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm 0
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 0
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 2
     displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-    displayName: extract and resolve kernel package
-  - bash: $(FLOWEY_BIN) e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 5
-    displayName: extract X86_64 sysroot.tar.gz
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 8
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-    displayName: cargo build openvmm_hcl
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 6
+    displayName: cargo build openvmm_vhost
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_vhost 0
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 5
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_initrd 4
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 2
-    displayName: building openhcl initrd
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 5
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 9
+    displayName: cargo build vmgstool
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_vmgstool 0
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 4
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+    displayName: cargo build vmgs_lib
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 3
+    displayName: test vmgs_lib
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 0
@@ -1462,188 +1986,23 @@ jobs:
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 9
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 4
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_igvmfilegen 4
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-    displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 9 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_initrd 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_initrd 3
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_igvmfilegen 3
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_initrd 2
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_igvmfilegen 2
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::copy_to_artifact_dir 1
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-    displayName: copying OpenHCL igvm files to artifact dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::copy_to_artifact_dir 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 7
-    displayName: copying OpenHCL igvm extras to artifact dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 5
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 11
-    displayName: cargo build pipette
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 8
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 12
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_pipette 0
-      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 8
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 7
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 17
-    displayName: cargo build tmk_vmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 11
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 18
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_tmk_vmm 0
-      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 6
-    displayName: cargo build openvmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 6
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm 0
-      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 4
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 6
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 9
-    displayName: cargo build openvmm_vhost
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 2
+    displayName: cargo build ohcldiag-dev
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 7
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 10
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_vhost 0
-      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_ohcldiag_dev 0
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 5
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -1655,13 +2014,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar2)
-      path: $(floweyvar1)
+      key: $(floweyvar3)
+      path: $(floweyvar2)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
@@ -1678,41 +2037,57 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 0
     displayName: installing cargo-nextest
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_nextest_archive 0
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 4
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 6
+    displayName: build + archive 'vmm_tests' nextests
+  - bash: $(FLOWEY_BIN) e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 7
+    displayName: extract X86_64 sysroot.tar.gz
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_nextest_archive 1
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 7
     displayName: build + archive 'vmm_tests' nextests
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm
-    displayName: 🌼📦 Publish x64-linux-musl-openvmm
-    artifact: x64-linux-musl-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost
-    displayName: 🌼📦 Publish x64-linux-musl-openvmm_vhost
-    artifact: x64-linux-musl-openvmm_vhost
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette
-    displayName: 🌼📦 Publish x64-linux-musl-pipette
-    artifact: x64-linux-musl-pipette
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-tmk_vmm
-    displayName: 🌼📦 Publish x64-linux-musl-tmk_vmm
-    artifact: x64-linux-musl-tmk_vmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-igvmfilegen
+    displayName: 🌼📦 Publish x64-linux-igvmfilegen
+    artifact: x64-linux-igvmfilegen
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-vmm-tests-archive
     displayName: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
     artifact: x64-linux-musl-vmm-tests-archive
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm
-    displayName: 🌼📦 Publish x64-openhcl-igvm
-    artifact: x64-openhcl-igvm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras
-    displayName: 🌼📦 Publish x64-openhcl-igvm-extras
-    artifact: x64-openhcl-igvm-extras
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-ohcldiag-dev
+    displayName: 🌼📦 Publish x64-linux-ohcldiag-dev
+    artifact: x64-linux-ohcldiag-dev
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm
+    displayName: 🌼📦 Publish x64-linux-openvmm
+    artifact: x64-linux-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm_vhost
+    displayName: 🌼📦 Publish x64-linux-openvmm_vhost
+    artifact: x64-linux-openvmm_vhost
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgs_lib
+    displayName: 🌼📦 Publish x64-linux-vmgs_lib
+    artifact: x64-linux-vmgs_lib
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgstool
+    displayName: 🌼📦 Publish x64-linux-vmgstool
+    artifact: x64-linux-vmgstool
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmm-tests-archive
+    displayName: 🌼📦 Publish x64-linux-vmm-tests-archive
+    artifact: x64-linux-vmm-tests-archive
 - job: job8
-  displayName: build openhcl [aarch64-linux]
+  displayName: build artifacts [x64-linux] (shared)
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -1747,31 +2122,61 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 8 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-pipette"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-tmk_vmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-guest_test_uefi"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-pipette"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-tmk_vmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-tpm_guest_tests"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-tmks"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-tmks" | $FLOWEY_BIN v 8 'artifact_publish_from_x64-tmks' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 8 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar1)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
   - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar2)
-      path: $(floweyvar1)
+      key: $(floweyvar3)
+      path: $(floweyvar2)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
@@ -1783,36 +2188,10 @@ jobs:
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 8 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (aarch64)
-  - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 8 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar3)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::resolve_protoc 0
@@ -1821,156 +2200,129 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 6
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 4
-    displayName: cargo build openhcl_boot
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 0
+    displayName: cargo build guest_test_uefi
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_guest_test_uefi 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 0
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 8
+    displayName: build guest_test_uefi.img
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 4
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 9
+    displayName: cargo build simple_tmk
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 5
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_boot 0
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_tmks 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 1
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-    displayName: extract and resolve kernel package
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 6
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 13
+    displayName: cargo build tpm_guest_tests
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 14
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_tpm_guest_tests 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 2
+    displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 8 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 1
-    displayName: extract Aarch64 sysroot.tar.gz
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-    displayName: cargo build openvmm_hcl
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 4
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 0
-    displayName: cargo build igvmfilegen
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 5
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_initrd 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::copy_to_artifact_dir 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-    displayName: copying OpenHCL igvm files to artifact dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::copy_to_artifact_dir 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 2
-    displayName: copying OpenHCL igvm extras to artifact dir
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 3
+    displayName: extract X86_64 sysroot.tar.gz
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 5
     displayName: cargo build pipette
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 6
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_pipette 0
-      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 4
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 5
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 11
     displayName: cargo build tmk_vmm
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 12
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_tmk_vmm 0
-      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 4
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 5
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 1
+    displayName: cargo build openvmm
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 5
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 2
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 3
+    displayName: cargo build openvmm_vhost
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 4
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm_vhost 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 6
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette
-    displayName: 🌼📦 Publish aarch64-linux-musl-pipette
-    artifact: aarch64-linux-musl-pipette
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-tmk_vmm
-    displayName: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
-    artifact: aarch64-linux-musl-tmk_vmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm
-    displayName: 🌼📦 Publish aarch64-openhcl-igvm
-    artifact: aarch64-openhcl-igvm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras
-    displayName: 🌼📦 Publish aarch64-openhcl-igvm-extras
-    artifact: aarch64-openhcl-igvm-extras
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-guest_test_uefi
+    displayName: 🌼📦 Publish x64-guest_test_uefi
+    artifact: x64-guest_test_uefi
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm
+    displayName: 🌼📦 Publish x64-linux-musl-openvmm
+    artifact: x64-linux-musl-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost
+    displayName: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+    artifact: x64-linux-musl-openvmm_vhost
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette
+    displayName: 🌼📦 Publish x64-linux-musl-pipette
+    artifact: x64-linux-musl-pipette
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-tmk_vmm
+    displayName: 🌼📦 Publish x64-linux-musl-tmk_vmm
+    artifact: x64-linux-musl-tmk_vmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-tpm_guest_tests
+    displayName: 🌼📦 Publish x64-linux-tpm_guest_tests
+    artifact: x64-linux-tpm_guest_tests
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-tmks
+    displayName: 🌼📦 Publish x64-tmks
+    artifact: x64-tmks
 - job: job7
-  displayName: build artifacts [x64-linux]
+  displayName: build artifacts [aarch64-linux] (for VMM tests)
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -2005,26 +2357,18 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 7 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-guest_test_uefi"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-igvmfilegen"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-igvmfilegen" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-ohcldiag-dev"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-ohcldiag-dev" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-openvmm_vhost"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-tpm_guest_tests"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmgs_lib"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgs_lib" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmgstool"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgstool" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmm-tests-archive"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmm-tests-archive" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-tmks"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-tmks" | $FLOWEY_BIN v 7 'artifact_publish_from_x64-tmks' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-igvmfilegen"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-igvmfilegen" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-ohcldiag-dev"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-ohcldiag-dev" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm_vhost" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-vmgs_lib"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgs_lib" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-vmgstool"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgstool" | $FLOWEY_BIN v 7 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::install_rust 0
     displayName: install Rust
@@ -2062,22 +2406,22 @@ jobs:
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
+      $(FLOWEY_BIN) e 7 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar5)
-      path: $(floweyvar4)
+      key: $(floweyvar3)
+      path: $(floweyvar2)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 7 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 7 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
@@ -2089,201 +2433,103 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 0
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 4
     displayName: cargo build openvmm
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_openvmm 0
       $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 1
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 6
     displayName: cargo build openvmm_vhost
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 7
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_openvmm_vhost 0
       $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 7
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 4
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 8
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 16
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 5
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 9
     displayName: cargo build vmgstool
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 5
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 17
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 10
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_vmgstool 0
       $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 3
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 7
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 15
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 4
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 8
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-    displayName: cargo build vmgs_lib
-  - bash: |-
-      set -e
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 2
       $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 8
-    displayName: test vmgs_lib
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 1
-    displayName: cargo build igvmfilegen
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 6
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 4
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 2
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 3
-    displayName: cargo build ohcldiag-dev
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 4
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
-      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 5
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 9
-    displayName: split debug symbols
+    displayName: cargo build vmgs_lib
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 0
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 0
-    displayName: cargo build guest_test_uefi
+    displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_guest_test_uefi 0
-      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 6
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 9
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 10
-    displayName: build guest_test_uefi.img
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 5
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 11
-    displayName: cargo build simple_tmk
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 12
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_tmks 0
-      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 7
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_igvmfilegen 0
+      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 4
       $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 5
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 6
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 13
-    displayName: cargo build tpm_guest_tests
+      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 2
+    displayName: cargo build ohcldiag-dev
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 14
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_tpm_guest_tests 0
-      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 8
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
+      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 5
     displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 7 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 7 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 7 flowey_lib_common::download_cargo_nextest 3
-    displayName: create cargo-nextest cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar3)
-      path: $(floweyvar2)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: cargo-nextest'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 7 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::download_cargo_nextest 4
-    displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::install_rust 2
-    displayName: report $CARGO_HOME
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::init_cross_build 1
-    displayName: installing cargo-nextest
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 7 flowey_lib_common::run_cargo_nextest_archive 0
-      $(FLOWEY_BIN) e 7 flowey_lib_hvlite::build_nextest_vmm_tests 0
-      $(FLOWEY_BIN) e 7 flowey_core::pipeline::artifact::publish 9
-    displayName: build + archive 'vmm_tests' nextests
   - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-guest_test_uefi
-    displayName: 🌼📦 Publish x64-guest_test_uefi
-    artifact: x64-guest_test_uefi
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-igvmfilegen
-    displayName: 🌼📦 Publish x64-linux-igvmfilegen
-    artifact: x64-linux-igvmfilegen
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-ohcldiag-dev
-    displayName: 🌼📦 Publish x64-linux-ohcldiag-dev
-    artifact: x64-linux-ohcldiag-dev
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm
-    displayName: 🌼📦 Publish x64-linux-openvmm
-    artifact: x64-linux-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm_vhost
-    displayName: 🌼📦 Publish x64-linux-openvmm_vhost
-    artifact: x64-linux-openvmm_vhost
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-tpm_guest_tests
-    displayName: 🌼📦 Publish x64-linux-tpm_guest_tests
-    artifact: x64-linux-tpm_guest_tests
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgs_lib
-    displayName: 🌼📦 Publish x64-linux-vmgs_lib
-    artifact: x64-linux-vmgs_lib
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgstool
-    displayName: 🌼📦 Publish x64-linux-vmgstool
-    artifact: x64-linux-vmgstool
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmm-tests-archive
-    displayName: 🌼📦 Publish x64-linux-vmm-tests-archive
-    artifact: x64-linux-vmm-tests-archive
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-tmks
-    displayName: 🌼📦 Publish x64-tmks
-    artifact: x64-tmks
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-igvmfilegen
+    displayName: 🌼📦 Publish aarch64-linux-igvmfilegen
+    artifact: aarch64-linux-igvmfilegen
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-ohcldiag-dev
+    displayName: 🌼📦 Publish aarch64-linux-ohcldiag-dev
+    artifact: aarch64-linux-ohcldiag-dev
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm
+    displayName: 🌼📦 Publish aarch64-linux-openvmm
+    artifact: aarch64-linux-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm_vhost
+    displayName: 🌼📦 Publish aarch64-linux-openvmm_vhost
+    artifact: aarch64-linux-openvmm_vhost
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgs_lib
+    displayName: 🌼📦 Publish aarch64-linux-vmgs_lib
+    artifact: aarch64-linux-vmgs_lib
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgstool
+    displayName: 🌼📦 Publish aarch64-linux-vmgstool
+    artifact: aarch64-linux-vmgstool
 - job: job6
-  displayName: build artifacts [aarch64-linux]
+  displayName: build artifacts [aarch64-linux] (shared)
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -2320,20 +2566,16 @@ jobs:
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-guest_test_uefi"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-guest_test_uefi" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-igvmfilegen"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-igvmfilegen" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-ohcldiag-dev"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-ohcldiag-dev" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-openvmm_vhost"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm_vhost" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-pipette"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-tmk_vmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-tpm_guest_tests"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-tpm_guest_tests" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-vmgs_lib"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgs_lib" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-vmgstool"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgstool" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-tmks"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-tmks" | $FLOWEY_BIN v 6 'artifact_publish_from_aarch64-tmks' --is-raw-string update
     displayName: 🌼🛫 Initialize job
@@ -2344,10 +2586,6 @@ jobs:
       $(FLOWEY_BIN) e 6 flowey_lib_common::install_rust 1
       $(FLOWEY_BIN) e 6 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
-  - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 6 flowey_lib_common::git_checkout 0
@@ -2392,6 +2630,10 @@ jobs:
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 6 flowey_lib_common::resolve_protoc 0
@@ -2400,82 +2642,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 2
-    displayName: symlink protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 5
-    displayName: cargo build openvmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_openvmm 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 3
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 7
-    displayName: cargo build openvmm_vhost
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 8
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_openvmm_vhost 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 1
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 6
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 8
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 16
-    displayName: cargo build vmgstool
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 5
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 17
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_vmgstool 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 5
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 7
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 15
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 7
-    displayName: cargo build vmgs_lib
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 1
-    displayName: cargo build igvmfilegen
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 6
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 1
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 3
-    displayName: cargo build ohcldiag-dev
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 4
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_ohcldiag_dev 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 5
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 8
-    displayName: split debug symbols
+    displayName: symlink protoc
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 0
@@ -2484,23 +2652,23 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_guest_test_uefi 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 6
+      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 0
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 9
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 8
     displayName: build guest_test_uefi.img
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 5
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 11
+      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 4
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 9
     displayName: cargo build simple_tmk
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 12
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 10
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_tmks 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 7
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 1
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2512,34 +2680,86 @@ jobs:
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 4
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 14
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_tpm_guest_tests 0
-      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 8
+      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 2
+    displayName: split debug symbols
+  - bash: $(FLOWEY_BIN) e 6 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 3
+    displayName: extract Aarch64 sysroot.tar.gz
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 5
+    displayName: cargo build pipette
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_pipette 0
+      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 4
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 5
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 11
+    displayName: cargo build tmk_vmm
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 12
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_tmk_vmm 0
+      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 4
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 5
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 1
+    displayName: cargo build openvmm
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_openvmm 0
+      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 5
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 2
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 3
+    displayName: cargo build openvmm_vhost
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 4
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_openvmm_vhost 0
+      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 6
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-guest_test_uefi
     displayName: 🌼📦 Publish aarch64-guest_test_uefi
     artifact: aarch64-guest_test_uefi
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-igvmfilegen
-    displayName: 🌼📦 Publish aarch64-linux-igvmfilegen
-    artifact: aarch64-linux-igvmfilegen
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-ohcldiag-dev
-    displayName: 🌼📦 Publish aarch64-linux-ohcldiag-dev
-    artifact: aarch64-linux-ohcldiag-dev
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm
-    displayName: 🌼📦 Publish aarch64-linux-openvmm
-    artifact: aarch64-linux-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm_vhost
-    displayName: 🌼📦 Publish aarch64-linux-openvmm_vhost
-    artifact: aarch64-linux-openvmm_vhost
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm
+    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm
+    artifact: aarch64-linux-musl-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost
+    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
+    artifact: aarch64-linux-musl-openvmm_vhost
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette
+    displayName: 🌼📦 Publish aarch64-linux-musl-pipette
+    artifact: aarch64-linux-musl-pipette
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-tmk_vmm
+    displayName: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
+    artifact: aarch64-linux-musl-tmk_vmm
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-tpm_guest_tests
     displayName: 🌼📦 Publish aarch64-linux-tpm_guest_tests
     artifact: aarch64-linux-tpm_guest_tests
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgs_lib
-    displayName: 🌼📦 Publish aarch64-linux-vmgs_lib
-    artifact: aarch64-linux-vmgs_lib
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgstool
-    displayName: 🌼📦 Publish aarch64-linux-vmgstool
-    artifact: aarch64-linux-vmgstool
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-tmks
     displayName: 🌼📦 Publish aarch64-tmks
     artifact: aarch64-tmks
@@ -2835,7 +3055,7 @@ jobs:
   - publish: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
     displayName: 🌼🥾 Publish bootstrapped flowey
     artifact: _internal-flowey-bootstrap-x86_64-windows-uid-3
-- job: job15
+- job: job17
   displayName: run vmm-tests [x64-linux-amd-kvm]
   pool:
     demands:
@@ -2844,7 +3064,7 @@ jobs:
   dependsOn:
   - job0
   - job5
-  - job7
+  - job8
   - job9
   condition: and(succeeded(), not(canceled()))
   variables:
@@ -2908,37 +3128,37 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 15 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 15 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 17 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 17 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 15 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 17 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 15 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-vmm-tests-archive" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 15 'artifact_use_from_x64-tmks' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 17 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-vmm-tests-archive" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 17 'artifact_use_from_x64-tmks' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-pipette' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
     displayName: ensure hypervisor device is accessible
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
     displayName: ensure 2 MiB hugetlb pages are available
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -2948,18 +3168,18 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -2971,30 +3191,30 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 7
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 7
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 6
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_dist_pkg 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::install_dist_pkg 0
     displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_dist_pkg 1
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::install_dist_pkg 1
     displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3004,48 +3224,48 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_azcopy 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_azcopy 0
     displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
     displayName: calculating required VMM tests disk images
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
     displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::resolve_openvmm_deps 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_uefi_mu_msvm 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_uefi_mu_msvm 0
     displayName: unpack mu_msvm package (x64)
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_vmm_tests_env 0
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::init_vmm_tests_env 0
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
     displayName: setting up vmm_tests env
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::install_vmm_tests_deps 0
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::install_vmm_tests_deps 0
     displayName: install vmm tests deps (linux)
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 17 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 17 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'vmm_tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -3056,16 +3276,16 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 2
+      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job17
+- job: job19
   displayName: run vmm-tests [x64-windows-intel-mi-secure]
   pool:
     demands:
@@ -3073,10 +3293,9 @@ jobs:
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
-  - job16
+  - job18
   - job5
-  - job7
-  - job9
+  - job8
   condition: and(succeeded(), not(canceled()))
   variables:
   - name: FLOWEY_TEMP_DIR
@@ -3169,39 +3388,39 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 17 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 17 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 19 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 19 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 17 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 19 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 17 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 17 'artifact_use_from_x64-tmks' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 19 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 19 'artifact_use_from_x64-tmks' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3211,18 +3430,18 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -3234,32 +3453,32 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 6
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 9
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 10
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 8
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
     displayName: resolve OpenHCL igvm artifact
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3269,54 +3488,54 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_azcopy 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_azcopy 0
     displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
     displayName: calculating required VMM tests disk images
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
     displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_uefi_mu_msvm 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
     displayName: unpack mu_msvm package (x64)
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::init_vmm_tests_env 0
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::init_vmm_tests_env 0
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
     displayName: setting up vmm_tests env
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::install_vmm_tests_deps 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
     displayName: install vmm tests deps (windows)
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
     displayName: starting test_igvm_agent_rpc_server
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
     displayName: run 'vmm_tests' nextest tests
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 17 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 17 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 19 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 19 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: stopping test_igvm_agent_rpc_server
   - task: PublishTestResults@2
     inputs:
@@ -3327,16 +3546,16 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 2
-      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 2
+      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job14
+- job: job16
   displayName: run vmm-tests [x64-windows-amd]
   pool:
     demands:
@@ -3344,9 +3563,9 @@ jobs:
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
+  - job11
   - job5
-  - job7
-  - job9
+  - job8
   condition: and(succeeded(), not(canceled()))
   variables:
   - name: FLOWEY_TEMP_DIR
@@ -3439,39 +3658,39 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 14 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 14 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 16 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 16 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 14 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 16 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 14 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 14 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 14 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 14 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 14 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 14 'artifact_use_from_x64-tmks' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 14 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 14 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 14 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 14 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 14 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 14 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 14 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 14 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 16 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 16 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 16 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 16 'artifact_use_from_x64-tmks' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3481,18 +3700,18 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -3504,32 +3723,32 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 14 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 14 flowey_core::pipeline::artifact::resolve 6
-      $(FLOWEY_BIN) e 14 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 14 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 14 flowey_core::pipeline::artifact::resolve 9
-      $(FLOWEY_BIN) e 14 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 14 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 14 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 14 flowey_core::pipeline::artifact::resolve 10
-      $(FLOWEY_BIN) e 14 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 14 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 8
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
     displayName: resolve OpenHCL igvm artifact
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3539,54 +3758,54 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_azcopy 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_azcopy 0
     displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
     displayName: calculating required VMM tests disk images
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
     displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::download_uefi_mu_msvm 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_uefi_mu_msvm 0
     displayName: unpack mu_msvm package (x64)
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_vmm_tests_env 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 14 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_vmm_tests_env 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
     displayName: setting up vmm_tests env
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::install_vmm_tests_deps 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::install_vmm_tests_deps 0
     displayName: install vmm tests deps (windows)
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
     displayName: starting test_igvm_agent_rpc_server
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
     displayName: run 'vmm_tests' nextest tests
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: stopping test_igvm_agent_rpc_server
   - task: PublishTestResults@2
     inputs:
@@ -3597,16 +3816,16 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 2
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job13
+- job: job15
   displayName: run vmm-tests [x64-windows-intel]
   pool:
     demands:
@@ -3614,9 +3833,9 @@ jobs:
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
+  - job11
   - job5
-  - job7
-  - job9
+  - job8
   condition: and(succeeded(), not(canceled()))
   variables:
   - name: FLOWEY_TEMP_DIR
@@ -3709,39 +3928,39 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 13 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 13 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 15 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 15 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 13 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 15 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 13 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 13 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 13 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 13 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 13 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 13 'artifact_use_from_x64-tmks' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 13 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 13 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 13 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 13 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 13 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 13 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 13 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 13 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 15 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 15 'artifact_use_from_x64-tmks' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3751,18 +3970,18 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -3774,32 +3993,32 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 13 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 13 flowey_core::pipeline::artifact::resolve 6
-      $(FLOWEY_BIN) e 13 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 13 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 13 flowey_core::pipeline::artifact::resolve 9
-      $(FLOWEY_BIN) e 13 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 13 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 13 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 13 flowey_core::pipeline::artifact::resolve 10
-      $(FLOWEY_BIN) e 13 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 13 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 8
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
     displayName: resolve OpenHCL igvm artifact
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3809,54 +4028,54 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_azcopy 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_azcopy 0
     displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
     displayName: calculating required VMM tests disk images
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
     displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::resolve_openvmm_deps 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::download_uefi_mu_msvm 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_uefi_mu_msvm 0
     displayName: unpack mu_msvm package (x64)
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_vmm_tests_env 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 13 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_vmm_tests_env 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
     displayName: setting up vmm_tests env
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::install_vmm_tests_deps 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::install_vmm_tests_deps 0
     displayName: install vmm tests deps (windows)
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
     displayName: starting test_igvm_agent_rpc_server
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
     displayName: run 'vmm_tests' nextest tests
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: stopping test_igvm_agent_rpc_server
   - task: PublishTestResults@2
     inputs:
@@ -3867,14 +4086,14 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 2
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
 - job: job4
   displayName: build artifacts (not for VMM tests) [x64-windows]

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -1810,7 +1810,7 @@ jobs:
     displayName: 🌼📦 Publish aarch64-openhcl-igvm-extras
     artifact: aarch64-openhcl-igvm-extras
 - job: job9
-  displayName: build artifacts [x64-linux] (for VMM tests)
+  displayName: build artifacts (for VMM tests) [x64-linux]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -1925,7 +1925,7 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 2
     displayName: symlink protoc
   - bash: |-
       set -e
@@ -1938,7 +1938,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 3
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -1951,7 +1951,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 7
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_vhost 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 5
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 6
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -1964,7 +1964,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 10
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_vmgstool 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 5
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -1977,7 +1977,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
     displayName: test vmgs_lib
   - bash: |-
       set -e
@@ -1990,7 +1990,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 7
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2044,14 +2044,8 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_nextest_archive 0
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 6
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 1
     displayName: build + archive 'vmm_tests' nextests
-  - bash: $(FLOWEY_BIN) e 9 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 7
-    displayName: extract X86_64 sysroot.tar.gz
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_nextest_archive 1
@@ -2087,7 +2081,7 @@ jobs:
     displayName: 🌼📦 Publish x64-linux-vmm-tests-archive
     artifact: x64-linux-vmm-tests-archive
 - job: job8
-  displayName: build artifacts [x64-linux] (shared)
+  displayName: build artifacts (shared VMM tests) [x64-linux]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -2322,7 +2316,7 @@ jobs:
     displayName: 🌼📦 Publish x64-tmks
     artifact: x64-tmks
 - job: job7
-  displayName: build artifacts [aarch64-linux] (for VMM tests)
+  displayName: build artifacts (for VMM tests) [aarch64-linux]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -2529,7 +2523,7 @@ jobs:
     displayName: 🌼📦 Publish aarch64-linux-vmgstool
     artifact: aarch64-linux-vmgstool
 - job: job6
-  displayName: build artifacts [aarch64-linux] (shared)
+  displayName: build artifacts (shared VMM tests) [aarch64-linux]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -1929,7 +1929,7 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 1
     displayName: symlink protoc
   - bash: |-
       set -e
@@ -1942,7 +1942,7 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm 0
       $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 3
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -1955,7 +1955,7 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 9
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm_vhost 0
       $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 5
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -1968,7 +1968,7 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 14
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_vmgstool 0
       $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 4
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -1981,7 +1981,7 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 2
       $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 2
     displayName: test vmgs_lib
   - bash: |-
       set -e
@@ -1994,7 +1994,7 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 6
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2080,7 +2080,7 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_archive 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_vmm_tests 0
       $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 8
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 7
     displayName: build + archive 'vmm_tests' nextests
   - bash: |-
       set -e

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -212,7 +212,7 @@ jobs:
   - publish: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
     displayName: 🌼🥾 Publish bootstrapped flowey
     artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
-- job: job20
+- job: job18
   displayName: build openhcl (mi-secure) [x64-linux]
   pool:
     demands:
@@ -242,28 +242,28 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 20 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 20 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 18 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 18 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 20 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 18 'verbose' update
       ${{ parameters.verbose }}
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 20 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 18 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | $FLOWEY_BIN v 20 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | $FLOWEY_BIN v 18 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::install_dist_pkg 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::install_dist_pkg 0
     displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::install_dist_pkg 1
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::install_dist_pkg 1
     displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -273,27 +273,27 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 20 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::install_rust 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 20 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -305,165 +305,165 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 8
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 9
     displayName: cargo build sidecar
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 10
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_sidecar 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_sidecar 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 3
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 4
+      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 4
     displayName: cargo build openhcl_boot
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 5
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_boot 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_boot 0
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
     displayName: extract and resolve kernel package
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 3
     displayName: extract X86_64 sysroot.tar.gz
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
     displayName: cargo build openvmm_hcl
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_initrd 2
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_initrd 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 2
     displayName: building openhcl initrd
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 0
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_split_debug_info 5
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_igvmfilegen 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_igvmfilegen 2
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_igvmfilegen 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
     displayName: building igvm file
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
     displayName: unpack mu_msvm package (x64)
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
     displayName: extract and resolve kernel package
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_initrd 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
     displayName: building openhcl initrd
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_igvmfilegen 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
     displayName: building igvm file
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_initrd 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_initrd 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
     displayName: building openhcl initrd
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_igvmfilegen 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
     displayName: building igvm file
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_common::copy_to_artifact_dir 1
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::copy_to_artifact_dir 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
     displayName: copying OpenHCL igvm files to artifact dir
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::copy_to_artifact_dir 0
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::copy_to_artifact_dir 0
     displayName: copying OpenHCL igvm extras to artifact dir
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm
     displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm
@@ -471,7 +471,7 @@ jobs:
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras
     displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
     artifact: x64-mi-secure-openhcl-igvm-extras
-- job: job16
+- job: job14
   displayName: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
   pool:
     demands:
@@ -501,25 +501,25 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 16 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 16 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 14 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 14 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 16 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 14 'verbose' update
       ${{ parameters.verbose }}
       EOF
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::install_rust 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 16 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
-      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -531,21 +531,21 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::install_dist_pkg 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_dist_pkg 0
     displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::install_dist_pkg 1
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_dist_pkg 1
     displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
+      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -555,68 +555,68 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
     displayName: extract X86_64 sysroot.tar.gz
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::resolve_protoc 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::resolve_protoc 0
     displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 2
     displayName: symlink protoc
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_clippy 4
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 4
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_clippy 1
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_clippy 6
-    displayName: cargo clippy
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_clippy 5
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_cross_build 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 6
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 5
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 0
+    displayName: cargo clippy
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 0
     displayName: cargo build xtask
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_xtask 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_xtask 0
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::check_clippy 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::check_clippy 0
     displayName: determine clippy exclusions
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_clippy 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 0
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_clippy 2
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 2
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_clippy 3
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 3
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
+      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -626,33 +626,33 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::install_rust 2
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 2
     displayName: report $CARGO_HOME
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_cross_build 3
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 4
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 5
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 5
-      $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 6
-      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
-      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 4
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 6
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 4
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (openssl)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -661,18 +661,18 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (openssl)
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 6
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 7
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
-      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 7
-      $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 8
-      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
-      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 6
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 7
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 7
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 8
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 6
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (symcrypt)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -681,18 +681,18 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
-      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 9
-      $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 8
-      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 9
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 8
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (all)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -703,30 +703,30 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 2
     displayName: cargo build xtask
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_xtask 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_xtask 1
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 8
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 9
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
-      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 8
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 9
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -735,18 +735,18 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-unit-tests
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 2
-      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 3
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
-      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 4
-      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 3
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 4
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 2
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (none)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -757,16 +757,16 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
     displayName: run doctests for x86_64-unknown-linux-musl
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job15
+- job: job13
   displayName: clippy [macos], unit tests [x64-linux]
   pool:
     demands:
@@ -796,29 +796,29 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 15 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 15 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 13 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 13 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 15 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 13 'verbose' update
       ${{ parameters.verbose }}
       EOF
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_rust 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_dist_pkg 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_dist_pkg 0
     displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_dist_pkg 1
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_dist_pkg 1
     displayName: installing packages
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar9
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar9
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -830,18 +830,18 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -851,52 +851,52 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 1
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 0
     displayName: cargo build xtask
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_xtask 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_xtask 0
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::check_clippy 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::check_clippy 0
     displayName: determine clippy exclusions
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_clippy 0
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 1
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -906,33 +906,33 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_rust 2
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 2
     displayName: report $CARGO_HOME
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 5
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 4
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (all)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -943,30 +943,30 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 2
     displayName: cargo build xtask
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_xtask 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_xtask 1
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 6
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 7
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 7
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 6
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 7
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 7
+      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 6
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -975,18 +975,18 @@ jobs:
       testRunTitle: x64-linux-unit-tests-unit-tests
     displayName: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 3
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 4
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 3
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 4
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (none)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -995,18 +995,18 @@ jobs:
       testRunTitle: x64-linux-unit-tests-unit-tests crypto (none)
     displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 4
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 5
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 6
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 4
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 6
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 2
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (openssl)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1017,16 +1017,16 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
     displayName: run doctests for x86_64-unknown-linux-gnu
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job14
+- job: job12
   displayName: clippy [x64-windows], unit tests [x64-windows]
   pool:
     demands:
@@ -1101,25 +1101,25 @@ jobs:
     displayName: 🌼🔎 Self-check YAML
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 14 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 14 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 12 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 12 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 14 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 12 'verbose' update
       ${{ parameters.verbose }}
       EOF
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 14 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar7
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar7
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -1131,18 +1131,18 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1152,48 +1152,48 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 2
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_xtask 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_xtask 0
     displayName: cargo build xtask
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::check_clippy 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::check_clippy 0
     displayName: determine clippy exclusions
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 0
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 1
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1203,33 +1203,33 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 14 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 2
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 2
     displayName: report $CARGO_HOME
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 2
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (none)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1240,25 +1240,25 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 3
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_xtask 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_xtask 1
     displayName: cargo build xtask
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 3
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 2
+      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1269,548 +1269,17 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
     displayName: run doctests for x86_64-pc-windows-msvc
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 7
-    displayName: 'validate cache entry: gh-release-download'
-- job: job13
-  displayName: build openhcl [x64-linux]
-  pool:
-    demands:
-    - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
-  dependsOn:
-  - job0
-  condition: and(succeeded(), not(canceled()))
-  variables:
-  - name: FLOWEY_TEMP_DIR
-    value: $(Build.StagingDirectory)/.flowey-internal
-  steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼🥾 Download bootstrapped flowey
-    inputs:
-      artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
-      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
-  - bash: |
-      set -e
-      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
-      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
-
-      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey"
-      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
-    displayName: Set flowey path
-  - bash: |
-      set -e
-      echo '"debug"' | $FLOWEY_BIN v 13 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 13 '_internal_WORKING_DIR' --is-raw-string update
-
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 13 'verbose' update
-      ${{ parameters.verbose }}
-      EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 13 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras" | $FLOWEY_BIN v 13 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
-    displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar2)
-      path: $(floweyvar1)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (x64)
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar3)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-    displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-    displayName: unpack protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 8
-    displayName: symlink protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 9
-    displayName: cargo build sidecar
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 6
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 10
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_sidecar 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 3
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 4
-    displayName: cargo build openhcl_boot
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 5
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 5
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_boot 0
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-    displayName: extract and resolve kernel package
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 3
-    displayName: extract X86_64 sysroot.tar.gz
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-    displayName: cargo build openvmm_hcl
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_initrd 4
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 2
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 0
-    displayName: cargo build igvmfilegen
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 7
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_igvmfilegen 4
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-    displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_initrd 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_initrd 3
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_igvmfilegen 3
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_initrd 2
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_igvmfilegen 2
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::copy_to_artifact_dir 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-    displayName: copying OpenHCL igvm files to artifact dir
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::copy_to_artifact_dir 0
-    displayName: copying OpenHCL igvm extras to artifact dir
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm
-    displayName: 🌼📦 Publish x64-openhcl-igvm
-    artifact: x64-openhcl-igvm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras
-    displayName: 🌼📦 Publish x64-openhcl-igvm-extras
-    artifact: x64-openhcl-igvm-extras
-- job: job12
-  displayName: build openhcl [aarch64-linux]
-  pool:
-    demands:
-    - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
-  dependsOn:
-  - job0
-  condition: and(succeeded(), not(canceled()))
-  variables:
-  - name: FLOWEY_TEMP_DIR
-    value: $(Build.StagingDirectory)/.flowey-internal
-  steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼🥾 Download bootstrapped flowey
-    inputs:
-      artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
-      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
-  - bash: |
-      set -e
-      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
-      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
-
-      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey"
-      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
-    displayName: Set flowey path
-  - bash: |
-      set -e
-      echo '"debug"' | $FLOWEY_BIN v 12 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 12 '_internal_WORKING_DIR' --is-raw-string update
-
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 12 'verbose' update
-      ${{ parameters.verbose }}
-      EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm" | $FLOWEY_BIN v 12 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras" | $FLOWEY_BIN v 12 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
-    displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar2)
-      path: $(floweyvar1)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (aarch64)
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar3)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-    displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-    displayName: unpack protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 3
-    displayName: symlink protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 4
-    displayName: cargo build openhcl_boot
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 5
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_boot 0
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-    displayName: extract and resolve kernel package
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 1
-    displayName: extract Aarch64 sysroot.tar.gz
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-    displayName: cargo build openvmm_hcl
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 2
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 0
-    displayName: cargo build igvmfilegen
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::copy_to_artifact_dir 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-    displayName: copying OpenHCL igvm files to artifact dir
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::copy_to_artifact_dir 0
-    displayName: copying OpenHCL igvm extras to artifact dir
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: cargo-nextest'
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm
-    displayName: 🌼📦 Publish aarch64-openhcl-igvm
-    artifact: aarch64-openhcl-igvm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras
-    displayName: 🌼📦 Publish aarch64-openhcl-igvm-extras
-    artifact: aarch64-openhcl-igvm-extras
 - job: job11
-  displayName: build artifacts (for VMM tests) [x64-linux]
+  displayName: build openhcl [x64-linux]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -1845,27 +1314,40 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 11 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-igvmfilegen"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-igvmfilegen" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm_vhost"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-vmm-tests-archive"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-vmm-tests-archive" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-ohcldiag-dev"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-ohcldiag-dev" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-openvmm_vhost"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmgs_lib"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgs_lib" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmgstool"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgstool" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmm-tests-archive"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmm-tests-archive" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-extras"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar2)
+      path: $(floweyvar1)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (x64)
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
@@ -1873,21 +1355,17 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 1
       $(FLOWEY_BIN) e 11 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
       $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar1)
+    persistCredentials: $(floweyvar3)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
@@ -1898,29 +1376,6 @@ jobs:
     displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar5)
-      path: $(floweyvar4)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 6
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::resolve_protoc 0
@@ -1929,60 +1384,67 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 8
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 4
-    displayName: cargo build openvmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 5
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm 0
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 3
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 8
-    displayName: cargo build openvmm_vhost
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 3
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 9
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm_vhost 0
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 5
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 7
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 13
-    displayName: cargo build vmgstool
+    displayName: cargo build sidecar
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 6
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 14
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_vmgstool 0
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_sidecar 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 3
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 6
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 12
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-    displayName: cargo build vmgs_lib
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 4
+    displayName: cargo build openhcl_boot
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_boot 0
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+    displayName: extract and resolve kernel package
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 3
+    displayName: extract X86_64 sysroot.tar.gz
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+    displayName: cargo build openvmm_hcl
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 2
-    displayName: test vmgs_lib
+    displayName: building openhcl initrd
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 0
@@ -1990,140 +1452,145 @@ jobs:
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 7
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 2
-    displayName: cargo build ohcldiag-dev
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+    displayName: building igvm file
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_ohcldiag_dev 0
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+    displayName: extract and resolve kernel package
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 8
-    displayName: extract X86_64 sysroot.tar.gz
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+    displayName: building openhcl initrd
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 6
-    displayName: cargo build openvmm
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+    displayName: extract and resolve kernel package
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+    displayName: building igvm file
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm 1
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 6
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 9
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 5
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 10
-    displayName: cargo build openvmm_vhost
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+    displayName: building openhcl initrd
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 11
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm_vhost 1
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 7
-    displayName: split debug symbols
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+    displayName: building igvm file
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 11 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 11 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 11 flowey_lib_common::download_cargo_nextest 3
-    displayName: create cargo-nextest cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar3)
-      path: $(floweyvar2)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: cargo-nextest'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 11 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_cargo_nextest 4
-    displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 2
-    displayName: report $CARGO_HOME
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 0
-    displayName: installing cargo-nextest
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_archive 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_vmm_tests 0
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 8
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 7
-    displayName: build + archive 'vmm_tests' nextests
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_archive 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_vmm_tests 1
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 9
-    displayName: build + archive 'vmm_tests' nextests
+      $(FLOWEY_BIN) e 11 flowey_lib_common::copy_to_artifact_dir 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+    displayName: copying OpenHCL igvm files to artifact dir
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::copy_to_artifact_dir 0
+    displayName: copying OpenHCL igvm extras to artifact dir
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-igvmfilegen
-    displayName: 🌼📦 Publish x64-linux-igvmfilegen
-    artifact: x64-linux-igvmfilegen
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm
-    displayName: 🌼📦 Publish x64-linux-musl-openvmm
-    artifact: x64-linux-musl-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost
-    displayName: 🌼📦 Publish x64-linux-musl-openvmm_vhost
-    artifact: x64-linux-musl-openvmm_vhost
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-vmm-tests-archive
-    displayName: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
-    artifact: x64-linux-musl-vmm-tests-archive
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-ohcldiag-dev
-    displayName: 🌼📦 Publish x64-linux-ohcldiag-dev
-    artifact: x64-linux-ohcldiag-dev
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm
-    displayName: 🌼📦 Publish x64-linux-openvmm
-    artifact: x64-linux-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm_vhost
-    displayName: 🌼📦 Publish x64-linux-openvmm_vhost
-    artifact: x64-linux-openvmm_vhost
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgs_lib
-    displayName: 🌼📦 Publish x64-linux-vmgs_lib
-    artifact: x64-linux-vmgs_lib
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgstool
-    displayName: 🌼📦 Publish x64-linux-vmgstool
-    artifact: x64-linux-vmgstool
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmm-tests-archive
-    displayName: 🌼📦 Publish x64-linux-vmm-tests-archive
-    artifact: x64-linux-vmm-tests-archive
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm
+    displayName: 🌼📦 Publish x64-openhcl-igvm
+    artifact: x64-openhcl-igvm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras
+    displayName: 🌼📦 Publish x64-openhcl-igvm-extras
+    artifact: x64-openhcl-igvm-extras
 - job: job10
-  displayName: build artifacts (shared VMM tests) [x64-linux]
+  displayName: build openhcl [aarch64-linux]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -2158,57 +1625,27 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 10 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-guest_test_uefi"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 10 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-pipette"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 10 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-tmk_vmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 10 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-tpm_guest_tests"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 10 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-tmks"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-tmks" | $FLOWEY_BIN v 10 'artifact_publish_from_x64-tmks' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-extras"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 10 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar1)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar3)
-      path: $(floweyvar2)
+      key: $(floweyvar2)
+      path: $(floweyvar1)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
@@ -2220,10 +1657,36 @@ jobs:
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (aarch64)
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 10 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar3)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_common::resolve_protoc 0
@@ -2232,97 +1695,122 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 3
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 0
-    displayName: cargo build guest_test_uefi
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_guest_test_uefi 0
-      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 1
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 4
-    displayName: build guest_test_uefi.img
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 5
-    displayName: cargo build simple_tmk
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_tmks 0
-      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 1
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 9
-    displayName: cargo build tpm_guest_tests
+    displayName: cargo build openhcl_boot
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 10
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_tpm_guest_tests 0
-      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_boot 0
     displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+    displayName: extract and resolve kernel package
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 3
-    displayName: extract X86_64 sysroot.tar.gz
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 1
+    displayName: extract Aarch64 sysroot.tar.gz
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 1
-    displayName: cargo build pipette
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_pipette 0
-      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 2
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 7
-    displayName: cargo build tmk_vmm
+      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+    displayName: cargo build openvmm_hcl
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 8
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_tmk_vmm 0
-      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 4
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
     displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 2
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 0
+    displayName: cargo build igvmfilegen
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_igvmfilegen 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_igvmfilegen 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+    displayName: extract and resolve kernel package
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_igvmfilegen 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::copy_to_artifact_dir 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+    displayName: copying OpenHCL igvm files to artifact dir
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::copy_to_artifact_dir 0
+    displayName: copying OpenHCL igvm extras to artifact dir
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-guest_test_uefi
-    displayName: 🌼📦 Publish x64-guest_test_uefi
-    artifact: x64-guest_test_uefi
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette
-    displayName: 🌼📦 Publish x64-linux-musl-pipette
-    artifact: x64-linux-musl-pipette
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-tmk_vmm
-    displayName: 🌼📦 Publish x64-linux-musl-tmk_vmm
-    artifact: x64-linux-musl-tmk_vmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-tpm_guest_tests
-    displayName: 🌼📦 Publish x64-linux-tpm_guest_tests
-    artifact: x64-linux-tpm_guest_tests
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-tmks
-    displayName: 🌼📦 Publish x64-tmks
-    artifact: x64-tmks
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm
+    displayName: 🌼📦 Publish aarch64-openhcl-igvm
+    artifact: aarch64-openhcl-igvm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras
+    displayName: 🌼📦 Publish aarch64-openhcl-igvm-extras
+    artifact: aarch64-openhcl-igvm-extras
 - job: job9
-  displayName: build artifacts (for VMM tests) [aarch64-linux]
+  displayName: build artifacts (for VMM tests) [x64-linux]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -2357,22 +1845,26 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 9 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-igvmfilegen"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-igvmfilegen" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-ohcldiag-dev"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-ohcldiag-dev" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-openvmm_vhost"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm_vhost" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-vmgs_lib"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgs_lib" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-vmgstool"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgstool" | $FLOWEY_BIN v 9 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-igvmfilegen"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-igvmfilegen" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-vmm-tests-archive"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-vmm-tests-archive" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-ohcldiag-dev"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-ohcldiag-dev" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmgs_lib"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgs_lib" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmgstool"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgstool" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmm-tests-archive"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmm-tests-archive" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::install_rust 0
     displayName: install Rust
@@ -2410,22 +1902,22 @@ jobs:
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar3)
-      path: $(floweyvar2)
+      key: $(floweyvar5)
+      path: $(floweyvar4)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
@@ -2437,7 +1929,7 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 1
     displayName: symlink protoc
   - bash: |-
       set -e
@@ -2450,7 +1942,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 3
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2463,7 +1955,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 9
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_vhost 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 5
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2476,17 +1968,21 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 14
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_vmgstool 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
     displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 6
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 12
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 1
     displayName: cargo build vmgs_lib
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 2
+    displayName: test vmgs_lib
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 0
@@ -2498,7 +1994,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 5
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 6
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2517,8 +2013,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 6
-    displayName: extract Aarch64 sysroot.tar.gz
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 8
+    displayName: extract X86_64 sysroot.tar.gz
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 3
@@ -2530,7 +2026,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 7
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm 1
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 6
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 7
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 9
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2544,34 +2040,90 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_vhost 1
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 7
     displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 9 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 9 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 9 flowey_lib_common::download_cargo_nextest 3
+    displayName: create cargo-nextest cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar3)
+      path: $(floweyvar2)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: cargo-nextest'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 9 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::download_cargo_nextest 4
+    displayName: downloading cargo-nextest
+  - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::install_rust 2
+    displayName: report $CARGO_HOME
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 0
+    displayName: installing cargo-nextest
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_nextest_archive 0
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 8
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 7
+    displayName: build + archive 'vmm_tests' nextests
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_nextest_archive 1
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 9
+    displayName: build + archive 'vmm_tests' nextests
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: cargo-nextest'
+  - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-igvmfilegen
-    displayName: 🌼📦 Publish aarch64-linux-igvmfilegen
-    artifact: aarch64-linux-igvmfilegen
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm
-    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm
-    artifact: aarch64-linux-musl-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost
-    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
-    artifact: aarch64-linux-musl-openvmm_vhost
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-ohcldiag-dev
-    displayName: 🌼📦 Publish aarch64-linux-ohcldiag-dev
-    artifact: aarch64-linux-ohcldiag-dev
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm
-    displayName: 🌼📦 Publish aarch64-linux-openvmm
-    artifact: aarch64-linux-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm_vhost
-    displayName: 🌼📦 Publish aarch64-linux-openvmm_vhost
-    artifact: aarch64-linux-openvmm_vhost
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgs_lib
-    displayName: 🌼📦 Publish aarch64-linux-vmgs_lib
-    artifact: aarch64-linux-vmgs_lib
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgstool
-    displayName: 🌼📦 Publish aarch64-linux-vmgstool
-    artifact: aarch64-linux-vmgstool
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-igvmfilegen
+    displayName: 🌼📦 Publish x64-linux-igvmfilegen
+    artifact: x64-linux-igvmfilegen
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm
+    displayName: 🌼📦 Publish x64-linux-musl-openvmm
+    artifact: x64-linux-musl-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-openvmm_vhost
+    displayName: 🌼📦 Publish x64-linux-musl-openvmm_vhost
+    artifact: x64-linux-musl-openvmm_vhost
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-vmm-tests-archive
+    displayName: 🌼📦 Publish x64-linux-musl-vmm-tests-archive
+    artifact: x64-linux-musl-vmm-tests-archive
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-ohcldiag-dev
+    displayName: 🌼📦 Publish x64-linux-ohcldiag-dev
+    artifact: x64-linux-ohcldiag-dev
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm
+    displayName: 🌼📦 Publish x64-linux-openvmm
+    artifact: x64-linux-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm_vhost
+    displayName: 🌼📦 Publish x64-linux-openvmm_vhost
+    artifact: x64-linux-openvmm_vhost
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgs_lib
+    displayName: 🌼📦 Publish x64-linux-vmgs_lib
+    artifact: x64-linux-vmgs_lib
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgstool
+    displayName: 🌼📦 Publish x64-linux-vmgstool
+    artifact: x64-linux-vmgstool
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmm-tests-archive
+    displayName: 🌼📦 Publish x64-linux-vmm-tests-archive
+    artifact: x64-linux-vmm-tests-archive
 - job: job8
-  displayName: build artifacts (shared VMM tests) [aarch64-linux]
+  displayName: build artifacts (for VMM tests) [aarch64-linux]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -2606,16 +2158,22 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 8 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-guest_test_uefi"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-guest_test_uefi" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-pipette"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-tmk_vmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-tpm_guest_tests"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-tpm_guest_tests" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-tmks"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-tmks" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-tmks' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-igvmfilegen"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-igvmfilegen" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-musl-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-musl-openvmm_vhost' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-ohcldiag-dev"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-ohcldiag-dev" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-openvmm_vhost"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm_vhost" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-vmgs_lib"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgs_lib" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-vmgstool"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgstool" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::install_rust 0
     displayName: install Rust
@@ -2624,6 +2182,10 @@ jobs:
       $(FLOWEY_BIN) e 8 flowey_lib_common::install_rust 1
       $(FLOWEY_BIN) e 8 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
+  - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::git_checkout 0
@@ -2668,10 +2230,6 @@ jobs:
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::resolve_protoc 0
@@ -2680,95 +2238,139 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 0
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 0
-    displayName: cargo build guest_test_uefi
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_guest_test_uefi 0
-      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 4
-    displayName: build guest_test_uefi.img
-  - bash: |-
-      set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 5
-    displayName: cargo build simple_tmk
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 4
+    displayName: cargo build openvmm
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_tmks 0
-      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 0
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 2
     displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 9
-    displayName: cargo build tpm_guest_tests
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 8
+    displayName: cargo build openvmm_vhost
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 10
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_tpm_guest_tests 0
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm_vhost 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 4
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 7
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 13
+    displayName: cargo build vmgstool
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 6
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 14
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_vmgstool 0
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 3
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 6
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 12
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 1
+    displayName: cargo build vmgs_lib
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 0
+    displayName: cargo build igvmfilegen
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_igvmfilegen 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 4
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 5
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 2
+    displayName: cargo build ohcldiag-dev
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_ohcldiag_dev 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 5
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 8 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 6
     displayName: extract Aarch64 sysroot.tar.gz
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 1
-    displayName: cargo build pipette
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 6
+    displayName: cargo build openvmm
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_pipette 0
-      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm 1
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 6
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 7
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 7
-    displayName: cargo build tmk_vmm
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 5
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 10
+    displayName: cargo build openvmm_vhost
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 8
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_tmk_vmm 0
-      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 4
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 11
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm_vhost 1
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 7
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-guest_test_uefi
-    displayName: 🌼📦 Publish aarch64-guest_test_uefi
-    artifact: aarch64-guest_test_uefi
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette
-    displayName: 🌼📦 Publish aarch64-linux-musl-pipette
-    artifact: aarch64-linux-musl-pipette
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-tmk_vmm
-    displayName: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
-    artifact: aarch64-linux-musl-tmk_vmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-tpm_guest_tests
-    displayName: 🌼📦 Publish aarch64-linux-tpm_guest_tests
-    artifact: aarch64-linux-tpm_guest_tests
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-tmks
-    displayName: 🌼📦 Publish aarch64-tmks
-    artifact: aarch64-tmks
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-igvmfilegen
+    displayName: 🌼📦 Publish aarch64-linux-igvmfilegen
+    artifact: aarch64-linux-igvmfilegen
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm
+    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm
+    artifact: aarch64-linux-musl-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-openvmm_vhost
+    displayName: 🌼📦 Publish aarch64-linux-musl-openvmm_vhost
+    artifact: aarch64-linux-musl-openvmm_vhost
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-ohcldiag-dev
+    displayName: 🌼📦 Publish aarch64-linux-ohcldiag-dev
+    artifact: aarch64-linux-ohcldiag-dev
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm
+    displayName: 🌼📦 Publish aarch64-linux-openvmm
+    artifact: aarch64-linux-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm_vhost
+    displayName: 🌼📦 Publish aarch64-linux-openvmm_vhost
+    artifact: aarch64-linux-openvmm_vhost
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgs_lib
+    displayName: 🌼📦 Publish aarch64-linux-vmgs_lib
+    artifact: aarch64-linux-vmgs_lib
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgstool
+    displayName: 🌼📦 Publish aarch64-linux-vmgstool
+    artifact: aarch64-linux-vmgstool
 - job: job7
   displayName: build artifacts (for VMM tests) [x64-windows]
   pool:
@@ -3049,7 +2651,7 @@ jobs:
     displayName: 🌼🥾 Publish bootstrapped flowey
     artifact: _internal-flowey-bootstrap-x86_64-windows-uid-3
 - job: job6
-  displayName: build artifacts (shared VMM tests) [x64-windows]
+  displayName: build artifacts (not for VMM tests) [x64-windows]
   pool:
     demands:
     - ImageOverride -equals win-amd64
@@ -3129,8 +2731,14 @@ jobs:
       cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 6 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-pipette"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 6 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-hypestv"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-hypestv" | $FLOWEY_BIN v 6 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-igvmfilegen"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-igvmfilegen" | $FLOWEY_BIN v 6 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-ohcldiag-dev"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-ohcldiag-dev" | $FLOWEY_BIN v 6 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-vmgs_lib"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-vmgs_lib" | $FLOWEY_BIN v 6 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::install_rust 0
     displayName: install Rust
@@ -3191,21 +2799,991 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 1
     displayName: symlink protoc
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 0
       $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 0
-      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_pipette 0
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_hypestv 0
       $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 0
-    displayName: cargo build pipette
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 0
+    displayName: cargo build hypestv
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+    displayName: cargo build vmgs_lib
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 2
+    displayName: test vmgs_lib
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_igvmfilegen 0
+      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::init_cross_build 3
+    displayName: cargo build igvmfilegen
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 6 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 6 flowey_lib_hvlite::build_ohcldiag_dev 0
+      $(FLOWEY_BIN) e 6 flowey_core::pipeline::artifact::publish 3
+    displayName: cargo build ohcldiag-dev
   - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-hypestv
+    displayName: 🌼📦 Publish x64-windows-hypestv
+    artifact: x64-windows-hypestv
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-igvmfilegen
+    displayName: 🌼📦 Publish x64-windows-igvmfilegen
+    artifact: x64-windows-igvmfilegen
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-ohcldiag-dev
+    displayName: 🌼📦 Publish x64-windows-ohcldiag-dev
+    artifact: x64-windows-ohcldiag-dev
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-vmgs_lib
+    displayName: 🌼📦 Publish x64-windows-vmgs_lib
+    artifact: x64-windows-vmgs_lib
+- job: job5
+  displayName: build artifacts (for VMM tests) [aarch64-windows]
+  pool:
+    demands:
+    - ImageOverride -equals win-amd64
+    name: openvmm-ado-amd-westus2
+  dependsOn:
+  - job0
+  condition: and(succeeded(), not(canceled()))
+  variables:
+  - name: FLOWEY_TEMP_DIR
+    value: $(Build.StagingDirectory)/.flowey-internal
+  steps:
+  - bash: |
+      set -x
+      i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+      sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+      . "$HOME/.cargo/env"
+      echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
+    condition: eq(variables['Agent.OS'], 'Linux')
+    displayName: rustup (Linux)
+  - bash: |
+      set -x
+      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+      ./rustup-init.exe -y --default-toolchain=1.95.0
+      echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+    displayName: rustup (Windows X64)
+  - bash: |
+      set -x
+      rustup show
+    displayName: Verify rustup installation
+  - checkout: self
+    fetchTags: false
+    fetchDepth: 1
+    path: flowey_bootstrap
+  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+    workingDirectory: ../flowey_bootstrap
+    displayName: Build flowey
+  - bash: |
+      mkdir ./flowey_bootstrap_temp
+      mv ./ci-flowey/openvmm-pr.yaml ./flowey_bootstrap_temp/pipeline.yaml
+      mv ./ci-flowey/openvmm-pr.json ./flowey_bootstrap_temp/pipeline.json
+      mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe ./flowey_bootstrap_temp/flowey.exe
+    workingDirectory: ../flowey_bootstrap
+    displayName: Stage flowey artifact
+  - task: CopyFiles@2
+    displayName: Copy flowey artifact
+    inputs:
+      SourceFolder: ../flowey_bootstrap/flowey_bootstrap_temp
+      TargetFolder: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - bash: rm -rf ./flowey_bootstrap_temp
+    workingDirectory: ../flowey_bootstrap
+    displayName: Cleanup staged flowey artifact
+  - bash: |
+      set -e
+      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
+      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
+
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey.exe"
+      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
+    displayName: Set flowey path
+  - bash: |-
+      ESCAPED_AGENT_TEMPDIR=$(
+      cat <<'EOF' | sed 's/\\/\\\\/g'
+      $(FLOWEY_TEMP_DIR)
+      EOF
+      )
+      $(FLOWEY_BIN) pipeline ado --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out ci-flowey/openvmm-pr.yaml ci checkin-gates --config=pr
+    displayName: 🌼🔎 Self-check YAML
+  - bash: |
+      set -e
+      echo '"debug"' | $FLOWEY_BIN v 5 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 5 '_internal_WORKING_DIR' --is-raw-string update
+
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 5 'verbose' update
+      ${{ parameters.verbose }}
+      EOF
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-openvmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-openvmm" | $FLOWEY_BIN v 5 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-prep_steps"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-prep_steps" | $FLOWEY_BIN v 5 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 5 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-tmk_vmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tmk_vmm" | $FLOWEY_BIN v 5 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-tpm_guest_tests"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tpm_guest_tests" | $FLOWEY_BIN v 5 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-vmgstool"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmgstool" | $FLOWEY_BIN v 5 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-vmm-tests-archive"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmm-tests-archive" | $FLOWEY_BIN v 5 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+    displayName: 🌼🛫 Initialize job
+  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 5 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar1)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar5)
+      path: $(floweyvar4)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 5 flowey_lib_common::cache 6
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    displayName: unpack protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 4
+    displayName: symlink protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_openvmm 0
+      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 0
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 1
+    displayName: cargo build openvmm
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_tmk_vmm 0
+      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 5
+    displayName: cargo build tmk_vmm
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_prep_steps 0
+      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 3
+    displayName: cargo build prep_steps
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 5
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_vmgstool 0
+      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 7
+    displayName: cargo build vmgstool
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 4
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_tpm_guest_tests 0
+      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 4
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 3
+    displayName: cargo build tpm_guest_tests
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 4
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 5
+    displayName: cargo build test_igvm_agent_rpc_server
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 5 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 5 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 5 flowey_lib_common::download_cargo_nextest 3
+    displayName: create cargo-nextest cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar3)
+      path: $(floweyvar2)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: cargo-nextest'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 5 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::download_cargo_nextest 4
+    displayName: downloading cargo-nextest
+  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::install_rust 2
+    displayName: report $CARGO_HOME
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 0
+    displayName: installing cargo-nextest
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_nextest_archive 0
+      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_nextest_vmm_tests 0
+      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 6
+    displayName: build + archive 'vmm_tests' nextests
+  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: cargo-nextest'
+  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::cache 7
+    displayName: 'validate cache entry: gh-release-download'
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-openvmm
+    displayName: 🌼📦 Publish aarch64-windows-openvmm
+    artifact: aarch64-windows-openvmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-prep_steps
+    displayName: 🌼📦 Publish aarch64-windows-prep_steps
+    artifact: aarch64-windows-prep_steps
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server
+    displayName: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
+    artifact: aarch64-windows-test_igvm_agent_rpc_server
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tmk_vmm
+    displayName: 🌼📦 Publish aarch64-windows-tmk_vmm
+    artifact: aarch64-windows-tmk_vmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tpm_guest_tests
+    displayName: 🌼📦 Publish aarch64-windows-tpm_guest_tests
+    artifact: aarch64-windows-tpm_guest_tests
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmgstool
+    displayName: 🌼📦 Publish aarch64-windows-vmgstool
+    artifact: aarch64-windows-vmgstool
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmm-tests-archive
+    displayName: 🌼📦 Publish aarch64-windows-vmm-tests-archive
+    artifact: aarch64-windows-vmm-tests-archive
+- job: job4
+  displayName: build artifacts (not for VMM tests) [aarch64-windows]
+  pool:
+    demands:
+    - ImageOverride -equals win-amd64
+    name: openvmm-ado-amd-westus2
+  dependsOn:
+  - job0
+  condition: and(succeeded(), not(canceled()))
+  variables:
+  - name: FLOWEY_TEMP_DIR
+    value: $(Build.StagingDirectory)/.flowey-internal
+  steps:
+  - bash: |
+      set -x
+      i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+      sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+      . "$HOME/.cargo/env"
+      echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
+    condition: eq(variables['Agent.OS'], 'Linux')
+    displayName: rustup (Linux)
+  - bash: |
+      set -x
+      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+      ./rustup-init.exe -y --default-toolchain=1.95.0
+      echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+    displayName: rustup (Windows X64)
+  - bash: |
+      set -x
+      rustup show
+    displayName: Verify rustup installation
+  - checkout: self
+    fetchTags: false
+    fetchDepth: 1
+    path: flowey_bootstrap
+  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+    workingDirectory: ../flowey_bootstrap
+    displayName: Build flowey
+  - bash: |
+      mkdir ./flowey_bootstrap_temp
+      mv ./ci-flowey/openvmm-pr.yaml ./flowey_bootstrap_temp/pipeline.yaml
+      mv ./ci-flowey/openvmm-pr.json ./flowey_bootstrap_temp/pipeline.json
+      mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe ./flowey_bootstrap_temp/flowey.exe
+    workingDirectory: ../flowey_bootstrap
+    displayName: Stage flowey artifact
+  - task: CopyFiles@2
+    displayName: Copy flowey artifact
+    inputs:
+      SourceFolder: ../flowey_bootstrap/flowey_bootstrap_temp
+      TargetFolder: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - bash: rm -rf ./flowey_bootstrap_temp
+    workingDirectory: ../flowey_bootstrap
+    displayName: Cleanup staged flowey artifact
+  - bash: |
+      set -e
+      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
+      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
+
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey.exe"
+      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
+    displayName: Set flowey path
+  - bash: |-
+      ESCAPED_AGENT_TEMPDIR=$(
+      cat <<'EOF' | sed 's/\\/\\\\/g'
+      $(FLOWEY_TEMP_DIR)
+      EOF
+      )
+      $(FLOWEY_BIN) pipeline ado --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out ci-flowey/openvmm-pr.yaml ci checkin-gates --config=pr
+    displayName: 🌼🔎 Self-check YAML
+  - bash: |
+      set -e
+      echo '"debug"' | $FLOWEY_BIN v 4 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 4 '_internal_WORKING_DIR' --is-raw-string update
+
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 4 'verbose' update
+      ${{ parameters.verbose }}
+      EOF
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-hypestv"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-hypestv" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-hypestv' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-igvmfilegen"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-igvmfilegen" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-igvmfilegen' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-ohcldiag-dev"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-ohcldiag-dev" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-vmgs_lib"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmgs_lib" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-vmgs_lib' --is-raw-string update
+    displayName: 🌼🛫 Initialize job
+  - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 4 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar1)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar3)
+      path: $(floweyvar2)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 4 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    displayName: unpack protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 1
+    displayName: symlink protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_hypestv 0
+      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 0
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 0
+    displayName: cargo build hypestv
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 2
+    displayName: cargo build vmgs_lib
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_igvmfilegen 0
+      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 3
+    displayName: cargo build igvmfilegen
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_ohcldiag_dev 0
+      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 3
+    displayName: cargo build ohcldiag-dev
+  - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: gh-release-download'
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-hypestv
+    displayName: 🌼📦 Publish aarch64-windows-hypestv
+    artifact: aarch64-windows-hypestv
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-igvmfilegen
+    displayName: 🌼📦 Publish aarch64-windows-igvmfilegen
+    artifact: aarch64-windows-igvmfilegen
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-ohcldiag-dev
+    displayName: 🌼📦 Publish aarch64-windows-ohcldiag-dev
+    artifact: aarch64-windows-ohcldiag-dev
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmgs_lib
+    displayName: 🌼📦 Publish aarch64-windows-vmgs_lib
+    artifact: aarch64-windows-vmgs_lib
+- job: job3
+  displayName: build artifacts (shared VMM tests) [linux]
+  pool:
+    demands:
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
+  dependsOn:
+  - job0
+  condition: and(succeeded(), not(canceled()))
+  variables:
+  - name: FLOWEY_TEMP_DIR
+    value: $(Build.StagingDirectory)/.flowey-internal
+  steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼🥾 Download bootstrapped flowey
+    inputs:
+      artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
+      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - bash: |
+      set -e
+      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
+      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
+
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey"
+      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
+    displayName: Set flowey path
+  - bash: |
+      set -e
+      echo '"debug"' | $FLOWEY_BIN v 3 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 3 '_internal_WORKING_DIR' --is-raw-string update
+
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 3 'verbose' update
+      ${{ parameters.verbose }}
+      EOF
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-guest_test_uefi"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-guest_test_uefi" | $FLOWEY_BIN v 3 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-pipette"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette" | $FLOWEY_BIN v 3 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-musl-tmk_vmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 3 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-tpm_guest_tests"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-tpm_guest_tests" | $FLOWEY_BIN v 3 'artifact_publish_from_aarch64-linux-tpm_guest_tests' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-tmks"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-tmks" | $FLOWEY_BIN v 3 'artifact_publish_from_aarch64-tmks' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-guest_test_uefi"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 3 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-pipette"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 3 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-musl-tmk_vmm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 3 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-tpm_guest_tests"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 3 'artifact_publish_from_x64-linux-tpm_guest_tests' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-tmks"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-tmks" | $FLOWEY_BIN v 3 'artifact_publish_from_x64-tmks' --is-raw-string update
+    displayName: 🌼🛫 Initialize job
+  - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 3 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar1)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar3)
+      path: $(floweyvar2)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 3 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    displayName: unpack protoc
+  - bash: $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+    displayName: symlink protoc
+  - bash: $(FLOWEY_BIN) e 3 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 1
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 2
+    displayName: extract Aarch64 sysroot.tar.gz
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 6
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 14
+    displayName: cargo build tmk_vmm
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 15
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_tmk_vmm 0
+      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 6
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 9
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 1
+    displayName: cargo build guest_test_uefi
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_guest_test_uefi 0
+      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 7
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 5
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 11
+    displayName: build guest_test_uefi.img
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 4
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 12
+    displayName: cargo build simple_tmk
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 13
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_tmks 0
+      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 8
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 6
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 9
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 20
+    displayName: cargo build tpm_guest_tests
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_split_debug_info 7
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 21
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_tpm_guest_tests 1
+      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 9
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 7
+    displayName: extract X86_64 sysroot.tar.gz
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 4
+    displayName: cargo build pipette
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_pipette 1
+      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 0
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 8
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 7
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 16
+    displayName: cargo build tmk_vmm
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_split_debug_info 6
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 17
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_tmk_vmm 1
+      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 4
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 0
+    displayName: cargo build guest_test_uefi
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_guest_test_uefi 1
+      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 7
+    displayName: build guest_test_uefi.img
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 5
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 8
+    displayName: cargo build simple_tmk
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_tmks 1
+      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 1
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 8
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 18
+    displayName: cargo build tpm_guest_tests
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 19
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_tpm_guest_tests 0
+      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 4
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 3
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 2
+    displayName: cargo build pipette
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_pipette 0
+      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 5
+    displayName: split debug symbols
+  - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: gh-release-download'
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-guest_test_uefi
+    displayName: 🌼📦 Publish aarch64-guest_test_uefi
+    artifact: aarch64-guest_test_uefi
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-pipette
+    displayName: 🌼📦 Publish aarch64-linux-musl-pipette
+    artifact: aarch64-linux-musl-pipette
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-musl-tmk_vmm
+    displayName: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
+    artifact: aarch64-linux-musl-tmk_vmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-tpm_guest_tests
+    displayName: 🌼📦 Publish aarch64-linux-tpm_guest_tests
+    artifact: aarch64-linux-tpm_guest_tests
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-tmks
+    displayName: 🌼📦 Publish aarch64-tmks
+    artifact: aarch64-tmks
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-guest_test_uefi
+    displayName: 🌼📦 Publish x64-guest_test_uefi
+    artifact: x64-guest_test_uefi
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-pipette
+    displayName: 🌼📦 Publish x64-linux-musl-pipette
+    artifact: x64-linux-musl-pipette
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-musl-tmk_vmm
+    displayName: 🌼📦 Publish x64-linux-musl-tmk_vmm
+    artifact: x64-linux-musl-tmk_vmm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-tpm_guest_tests
+    displayName: 🌼📦 Publish x64-linux-tpm_guest_tests
+    artifact: x64-linux-tpm_guest_tests
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-tmks
+    displayName: 🌼📦 Publish x64-tmks
+    artifact: x64-tmks
+- job: job2
+  displayName: build artifacts (shared VMM tests) [windows]
+  pool:
+    demands:
+    - ImageOverride -equals win-amd64
+    name: openvmm-ado-amd-westus2
+  dependsOn:
+  - job0
+  condition: and(succeeded(), not(canceled()))
+  variables:
+  - name: FLOWEY_TEMP_DIR
+    value: $(Build.StagingDirectory)/.flowey-internal
+  steps:
+  - bash: |
+      set -x
+      i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+      sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+      . "$HOME/.cargo/env"
+      echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
+    condition: eq(variables['Agent.OS'], 'Linux')
+    displayName: rustup (Linux)
+  - bash: |
+      set -x
+      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+      ./rustup-init.exe -y --default-toolchain=1.95.0
+      echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+    displayName: rustup (Windows X64)
+  - bash: |
+      set -x
+      rustup show
+    displayName: Verify rustup installation
+  - checkout: self
+    fetchTags: false
+    fetchDepth: 1
+    path: flowey_bootstrap
+  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+    workingDirectory: ../flowey_bootstrap
+    displayName: Build flowey
+  - bash: |
+      mkdir ./flowey_bootstrap_temp
+      mv ./ci-flowey/openvmm-pr.yaml ./flowey_bootstrap_temp/pipeline.yaml
+      mv ./ci-flowey/openvmm-pr.json ./flowey_bootstrap_temp/pipeline.json
+      mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe ./flowey_bootstrap_temp/flowey.exe
+    workingDirectory: ../flowey_bootstrap
+    displayName: Stage flowey artifact
+  - task: CopyFiles@2
+    displayName: Copy flowey artifact
+    inputs:
+      SourceFolder: ../flowey_bootstrap/flowey_bootstrap_temp
+      TargetFolder: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - bash: rm -rf ./flowey_bootstrap_temp
+    workingDirectory: ../flowey_bootstrap
+    displayName: Cleanup staged flowey artifact
+  - bash: |
+      set -e
+      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
+      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
+
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey.exe"
+      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
+    displayName: Set flowey path
+  - bash: |-
+      ESCAPED_AGENT_TEMPDIR=$(
+      cat <<'EOF' | sed 's/\\/\\\\/g'
+      $(FLOWEY_TEMP_DIR)
+      EOF
+      )
+      $(FLOWEY_BIN) pipeline ado --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out ci-flowey/openvmm-pr.yaml ci checkin-gates --config=pr
+    displayName: 🌼🔎 Self-check YAML
+  - bash: |
+      set -e
+      echo '"debug"' | $FLOWEY_BIN v 2 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 2 '_internal_WORKING_DIR' --is-raw-string update
+
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 2 'verbose' update
+      ${{ parameters.verbose }}
+      EOF
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-pipette"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-pipette" | $FLOWEY_BIN v 2 'artifact_publish_from_aarch64-windows-pipette' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-pipette"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 2 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
+    displayName: 🌼🛫 Initialize job
+  - bash: $(FLOWEY_BIN) e 2 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 2 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 2 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 2 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar1)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 2 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 2 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: $(FLOWEY_BIN) e 2 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 2 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar3)
+      path: $(floweyvar2)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 2 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 2 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 2 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    displayName: unpack protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::init_cross_build 0
+    displayName: symlink protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 2 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::build_pipette 0
+      $(FLOWEY_BIN) e 2 flowey_core::pipeline::artifact::publish 0
+      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::init_cross_build 1
+    displayName: cargo build pipette
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 2 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::build_pipette 1
+      $(FLOWEY_BIN) e 2 flowey_core::pipeline::artifact::publish 1
+    displayName: cargo build pipette
+  - bash: $(FLOWEY_BIN) e 2 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: gh-release-download'
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-pipette
+    displayName: 🌼📦 Publish aarch64-windows-pipette
+    artifact: aarch64-windows-pipette
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-pipette
     displayName: 🌼📦 Publish x64-windows-pipette
     artifact: x64-windows-pipette
-- job: job21
+- job: job19
   displayName: run vmm-tests [x64-windows-intel-mi-secure]
   pool:
     demands:
@@ -3213,9 +3791,9 @@ jobs:
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
-  - job10
-  - job20
-  - job6
+  - job18
+  - job2
+  - job3
   - job7
   condition: and(succeeded(), not(canceled()))
   variables:
@@ -3309,39 +3887,39 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 21 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 21 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 19 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 19 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 21 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 19 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 21 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 21 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 21 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 21 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 21 'artifact_use_from_x64-tmks' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 21 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 19 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 19 'artifact_use_from_x64-tmks' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 21 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 21 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 21 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 21 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 21 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3351,18 +3929,18 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 21 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 21 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 21 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -3374,32 +3952,32 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 21 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 6
-      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 9
-      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 10
-      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 8
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
     displayName: resolve OpenHCL igvm artifact
-  - bash: $(FLOWEY_BIN) e 21 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 21 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 21 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3409,54 +3987,54 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 21 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 21 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 21 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 21 flowey_lib_common::download_azcopy 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_azcopy 0
     displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
     displayName: calculating required VMM tests disk images
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
     displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
     displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
     displayName: unpack mu_msvm package (x64)
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 21 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::init_vmm_tests_env 0
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
     displayName: setting up vmm_tests env
-  - bash: $(FLOWEY_BIN) e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
-  - bash: $(FLOWEY_BIN) e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
     displayName: install vmm tests deps (windows)
-  - bash: $(FLOWEY_BIN) e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
     displayName: starting test_igvm_agent_rpc_server
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 21 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 21 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
     displayName: run 'vmm_tests' nextest tests
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      $(FLOWEY_BIN) e 21 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 21 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 21 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 21 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 19 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 19 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: stopping test_igvm_agent_rpc_server
   - task: PublishTestResults@2
     inputs:
@@ -3467,16 +4045,16 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-      $(FLOWEY_BIN) e 21 flowey_lib_common::publish_test_results 2
-      $(FLOWEY_BIN) e 21 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 2
+      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 21 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 21 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job19
+- job: job17
   displayName: run vmm-tests [x64-linux-amd-kvm]
   pool:
     demands:
@@ -3484,9 +4062,9 @@ jobs:
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
-  - job10
-  - job11
-  - job6
+  - job2
+  - job3
+  - job9
   condition: and(succeeded(), not(canceled()))
   variables:
   - name: FLOWEY_TEMP_DIR
@@ -3549,538 +4127,6 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 19 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 19 '_internal_WORKING_DIR' --is-raw-string update
-
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 19 'verbose' update
-      ${{ parameters.verbose }}
-      EOF
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 19 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-vmm-tests-archive" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 19 'artifact_use_from_x64-tmks' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-    displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-    displayName: ensure hypervisor device is accessible
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
-    displayName: ensure 2 MiB hugetlb pages are available
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 3
-    displayName: create cargo-nextest cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar4)
-      path: $(floweyvar3)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: cargo-nextest'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 4
-    displayName: downloading cargo-nextest
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar2)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 7
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 6
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-    displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar6)
-      path: $(floweyvar5)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 6
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_azcopy 0
-    displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-    displayName: calculating required VMM tests disk images
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-    displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (x64)
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::init_vmm_tests_env 0
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
-    displayName: setting up vmm_tests env
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-    displayName: generate nextest command
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
-    displayName: install vmm tests deps (linux)
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 19 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 19 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'vmm_tests' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar1)
-      testRunTitle: x64-linux-amd-kvm-vmm-tests
-    displayName: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 2
-      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-    displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::cache 7
-    displayName: 'validate cache entry: gh-release-download'
-- job: job18
-  displayName: run vmm-tests [x64-windows-amd]
-  pool:
-    demands:
-    - ImageOverride -equals win-amd64
-    name: openvmm-ado-amd-westus2
-  dependsOn:
-  - job0
-  - job10
-  - job13
-  - job6
-  - job7
-  condition: and(succeeded(), not(canceled()))
-  variables:
-  - name: FLOWEY_TEMP_DIR
-    value: $(Build.StagingDirectory)/.flowey-internal
-  steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼🥾 Download bootstrapped flowey
-    inputs:
-      artifact: _internal-flowey-bootstrap-x86_64-windows-uid-3
-      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-guest_test_uefi
-    inputs:
-      artifact: x64-guest_test_uefi
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-musl-pipette
-    inputs:
-      artifact: x64-linux-musl-pipette
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-musl-tmk_vmm
-    inputs:
-      artifact: x64-linux-musl-tmk_vmm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-tpm_guest_tests
-    inputs:
-      artifact: x64-linux-tpm_guest_tests
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-openhcl-igvm
-    inputs:
-      artifact: x64-openhcl-igvm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-tmks
-    inputs:
-      artifact: x64-tmks
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-openvmm
-    inputs:
-      artifact: x64-windows-openvmm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-pipette
-    inputs:
-      artifact: x64-windows-pipette
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-prep_steps
-    inputs:
-      artifact: x64-windows-prep_steps
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-test_igvm_agent_rpc_server
-    inputs:
-      artifact: x64-windows-test_igvm_agent_rpc_server
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-tmk_vmm
-    inputs:
-      artifact: x64-windows-tmk_vmm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-tpm_guest_tests
-    inputs:
-      artifact: x64-windows-tpm_guest_tests
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-vmgstool
-    inputs:
-      artifact: x64-windows-vmgstool
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-vmm-tests-archive
-    inputs:
-      artifact: x64-windows-vmm-tests-archive
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive
-  - bash: |
-      set -e
-      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
-      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
-
-      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
-      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey.exe"
-      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
-    displayName: Set flowey path
-  - bash: |
-      set -e
-      echo '"debug"' | $FLOWEY_BIN v 18 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 18 '_internal_WORKING_DIR' --is-raw-string update
-
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 18 'verbose' update
-      ${{ parameters.verbose }}
-      EOF
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 18 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 18 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 18 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 18 'artifact_use_from_x64-tmks' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-    displayName: 🌼🛫 Initialize job
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 3
-    displayName: create cargo-nextest cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar4)
-      path: $(floweyvar3)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: cargo-nextest'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 4
-    displayName: downloading cargo-nextest
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar2)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 6
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 9
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 10
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 8
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-    displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-    displayName: resolve OpenHCL igvm artifact
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar6)
-      path: $(floweyvar5)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 6
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_azcopy 0
-    displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-    displayName: calculating required VMM tests disk images
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-    displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (x64)
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_vmm_tests_env 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-    displayName: setting up vmm_tests env
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-    displayName: generate nextest command
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::install_vmm_tests_deps 0
-    displayName: install vmm tests deps (windows)
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-    displayName: starting test_igvm_agent_rpc_server
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-    displayName: run 'vmm_tests' nextest tests
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 18 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 18 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: stopping test_igvm_agent_rpc_server
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar1)
-      testRunTitle: x64-windows-amd-vmm-tests
-    displayName: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-      $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 2
-      $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-    displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::cache 7
-    displayName: 'validate cache entry: gh-release-download'
-- job: job17
-  displayName: run vmm-tests [x64-windows-intel]
-  pool:
-    demands:
-    - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
-  dependsOn:
-  - job0
-  - job10
-  - job13
-  - job6
-  - job7
-  condition: and(succeeded(), not(canceled()))
-  variables:
-  - name: FLOWEY_TEMP_DIR
-    value: $(Build.StagingDirectory)/.flowey-internal
-  steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼🥾 Download bootstrapped flowey
-    inputs:
-      artifact: _internal-flowey-bootstrap-x86_64-windows-uid-3
-      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-guest_test_uefi
-    inputs:
-      artifact: x64-guest_test_uefi
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-musl-pipette
-    inputs:
-      artifact: x64-linux-musl-pipette
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-musl-tmk_vmm
-    inputs:
-      artifact: x64-linux-musl-tmk_vmm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-tpm_guest_tests
-    inputs:
-      artifact: x64-linux-tpm_guest_tests
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-openhcl-igvm
-    inputs:
-      artifact: x64-openhcl-igvm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-tmks
-    inputs:
-      artifact: x64-tmks
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-openvmm
-    inputs:
-      artifact: x64-windows-openvmm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-pipette
-    inputs:
-      artifact: x64-windows-pipette
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-prep_steps
-    inputs:
-      artifact: x64-windows-prep_steps
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-test_igvm_agent_rpc_server
-    inputs:
-      artifact: x64-windows-test_igvm_agent_rpc_server
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-tmk_vmm
-    inputs:
-      artifact: x64-windows-tmk_vmm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-tpm_guest_tests
-    inputs:
-      artifact: x64-windows-tpm_guest_tests
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-vmgstool
-    inputs:
-      artifact: x64-windows-vmgstool
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-vmm-tests-archive
-    inputs:
-      artifact: x64-windows-vmm-tests-archive
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive
-  - bash: |
-      set -e
-      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
-      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
-
-      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
-      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey.exe"
-      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
-    displayName: Set flowey path
-  - bash: |
-      set -e
       echo '"debug"' | $FLOWEY_BIN v 17 'FLOWEY_LOG' update
       echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 17 '_internal_WORKING_DIR' --is-raw-string update
 
@@ -4090,18 +4136,16 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 17 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-vmm-tests-archive" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 17 'artifact_use_from_x64-tmks' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
     displayName: 🌼🛫 Initialize job
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+    displayName: ensure hypervisor device is accessible
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+    displayName: ensure 2 MiB hugetlb pages are available
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 0
@@ -4149,22 +4193,20 @@ jobs:
       $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 2
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 7
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 1
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 9
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 10
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 6
     displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-    displayName: resolve OpenHCL igvm artifact
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -4204,31 +4246,567 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::init_vmm_tests_env 0
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 12
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
     displayName: setting up vmm_tests env
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::install_vmm_tests_deps 0
-    displayName: install vmm tests deps (windows)
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-    displayName: starting test_igvm_agent_rpc_server
+    displayName: install vmm tests deps (linux)
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-    displayName: run 'vmm_tests' nextest tests
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 17 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 0
       $FLOWEY_BIN v 17 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
       $FLOWEY_BIN v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'vmm_tests' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar1)
+      testRunTitle: x64-linux-amd-kvm-vmm-tests
+    displayName: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 2
+      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+    displayName: report test results to overall pipeline status
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: cargo-nextest'
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 7
+    displayName: 'validate cache entry: gh-release-download'
+- job: job16
+  displayName: run vmm-tests [x64-windows-amd]
+  pool:
+    demands:
+    - ImageOverride -equals win-amd64
+    name: openvmm-ado-amd-westus2
+  dependsOn:
+  - job0
+  - job11
+  - job2
+  - job3
+  - job7
+  condition: and(succeeded(), not(canceled()))
+  variables:
+  - name: FLOWEY_TEMP_DIR
+    value: $(Build.StagingDirectory)/.flowey-internal
+  steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼🥾 Download bootstrapped flowey
+    inputs:
+      artifact: _internal-flowey-bootstrap-x86_64-windows-uid-3
+      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-guest_test_uefi
+    inputs:
+      artifact: x64-guest_test_uefi
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-musl-pipette
+    inputs:
+      artifact: x64-linux-musl-pipette
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-musl-tmk_vmm
+    inputs:
+      artifact: x64-linux-musl-tmk_vmm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-tpm_guest_tests
+    inputs:
+      artifact: x64-linux-tpm_guest_tests
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-openhcl-igvm
+    inputs:
+      artifact: x64-openhcl-igvm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-tmks
+    inputs:
+      artifact: x64-tmks
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-openvmm
+    inputs:
+      artifact: x64-windows-openvmm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-pipette
+    inputs:
+      artifact: x64-windows-pipette
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-prep_steps
+    inputs:
+      artifact: x64-windows-prep_steps
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-test_igvm_agent_rpc_server
+    inputs:
+      artifact: x64-windows-test_igvm_agent_rpc_server
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-tmk_vmm
+    inputs:
+      artifact: x64-windows-tmk_vmm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-tpm_guest_tests
+    inputs:
+      artifact: x64-windows-tpm_guest_tests
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-vmgstool
+    inputs:
+      artifact: x64-windows-vmgstool
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-vmm-tests-archive
+    inputs:
+      artifact: x64-windows-vmm-tests-archive
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive
+  - bash: |
+      set -e
+      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
+      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
+
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey.exe"
+      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
+    displayName: Set flowey path
+  - bash: |
+      set -e
+      echo '"debug"' | $FLOWEY_BIN v 16 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 16 '_internal_WORKING_DIR' --is-raw-string update
+
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 16 'verbose' update
+      ${{ parameters.verbose }}
+      EOF
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 16 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 16 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 16 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 16 'artifact_use_from_x64-tmks' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+    displayName: 🌼🛫 Initialize job
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 3
+    displayName: create cargo-nextest cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar4)
+      path: $(floweyvar3)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: cargo-nextest'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 4
+    displayName: downloading cargo-nextest
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar2)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 8
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+    displayName: creating new test content dir
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+    displayName: resolve OpenHCL igvm artifact
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar6)
+      path: $(floweyvar5)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 6
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_azcopy 0
+    displayName: extract azcopy from archive
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+    displayName: calculating required VMM tests disk images
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+    displayName: downloading VMM test disk images
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (x64)
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_vmm_tests_env 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+    displayName: setting up vmm_tests env
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+    displayName: generate nextest command
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::install_vmm_tests_deps 0
+    displayName: install vmm tests deps (windows)
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+    displayName: starting test_igvm_agent_rpc_server
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+    displayName: run 'vmm_tests' nextest tests
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: stopping test_igvm_agent_rpc_server
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar1)
+      testRunTitle: x64-windows-amd-vmm-tests
+    displayName: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 2
+      $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+    displayName: report test results to overall pipeline status
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: cargo-nextest'
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::cache 7
+    displayName: 'validate cache entry: gh-release-download'
+- job: job15
+  displayName: run vmm-tests [x64-windows-intel]
+  pool:
+    demands:
+    - ImageOverride -equals win-amd64
+    name: openvmm-ado-intel-centralus
+  dependsOn:
+  - job0
+  - job11
+  - job2
+  - job3
+  - job7
+  condition: and(succeeded(), not(canceled()))
+  variables:
+  - name: FLOWEY_TEMP_DIR
+    value: $(Build.StagingDirectory)/.flowey-internal
+  steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼🥾 Download bootstrapped flowey
+    inputs:
+      artifact: _internal-flowey-bootstrap-x86_64-windows-uid-3
+      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-guest_test_uefi
+    inputs:
+      artifact: x64-guest_test_uefi
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-musl-pipette
+    inputs:
+      artifact: x64-linux-musl-pipette
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-musl-tmk_vmm
+    inputs:
+      artifact: x64-linux-musl-tmk_vmm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-tpm_guest_tests
+    inputs:
+      artifact: x64-linux-tpm_guest_tests
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-openhcl-igvm
+    inputs:
+      artifact: x64-openhcl-igvm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-tmks
+    inputs:
+      artifact: x64-tmks
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-openvmm
+    inputs:
+      artifact: x64-windows-openvmm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-pipette
+    inputs:
+      artifact: x64-windows-pipette
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-prep_steps
+    inputs:
+      artifact: x64-windows-prep_steps
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-test_igvm_agent_rpc_server
+    inputs:
+      artifact: x64-windows-test_igvm_agent_rpc_server
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-tmk_vmm
+    inputs:
+      artifact: x64-windows-tmk_vmm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-tpm_guest_tests
+    inputs:
+      artifact: x64-windows-tpm_guest_tests
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-vmgstool
+    inputs:
+      artifact: x64-windows-vmgstool
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-vmm-tests-archive
+    inputs:
+      artifact: x64-windows-vmm-tests-archive
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive
+  - bash: |
+      set -e
+      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
+      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
+
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey.exe"
+      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
+    displayName: Set flowey path
+  - bash: |
+      set -e
+      echo '"debug"' | $FLOWEY_BIN v 15 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 15 '_internal_WORKING_DIR' --is-raw-string update
+
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 15 'verbose' update
+      ${{ parameters.verbose }}
+      EOF
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 15 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 15 'artifact_use_from_x64-tmks' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+    displayName: 🌼🛫 Initialize job
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 3
+    displayName: create cargo-nextest cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar4)
+      path: $(floweyvar3)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: cargo-nextest'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 4
+    displayName: downloading cargo-nextest
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar2)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 8
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+    displayName: creating new test content dir
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+    displayName: resolve OpenHCL igvm artifact
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar6)
+      path: $(floweyvar5)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 6
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_azcopy 0
+    displayName: extract azcopy from archive
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+    displayName: calculating required VMM tests disk images
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+    displayName: downloading VMM test disk images
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (x64)
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_vmm_tests_env 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+    displayName: setting up vmm_tests env
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+    displayName: generate nextest command
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::install_vmm_tests_deps 0
+    displayName: install vmm tests deps (windows)
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+    displayName: starting test_igvm_agent_rpc_server
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+    displayName: run 'vmm_tests' nextest tests
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: stopping test_igvm_agent_rpc_server
   - task: PublishTestResults@2
     inputs:
@@ -4239,844 +4817,15 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 2
-      $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job5
-  displayName: build artifacts (not for VMM tests) [x64-windows]
-  pool:
-    demands:
-    - ImageOverride -equals win-amd64
-    name: openvmm-ado-amd-westus2
-  dependsOn:
-  - job0
-  condition: and(succeeded(), not(canceled()))
-  variables:
-  - name: FLOWEY_TEMP_DIR
-    value: $(Build.StagingDirectory)/.flowey-internal
-  steps:
-  - bash: |
-      set -x
-      i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-      sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-      . "$HOME/.cargo/env"
-      echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
-    condition: eq(variables['Agent.OS'], 'Linux')
-    displayName: rustup (Linux)
-  - bash: |
-      set -x
-      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.95.0
-      echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-    displayName: rustup (Windows X64)
-  - bash: |
-      set -x
-      rustup show
-    displayName: Verify rustup installation
-  - checkout: self
-    fetchTags: false
-    fetchDepth: 1
-    path: flowey_bootstrap
-  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
-    workingDirectory: ../flowey_bootstrap
-    displayName: Build flowey
-  - bash: |
-      mkdir ./flowey_bootstrap_temp
-      mv ./ci-flowey/openvmm-pr.yaml ./flowey_bootstrap_temp/pipeline.yaml
-      mv ./ci-flowey/openvmm-pr.json ./flowey_bootstrap_temp/pipeline.json
-      mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe ./flowey_bootstrap_temp/flowey.exe
-    workingDirectory: ../flowey_bootstrap
-    displayName: Stage flowey artifact
-  - task: CopyFiles@2
-    displayName: Copy flowey artifact
-    inputs:
-      SourceFolder: ../flowey_bootstrap/flowey_bootstrap_temp
-      TargetFolder: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
-  - bash: rm -rf ./flowey_bootstrap_temp
-    workingDirectory: ../flowey_bootstrap
-    displayName: Cleanup staged flowey artifact
-  - bash: |
-      set -e
-      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
-      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
-
-      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
-      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey.exe"
-      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
-    displayName: Set flowey path
-  - bash: |-
-      ESCAPED_AGENT_TEMPDIR=$(
-      cat <<'EOF' | sed 's/\\/\\\\/g'
-      $(FLOWEY_TEMP_DIR)
-      EOF
-      )
-      $(FLOWEY_BIN) pipeline ado --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out ci-flowey/openvmm-pr.yaml ci checkin-gates --config=pr
-    displayName: 🌼🔎 Self-check YAML
-  - bash: |
-      set -e
-      echo '"debug"' | $FLOWEY_BIN v 5 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 5 '_internal_WORKING_DIR' --is-raw-string update
-
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 5 'verbose' update
-      ${{ parameters.verbose }}
-      EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-hypestv"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-hypestv" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-igvmfilegen"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-igvmfilegen" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-ohcldiag-dev"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-ohcldiag-dev" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-windows-vmgs_lib"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-vmgs_lib" | $FLOWEY_BIN v 5 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
-    displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 5 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar1)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-    displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar3)
-      path: $(floweyvar2)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 5 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-    displayName: unpack protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 1
-    displayName: symlink protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 0
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_hypestv 0
-      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 0
-    displayName: cargo build hypestv
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-    displayName: cargo build vmgs_lib
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 2
-    displayName: test vmgs_lib
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::init_cross_build 3
-    displayName: cargo build igvmfilegen
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 5 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 5 flowey_lib_hvlite::build_ohcldiag_dev 0
-      $(FLOWEY_BIN) e 5 flowey_core::pipeline::artifact::publish 3
-    displayName: cargo build ohcldiag-dev
-  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-hypestv
-    displayName: 🌼📦 Publish x64-windows-hypestv
-    artifact: x64-windows-hypestv
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-igvmfilegen
-    displayName: 🌼📦 Publish x64-windows-igvmfilegen
-    artifact: x64-windows-igvmfilegen
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-ohcldiag-dev
-    displayName: 🌼📦 Publish x64-windows-ohcldiag-dev
-    artifact: x64-windows-ohcldiag-dev
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-windows-vmgs_lib
-    displayName: 🌼📦 Publish x64-windows-vmgs_lib
-    artifact: x64-windows-vmgs_lib
-- job: job4
-  displayName: build artifacts (for VMM tests) [aarch64-windows]
-  pool:
-    demands:
-    - ImageOverride -equals win-amd64
-    name: openvmm-ado-amd-westus2
-  dependsOn:
-  - job0
-  condition: and(succeeded(), not(canceled()))
-  variables:
-  - name: FLOWEY_TEMP_DIR
-    value: $(Build.StagingDirectory)/.flowey-internal
-  steps:
-  - bash: |
-      set -x
-      i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-      sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-      . "$HOME/.cargo/env"
-      echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
-    condition: eq(variables['Agent.OS'], 'Linux')
-    displayName: rustup (Linux)
-  - bash: |
-      set -x
-      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.95.0
-      echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-    displayName: rustup (Windows X64)
-  - bash: |
-      set -x
-      rustup show
-    displayName: Verify rustup installation
-  - checkout: self
-    fetchTags: false
-    fetchDepth: 1
-    path: flowey_bootstrap
-  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
-    workingDirectory: ../flowey_bootstrap
-    displayName: Build flowey
-  - bash: |
-      mkdir ./flowey_bootstrap_temp
-      mv ./ci-flowey/openvmm-pr.yaml ./flowey_bootstrap_temp/pipeline.yaml
-      mv ./ci-flowey/openvmm-pr.json ./flowey_bootstrap_temp/pipeline.json
-      mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe ./flowey_bootstrap_temp/flowey.exe
-    workingDirectory: ../flowey_bootstrap
-    displayName: Stage flowey artifact
-  - task: CopyFiles@2
-    displayName: Copy flowey artifact
-    inputs:
-      SourceFolder: ../flowey_bootstrap/flowey_bootstrap_temp
-      TargetFolder: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
-  - bash: rm -rf ./flowey_bootstrap_temp
-    workingDirectory: ../flowey_bootstrap
-    displayName: Cleanup staged flowey artifact
-  - bash: |
-      set -e
-      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
-      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
-
-      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
-      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey.exe"
-      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
-    displayName: Set flowey path
-  - bash: |-
-      ESCAPED_AGENT_TEMPDIR=$(
-      cat <<'EOF' | sed 's/\\/\\\\/g'
-      $(FLOWEY_TEMP_DIR)
-      EOF
-      )
-      $(FLOWEY_BIN) pipeline ado --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out ci-flowey/openvmm-pr.yaml ci checkin-gates --config=pr
-    displayName: 🌼🔎 Self-check YAML
-  - bash: |
-      set -e
-      echo '"debug"' | $FLOWEY_BIN v 4 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 4 '_internal_WORKING_DIR' --is-raw-string update
-
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 4 'verbose' update
-      ${{ parameters.verbose }}
-      EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-openvmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-openvmm" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-prep_steps"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-prep_steps" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-prep_steps' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-tmk_vmm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tmk_vmm" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-tpm_guest_tests"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tpm_guest_tests" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-tpm_guest_tests' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-vmgstool"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmgstool" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-vmm-tests-archive"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmm-tests-archive" | $FLOWEY_BIN v 4 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
-    displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 4 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar1)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-    displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 4 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 4 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar5)
-      path: $(floweyvar4)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 4 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 4 flowey_lib_common::cache 6
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-    displayName: unpack protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 1
-    displayName: symlink protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 5
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_tmk_vmm 0
-      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 3
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 5
-    displayName: cargo build tmk_vmm
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_prep_steps 0
-      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 3
-    displayName: cargo build prep_steps
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 5
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 9
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_vmgstool 0
-      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 5
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 2
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 7
-    displayName: cargo build vmgstool
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 4
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 8
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_tpm_guest_tests 0
-      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 6
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 6
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 3
-    displayName: cargo build tpm_guest_tests
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 4
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 0
-    displayName: cargo build test_igvm_agent_rpc_server
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 4 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 4 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 4 flowey_lib_common::download_cargo_nextest 3
-    displayName: create cargo-nextest cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar3)
-      path: $(floweyvar2)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: cargo-nextest'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 4 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::download_cargo_nextest 4
-    displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::install_rust 2
-    displayName: report $CARGO_HOME
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 0
-    displayName: installing cargo-nextest
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_nextest_archive 0
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_nextest_vmm_tests 0
-      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::init_cross_build 4
-    displayName: build + archive 'vmm_tests' nextests
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 4 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::run_cargo_build 0
-      $(FLOWEY_BIN) e 4 flowey_lib_hvlite::build_openvmm 0
-      $(FLOWEY_BIN) e 4 flowey_core::pipeline::artifact::publish 2
-    displayName: cargo build openvmm
-  - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::cache 7
-    displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-openvmm
-    displayName: 🌼📦 Publish aarch64-windows-openvmm
-    artifact: aarch64-windows-openvmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-prep_steps
-    displayName: 🌼📦 Publish aarch64-windows-prep_steps
-    artifact: aarch64-windows-prep_steps
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-test_igvm_agent_rpc_server
-    displayName: 🌼📦 Publish aarch64-windows-test_igvm_agent_rpc_server
-    artifact: aarch64-windows-test_igvm_agent_rpc_server
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tmk_vmm
-    displayName: 🌼📦 Publish aarch64-windows-tmk_vmm
-    artifact: aarch64-windows-tmk_vmm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-tpm_guest_tests
-    displayName: 🌼📦 Publish aarch64-windows-tpm_guest_tests
-    artifact: aarch64-windows-tpm_guest_tests
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmgstool
-    displayName: 🌼📦 Publish aarch64-windows-vmgstool
-    artifact: aarch64-windows-vmgstool
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmm-tests-archive
-    displayName: 🌼📦 Publish aarch64-windows-vmm-tests-archive
-    artifact: aarch64-windows-vmm-tests-archive
-- job: job3
-  displayName: build artifacts (shared VMM tests) [aarch64-windows]
-  pool:
-    demands:
-    - ImageOverride -equals win-amd64
-    name: openvmm-ado-amd-westus2
-  dependsOn:
-  - job0
-  condition: and(succeeded(), not(canceled()))
-  variables:
-  - name: FLOWEY_TEMP_DIR
-    value: $(Build.StagingDirectory)/.flowey-internal
-  steps:
-  - bash: |
-      set -x
-      i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-      sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-      . "$HOME/.cargo/env"
-      echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
-    condition: eq(variables['Agent.OS'], 'Linux')
-    displayName: rustup (Linux)
-  - bash: |
-      set -x
-      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.95.0
-      echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-    displayName: rustup (Windows X64)
-  - bash: |
-      set -x
-      rustup show
-    displayName: Verify rustup installation
-  - checkout: self
-    fetchTags: false
-    fetchDepth: 1
-    path: flowey_bootstrap
-  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
-    workingDirectory: ../flowey_bootstrap
-    displayName: Build flowey
-  - bash: |
-      mkdir ./flowey_bootstrap_temp
-      mv ./ci-flowey/openvmm-pr.yaml ./flowey_bootstrap_temp/pipeline.yaml
-      mv ./ci-flowey/openvmm-pr.json ./flowey_bootstrap_temp/pipeline.json
-      mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe ./flowey_bootstrap_temp/flowey.exe
-    workingDirectory: ../flowey_bootstrap
-    displayName: Stage flowey artifact
-  - task: CopyFiles@2
-    displayName: Copy flowey artifact
-    inputs:
-      SourceFolder: ../flowey_bootstrap/flowey_bootstrap_temp
-      TargetFolder: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
-  - bash: rm -rf ./flowey_bootstrap_temp
-    workingDirectory: ../flowey_bootstrap
-    displayName: Cleanup staged flowey artifact
-  - bash: |
-      set -e
-      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
-      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
-
-      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
-      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey.exe"
-      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
-    displayName: Set flowey path
-  - bash: |-
-      ESCAPED_AGENT_TEMPDIR=$(
-      cat <<'EOF' | sed 's/\\/\\\\/g'
-      $(FLOWEY_TEMP_DIR)
-      EOF
-      )
-      $(FLOWEY_BIN) pipeline ado --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out ci-flowey/openvmm-pr.yaml ci checkin-gates --config=pr
-    displayName: 🌼🔎 Self-check YAML
-  - bash: |
-      set -e
-      echo '"debug"' | $FLOWEY_BIN v 3 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 3 '_internal_WORKING_DIR' --is-raw-string update
-
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 3 'verbose' update
-      ${{ parameters.verbose }}
-      EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-pipette"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-pipette" | $FLOWEY_BIN v 3 'artifact_publish_from_aarch64-windows-pipette' --is-raw-string update
-    displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 3 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar1)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-    displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar3)
-      path: $(floweyvar2)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 3 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-    displayName: unpack protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::init_cross_build 0
-    displayName: symlink protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 3 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::run_cargo_build 0
-      $(FLOWEY_BIN) e 3 flowey_lib_hvlite::build_pipette 0
-      $(FLOWEY_BIN) e 3 flowey_core::pipeline::artifact::publish 0
-    displayName: cargo build pipette
-  - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-pipette
-    displayName: 🌼📦 Publish aarch64-windows-pipette
-    artifact: aarch64-windows-pipette
-- job: job2
-  displayName: build artifacts (not for VMM tests) [aarch64-windows]
-  pool:
-    demands:
-    - ImageOverride -equals win-amd64
-    name: openvmm-ado-amd-westus2
-  dependsOn:
-  - job0
-  condition: and(succeeded(), not(canceled()))
-  variables:
-  - name: FLOWEY_TEMP_DIR
-    value: $(Build.StagingDirectory)/.flowey-internal
-  steps:
-  - bash: |
-      set -x
-      i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-      sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-      curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-      . "$HOME/.cargo/env"
-      echo '##vso[task.prependpath]$(HOME)/.cargo/bin'
-    condition: eq(variables['Agent.OS'], 'Linux')
-    displayName: rustup (Linux)
-  - bash: |
-      set -x
-      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-      ./rustup-init.exe -y --default-toolchain=1.95.0
-      echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-    displayName: rustup (Windows X64)
-  - bash: |
-      set -x
-      rustup show
-    displayName: Verify rustup installation
-  - checkout: self
-    fetchTags: false
-    fetchDepth: 1
-    path: flowey_bootstrap
-  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
-    workingDirectory: ../flowey_bootstrap
-    displayName: Build flowey
-  - bash: |
-      mkdir ./flowey_bootstrap_temp
-      mv ./ci-flowey/openvmm-pr.yaml ./flowey_bootstrap_temp/pipeline.yaml
-      mv ./ci-flowey/openvmm-pr.json ./flowey_bootstrap_temp/pipeline.json
-      mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe ./flowey_bootstrap_temp/flowey.exe
-    workingDirectory: ../flowey_bootstrap
-    displayName: Stage flowey artifact
-  - task: CopyFiles@2
-    displayName: Copy flowey artifact
-    inputs:
-      SourceFolder: ../flowey_bootstrap/flowey_bootstrap_temp
-      TargetFolder: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
-  - bash: rm -rf ./flowey_bootstrap_temp
-    workingDirectory: ../flowey_bootstrap
-    displayName: Cleanup staged flowey artifact
-  - bash: |
-      set -e
-      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
-      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
-
-      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
-      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey.exe"
-      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
-    displayName: Set flowey path
-  - bash: |-
-      ESCAPED_AGENT_TEMPDIR=$(
-      cat <<'EOF' | sed 's/\\/\\\\/g'
-      $(FLOWEY_TEMP_DIR)
-      EOF
-      )
-      $(FLOWEY_BIN) pipeline ado --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out ci-flowey/openvmm-pr.yaml ci checkin-gates --config=pr
-    displayName: 🌼🔎 Self-check YAML
-  - bash: |
-      set -e
-      echo '"debug"' | $FLOWEY_BIN v 2 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 2 '_internal_WORKING_DIR' --is-raw-string update
-
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 2 'verbose' update
-      ${{ parameters.verbose }}
-      EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-hypestv"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-hypestv" | $FLOWEY_BIN v 2 'artifact_publish_from_aarch64-windows-hypestv' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-igvmfilegen"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-igvmfilegen" | $FLOWEY_BIN v 2 'artifact_publish_from_aarch64-windows-igvmfilegen' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-ohcldiag-dev"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-ohcldiag-dev" | $FLOWEY_BIN v 2 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-windows-vmgs_lib"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmgs_lib" | $FLOWEY_BIN v 2 'artifact_publish_from_aarch64-windows-vmgs_lib' --is-raw-string update
-    displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 2 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 2 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 2 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 2 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar1)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 2 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 2 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-    displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 2 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 2 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar3)
-      path: $(floweyvar2)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 2 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 2 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 2 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-    displayName: unpack protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::init_cross_build 1
-    displayName: symlink protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 2 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::run_cargo_build 0
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::build_hypestv 0
-      $(FLOWEY_BIN) e 2 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::init_cross_build 0
-    displayName: cargo build hypestv
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 2 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      $(FLOWEY_BIN) e 2 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::init_cross_build 2
-    displayName: cargo build vmgs_lib
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 2 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 2 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::init_cross_build 3
-    displayName: cargo build igvmfilegen
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 2 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 2 flowey_lib_hvlite::build_ohcldiag_dev 0
-      $(FLOWEY_BIN) e 2 flowey_core::pipeline::artifact::publish 3
-    displayName: cargo build ohcldiag-dev
-  - bash: $(FLOWEY_BIN) e 2 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-hypestv
-    displayName: 🌼📦 Publish aarch64-windows-hypestv
-    artifact: aarch64-windows-hypestv
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-igvmfilegen
-    displayName: 🌼📦 Publish aarch64-windows-igvmfilegen
-    artifact: aarch64-windows-igvmfilegen
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-ohcldiag-dev
-    displayName: 🌼📦 Publish aarch64-windows-ohcldiag-dev
-    artifact: aarch64-windows-ohcldiag-dev
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-windows-vmgs_lib
-    displayName: 🌼📦 Publish aarch64-windows-vmgs_lib
-    artifact: aarch64-windows-vmgs_lib
 - job: job1
   displayName: xtask fmt (windows)
   pool:

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -735,106 +735,117 @@ impl IntoPipeline for CheckinGatesCli {
             }
 
             // Emit a job for building dependencies used by just linux vmm tests
-            // No ARM64 VMM tests yet
-            if matches!(arch, CommonArch::X86_64) {
-                let pub_vmm_tests_archive_linux_x86 =
-                    pub_vmm_tests_archive_linux_x86.take().unwrap();
-                let pub_vmm_tests_archive_linux_musl_x86 =
-                    pub_vmm_tests_archive_linux_musl_x86.take().unwrap();
 
-                let job = pipeline
-                    .new_job(
-                        FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
-                        FlowArch::X86_64,
-                        format!("build artifacts (for VMM tests) [{arch_tag}-linux]"),
-                    )
-                    .gh_set_pool(gh_pools::default_linux())
-                    .ado_set_pool(ado_pools::default_linux())
-                    .publish(pub_openvmm, |openvmm| {
-                        flowey_lib_hvlite::build_openvmm::Request {
-                            params: flowey_lib_hvlite::build_openvmm::OpenvmmBuildParams {
+            let mut job = pipeline
+                .new_job(
+                    FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
+                    FlowArch::X86_64,
+                    format!("build artifacts (for VMM tests) [{arch_tag}-linux]"),
+                )
+                .gh_set_pool(gh_pools::default_linux())
+                .ado_set_pool(ado_pools::default_linux())
+                .publish(pub_openvmm, |openvmm| {
+                    flowey_lib_hvlite::build_openvmm::Request {
+                        params: flowey_lib_hvlite::build_openvmm::OpenvmmBuildParams {
+                            target: CommonTriple::Common {
+                                arch,
+                                platform: CommonPlatform::LinuxGnu,
+                            },
+                            profile: CommonProfile::from_release(release),
+                            // FIXME: this relies on openvmm default features
+                            features: [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::Tpm]
+                                .into(),
+                        },
+                        openvmm,
+                    }
+                })
+                .publish(pub_openvmm_vhost, |openvmm_vhost| {
+                    flowey_lib_hvlite::build_openvmm_vhost::Request {
+                        params: flowey_lib_hvlite::build_openvmm_vhost::OpenvmmVhostBuildParams {
+                            target: CommonTriple::Common {
+                                arch,
+                                platform: CommonPlatform::LinuxGnu,
+                            },
+                            profile: CommonProfile::from_release(release),
+                        },
+                        openvmm_vhost,
+                    }
+                })
+                .publish(pub_vmgstool, |vmgstool| {
+                    flowey_lib_hvlite::build_vmgstool::Request {
+                        target: vmgstool_target,
+                        profile: CommonProfile::from_release(release),
+                        with_crypto: true,
+                        with_test_helpers: true,
+                        vmgstool,
+                    }
+                })
+                .publish(pub_vmgs_lib, |vmgs_lib| {
+                    flowey_lib_hvlite::build_and_test_vmgs_lib::Request {
+                        target: CommonTriple::Common {
+                            arch,
+                            platform: CommonPlatform::LinuxGnu,
+                        },
+                        profile: CommonProfile::from_release(release),
+                        vmgs_lib,
+                    }
+                })
+                .publish(pub_igvmfilegen, |igvmfilegen| {
+                    flowey_lib_hvlite::build_igvmfilegen::Request {
+                        build_params:
+                            flowey_lib_hvlite::build_igvmfilegen::IgvmfilegenBuildParams {
                                 target: CommonTriple::Common {
                                     arch,
                                     platform: CommonPlatform::LinuxGnu,
                                 },
-                                profile: CommonProfile::from_release(release),
-                                // FIXME: this relies on openvmm default features
-                                features: [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::Tpm]
-                                    .into(),
+                                profile: CommonProfile::from_release(release).into(),
                             },
-                            openvmm,
-                        }
-                    })
-                    .publish(pub_openvmm_vhost, |openvmm_vhost| {
-                        flowey_lib_hvlite::build_openvmm_vhost::Request {
-                            params:
-                                flowey_lib_hvlite::build_openvmm_vhost::OpenvmmVhostBuildParams {
-                                    target: CommonTriple::Common {
-                                        arch,
-                                        platform: CommonPlatform::LinuxGnu,
-                                    },
-                                    profile: CommonProfile::from_release(release),
-                                },
-                            openvmm_vhost,
-                        }
-                    })
-                    .publish(pub_vmgstool, |vmgstool| {
-                        flowey_lib_hvlite::build_vmgstool::Request {
-                            target: vmgstool_target,
-                            profile: CommonProfile::from_release(release),
-                            with_crypto: true,
-                            with_test_helpers: true,
-                            vmgstool,
-                        }
-                    })
-                    .publish(pub_vmgs_lib, |vmgs_lib| {
-                        flowey_lib_hvlite::build_and_test_vmgs_lib::Request {
-                            target: CommonTriple::Common {
-                                arch,
-                                platform: CommonPlatform::LinuxGnu,
-                            },
-                            profile: CommonProfile::from_release(release),
-                            vmgs_lib,
-                        }
-                    })
-                    .publish(pub_igvmfilegen, |igvmfilegen| {
-                        flowey_lib_hvlite::build_igvmfilegen::Request {
-                            build_params:
-                                flowey_lib_hvlite::build_igvmfilegen::IgvmfilegenBuildParams {
-                                    target: CommonTriple::Common {
-                                        arch,
-                                        platform: CommonPlatform::LinuxGnu,
-                                    },
-                                    profile: CommonProfile::from_release(release).into(),
-                                },
-                            igvmfilegen,
-                        }
-                    })
-                    .publish(pub_ohcldiag_dev, |ohcldiag_dev| {
-                        flowey_lib_hvlite::build_ohcldiag_dev::Request {
-                            target: CommonTriple::Common {
-                                arch,
-                                platform: CommonPlatform::LinuxGnu,
-                            },
-                            profile: CommonProfile::from_release(release),
-                            ohcldiag_dev,
-                        }
-                    }).publish(pub_vmm_tests_archive_linux_x86, |archive| flowey_lib_hvlite::build_nextest_vmm_tests::Request {
-                    target: CommonTriple::X86_64_LINUX_GNU.as_triple(),
-                    profile: CommonProfile::from_release(release),
-                    build_mode: flowey_lib_hvlite::build_nextest_vmm_tests::BuildNextestVmmTestsMode::Archive(
-                        archive,
-                    ),
-                }).publish(pub_vmm_tests_archive_linux_musl_x86, |archive| flowey_lib_hvlite::build_nextest_vmm_tests::Request {
-                    target: CommonTriple::X86_64_LINUX_MUSL.as_triple(),
-                    profile: CommonProfile::from_release(release),
-                    build_mode: flowey_lib_hvlite::build_nextest_vmm_tests::BuildNextestVmmTestsMode::Archive(
-                        archive,
-                    ),
+                        igvmfilegen,
+                    }
+                })
+                .publish(pub_ohcldiag_dev, |ohcldiag_dev| {
+                    flowey_lib_hvlite::build_ohcldiag_dev::Request {
+                        target: CommonTriple::Common {
+                            arch,
+                            platform: CommonPlatform::LinuxGnu,
+                        },
+                        profile: CommonProfile::from_release(release),
+                        ohcldiag_dev,
+                    }
                 });
 
-                all_jobs.push(job.finish());
+            // No ARM64 VMM tests yet
+            if matches!(arch, CommonArch::X86_64) {
+                let pub_vmm_tests_archive_linux = pub_vmm_tests_archive_linux_x86.take().unwrap();
+                let pub_vmm_tests_archive_linux_musl =
+                    pub_vmm_tests_archive_linux_musl_x86.take().unwrap();
+
+                job = job.publish(pub_vmm_tests_archive_linux, |archive| {
+                        flowey_lib_hvlite::build_nextest_vmm_tests::Request {
+                            target: CommonTriple::Common {
+                                arch,
+                                platform: CommonPlatform::LinuxGnu,
+                            }.as_triple(),
+                            profile: CommonProfile::from_release(release),
+                            build_mode: flowey_lib_hvlite::build_nextest_vmm_tests::BuildNextestVmmTestsMode::Archive(
+                                archive,
+                            ),
+                        }
+                    }).publish(pub_vmm_tests_archive_linux_musl, |archive| {
+                    flowey_lib_hvlite::build_nextest_vmm_tests::Request {
+                            target: CommonTriple::Common {
+                                arch,
+                                platform: CommonPlatform::LinuxGnu,
+                            }.as_triple(),
+                            profile: CommonProfile::from_release(release),
+                            build_mode: flowey_lib_hvlite::build_nextest_vmm_tests::BuildNextestVmmTestsMode::Archive(
+                                archive,
+                            ),
+                        }
+                    });
             }
+
+            all_jobs.push(job.finish());
         }
 
         // emit openhcl build job

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -430,6 +430,28 @@ impl IntoPipeline for CheckinGatesCli {
 
             all_jobs.push(job.finish());
 
+            // emit a job for artifacts used by VMM tests on multiple platforms
+            let job = pipeline
+                .new_job(
+                    FlowPlatform::Windows,
+                    FlowArch::X86_64,
+                    format!("build artifacts (shared VMM tests) [{arch_tag}-windows]"),
+                )
+                .gh_set_pool(gh_pools::default_windows())
+                .ado_set_pool(ado_pools::default_windows())
+                .publish(pub_pipette_windows, |pipette| {
+                    flowey_lib_hvlite::build_pipette::Request {
+                        target: CommonTriple::Common {
+                            arch,
+                            platform: CommonPlatform::WindowsMsvc,
+                        },
+                        profile: CommonProfile::from_release(release),
+                        pipette,
+                    }
+                });
+
+            all_jobs.push(job.finish());
+
             let vmgstool_target = CommonTriple::Common {
                 arch,
                 platform: CommonPlatform::WindowsMsvc,
@@ -468,18 +490,6 @@ impl IntoPipeline for CheckinGatesCli {
                             },
                         },
                         openvmm,
-                    }
-                })
-                // TODO: As of writing this, pipette_windows is the only windows-built artifact used by
-                // linux vmm tests. Consider splitting it into its own job to let them start sooner.
-                .publish(pub_pipette_windows, |pipette| {
-                    flowey_lib_hvlite::build_pipette::Request {
-                        target: CommonTriple::Common {
-                            arch,
-                            platform: CommonPlatform::WindowsMsvc,
-                        },
-                        profile: CommonProfile::from_release(release),
-                        pipette,
                     }
                 })
                 .publish(pub_tmk_vmm, |tmk_vmm| {

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -470,7 +470,7 @@ impl IntoPipeline for CheckinGatesCli {
                         openvmm,
                     }
                 })
-                // TODO: As of writing pipette_windows is the only windows-built artifact used by
+                // TODO: As of writing this, pipette_windows is the only windows-built artifact used by
                 // linux vmm tests. Consider splitting it into its own job to let them start sooner.
                 .publish(pub_pipette_windows, |pipette| {
                     flowey_lib_hvlite::build_pipette::Request {

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -470,6 +470,8 @@ impl IntoPipeline for CheckinGatesCli {
                         openvmm,
                     }
                 })
+                // TODO: As of writing pipette_windows is the only windows-built artifact used by
+                // linux vmm tests. Consider splitting it into its own job to let them start sooner.
                 .publish(pub_pipette_windows, |pipette| {
                     flowey_lib_hvlite::build_pipette::Request {
                         target: CommonTriple::Common {

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -829,11 +829,12 @@ impl IntoPipeline for CheckinGatesCli {
             // Hang building the linux VMM tests off this big linux job.
             // No ARM64 VMM tests yet
             if matches!(arch, CommonArch::X86_64) {
-                let pub_vmm_tests_archive_linux = pub_vmm_tests_archive_linux_x86.take().unwrap();
-                let pub_vmm_tests_archive_linux_musl =
+                let pub_vmm_tests_archive_linux_x86 =
+                    pub_vmm_tests_archive_linux_x86.take().unwrap();
+                let pub_vmm_tests_archive_linux_musl_x86 =
                     pub_vmm_tests_archive_linux_musl_x86.take().unwrap();
 
-                job = job.publish(pub_vmm_tests_archive_linux, |archive| {
+                job = job.publish(pub_vmm_tests_archive_linux_x86, |archive| {
                         flowey_lib_hvlite::build_nextest_vmm_tests::Request {
                             target: CommonTriple::Common {
                                 arch,
@@ -844,11 +845,11 @@ impl IntoPipeline for CheckinGatesCli {
                                 archive,
                             ),
                         }
-                    }).publish(pub_vmm_tests_archive_linux_musl, |archive| {
+                    }).publish(pub_vmm_tests_archive_linux_musl_x86, |archive| {
                     flowey_lib_hvlite::build_nextest_vmm_tests::Request {
                             target: CommonTriple::Common {
                                 arch,
-                                platform: CommonPlatform::LinuxGnu,
+                                platform: CommonPlatform::LinuxMusl,
                             }.as_triple(),
                             profile: CommonProfile::from_release(release),
                             build_mode: flowey_lib_hvlite::build_nextest_vmm_tests::BuildNextestVmmTestsMode::Archive(

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -586,15 +586,19 @@ impl IntoPipeline for CheckinGatesCli {
             let (pub_tmks, use_tmks) = pipeline.new_typed_artifact(format!("{arch_tag}-tmks"));
             let (pub_tpm_guest_tests, use_tpm_guest_tests) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-tpm_guest_tests"));
-
-            // NOTE: the choice to build it as part of this linux job was pretty
-            // arbitrary. It could just as well hang off the windows job.
-            //
-            // At this time though, having it here results in a net-reduction in
-            // E2E pipeline times, owing to how the VMM tests artifact dependency
-            // graph looks like.
             let (pub_guest_test_uefi, use_guest_test_uefi) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-guest_test_uefi"));
+            let (pub_pipette_linux_musl, use_pipette_linux_musl) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-pipette"));
+            let (pub_tmk_vmm, use_tmk_vmm) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-tmk_vmm"));
+            // Also build openvmm and openvmm_vhost for musl on this job,
+            // alongside pipette and tmk_vmm. This enables running VMM tests
+            // on Azure Linux (MSHV) runners which have an older glibc.
+            let (pub_openvmm_musl, use_openvmm_musl) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm"));
+            let (pub_openvmm_vhost_musl, use_openvmm_vhost_musl) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm_vhost"));
 
             // skim off interesting artifacts required by the VMM tests job
             match arch {
@@ -610,17 +614,114 @@ impl IntoPipeline for CheckinGatesCli {
                     vmm_tests_artifacts_linux_x86.use_tmks = Some(use_tmks.clone());
                     vmm_tests_artifacts_windows_x86.use_tpm_guest_tests_linux =
                         Some(use_tpm_guest_tests.clone());
-                    // arch-neutral artifacts for musl MSHV test job
                     vmm_tests_artifacts_linux_musl_x86.use_guest_test_uefi =
                         Some(use_guest_test_uefi.clone());
                     vmm_tests_artifacts_linux_musl_x86.use_tmks = Some(use_tmks.clone());
+                    vmm_tests_artifacts_windows_x86.use_pipette_linux_musl =
+                        Some(use_pipette_linux_musl.clone());
+                    vmm_tests_artifacts_linux_x86.use_pipette_linux_musl =
+                        Some(use_pipette_linux_musl.clone());
+                    vmm_tests_artifacts_linux_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
+                    vmm_tests_artifacts_windows_x86.use_tmk_vmm_linux_musl =
+                        Some(use_tmk_vmm.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_openvmm = Some(use_openvmm_musl.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_openvmm_vhost =
+                        Some(use_openvmm_vhost_musl.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_pipette_linux_musl =
+                        Some(use_pipette_linux_musl.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
                 }
                 CommonArch::Aarch64 => {
                     vmm_tests_artifacts_windows_aarch64.use_guest_test_uefi =
                         Some(use_guest_test_uefi.clone());
                     vmm_tests_artifacts_windows_aarch64.use_tmks = Some(use_tmks.clone());
+                    vmm_tests_artifacts_windows_aarch64.use_pipette_linux_musl =
+                        Some(use_pipette_linux_musl.clone());
+                    vmm_tests_artifacts_windows_aarch64.use_tmk_vmm_linux_musl =
+                        Some(use_tmk_vmm.clone());
                 }
             }
+
+            // Emit a job for building dependencies used by all platforms vmm tests
+            let shared_job = pipeline
+                .new_job(
+                    FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
+                    FlowArch::X86_64,
+                    format!("build artifacts [{arch_tag}-linux] (shared)"),
+                )
+                .gh_set_pool(gh_pools::default_linux())
+                .ado_set_pool(ado_pools::default_linux())
+                .publish(pub_guest_test_uefi, |guest_test_uefi| {
+                    flowey_lib_hvlite::build_guest_test_uefi::Request {
+                        arch,
+                        profile: CommonProfile::from_release(release),
+                        guest_test_uefi,
+                    }
+                })
+                .publish(pub_tmks, |tmks| flowey_lib_hvlite::build_tmks::Request {
+                    arch,
+                    profile: CommonProfile::from_release(release),
+                    tmks,
+                })
+                .publish(pub_tpm_guest_tests, |tpm_guest_tests| {
+                    flowey_lib_hvlite::build_tpm_guest_tests::Request {
+                        target: CommonTriple::Common {
+                            arch,
+                            platform: CommonPlatform::LinuxGnu,
+                        },
+                        profile: CommonProfile::from_release(release),
+                        tpm_guest_tests,
+                    }
+                })
+                .publish(pub_pipette_linux_musl, |pipette| {
+                    flowey_lib_hvlite::build_pipette::Request {
+                        target: CommonTriple::Common {
+                            arch,
+                            platform: CommonPlatform::LinuxMusl,
+                        },
+                        profile: CommonProfile::from_release(release),
+                        pipette,
+                    }
+                })
+                .publish(pub_tmk_vmm, |tmk_vmm| {
+                    flowey_lib_hvlite::build_tmk_vmm::Request {
+                        target: CommonTriple::Common {
+                            arch,
+                            platform: CommonPlatform::LinuxMusl,
+                        },
+                        profile: CommonProfile::from_release(release),
+                        unstable_whp: false,
+                        tmk_vmm,
+                    }
+                })
+                .publish(pub_openvmm_musl, |openvmm| {
+                    flowey_lib_hvlite::build_openvmm::Request {
+                        params: flowey_lib_hvlite::build_openvmm::OpenvmmBuildParams {
+                            target: CommonTriple::Common {
+                                arch,
+                                platform: CommonPlatform::LinuxMusl,
+                            },
+                            profile: CommonProfile::from_release(release),
+                            features: [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::Tpm]
+                                .into(),
+                        },
+                        openvmm,
+                    }
+                })
+                .publish(pub_openvmm_vhost_musl, |openvmm_vhost| {
+                    flowey_lib_hvlite::build_openvmm_vhost::Request {
+                        params: flowey_lib_hvlite::build_openvmm_vhost::OpenvmmVhostBuildParams {
+                            target: CommonTriple::Common {
+                                arch,
+                                platform: CommonPlatform::LinuxMusl,
+                            },
+                            profile: CommonProfile::from_release(release),
+                        },
+                        openvmm_vhost,
+                    }
+                })
+                .finish();
+            all_jobs.push(shared_job);
 
             let vmgstool_target = CommonTriple::Common {
                 arch,
@@ -633,11 +734,12 @@ impl IntoPipeline for CheckinGatesCli {
                 anyhow::bail!("multiple vmgstools for the same target");
             }
 
+            // Emit a job for building dependencies used by just linux vmm tests
             let mut job = pipeline
                 .new_job(
                     FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                     FlowArch::X86_64,
-                    format!("build artifacts [{arch_tag}-linux]"),
+                    format!("build artifacts [{arch_tag}-linux] (for VMM tests)"),
                 )
                 .gh_set_pool(gh_pools::default_linux())
                 .ado_set_pool(ado_pools::default_linux())
@@ -709,28 +811,6 @@ impl IntoPipeline for CheckinGatesCli {
                         profile: CommonProfile::from_release(release),
                         ohcldiag_dev,
                     }
-                })
-                .publish(pub_guest_test_uefi, |guest_test_uefi| {
-                    flowey_lib_hvlite::build_guest_test_uefi::Request {
-                        arch,
-                        profile: CommonProfile::from_release(release),
-                        guest_test_uefi,
-                    }
-                })
-                .publish(pub_tmks, |tmks| flowey_lib_hvlite::build_tmks::Request {
-                    arch,
-                    profile: CommonProfile::from_release(release),
-                    tmks,
-                })
-                .publish(pub_tpm_guest_tests, |tpm_guest_tests| {
-                    flowey_lib_hvlite::build_tpm_guest_tests::Request {
-                        target: CommonTriple::Common {
-                            arch,
-                            platform: CommonPlatform::LinuxGnu,
-                        },
-                        profile: CommonProfile::from_release(release),
-                        tpm_guest_tests,
-                    }
                 });
 
             // Hang building the linux VMM tests off this big linux job.
@@ -741,6 +821,16 @@ impl IntoPipeline for CheckinGatesCli {
                     pub_vmm_tests_archive_linux_x86.take().unwrap();
                 job = job.publish(pub_vmm_tests_archive_linux_x86, |archive| flowey_lib_hvlite::build_nextest_vmm_tests::Request {
                     target: CommonTriple::X86_64_LINUX_GNU.as_triple(),
+                    profile: CommonProfile::from_release(release),
+                    build_mode: flowey_lib_hvlite::build_nextest_vmm_tests::BuildNextestVmmTestsMode::Archive(
+                        archive,
+                    ),
+                });
+
+                let pub_vmm_tests_archive_linux_musl_x86 =
+                    pub_vmm_tests_archive_linux_musl_x86.take().unwrap();
+                job = job.publish(pub_vmm_tests_archive_linux_musl_x86, |archive| flowey_lib_hvlite::build_nextest_vmm_tests::Request {
+                    target: CommonTriple::X86_64_LINUX_MUSL.as_triple(),
                     profile: CommonProfile::from_release(release),
                     build_mode: flowey_lib_hvlite::build_nextest_vmm_tests::BuildNextestVmmTestsMode::Archive(
                         archive,
@@ -777,58 +867,15 @@ impl IntoPipeline for CheckinGatesCli {
                     (None, None)
                 };
 
-            // also build pipette musl on this job, as until we land the
-            // refactor that allows building musl without the full openhcl
-            // toolchain, it would require pulling in all the openhcl
-            // toolchain deps...
-            let (pub_pipette_linux_musl, use_pipette_linux_musl) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-pipette"));
-
-            let (pub_tmk_vmm, use_tmk_vmm) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-tmk_vmm"));
-
-            // Also build openvmm and openvmm_vhost for musl on this job,
-            // alongside pipette and tmk_vmm. This enables running VMM tests
-            // on Azure Linux (MSHV) runners which have an older glibc.
-            // Only needed for x86_64 (the MSHV test job is x64-only).
-            let (pub_openvmm_musl, use_openvmm_musl) = matches!(arch, CommonArch::X86_64)
-                .then(|| pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm")))
-                .unzip();
-            let (pub_openvmm_vhost_musl, use_openvmm_vhost_musl) =
-                matches!(arch, CommonArch::X86_64)
-                    .then(|| {
-                        pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm_vhost"))
-                    })
-                    .unzip();
-
             // skim off interesting artifacts required by the VMM tests job
             match arch {
                 CommonArch::X86_64 => {
                     vmm_tests_artifacts_windows_x86.use_openhcl_igvm_files =
                         Some(use_openhcl_igvm.clone());
-                    vmm_tests_artifacts_windows_x86.use_pipette_linux_musl =
-                        Some(use_pipette_linux_musl.clone());
-                    vmm_tests_artifacts_linux_x86.use_pipette_linux_musl =
-                        Some(use_pipette_linux_musl.clone());
-                    vmm_tests_artifacts_linux_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
-                    vmm_tests_artifacts_windows_x86.use_tmk_vmm_linux_musl =
-                        Some(use_tmk_vmm.clone());
-                    // musl artifacts for MSHV test job
-                    vmm_tests_artifacts_linux_musl_x86.use_openvmm =
-                        Some(use_openvmm_musl.clone().unwrap());
-                    vmm_tests_artifacts_linux_musl_x86.use_openvmm_vhost =
-                        Some(use_openvmm_vhost_musl.clone().unwrap());
-                    vmm_tests_artifacts_linux_musl_x86.use_pipette_linux_musl =
-                        Some(use_pipette_linux_musl.clone());
-                    vmm_tests_artifacts_linux_musl_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
                 }
                 CommonArch::Aarch64 => {
                     vmm_tests_artifacts_windows_aarch64.use_openhcl_igvm_files =
                         Some(use_openhcl_igvm.clone());
-                    vmm_tests_artifacts_windows_aarch64.use_pipette_linux_musl =
-                        Some(use_pipette_linux_musl.clone());
-                    vmm_tests_artifacts_windows_aarch64.use_tmk_vmm_linux_musl =
-                        Some(use_tmk_vmm.clone());
                 }
             }
             let igvm_recipes = match arch {
@@ -848,7 +895,7 @@ impl IntoPipeline for CheckinGatesCli {
             };
 
             let build_openhcl_job_tag = |arch_tag| format!("build openhcl [{arch_tag}-linux]");
-            let mut job = pipeline
+            let job = pipeline
                 .new_job(
                     FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                     FlowArch::X86_64,
@@ -880,68 +927,7 @@ impl IntoPipeline for CheckinGatesCli {
                         artifact_openhcl_verify_size_baseline: publish_baseline_artifact,
                         done: ctx.new_done_handle(),
                     }
-                })
-                .publish(pub_pipette_linux_musl, |pipette| {
-                    flowey_lib_hvlite::build_pipette::Request {
-                        target: CommonTriple::Common {
-                            arch,
-                            platform: CommonPlatform::LinuxMusl,
-                        },
-                        profile: CommonProfile::from_release(release),
-                        pipette,
-                    }
-                })
-                .publish(pub_tmk_vmm, |tmk_vmm| {
-                    flowey_lib_hvlite::build_tmk_vmm::Request {
-                        target: CommonTriple::Common {
-                            arch,
-                            platform: CommonPlatform::LinuxMusl,
-                        },
-                        profile: CommonProfile::from_release(release),
-                        unstable_whp: false,
-                        tmk_vmm,
-                    }
                 });
-
-            // Build musl openvmm, openvmm_vhost, and VMM tests archive on the
-            // OpenHCL x86 job only (the MSHV test job is x64-only).
-            if let (Some(pub_openvmm_musl), Some(pub_openvmm_vhost_musl)) =
-                (pub_openvmm_musl, pub_openvmm_vhost_musl)
-            {
-                job = job
-                    .dep_on(|ctx| flowey_lib_hvlite::build_openvmm::Request {
-                        params: flowey_lib_hvlite::build_openvmm::OpenvmmBuildParams {
-                            target: CommonTriple::Common {
-                                arch,
-                                platform: CommonPlatform::LinuxMusl,
-                            },
-                            profile: CommonProfile::from_release(release),
-                            features: [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::Tpm]
-                                .into(),
-                        },
-                        openvmm: ctx.publish_typed_artifact(pub_openvmm_musl),
-                    })
-                    .dep_on(|ctx| flowey_lib_hvlite::build_openvmm_vhost::Request {
-                        params: flowey_lib_hvlite::build_openvmm_vhost::OpenvmmVhostBuildParams {
-                            target: CommonTriple::Common {
-                                arch,
-                                platform: CommonPlatform::LinuxMusl,
-                            },
-                            profile: CommonProfile::from_release(release),
-                        },
-                        openvmm_vhost: ctx.publish_typed_artifact(pub_openvmm_vhost_musl),
-                    });
-
-                let pub_vmm_tests_archive_linux_musl_x86 =
-                    pub_vmm_tests_archive_linux_musl_x86.take().unwrap();
-                job = job.dep_on(|ctx| flowey_lib_hvlite::build_nextest_vmm_tests::Request {
-                    target: CommonTriple::X86_64_LINUX_MUSL.as_triple(),
-                    profile: CommonProfile::from_release(release),
-                    build_mode: flowey_lib_hvlite::build_nextest_vmm_tests::BuildNextestVmmTestsMode::Archive(
-                        ctx.publish_typed_artifact(pub_vmm_tests_archive_linux_musl_x86),
-                    ),
-                });
-            }
 
             all_jobs.push(job.finish());
 

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -571,19 +571,6 @@ impl IntoPipeline for CheckinGatesCli {
                 CommonArch::Aarch64 => "aarch64",
             };
 
-            let (pub_openvmm, use_openvmm) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-openvmm"));
-            let (pub_openvmm_vhost, use_openvmm_vhost) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-openvmm_vhost"));
-            let (pub_igvmfilegen, _) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-igvmfilegen"));
-            let (pub_vmgs_lib, _) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-vmgs_lib"));
-            let (pub_vmgstool, use_vmgstool) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-vmgstool"));
-            let (pub_ohcldiag_dev, _) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-ohcldiag-dev"));
-            let (pub_tmks, use_tmks) = pipeline.new_typed_artifact(format!("{arch_tag}-tmks"));
             let (pub_tpm_guest_tests, use_tpm_guest_tests) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-tpm_guest_tests"));
             let (pub_guest_test_uefi, use_guest_test_uefi) =
@@ -592,55 +579,7 @@ impl IntoPipeline for CheckinGatesCli {
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-pipette"));
             let (pub_tmk_vmm, use_tmk_vmm) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-tmk_vmm"));
-            // Also build openvmm and openvmm_vhost for musl on this job,
-            // alongside pipette and tmk_vmm. This enables running VMM tests
-            // on Azure Linux (MSHV) runners which have an older glibc.
-            let (pub_openvmm_musl, use_openvmm_musl) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm"));
-            let (pub_openvmm_vhost_musl, use_openvmm_vhost_musl) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm_vhost"));
-
-            // skim off interesting artifacts required by the VMM tests job
-            match arch {
-                CommonArch::X86_64 => {
-                    vmm_tests_artifacts_linux_x86.use_openvmm = Some(use_openvmm.clone());
-                    vmm_tests_artifacts_linux_x86.use_openvmm_vhost =
-                        Some(use_openvmm_vhost.clone());
-                    vmm_tests_artifacts_linux_x86.use_guest_test_uefi =
-                        Some(use_guest_test_uefi.clone());
-                    vmm_tests_artifacts_windows_x86.use_guest_test_uefi =
-                        Some(use_guest_test_uefi.clone());
-                    vmm_tests_artifacts_windows_x86.use_tmks = Some(use_tmks.clone());
-                    vmm_tests_artifacts_linux_x86.use_tmks = Some(use_tmks.clone());
-                    vmm_tests_artifacts_windows_x86.use_tpm_guest_tests_linux =
-                        Some(use_tpm_guest_tests.clone());
-                    vmm_tests_artifacts_linux_musl_x86.use_guest_test_uefi =
-                        Some(use_guest_test_uefi.clone());
-                    vmm_tests_artifacts_linux_musl_x86.use_tmks = Some(use_tmks.clone());
-                    vmm_tests_artifacts_windows_x86.use_pipette_linux_musl =
-                        Some(use_pipette_linux_musl.clone());
-                    vmm_tests_artifacts_linux_x86.use_pipette_linux_musl =
-                        Some(use_pipette_linux_musl.clone());
-                    vmm_tests_artifacts_linux_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
-                    vmm_tests_artifacts_windows_x86.use_tmk_vmm_linux_musl =
-                        Some(use_tmk_vmm.clone());
-                    vmm_tests_artifacts_linux_musl_x86.use_openvmm = Some(use_openvmm_musl.clone());
-                    vmm_tests_artifacts_linux_musl_x86.use_openvmm_vhost =
-                        Some(use_openvmm_vhost_musl.clone());
-                    vmm_tests_artifacts_linux_musl_x86.use_pipette_linux_musl =
-                        Some(use_pipette_linux_musl.clone());
-                    vmm_tests_artifacts_linux_musl_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
-                }
-                CommonArch::Aarch64 => {
-                    vmm_tests_artifacts_windows_aarch64.use_guest_test_uefi =
-                        Some(use_guest_test_uefi.clone());
-                    vmm_tests_artifacts_windows_aarch64.use_tmks = Some(use_tmks.clone());
-                    vmm_tests_artifacts_windows_aarch64.use_pipette_linux_musl =
-                        Some(use_pipette_linux_musl.clone());
-                    vmm_tests_artifacts_windows_aarch64.use_tmk_vmm_linux_musl =
-                        Some(use_tmk_vmm.clone());
-                }
-            }
+            let (pub_tmks, use_tmks) = pipeline.new_typed_artifact(format!("{arch_tag}-tmks"));
 
             // Emit a job for building dependencies used by all platforms vmm tests
             let shared_job = pipeline
@@ -694,34 +633,70 @@ impl IntoPipeline for CheckinGatesCli {
                         tmk_vmm,
                     }
                 })
-                .publish(pub_openvmm_musl, |openvmm| {
-                    flowey_lib_hvlite::build_openvmm::Request {
-                        params: flowey_lib_hvlite::build_openvmm::OpenvmmBuildParams {
-                            target: CommonTriple::Common {
-                                arch,
-                                platform: CommonPlatform::LinuxMusl,
-                            },
-                            profile: CommonProfile::from_release(release),
-                            features: [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::Tpm]
-                                .into(),
-                        },
-                        openvmm,
-                    }
-                })
-                .publish(pub_openvmm_vhost_musl, |openvmm_vhost| {
-                    flowey_lib_hvlite::build_openvmm_vhost::Request {
-                        params: flowey_lib_hvlite::build_openvmm_vhost::OpenvmmVhostBuildParams {
-                            target: CommonTriple::Common {
-                                arch,
-                                platform: CommonPlatform::LinuxMusl,
-                            },
-                            profile: CommonProfile::from_release(release),
-                        },
-                        openvmm_vhost,
-                    }
-                })
                 .finish();
             all_jobs.push(shared_job);
+
+            let (pub_openvmm, use_openvmm) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-openvmm"));
+            let (pub_openvmm_vhost, use_openvmm_vhost) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-openvmm_vhost"));
+            let (pub_igvmfilegen, _) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-igvmfilegen"));
+            let (pub_vmgs_lib, _) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-vmgs_lib"));
+            let (pub_vmgstool, use_vmgstool) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-vmgstool"));
+            let (pub_ohcldiag_dev, _) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-ohcldiag-dev"));
+            // Also build openvmm and openvmm_vhost for musl on this job,
+            // alongside pipette and tmk_vmm. This enables running VMM tests
+            // on Azure Linux (MSHV) runners which have an older glibc.
+            let (pub_openvmm_musl, use_openvmm_musl) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm"));
+            let (pub_openvmm_vhost_musl, use_openvmm_vhost_musl) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm_vhost"));
+
+            // skim off interesting artifacts required by the VMM tests job
+            match arch {
+                CommonArch::X86_64 => {
+                    vmm_tests_artifacts_linux_x86.use_openvmm = Some(use_openvmm.clone());
+                    vmm_tests_artifacts_linux_x86.use_openvmm_vhost =
+                        Some(use_openvmm_vhost.clone());
+                    vmm_tests_artifacts_linux_x86.use_guest_test_uefi =
+                        Some(use_guest_test_uefi.clone());
+                    vmm_tests_artifacts_windows_x86.use_guest_test_uefi =
+                        Some(use_guest_test_uefi.clone());
+                    vmm_tests_artifacts_windows_x86.use_tmks = Some(use_tmks.clone());
+                    vmm_tests_artifacts_linux_x86.use_tmks = Some(use_tmks.clone());
+                    vmm_tests_artifacts_windows_x86.use_tpm_guest_tests_linux =
+                        Some(use_tpm_guest_tests.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_guest_test_uefi =
+                        Some(use_guest_test_uefi.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_tmks = Some(use_tmks.clone());
+                    vmm_tests_artifacts_windows_x86.use_pipette_linux_musl =
+                        Some(use_pipette_linux_musl.clone());
+                    vmm_tests_artifacts_linux_x86.use_pipette_linux_musl =
+                        Some(use_pipette_linux_musl.clone());
+                    vmm_tests_artifacts_linux_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
+                    vmm_tests_artifacts_windows_x86.use_tmk_vmm_linux_musl =
+                        Some(use_tmk_vmm.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_openvmm = Some(use_openvmm_musl.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_openvmm_vhost =
+                        Some(use_openvmm_vhost_musl.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_pipette_linux_musl =
+                        Some(use_pipette_linux_musl.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
+                }
+                CommonArch::Aarch64 => {
+                    vmm_tests_artifacts_windows_aarch64.use_guest_test_uefi =
+                        Some(use_guest_test_uefi.clone());
+                    vmm_tests_artifacts_windows_aarch64.use_tmks = Some(use_tmks.clone());
+                    vmm_tests_artifacts_windows_aarch64.use_pipette_linux_musl =
+                        Some(use_pipette_linux_musl.clone());
+                    vmm_tests_artifacts_windows_aarch64.use_tmk_vmm_linux_musl =
+                        Some(use_tmk_vmm.clone());
+                }
+            }
 
             let vmgstool_target = CommonTriple::Common {
                 arch,
@@ -735,7 +710,6 @@ impl IntoPipeline for CheckinGatesCli {
             }
 
             // Emit a job for building dependencies used by just linux vmm tests
-
             let mut job = pipeline
                 .new_job(
                     FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
@@ -812,8 +786,35 @@ impl IntoPipeline for CheckinGatesCli {
                         profile: CommonProfile::from_release(release),
                         ohcldiag_dev,
                     }
+                })
+                .publish(pub_openvmm_musl, |openvmm| {
+                    flowey_lib_hvlite::build_openvmm::Request {
+                        params: flowey_lib_hvlite::build_openvmm::OpenvmmBuildParams {
+                            target: CommonTriple::Common {
+                                arch,
+                                platform: CommonPlatform::LinuxMusl,
+                            },
+                            profile: CommonProfile::from_release(release),
+                            features: [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::Tpm]
+                                .into(),
+                        },
+                        openvmm,
+                    }
+                })
+                .publish(pub_openvmm_vhost_musl, |openvmm_vhost| {
+                    flowey_lib_hvlite::build_openvmm_vhost::Request {
+                        params: flowey_lib_hvlite::build_openvmm_vhost::OpenvmmVhostBuildParams {
+                            target: CommonTriple::Common {
+                                arch,
+                                platform: CommonPlatform::LinuxMusl,
+                            },
+                            profile: CommonProfile::from_release(release),
+                        },
+                        openvmm_vhost,
+                    }
                 });
 
+            // Hang building the linux VMM tests off this big linux job.
             // No ARM64 VMM tests yet
             if matches!(arch, CommonArch::X86_64) {
                 let pub_vmm_tests_archive_linux = pub_vmm_tests_archive_linux_x86.take().unwrap();

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -342,7 +342,7 @@ impl IntoPipeline for CheckinGatesCli {
             .new_job(
                 FlowPlatform::Windows,
                 FlowArch::X86_64,
-                format!("build artifacts (shared VMM tests) [windows]"),
+                "build artifacts (shared VMM tests) [windows]".to_string(),
             )
             .gh_set_pool(gh_pools::default_windows())
             .ado_set_pool(ado_pools::default_windows());

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -431,7 +431,7 @@ impl IntoPipeline for CheckinGatesCli {
             .new_job(
                 FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 FlowArch::X86_64,
-                format!("build artifacts (shared VMM tests) [linux]"),
+                "build artifacts (shared VMM tests) [linux]".to_string(),
             )
             .gh_set_pool(gh_pools::default_linux())
             .ado_set_pool(ado_pools::default_linux());

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -647,7 +647,7 @@ impl IntoPipeline for CheckinGatesCli {
                 .new_job(
                     FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                     FlowArch::X86_64,
-                    format!("build artifacts [{arch_tag}-linux] (shared)"),
+                    format!("build artifacts (shared VMM tests) [{arch_tag}-linux]"),
                 )
                 .gh_set_pool(gh_pools::default_linux())
                 .ado_set_pool(ado_pools::default_linux())
@@ -735,110 +735,106 @@ impl IntoPipeline for CheckinGatesCli {
             }
 
             // Emit a job for building dependencies used by just linux vmm tests
-            let mut job = pipeline
-                .new_job(
-                    FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
-                    FlowArch::X86_64,
-                    format!("build artifacts [{arch_tag}-linux] (for VMM tests)"),
-                )
-                .gh_set_pool(gh_pools::default_linux())
-                .ado_set_pool(ado_pools::default_linux())
-                .publish(pub_openvmm, |openvmm| {
-                    flowey_lib_hvlite::build_openvmm::Request {
-                        params: flowey_lib_hvlite::build_openvmm::OpenvmmBuildParams {
-                            target: CommonTriple::Common {
-                                arch,
-                                platform: CommonPlatform::LinuxGnu,
-                            },
-                            profile: CommonProfile::from_release(release),
-                            // FIXME: this relies on openvmm default features
-                            features: [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::Tpm]
-                                .into(),
-                        },
-                        openvmm,
-                    }
-                })
-                .publish(pub_openvmm_vhost, |openvmm_vhost| {
-                    flowey_lib_hvlite::build_openvmm_vhost::Request {
-                        params: flowey_lib_hvlite::build_openvmm_vhost::OpenvmmVhostBuildParams {
-                            target: CommonTriple::Common {
-                                arch,
-                                platform: CommonPlatform::LinuxGnu,
-                            },
-                            profile: CommonProfile::from_release(release),
-                        },
-                        openvmm_vhost,
-                    }
-                })
-                .publish(pub_vmgstool, |vmgstool| {
-                    flowey_lib_hvlite::build_vmgstool::Request {
-                        target: vmgstool_target,
-                        profile: CommonProfile::from_release(release),
-                        with_crypto: true,
-                        with_test_helpers: true,
-                        vmgstool,
-                    }
-                })
-                .publish(pub_vmgs_lib, |vmgs_lib| {
-                    flowey_lib_hvlite::build_and_test_vmgs_lib::Request {
-                        target: CommonTriple::Common {
-                            arch,
-                            platform: CommonPlatform::LinuxGnu,
-                        },
-                        profile: CommonProfile::from_release(release),
-                        vmgs_lib,
-                    }
-                })
-                .publish(pub_igvmfilegen, |igvmfilegen| {
-                    flowey_lib_hvlite::build_igvmfilegen::Request {
-                        build_params:
-                            flowey_lib_hvlite::build_igvmfilegen::IgvmfilegenBuildParams {
-                                target: CommonTriple::Common {
-                                    arch,
-                                    platform: CommonPlatform::LinuxGnu,
-                                },
-                                profile: CommonProfile::from_release(release).into(),
-                            },
-                        igvmfilegen,
-                    }
-                })
-                .publish(pub_ohcldiag_dev, |ohcldiag_dev| {
-                    flowey_lib_hvlite::build_ohcldiag_dev::Request {
-                        target: CommonTriple::Common {
-                            arch,
-                            platform: CommonPlatform::LinuxGnu,
-                        },
-                        profile: CommonProfile::from_release(release),
-                        ohcldiag_dev,
-                    }
-                });
-
-            // Hang building the linux VMM tests off this big linux job.
-            //
             // No ARM64 VMM tests yet
             if matches!(arch, CommonArch::X86_64) {
                 let pub_vmm_tests_archive_linux_x86 =
                     pub_vmm_tests_archive_linux_x86.take().unwrap();
-                job = job.publish(pub_vmm_tests_archive_linux_x86, |archive| flowey_lib_hvlite::build_nextest_vmm_tests::Request {
+                let pub_vmm_tests_archive_linux_musl_x86 =
+                    pub_vmm_tests_archive_linux_musl_x86.take().unwrap();
+
+                let job = pipeline
+                    .new_job(
+                        FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
+                        FlowArch::X86_64,
+                        format!("build artifacts (for VMM tests) [{arch_tag}-linux]"),
+                    )
+                    .gh_set_pool(gh_pools::default_linux())
+                    .ado_set_pool(ado_pools::default_linux())
+                    .publish(pub_openvmm, |openvmm| {
+                        flowey_lib_hvlite::build_openvmm::Request {
+                            params: flowey_lib_hvlite::build_openvmm::OpenvmmBuildParams {
+                                target: CommonTriple::Common {
+                                    arch,
+                                    platform: CommonPlatform::LinuxGnu,
+                                },
+                                profile: CommonProfile::from_release(release),
+                                // FIXME: this relies on openvmm default features
+                                features: [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::Tpm]
+                                    .into(),
+                            },
+                            openvmm,
+                        }
+                    })
+                    .publish(pub_openvmm_vhost, |openvmm_vhost| {
+                        flowey_lib_hvlite::build_openvmm_vhost::Request {
+                            params:
+                                flowey_lib_hvlite::build_openvmm_vhost::OpenvmmVhostBuildParams {
+                                    target: CommonTriple::Common {
+                                        arch,
+                                        platform: CommonPlatform::LinuxGnu,
+                                    },
+                                    profile: CommonProfile::from_release(release),
+                                },
+                            openvmm_vhost,
+                        }
+                    })
+                    .publish(pub_vmgstool, |vmgstool| {
+                        flowey_lib_hvlite::build_vmgstool::Request {
+                            target: vmgstool_target,
+                            profile: CommonProfile::from_release(release),
+                            with_crypto: true,
+                            with_test_helpers: true,
+                            vmgstool,
+                        }
+                    })
+                    .publish(pub_vmgs_lib, |vmgs_lib| {
+                        flowey_lib_hvlite::build_and_test_vmgs_lib::Request {
+                            target: CommonTriple::Common {
+                                arch,
+                                platform: CommonPlatform::LinuxGnu,
+                            },
+                            profile: CommonProfile::from_release(release),
+                            vmgs_lib,
+                        }
+                    })
+                    .publish(pub_igvmfilegen, |igvmfilegen| {
+                        flowey_lib_hvlite::build_igvmfilegen::Request {
+                            build_params:
+                                flowey_lib_hvlite::build_igvmfilegen::IgvmfilegenBuildParams {
+                                    target: CommonTriple::Common {
+                                        arch,
+                                        platform: CommonPlatform::LinuxGnu,
+                                    },
+                                    profile: CommonProfile::from_release(release).into(),
+                                },
+                            igvmfilegen,
+                        }
+                    })
+                    .publish(pub_ohcldiag_dev, |ohcldiag_dev| {
+                        flowey_lib_hvlite::build_ohcldiag_dev::Request {
+                            target: CommonTriple::Common {
+                                arch,
+                                platform: CommonPlatform::LinuxGnu,
+                            },
+                            profile: CommonProfile::from_release(release),
+                            ohcldiag_dev,
+                        }
+                    }).publish(pub_vmm_tests_archive_linux_x86, |archive| flowey_lib_hvlite::build_nextest_vmm_tests::Request {
                     target: CommonTriple::X86_64_LINUX_GNU.as_triple(),
                     profile: CommonProfile::from_release(release),
                     build_mode: flowey_lib_hvlite::build_nextest_vmm_tests::BuildNextestVmmTestsMode::Archive(
                         archive,
                     ),
-                });
-
-                let pub_vmm_tests_archive_linux_musl_x86 =
-                    pub_vmm_tests_archive_linux_musl_x86.take().unwrap();
-                job = job.publish(pub_vmm_tests_archive_linux_musl_x86, |archive| flowey_lib_hvlite::build_nextest_vmm_tests::Request {
+                }).publish(pub_vmm_tests_archive_linux_musl_x86, |archive| flowey_lib_hvlite::build_nextest_vmm_tests::Request {
                     target: CommonTriple::X86_64_LINUX_MUSL.as_triple(),
                     profile: CommonProfile::from_release(release),
                     build_mode: flowey_lib_hvlite::build_nextest_vmm_tests::BuildNextestVmmTestsMode::Archive(
                         archive,
                     ),
                 });
-            }
 
-            all_jobs.push(job.finish());
+                all_jobs.push(job.finish());
+            }
         }
 
         // emit openhcl build job
@@ -942,8 +938,8 @@ impl IntoPipeline for CheckinGatesCli {
                         format!("verify openhcl binary size [{}]", arch_tag),
                     )
                     .gh_set_pool(gh_pools::linux_x64_gh())
-                    .side_effect(
-                        |done| flowey_lib_hvlite::_jobs::check_openvmm_hcl_size::Request {
+                    .side_effect(|done| {
+                        flowey_lib_hvlite::_jobs::check_openvmm_hcl_size::Request {
                             target: CommonTriple::Common {
                                 arch,
                                 platform: CommonPlatform::LinuxMusl,
@@ -951,10 +947,9 @@ impl IntoPipeline for CheckinGatesCli {
                             done,
                             pipeline_name: "openvmm-ci.yaml".into(),
                             job_name: build_openhcl_job_tag(arch_tag),
-                        },
-                    )
-                    .finish();
-                all_jobs.push(job);
+                        }
+                    });
+                all_jobs.push(job.finish());
             }
         }
 
@@ -1470,9 +1465,8 @@ impl IntoPipeline for CheckinGatesCli {
                             base_recipe: OpenhclIgvmRecipe::X64,
                             done,
                         }
-                    })
-                    .finish();
-                all_jobs.push(job);
+                    });
+                all_jobs.push(job.finish());
             }
         }
 

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -304,6 +304,194 @@ impl IntoPipeline for CheckinGatesCli {
             all_jobs.push(windows_fmt_job);
         }
 
+        // emit shared dependencies jobs
+        //
+        // In order to ensure we start running VMM tests as soon as possible, we emit
+        // a job for windows and linux building dependencies used by VMM tests on all platforms.
+        // These jobs build dependencies for all architectures, as these dependencies are typically
+        // small and fast to build.
+        //
+        // We have to create the per-arch artifacts up front so that we don't try
+        // to mutably borrow `pipeline` while a job builder also holds a mutable borrow.
+        let mut shared_win_pipette_artifacts = Vec::new();
+        for arch in [CommonArch::Aarch64, CommonArch::X86_64] {
+            let arch_tag = match arch {
+                CommonArch::X86_64 => "x64",
+                CommonArch::Aarch64 => "aarch64",
+            };
+            let (pub_pipette_windows, use_pipette_windows) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-windows-pipette"));
+            // filter off artifacts required by the VMM tests job
+            match arch {
+                CommonArch::X86_64 => {
+                    vmm_tests_artifacts_linux_x86.use_pipette_windows =
+                        Some(use_pipette_windows.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_pipette_windows =
+                        Some(use_pipette_windows.clone());
+                    vmm_tests_artifacts_windows_x86.use_pipette_windows =
+                        Some(use_pipette_windows.clone());
+                }
+                CommonArch::Aarch64 => {
+                    vmm_tests_artifacts_windows_aarch64.use_pipette_windows =
+                        Some(use_pipette_windows.clone());
+                }
+            }
+            shared_win_pipette_artifacts.push((arch, pub_pipette_windows));
+        }
+        let mut shared_win_job = pipeline
+            .new_job(
+                FlowPlatform::Windows,
+                FlowArch::X86_64,
+                format!("build artifacts (shared VMM tests) [windows]"),
+            )
+            .gh_set_pool(gh_pools::default_windows())
+            .ado_set_pool(ado_pools::default_windows());
+        for (arch, pub_pipette_windows) in shared_win_pipette_artifacts {
+            shared_win_job = shared_win_job.publish(pub_pipette_windows, |pipette| {
+                flowey_lib_hvlite::build_pipette::Request {
+                    target: CommonTriple::Common {
+                        arch,
+                        platform: CommonPlatform::WindowsMsvc,
+                    },
+                    profile: CommonProfile::from_release(release),
+                    pipette,
+                }
+            });
+        }
+        all_jobs.push(shared_win_job.finish());
+
+        // Now do linux
+        //
+        // Create the per-arch artifacts up front so that we don't try to
+        // mutably borrow `pipeline` while the job builder also holds a
+        // mutable borrow.
+        let mut shared_linux_artifacts = Vec::new();
+        for arch in [CommonArch::Aarch64, CommonArch::X86_64] {
+            let arch_tag = match arch {
+                CommonArch::X86_64 => "x64",
+                CommonArch::Aarch64 => "aarch64",
+            };
+
+            let (pub_tpm_guest_tests, use_tpm_guest_tests) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-tpm_guest_tests"));
+            let (pub_guest_test_uefi, use_guest_test_uefi) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-guest_test_uefi"));
+            let (pub_pipette_linux_musl, use_pipette_linux_musl) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-pipette"));
+            let (pub_tmk_vmm, use_tmk_vmm) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-tmk_vmm"));
+            let (pub_tmks, use_tmks) = pipeline.new_typed_artifact(format!("{arch_tag}-tmks"));
+
+            match arch {
+                CommonArch::X86_64 => {
+                    vmm_tests_artifacts_linux_x86.use_guest_test_uefi =
+                        Some(use_guest_test_uefi.clone());
+                    vmm_tests_artifacts_windows_x86.use_guest_test_uefi =
+                        Some(use_guest_test_uefi.clone());
+                    vmm_tests_artifacts_windows_x86.use_tmks = Some(use_tmks.clone());
+                    vmm_tests_artifacts_linux_x86.use_tmks = Some(use_tmks.clone());
+                    vmm_tests_artifacts_windows_x86.use_tpm_guest_tests_linux =
+                        Some(use_tpm_guest_tests.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_guest_test_uefi =
+                        Some(use_guest_test_uefi.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_tmks = Some(use_tmks.clone());
+                    vmm_tests_artifacts_windows_x86.use_pipette_linux_musl =
+                        Some(use_pipette_linux_musl.clone());
+                    vmm_tests_artifacts_linux_x86.use_pipette_linux_musl =
+                        Some(use_pipette_linux_musl.clone());
+                    vmm_tests_artifacts_linux_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
+                    vmm_tests_artifacts_windows_x86.use_tmk_vmm_linux_musl =
+                        Some(use_tmk_vmm.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_pipette_linux_musl =
+                        Some(use_pipette_linux_musl.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
+                }
+                CommonArch::Aarch64 => {
+                    vmm_tests_artifacts_windows_aarch64.use_guest_test_uefi =
+                        Some(use_guest_test_uefi.clone());
+                    vmm_tests_artifacts_windows_aarch64.use_tmks = Some(use_tmks.clone());
+                    vmm_tests_artifacts_windows_aarch64.use_pipette_linux_musl =
+                        Some(use_pipette_linux_musl.clone());
+                    vmm_tests_artifacts_windows_aarch64.use_tmk_vmm_linux_musl =
+                        Some(use_tmk_vmm.clone());
+                }
+            }
+
+            shared_linux_artifacts.push((
+                arch,
+                pub_tpm_guest_tests,
+                pub_guest_test_uefi,
+                pub_pipette_linux_musl,
+                pub_tmk_vmm,
+                pub_tmks,
+            ));
+        }
+
+        let mut shared_linux_job = pipeline
+            .new_job(
+                FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
+                FlowArch::X86_64,
+                format!("build artifacts (shared VMM tests) [linux]"),
+            )
+            .gh_set_pool(gh_pools::default_linux())
+            .ado_set_pool(ado_pools::default_linux());
+        for (
+            arch,
+            pub_tpm_guest_tests,
+            pub_guest_test_uefi,
+            pub_pipette_linux_musl,
+            pub_tmk_vmm,
+            pub_tmks,
+        ) in shared_linux_artifacts
+        {
+            shared_linux_job = shared_linux_job
+                .publish(pub_guest_test_uefi, |guest_test_uefi| {
+                    flowey_lib_hvlite::build_guest_test_uefi::Request {
+                        arch,
+                        profile: CommonProfile::from_release(release),
+                        guest_test_uefi,
+                    }
+                })
+                .publish(pub_tmks, |tmks| flowey_lib_hvlite::build_tmks::Request {
+                    arch,
+                    profile: CommonProfile::from_release(release),
+                    tmks,
+                })
+                .publish(pub_tpm_guest_tests, |tpm_guest_tests| {
+                    flowey_lib_hvlite::build_tpm_guest_tests::Request {
+                        target: CommonTriple::Common {
+                            arch,
+                            platform: CommonPlatform::LinuxGnu,
+                        },
+                        profile: CommonProfile::from_release(release),
+                        tpm_guest_tests,
+                    }
+                })
+                .publish(pub_pipette_linux_musl, |pipette| {
+                    flowey_lib_hvlite::build_pipette::Request {
+                        target: CommonTriple::Common {
+                            arch,
+                            platform: CommonPlatform::LinuxMusl,
+                        },
+                        profile: CommonProfile::from_release(release),
+                        pipette,
+                    }
+                })
+                .publish(pub_tmk_vmm, |tmk_vmm| {
+                    flowey_lib_hvlite::build_tmk_vmm::Request {
+                        target: CommonTriple::Common {
+                            arch,
+                            platform: CommonPlatform::LinuxMusl,
+                        },
+                        profile: CommonProfile::from_release(release),
+                        unstable_whp: false,
+                        tmk_vmm,
+                    }
+                });
+        }
+
+        all_jobs.push(shared_linux_job.finish());
+
         // emit windows build machine jobs
         //
         // In order to ensure we start running VMM tests as soon as possible, we emit
@@ -319,9 +507,6 @@ impl IntoPipeline for CheckinGatesCli {
             // artifacts which _are_ in the VMM tests "hot path"
             let (pub_openvmm, use_openvmm) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-windows-openvmm"));
-
-            let (pub_pipette_windows, use_pipette_windows) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-windows-pipette"));
 
             let (pub_tmk_vmm, use_tmk_vmm) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-windows-tmk_vmm"));
@@ -341,13 +526,7 @@ impl IntoPipeline for CheckinGatesCli {
             // filter off interesting artifacts required by the VMM tests job
             match arch {
                 CommonArch::X86_64 => {
-                    vmm_tests_artifacts_linux_x86.use_pipette_windows =
-                        Some(use_pipette_windows.clone());
-                    vmm_tests_artifacts_linux_musl_x86.use_pipette_windows =
-                        Some(use_pipette_windows.clone());
                     vmm_tests_artifacts_windows_x86.use_openvmm = Some(use_openvmm.clone());
-                    vmm_tests_artifacts_windows_x86.use_pipette_windows =
-                        Some(use_pipette_windows.clone());
                     vmm_tests_artifacts_windows_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
                     vmm_tests_artifacts_windows_x86.use_prep_steps = Some(use_prep_steps.clone());
                     vmm_tests_artifacts_windows_x86.use_vmgstool = Some(use_vmgstool.clone());
@@ -358,8 +537,6 @@ impl IntoPipeline for CheckinGatesCli {
                 }
                 CommonArch::Aarch64 => {
                     vmm_tests_artifacts_windows_aarch64.use_openvmm = Some(use_openvmm.clone());
-                    vmm_tests_artifacts_windows_aarch64.use_pipette_windows =
-                        Some(use_pipette_windows.clone());
                     vmm_tests_artifacts_windows_aarch64.use_tmk_vmm = Some(use_tmk_vmm.clone());
                     vmm_tests_artifacts_windows_aarch64.use_vmgstool = Some(use_vmgstool.clone());
                 }
@@ -425,28 +602,6 @@ impl IntoPipeline for CheckinGatesCli {
                         },
                         profile: CommonProfile::from_release(release),
                         ohcldiag_dev,
-                    }
-                });
-
-            all_jobs.push(job.finish());
-
-            // emit a job for artifacts used by VMM tests on multiple platforms
-            let job = pipeline
-                .new_job(
-                    FlowPlatform::Windows,
-                    FlowArch::X86_64,
-                    format!("build artifacts (shared VMM tests) [{arch_tag}-windows]"),
-                )
-                .gh_set_pool(gh_pools::default_windows())
-                .ado_set_pool(ado_pools::default_windows())
-                .publish(pub_pipette_windows, |pipette| {
-                    flowey_lib_hvlite::build_pipette::Request {
-                        target: CommonTriple::Common {
-                            arch,
-                            platform: CommonPlatform::WindowsMsvc,
-                        },
-                        profile: CommonProfile::from_release(release),
-                        pipette,
                     }
                 });
 
@@ -583,71 +738,6 @@ impl IntoPipeline for CheckinGatesCli {
                 CommonArch::Aarch64 => "aarch64",
             };
 
-            let (pub_tpm_guest_tests, use_tpm_guest_tests) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-tpm_guest_tests"));
-            let (pub_guest_test_uefi, use_guest_test_uefi) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-guest_test_uefi"));
-            let (pub_pipette_linux_musl, use_pipette_linux_musl) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-pipette"));
-            let (pub_tmk_vmm, use_tmk_vmm) =
-                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-tmk_vmm"));
-            let (pub_tmks, use_tmks) = pipeline.new_typed_artifact(format!("{arch_tag}-tmks"));
-
-            // Emit a job for building dependencies used by all platforms vmm tests
-            let shared_job = pipeline
-                .new_job(
-                    FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
-                    FlowArch::X86_64,
-                    format!("build artifacts (shared VMM tests) [{arch_tag}-linux]"),
-                )
-                .gh_set_pool(gh_pools::default_linux())
-                .ado_set_pool(ado_pools::default_linux())
-                .publish(pub_guest_test_uefi, |guest_test_uefi| {
-                    flowey_lib_hvlite::build_guest_test_uefi::Request {
-                        arch,
-                        profile: CommonProfile::from_release(release),
-                        guest_test_uefi,
-                    }
-                })
-                .publish(pub_tmks, |tmks| flowey_lib_hvlite::build_tmks::Request {
-                    arch,
-                    profile: CommonProfile::from_release(release),
-                    tmks,
-                })
-                .publish(pub_tpm_guest_tests, |tpm_guest_tests| {
-                    flowey_lib_hvlite::build_tpm_guest_tests::Request {
-                        target: CommonTriple::Common {
-                            arch,
-                            platform: CommonPlatform::LinuxGnu,
-                        },
-                        profile: CommonProfile::from_release(release),
-                        tpm_guest_tests,
-                    }
-                })
-                .publish(pub_pipette_linux_musl, |pipette| {
-                    flowey_lib_hvlite::build_pipette::Request {
-                        target: CommonTriple::Common {
-                            arch,
-                            platform: CommonPlatform::LinuxMusl,
-                        },
-                        profile: CommonProfile::from_release(release),
-                        pipette,
-                    }
-                })
-                .publish(pub_tmk_vmm, |tmk_vmm| {
-                    flowey_lib_hvlite::build_tmk_vmm::Request {
-                        target: CommonTriple::Common {
-                            arch,
-                            platform: CommonPlatform::LinuxMusl,
-                        },
-                        profile: CommonProfile::from_release(release),
-                        unstable_whp: false,
-                        tmk_vmm,
-                    }
-                })
-                .finish();
-            all_jobs.push(shared_job);
-
             let (pub_openvmm, use_openvmm) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-openvmm"));
             let (pub_openvmm_vhost, use_openvmm_vhost) =
@@ -674,40 +764,11 @@ impl IntoPipeline for CheckinGatesCli {
                     vmm_tests_artifacts_linux_x86.use_openvmm = Some(use_openvmm.clone());
                     vmm_tests_artifacts_linux_x86.use_openvmm_vhost =
                         Some(use_openvmm_vhost.clone());
-                    vmm_tests_artifacts_linux_x86.use_guest_test_uefi =
-                        Some(use_guest_test_uefi.clone());
-                    vmm_tests_artifacts_windows_x86.use_guest_test_uefi =
-                        Some(use_guest_test_uefi.clone());
-                    vmm_tests_artifacts_windows_x86.use_tmks = Some(use_tmks.clone());
-                    vmm_tests_artifacts_linux_x86.use_tmks = Some(use_tmks.clone());
-                    vmm_tests_artifacts_windows_x86.use_tpm_guest_tests_linux =
-                        Some(use_tpm_guest_tests.clone());
-                    vmm_tests_artifacts_linux_musl_x86.use_guest_test_uefi =
-                        Some(use_guest_test_uefi.clone());
-                    vmm_tests_artifacts_linux_musl_x86.use_tmks = Some(use_tmks.clone());
-                    vmm_tests_artifacts_windows_x86.use_pipette_linux_musl =
-                        Some(use_pipette_linux_musl.clone());
-                    vmm_tests_artifacts_linux_x86.use_pipette_linux_musl =
-                        Some(use_pipette_linux_musl.clone());
-                    vmm_tests_artifacts_linux_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
-                    vmm_tests_artifacts_windows_x86.use_tmk_vmm_linux_musl =
-                        Some(use_tmk_vmm.clone());
                     vmm_tests_artifacts_linux_musl_x86.use_openvmm = Some(use_openvmm_musl.clone());
                     vmm_tests_artifacts_linux_musl_x86.use_openvmm_vhost =
                         Some(use_openvmm_vhost_musl.clone());
-                    vmm_tests_artifacts_linux_musl_x86.use_pipette_linux_musl =
-                        Some(use_pipette_linux_musl.clone());
-                    vmm_tests_artifacts_linux_musl_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
                 }
-                CommonArch::Aarch64 => {
-                    vmm_tests_artifacts_windows_aarch64.use_guest_test_uefi =
-                        Some(use_guest_test_uefi.clone());
-                    vmm_tests_artifacts_windows_aarch64.use_tmks = Some(use_tmks.clone());
-                    vmm_tests_artifacts_windows_aarch64.use_pipette_linux_musl =
-                        Some(use_pipette_linux_musl.clone());
-                    vmm_tests_artifacts_windows_aarch64.use_tmk_vmm_linux_musl =
-                        Some(use_tmk_vmm.clone());
-                }
+                CommonArch::Aarch64 => {}
             }
 
             let vmgstool_target = CommonTriple::Common {

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -342,7 +342,7 @@ impl IntoPipeline for CheckinGatesCli {
             .new_job(
                 FlowPlatform::Windows,
                 FlowArch::X86_64,
-                "build artifacts (shared VMM tests) [windows]".to_string(),
+                "build artifacts (shared VMM tests) [windows]",
             )
             .gh_set_pool(gh_pools::default_windows())
             .ado_set_pool(ado_pools::default_windows());
@@ -431,7 +431,7 @@ impl IntoPipeline for CheckinGatesCli {
             .new_job(
                 FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 FlowArch::X86_64,
-                "build artifacts (shared VMM tests) [linux]".to_string(),
+                "build artifacts (shared VMM tests) [linux]",
             )
             .gh_set_pool(gh_pools::default_linux())
             .ado_set_pool(ado_pools::default_linux());

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_boot.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_boot.rs
@@ -40,7 +40,6 @@ impl FlowNode for Node {
 
     fn imports(ctx: &mut ImportCtx<'_>) {
         ctx.import::<crate::run_cargo_build::Node>();
-        ctx.import::<flowey_lib_common::install_dist_pkg::Node>();
     }
 
     fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
@@ -73,21 +72,6 @@ impl FlowNode for Node {
                 OpenhclBootBuildProfile::Release => BuildProfile::BootRelease,
             };
 
-            let mut pre_build_deps = Vec::new();
-
-            // TODO: install build tools for other platforms
-            if matches!(
-                ctx.platform(),
-                FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu)
-            ) {
-                pre_build_deps.push(ctx.reqv(|v| {
-                    flowey_lib_common::install_dist_pkg::Request::Install {
-                        package_names: vec!["build-essential".into()],
-                        done: v,
-                    }
-                }));
-            }
-
             let output = ctx.reqv(|v| crate::run_cargo_build::Request {
                 crate_name: "openhcl_boot".into(),
                 out_name: "openhcl_boot".into(),
@@ -101,7 +85,7 @@ impl FlowNode for Node {
                         .into_iter()
                         .collect(),
                 )),
-                pre_build_deps,
+                pre_build_deps: Vec::new(),
                 output: v,
             });
 

--- a/flowey/flowey_lib_hvlite/src/build_openvmm.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openvmm.rs
@@ -69,7 +69,7 @@ impl FlowNode for Node {
         ) {
             pre_build_deps.push(ctx.reqv(|v| {
                 flowey_lib_common::install_dist_pkg::Request::Install {
-                    package_names: vec!["libssl-dev".into(), "build-essential".into()],
+                    package_names: vec!["libssl-dev".into(), "pkg-config".into()],
                     done: v,
                 }
             }));

--- a/flowey/flowey_lib_hvlite/src/build_openvmm_hcl.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openvmm_hcl.rs
@@ -84,7 +84,6 @@ impl FlowNode for Node {
     fn imports(ctx: &mut ImportCtx<'_>) {
         ctx.import::<crate::run_cargo_build::Node>();
         ctx.import::<crate::init_openvmm_magicpath_openhcl_sysroot::Node>();
-        ctx.import::<flowey_lib_common::install_dist_pkg::Node>();
     }
 
     fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
@@ -124,20 +123,7 @@ impl FlowNode for Node {
                 .reqv(|v| crate::init_openvmm_magicpath_openhcl_sysroot::Request { arch, path: v });
 
             // required due to ambient dependencies in openvmm_hcl's source code
-            pre_build_deps.push(openhcl_deps_path.clone().into_side_effect());
-
-            // TODO: install build tools for other platforms
-            if matches!(
-                ctx.platform(),
-                FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu)
-            ) {
-                pre_build_deps.push(ctx.reqv(|v| {
-                    flowey_lib_common::install_dist_pkg::Request::Install {
-                        package_names: vec!["build-essential".into()],
-                        done: v,
-                    }
-                }));
-            }
+            pre_build_deps.push(openhcl_deps_path.into_side_effect());
 
             let mut features = features
                 .into_iter()

--- a/flowey/flowey_lib_hvlite/src/build_sidecar.rs
+++ b/flowey/flowey_lib_hvlite/src/build_sidecar.rs
@@ -40,7 +40,6 @@ impl FlowNode for Node {
 
     fn imports(ctx: &mut ImportCtx<'_>) {
         ctx.import::<crate::run_cargo_build::Node>();
-        ctx.import::<flowey_lib_common::install_dist_pkg::Node>();
     }
 
     fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
@@ -73,21 +72,6 @@ impl FlowNode for Node {
                 SidecarBuildProfile::Release => BuildProfile::BootRelease,
             };
 
-            let mut pre_build_deps = Vec::new();
-
-            // TODO: install build tools for other platforms
-            if matches!(
-                ctx.platform(),
-                FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu)
-            ) {
-                pre_build_deps.push(ctx.reqv(|v| {
-                    flowey_lib_common::install_dist_pkg::Request::Install {
-                        package_names: vec!["build-essential".into()],
-                        done: v,
-                    }
-                }));
-            }
-
             let output = ctx.reqv(|v| crate::run_cargo_build::Request {
                 crate_name: "sidecar".into(),
                 out_name: "sidecar".into(),
@@ -101,7 +85,7 @@ impl FlowNode for Node {
                         .into_iter()
                         .collect(),
                 )),
-                pre_build_deps,
+                pre_build_deps: Vec::new(),
                 output: v,
             });
 

--- a/flowey/flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs
+++ b/flowey/flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs
@@ -22,6 +22,7 @@ impl FlowNode for Node {
         ctx.import::<crate::init_openvmm_magicpath_protoc::Node>();
         ctx.import::<crate::init_openvmm_cargo_config_deny_warnings::Node>();
         ctx.import::<flowey_lib_common::install_rust::Node>();
+        ctx.import::<flowey_lib_common::install_dist_pkg::Node>();
     }
 
     fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
@@ -29,11 +30,25 @@ impl FlowNode for Node {
             return Ok(());
         }
 
-        let side_effects = [
+        let mut side_effects = vec![
             ctx.reqv(crate::init_openvmm_cargo_config_deny_warnings::Request::Done),
             ctx.reqv(crate::init_openvmm_magicpath_protoc::Request),
             ctx.reqv(flowey_lib_common::install_rust::Request::EnsureInstalled),
         ];
+
+        // On Ubuntu, we need the `build-essential` package to ensure that
+        // the system has a working linker.
+        if matches!(
+            ctx.platform(),
+            FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu)
+        ) {
+            side_effects.push(ctx.reqv(|v| {
+                flowey_lib_common::install_dist_pkg::Request::Install {
+                    package_names: vec!["build-essential".into()],
+                    done: v,
+                }
+            }));
+        }
 
         ctx.emit_side_effect_step(side_effects, requests.into_iter().map(|x| x.0));
 


### PR DESCRIPTION
This PR introduces the concept of a "shared" artifact build job, in addition to our preexisting for-vmm-test and not-for-vmm-test jobs. This new job takes over building artifacts used by VMM tests on multiple platforms, while the for-vmm-test jobs are relegated to only building artifacts used by VMM tests on that particular platform. This spreads the load out, cleans up our job dependency graph, and hopefully should allow VMM tests to begin running slightly sooner.

The end result is that every "run VMM tests job" now always depends on:
build "shared" artifacts (both linux and windows)
build "for VMM tests" artifacts on same OS for architecture

...and optionally, if it runs OpenHCL tests:
build OpenHCL for architecture

We now also always run a "build "for VMM tests" artifacts for aarch64-linux" job even though we have no VMM tests on aarch64-linux yet, to ensure that these artifacts still build properly. We could consider removing this job until it is needed.

As a result of this split I needed to move the installation of the "build-essential" package to be required by all cargo build invocations, which is probably where it should've been to begin with.

Before:
<img width="648" height="498" alt="image" src="https://github.com/user-attachments/assets/fa3ee1cf-74c5-4ff5-94d3-4e9881a70fa8" />


After:
<img width="260" height="271" alt="image" src="https://github.com/user-attachments/assets/b44af2d7-23fb-4b81-bc71-30a2e81c2741" />



