### PR TITLE
Guide: Tell people to install symcrypt

### DIFF
--- a/Guide/src/dev_guide/getting_started/linux.md
+++ b/Guide/src/dev_guide/getting_started/linux.md
@@ -66,6 +66,7 @@ $ sudo apt install \
   build-essential       \
   gcc-aarch64-linux-gnu \
   libssl-dev            \
+  symcrypt              \
   pkg-config
 ```
 


### PR DESCRIPTION
OpenHCL will likely start requiring symcrypt soon, and the crypto crate already does with the right feature specified. Tell people to install it so the default linux-gnu builds will still work for them.