### PR TITLE
virt_mshv: fix synic message delivery race and unify VP run loop

### DIFF
--- a/vmm_core/virt_mshv/src/aarch64/mod.rs
+++ b/vmm_core/virt_mshv/src/aarch64/mod.rs
@@ -11,7 +11,6 @@ use crate::MshvPartitionInner;
 use crate::MshvProcessor;
 use crate::MshvProcessorBinder;
 use crate::MshvProtoPartition;
-use crate::MshvVpInnerCleaner;
 use crate::MshvVpRunner;
 use crate::VcpuFdExt;
 use crate::common_synthetic_features;
@@ -31,15 +30,12 @@ use hvdef::HvPartitionPropertyCode;
 use hvdef::Vtl;
 use hvdef::hypercall::HvRegisterAssoc;
 use pal::unix::pthread::Pthread;
-use parking_lot::Mutex;
 use pci_core::msi::SignalMsi;
-use std::convert::Infallible;
 use std::sync::Arc;
 use virt::Hv1;
 use virt::PartitionConfig;
 use virt::ProtoPartition;
 use virt::ProtoPartitionConfig;
-use virt::StopVp;
 use virt::VpHaltReason;
 use virt::VpIndex;
 use virt::aarch64::Aarch64PartitionCapabilities;
@@ -48,7 +44,6 @@ use virt::io::CpuIo;
 use virt::irqcon::ControlGic as _;
 use virt::irqcon::MsiRequest;
 use virt::state::HvRegisterState;
-use virt::x86::DebugState;
 use vmcore::reference_time::ReferenceTimeSource;
 use zerocopy::FromZeros;
 
@@ -153,7 +148,7 @@ impl ProtoPartition for MshvProtoPartition<'_> {
             vps: self.vps,
             caps,
             synic_ports: Default::default(),
-            time_frozen: Mutex::new(false),
+            time_frozen: false.into(),
         });
 
         let partition = MshvPartition {
@@ -349,6 +344,7 @@ impl virt::BindProcessor for MshvProcessorBinder {
             inner,
             vpindex: self.vpindex,
             runner,
+            deliverability_notifications: HvDeliverabilityNotificationsRegister::new(),
         })
     }
 }
@@ -519,110 +515,50 @@ impl MshvProcessor<'_> {
 
         Ok(())
     }
-}
 
-impl virt::Processor for MshvProcessor<'_> {
-    type StateAccess<'a>
-        = &'a mut Self
-    where
-        Self: 'a;
-
-    fn set_debug_state(
+    pub(crate) async fn handle_exit(
         &mut self,
-        _vtl: Vtl,
-        _state: Option<&DebugState>,
-    ) -> Result<(), <&mut Self as virt::vp::AccessVpState>::Error> {
-        Err(ErrorInner::NotSupported.into())
-    }
-
-    async fn run_vp(
-        &mut self,
-        stop: StopVp<'_>,
+        exit: &HvMessage,
         dev: &impl CpuIo,
-    ) -> Result<Infallible, VpHaltReason> {
-        let vpinner = self.inner;
-        let _cleaner = MshvVpInnerCleaner { vpinner };
-
-        assert!(vpinner.thread.write().replace(Pthread::current()).is_none());
-
-        self.partition
-            .thaw_time()
-            .expect("failed to thaw partition time");
-
-        loop {
-            vpinner.needs_yield.maybe_yield().await;
-            stop.check()?;
-
-            match self.runner.run() {
-                Ok(exit) => match exit.header.typ {
-                    HvMessageType::HvMessageTypeUnrecoverableException => {
-                        return Err(VpHaltReason::TripleFault { vtl: Vtl::Vtl0 });
+    ) -> Result<(), VpHaltReason> {
+        match exit.header.typ {
+            HvMessageType::HvMessageTypeUnrecoverableException => {
+                return Err(VpHaltReason::TripleFault { vtl: Vtl::Vtl0 });
+            }
+            HvMessageType::HvMessageTypeUnmappedGpa | HvMessageType::HvMessageTypeGpaIntercept => {
+                self.handle_memory_intercept(exit, dev).await?;
+            }
+            HvMessageType::HvMessageTypeSynicSintDeliverable => {
+                let info = exit.as_message::<hvdef::HvArm64SynicSintDeliverableMessage>();
+                self.handle_sint_deliverable(info.deliverable_sints);
+            }
+            HvMessageType::HvMessageTypeHypercallIntercept => {
+                tracing::trace!("HYPERCALL_INTERCEPT");
+                self.handle_hypercall_intercept(exit);
+            }
+            HvMessageType::HvMessageTypeArm64ResetIntercept => {
+                let info = exit.as_message::<hvdef::HvArm64ResetInterceptMessage>();
+                match info.reset_type {
+                    hvdef::HvArm64ResetType::POWER_OFF => {
+                        return Err(VpHaltReason::PowerOff);
                     }
-                    HvMessageType::HvMessageTypeUnmappedGpa
-                    | HvMessageType::HvMessageTypeGpaIntercept => {
-                        self.handle_memory_intercept(&exit, dev).await?;
+                    hvdef::HvArm64ResetType::REBOOT => {
+                        return Err(VpHaltReason::Reset);
                     }
-                    HvMessageType::HvMessageTypeSynicSintDeliverable => {
-                        let info = exit.as_message::<hvdef::HvArm64SynicSintDeliverableMessage>();
-                        self.flush_messages(info.deliverable_sints);
+                    _ => {
+                        tracelimit::warn_ratelimited!(
+                            reset_type = ?info.reset_type,
+                            "unknown reset type"
+                        );
+                        return Err(VpHaltReason::Reset);
                     }
-                    HvMessageType::HvMessageTypeHypercallIntercept => {
-                        tracing::trace!("HYPERCALL_INTERCEPT");
-                        self.handle_hypercall_intercept(&exit);
-                    }
-                    HvMessageType::HvMessageTypeArm64ResetIntercept => {
-                        let info = exit.as_message::<hvdef::HvArm64ResetInterceptMessage>();
-                        match info.reset_type {
-                            hvdef::HvArm64ResetType::POWER_OFF => {
-                                return Err(VpHaltReason::PowerOff);
-                            }
-                            hvdef::HvArm64ResetType::REBOOT => {
-                                return Err(VpHaltReason::Reset);
-                            }
-                            _ => {
-                                tracelimit::warn_ratelimited!(
-                                    reset_type = ?info.reset_type,
-                                    "unknown reset type"
-                                );
-                                return Err(VpHaltReason::Reset);
-                            }
-                        }
-                    }
-                    exit_type => {
-                        panic!("Unhandled vcpu exit code {exit_type:?}");
-                    }
-                },
-
-                Err(e) => match e.errno() {
-                    libc::EAGAIN | libc::EINTR => {}
-                    _ => tracing::error!(
-                        error = &e as &dyn std::error::Error,
-                        "vcpufd.run returned error"
-                    ),
-                },
+                }
+            }
+            exit_type => {
+                panic!("Unhandled vcpu exit code {exit_type:?}");
             }
         }
-    }
-
-    fn flush_async_requests(&mut self) {}
-
-    fn access_state(&mut self, vtl: Vtl) -> Self::StateAccess<'_> {
-        assert_eq!(vtl, Vtl::Vtl0);
-        self
-    }
-
-    fn reset(&mut self) -> Result<(), impl std::error::Error + Send + Sync + 'static> {
-        use virt::aarch64::vp::AccessVpState;
-
-        let vp_info = self.inner.vp_info;
-        self.access_state(Vtl::Vtl0)
-            .reset_all(&vp_info)
-            .map_err(|e| Error(ErrorInner::ResetState(Box::new(e))))?;
-
-        self.inner.message_queues.clear();
-        *self.inner.deliverability_notifications.lock() =
-            HvDeliverabilityNotificationsRegister::new();
-        Ok::<(), Error>(())
+        Ok(())
     }
 }
 
@@ -665,8 +601,8 @@ impl virt::vp::AccessVpState for &'_ mut MshvProcessor<'_> {
 // Hypercall handler
 // ---------------------------------------------------------------------------
 
-struct MshvHypercallHandler<'a> {
-    partition: &'a MshvPartitionInner,
+pub(crate) struct MshvHypercallHandler<'a> {
+    pub(crate) partition: &'a MshvPartitionInner,
     x: [u64; 18],
     pc: u64,
     dirty: bool,
@@ -696,21 +632,5 @@ impl hv1_hypercall::Arm64RegisterState for MshvHypercallHandler<'_> {
     fn set_x(&mut self, n: u8, v: u64) {
         self.x[n as usize] = v;
         self.dirty = true;
-    }
-}
-
-impl hv1_hypercall::PostMessage for MshvHypercallHandler<'_> {
-    fn post_message(&mut self, connection_id: u32, message: &[u8]) -> hvdef::HvResult<()> {
-        self.partition
-            .synic_ports
-            .handle_post_message(Vtl::Vtl0, connection_id, false, message)
-    }
-}
-
-impl hv1_hypercall::SignalEvent for MshvHypercallHandler<'_> {
-    fn signal_event(&mut self, connection_id: u32, flag: u16) -> hvdef::HvResult<()> {
-        self.partition
-            .synic_ports
-            .handle_signal_event(Vtl::Vtl0, connection_id, flag)
     }
 }

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -7,11 +7,15 @@
 // UNSAFETY: Calling HV APIs and manually managing memory.
 #![expect(unsafe_code)]
 
+#[cfg(guest_arch = "aarch64")]
+mod aarch64;
 #[cfg(guest_arch = "x86_64")]
 mod x86_64;
 
 #[cfg(guest_arch = "aarch64")]
-mod aarch64;
+use aarch64 as arch;
+#[cfg(guest_arch = "x86_64")]
+use x86_64 as arch;
 
 // irqfd is arch-independent but only wired up on x86_64 for now.
 // TODO: wire up on aarch64 once MSI signaling is implemented.
@@ -45,6 +49,8 @@ use pal::unix::pthread::*;
 use pal_event::Event;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
+use std::convert::Infallible;
+use std::future::poll_fn;
 use std::io;
 use std::os::fd::AsFd;
 use std::os::fd::AsRawFd;
@@ -52,11 +58,17 @@ use std::os::fd::IntoRawFd as _;
 use std::sync::Arc;
 use std::sync::Once;
 use std::sync::Weak;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::task::Waker;
 use thiserror::Error;
 use virt::NeedsYield;
 use virt::PartitionAccessState;
 use virt::ProtoPartitionConfig;
+use virt::StopVp;
+use virt::VpHaltReason;
 use virt::VpIndex;
+use virt::io::CpuIo;
 use vmcore::interrupt::Interrupt;
 use vmcore::reference_time::GetReferenceTime;
 use vmcore::reference_time::ReferenceTimeResult;
@@ -137,9 +149,8 @@ impl<'a> MshvProtoPartition<'a> {
                 thread: RwLock::new(None),
                 needs_yield: NeedsYield::new(),
                 message_queues: MessageQueues::new(),
-                deliverability_notifications: Mutex::new(
-                    HvDeliverabilityNotificationsRegister::new(),
-                ),
+                message_queues_pending: AtomicBool::new(false),
+                waker: RwLock::new(None),
             })
             .collect();
 
@@ -260,7 +271,12 @@ struct MshvVpInner {
     thread: RwLock<Option<Pthread>>,
     needs_yield: NeedsYield,
     message_queues: MessageQueues,
-    deliverability_notifications: Mutex<HvDeliverabilityNotificationsRegister>,
+    /// Set by device threads after enqueuing a message to signal the VP
+    /// thread to flush its message queues.
+    message_queues_pending: AtomicBool,
+    /// Waker for the VP run loop task. Set by the VP thread, used by device
+    /// threads to re-poll the run loop when new messages are enqueued.
+    waker: RwLock<Option<Waker>>,
 }
 
 struct MshvVpInnerCleaner<'a> {
@@ -320,24 +336,13 @@ impl MshvPartitionInner {
     }
 
     fn post_message(&self, vp_index: VpIndex, sint: u8, message: &HvMessage) {
-        let request_notification = self
-            .vp(vp_index)
-            .message_queues
-            .enqueue_message(sint, message);
-
-        if request_notification {
-            self.request_sint_notifications(vp_index, 1 << sint);
-        }
-    }
-
-    fn request_sint_notifications(&self, vp_index: VpIndex, sints: u16) {
-        // To avoid an additional get_reg hypercall, clear w/ deliverable sints mask
-        let mut notifications = self.vp(vp_index).deliverability_notifications.lock();
-        if notifications.sints() != sints {
-            notifications.set_sints(sints);
-            self.vmfd
-                .register_deliverabilty_notifications(vp_index.index(), (*notifications).into())
-                .expect("Requesting deliverability is not a fallible operation");
+        let vp = self.vp(vp_index);
+        let wake = vp.message_queues.enqueue_message(sint, message);
+        // Signal the VP thread to flush message queues.
+        if wake && !vp.message_queues_pending.swap(true, Ordering::Release) {
+            if let Some(waker) = &*vp.waker.read() {
+                waker.wake_by_ref();
+            }
         }
     }
 
@@ -446,10 +451,17 @@ pub struct MshvProcessor<'a> {
     vpindex: VpIndex,
     #[inspect(skip)]
     runner: MshvVpRunner<'a>,
+    /// The deliverability notification state currently registered with the
+    /// hypervisor.
+    #[inspect(skip)]
+    deliverability_notifications: HvDeliverabilityNotificationsRegister,
 }
 
 impl MshvProcessor<'_> {
-    fn flush_messages(&self, deliverable_sints: u16) {
+    /// Posts any queued messages for the given sints, and requests
+    /// deliverability notifications for any sints that still have pending
+    /// messages.
+    fn flush_messages(&mut self, deliverable_sints: u16) {
         let nonempty_sints =
             self.inner
                 .message_queues
@@ -472,16 +484,145 @@ impl MshvProcessor<'_> {
                     }
                 });
 
-        {
-            let mut notifications = self.inner.deliverability_notifications.lock();
-            let remaining_sints = notifications.sints() & !deliverable_sints;
-            notifications.set_sints(remaining_sints);
-        }
-
-        if nonempty_sints != 0 {
+        if self.deliverability_notifications.sints() != nonempty_sints {
+            let notifications = self.deliverability_notifications.with_sints(nonempty_sints);
+            tracing::trace!(?notifications, "setting deliverability notifications");
             self.partition
-                .request_sint_notifications(self.vpindex, nonempty_sints);
+                .vmfd
+                .register_deliverabilty_notifications(
+                    self.vpindex.index(),
+                    u64::from(notifications),
+                )
+                .expect("requesting deliverability is not a fallible operation");
+            self.deliverability_notifications = notifications;
         }
+    }
+
+    /// Handles a synic sint deliverable exit. The deliverable sints bitmap
+    /// is architecture-specific (different message types for x86_64 and
+    /// aarch64), so the caller extracts it and passes it here.
+    fn handle_sint_deliverable(&mut self, deliverable_sints: u16) {
+        // Clear the delivered sints from both the current and next state.
+        self.deliverability_notifications
+            .set_sints(self.deliverability_notifications.sints() & !deliverable_sints);
+
+        self.flush_messages(deliverable_sints);
+    }
+
+    /// Resets the VP's message queue and deliverability notification state.
+    fn reset_synic_state(&mut self) {
+        self.inner.message_queues.clear();
+        self.inner
+            .message_queues_pending
+            .store(false, Ordering::Relaxed);
+        self.deliverability_notifications = HvDeliverabilityNotificationsRegister::new();
+    }
+}
+
+impl virt::Processor for MshvProcessor<'_> {
+    type StateAccess<'a>
+        = &'a mut Self
+    where
+        Self: 'a;
+
+    fn set_debug_state(
+        &mut self,
+        _vtl: Vtl,
+        _state: Option<&virt::x86::DebugState>,
+    ) -> Result<(), <&mut Self as virt::vp::AccessVpState>::Error> {
+        Err(ErrorInner::NotSupported.into())
+    }
+
+    async fn run_vp(
+        &mut self,
+        stop: StopVp<'_>,
+        dev: &impl CpuIo,
+    ) -> Result<Infallible, VpHaltReason> {
+        let vpinner = self.inner;
+        let _cleaner = MshvVpInnerCleaner { vpinner };
+
+        assert!(vpinner.thread.write().replace(Pthread::current()).is_none());
+
+        self.partition
+            .thaw_time()
+            .expect("failed to thaw partition time");
+
+        let mut last_waker: Option<Waker> = None;
+
+        loop {
+            vpinner.needs_yield.maybe_yield().await;
+            stop.check()?;
+
+            // Ensure the waker is set so device threads can wake us.
+            poll_fn(|cx| {
+                if !last_waker.as_ref().is_some_and(|w| cx.waker().will_wake(w)) {
+                    last_waker = Some(cx.waker().clone());
+                    *vpinner.waker.write() = last_waker.clone();
+                }
+                std::task::Poll::Ready(())
+            })
+            .await;
+
+            // Flush any messages enqueued by device threads.
+            if vpinner.message_queues_pending.load(Ordering::Relaxed) {
+                vpinner
+                    .message_queues_pending
+                    .store(false, Ordering::SeqCst);
+                let pending_sints = vpinner.message_queues.pending_sints();
+                if pending_sints != 0 {
+                    self.flush_messages(pending_sints);
+                }
+            }
+
+            match self.runner.run() {
+                Ok(exit) => {
+                    self.handle_exit(&exit, dev).await?;
+                }
+                Err(e) => match e.errno() {
+                    libc::EAGAIN | libc::EINTR => {}
+                    _ => tracing::error!(
+                        error = &e as &dyn std::error::Error,
+                        "vcpufd.run returned error"
+                    ),
+                },
+            }
+        }
+    }
+
+    fn flush_async_requests(&mut self) {}
+
+    fn access_state(&mut self, vtl: Vtl) -> Self::StateAccess<'_> {
+        assert_eq!(vtl, Vtl::Vtl0);
+        self
+    }
+
+    fn reset(&mut self) -> Result<(), impl std::error::Error + Send + Sync + 'static> {
+        use virt::vp::AccessVpState;
+
+        let vp_info = self.inner.vp_info;
+        self.access_state(Vtl::Vtl0)
+            .reset_all(&vp_info)
+            .map_err(|e| ErrorInner::ResetState(Box::new(e)))?;
+
+        self.reset_synic_state();
+
+        Ok::<(), Error>(())
+    }
+}
+
+impl hv1_hypercall::PostMessage for arch::MshvHypercallHandler<'_> {
+    fn post_message(&mut self, connection_id: u32, message: &[u8]) -> hvdef::HvResult<()> {
+        self.partition
+            .synic_ports
+            .handle_post_message(Vtl::Vtl0, connection_id, false, message)
+    }
+}
+
+impl hv1_hypercall::SignalEvent for arch::MshvHypercallHandler<'_> {
+    fn signal_event(&mut self, connection_id: u32, flag: u16) -> hvdef::HvResult<()> {
+        self.partition
+            .synic_ports
+            .handle_signal_event(Vtl::Vtl0, connection_id, flag)
     }
 }
 

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -547,6 +547,14 @@ impl virt::Processor for MshvProcessor<'_> {
             .thaw_time()
             .expect("failed to thaw partition time");
 
+        // Ensure any messages present from a state restore are flushed on
+        // the first loop iteration.
+        if vpinner.message_queues.pending_sints() != 0 {
+            vpinner
+                .message_queues_pending
+                .store(true, Ordering::Relaxed);
+        }
+
         let mut last_waker: Option<Waker> = None;
 
         loop {

--- a/vmm_core/virt_mshv/src/x86_64/mod.rs
+++ b/vmm_core/virt_mshv/src/x86_64/mod.rs
@@ -15,7 +15,6 @@ use crate::MshvPartitionInner;
 use crate::MshvProcessor;
 use crate::MshvProcessorBinder;
 use crate::MshvProtoPartition;
-use crate::MshvVpInnerCleaner;
 use crate::MshvVpRunner;
 use crate::VcpuFdExt;
 use crate::common_synthetic_features;
@@ -38,14 +37,12 @@ use mshv_ioctls::VcpuFd;
 use pal::unix::pthread::Pthread;
 use parking_lot::Mutex;
 use pci_core::msi::SignalMsi;
-use std::convert::Infallible;
 use std::sync::Arc;
 use virt::Hv1;
 use virt::PartitionAccessState;
 use virt::PartitionConfig;
 use virt::ProtoPartition;
 use virt::ProtoPartitionConfig;
-use virt::StopVp;
 use virt::VpHaltReason;
 use virt::VpIndex;
 use virt::io::CpuIo;
@@ -542,6 +539,7 @@ impl virt::BindProcessor for MshvProcessorBinder {
             inner,
             vpindex: self.vpindex,
             runner,
+            deliverability_notifications: HvDeliverabilityNotificationsRegister::new(),
         };
 
         // Set the APIC state.
@@ -591,6 +589,41 @@ impl MshvProcessor<'_> {
         virt_support_x86emu::emulate::emulate(&mut support, &emu_mem, devices).await
     }
 
+    pub(crate) async fn handle_exit(
+        &mut self,
+        exit: &HvMessage,
+        dev: &impl CpuIo,
+    ) -> Result<(), VpHaltReason> {
+        match exit.header.typ {
+            HvMessageType::HvMessageTypeUnrecoverableException => {
+                return Err(VpHaltReason::TripleFault { vtl: Vtl::Vtl0 });
+            }
+            HvMessageType::HvMessageTypeX64IoPortIntercept => {
+                self.handle_io_port_intercept(exit, dev).await?;
+            }
+            HvMessageType::HvMessageTypeUnmappedGpa | HvMessageType::HvMessageTypeGpaIntercept => {
+                self.handle_mmio_intercept(exit, dev).await?;
+            }
+            HvMessageType::HvMessageTypeSynicSintDeliverable => {
+                tracing::trace!("SYNIC_SINT_DELIVERABLE");
+                let info = exit.as_message::<hvdef::HvX64SynicSintDeliverableMessage>();
+                self.handle_sint_deliverable(info.deliverable_sints);
+            }
+            HvMessageType::HvMessageTypeHypercallIntercept => {
+                tracing::trace!("HYPERCALL_INTERCEPT");
+                self.handle_hypercall_intercept(exit, dev);
+            }
+            HvMessageType::HvMessageTypeX64ApicEoi => {
+                let msg = exit.as_message::<hvdef::HvX64ApicEoiMessage>();
+                dev.handle_eoi(msg.interrupt_vector);
+            }
+            exit_type => {
+                panic!("Unhandled vcpu exit code {exit_type:?}");
+            }
+        }
+        Ok(())
+    }
+
     async fn handle_io_port_intercept(
         &mut self,
         message: &HvMessage,
@@ -636,11 +669,6 @@ impl MshvProcessor<'_> {
         self.emulate(message, devices, interruption_pending).await
     }
 
-    fn handle_synic_deliverable_exit(&self, message: &HvMessage, _devices: &impl CpuIo) {
-        let info = message.as_message::<hvdef::HvX64SynicSintDeliverableMessage>();
-        self.flush_messages(info.deliverable_sints);
-    }
-
     fn handle_hypercall_intercept(&mut self, message: &HvMessage, _devices: &impl CpuIo) {
         let info = message.as_message::<hvdef::HvX64HypercallInterceptMessage>();
         let is_64bit =
@@ -655,101 +683,6 @@ impl MshvProcessor<'_> {
             &self.partition.gm,
             X64RegisterIo::new(&mut handler, is_64bit),
         );
-    }
-}
-
-impl virt::Processor for MshvProcessor<'_> {
-    type StateAccess<'a>
-        = &'a mut Self
-    where
-        Self: 'a;
-
-    fn set_debug_state(
-        &mut self,
-        _vtl: Vtl,
-        _state: Option<&virt::x86::DebugState>,
-    ) -> Result<(), <&mut Self as virt::vp::AccessVpState>::Error> {
-        Err(ErrorInner::NotSupported.into())
-    }
-
-    async fn run_vp(
-        &mut self,
-        stop: StopVp<'_>,
-        dev: &impl CpuIo,
-    ) -> Result<Infallible, VpHaltReason> {
-        let vpinner = self.inner;
-        let _cleaner = MshvVpInnerCleaner { vpinner };
-
-        assert!(vpinner.thread.write().replace(Pthread::current()).is_none());
-
-        self.partition
-            .thaw_time()
-            .expect("failed to thaw partition time");
-
-        loop {
-            vpinner.needs_yield.maybe_yield().await;
-            stop.check()?;
-
-            match self.runner.run() {
-                Ok(exit) => match exit.header.typ {
-                    HvMessageType::HvMessageTypeUnrecoverableException => {
-                        return Err(VpHaltReason::TripleFault { vtl: Vtl::Vtl0 });
-                    }
-                    HvMessageType::HvMessageTypeX64IoPortIntercept => {
-                        self.handle_io_port_intercept(&exit, dev).await?;
-                    }
-                    HvMessageType::HvMessageTypeUnmappedGpa
-                    | HvMessageType::HvMessageTypeGpaIntercept => {
-                        self.handle_mmio_intercept(&exit, dev).await?;
-                    }
-                    HvMessageType::HvMessageTypeSynicSintDeliverable => {
-                        tracing::trace!("SYNIC_SINT_DELIVERABLE");
-                        self.handle_synic_deliverable_exit(&exit, dev);
-                    }
-                    HvMessageType::HvMessageTypeHypercallIntercept => {
-                        tracing::trace!("HYPERCALL_INTERCEPT");
-                        self.handle_hypercall_intercept(&exit, dev);
-                    }
-                    HvMessageType::HvMessageTypeX64ApicEoi => {
-                        let msg = exit.as_message::<hvdef::HvX64ApicEoiMessage>();
-                        dev.handle_eoi(msg.interrupt_vector);
-                    }
-                    exit => {
-                        panic!("Unhandled vcpu exit code {exit:?}");
-                    }
-                },
-
-                Err(e) => match e.errno() {
-                    libc::EAGAIN | libc::EINTR => {}
-                    _ => tracing::error!(
-                        error = &e as &dyn std::error::Error,
-                        "vcpufd.run returned error"
-                    ),
-                },
-            }
-        }
-    }
-
-    fn flush_async_requests(&mut self) {}
-
-    fn access_state(&mut self, vtl: Vtl) -> Self::StateAccess<'_> {
-        assert_eq!(vtl, Vtl::Vtl0);
-        self
-    }
-
-    fn reset(&mut self) -> Result<(), impl std::error::Error + Send + Sync + 'static> {
-        use virt::x86::vp::AccessVpState;
-
-        let vp_info = self.inner.vp_info;
-        self.access_state(Vtl::Vtl0)
-            .reset_all(&vp_info)
-            .map_err(|e| ErrorInner::ResetState(Box::new(e)))?;
-
-        self.inner.message_queues.clear();
-        *self.inner.deliverability_notifications.lock() =
-            HvDeliverabilityNotificationsRegister::new();
-
-        Ok::<(), Error>(())
     }
 }
 
@@ -1015,9 +948,9 @@ impl hv1_hypercall::X64RegisterState for MshvHypercallHandler<'_> {
     }
 }
 
-struct MshvHypercallHandler<'a> {
-    partition: &'a MshvPartitionInner,
-    reg_page: &'a mut HvX64RegisterPage,
+pub(crate) struct MshvHypercallHandler<'a> {
+    pub(crate) partition: &'a MshvPartitionInner,
+    pub(crate) reg_page: &'a mut HvX64RegisterPage,
 }
 
 impl MshvHypercallHandler<'_> {
@@ -1029,22 +962,6 @@ impl MshvHypercallHandler<'_> {
             hv1_hypercall::HvRetargetDeviceInterrupt,
         ],
     );
-}
-
-impl hv1_hypercall::PostMessage for MshvHypercallHandler<'_> {
-    fn post_message(&mut self, connection_id: u32, message: &[u8]) -> hvdef::HvResult<()> {
-        self.partition
-            .synic_ports
-            .handle_post_message(Vtl::Vtl0, connection_id, false, message)
-    }
-}
-
-impl hv1_hypercall::SignalEvent for MshvHypercallHandler<'_> {
-    fn signal_event(&mut self, connection_id: u32, flag: u16) -> hvdef::HvResult<()> {
-        self.partition
-            .synic_ports
-            .handle_signal_event(Vtl::Vtl0, connection_id, flag)
-    }
 }
 
 impl hv1_hypercall::RetargetDeviceInterrupt for MshvHypercallHandler<'_> {


### PR DESCRIPTION
The synic deliverability notification register was previously stored on the shared MshvVpInner behind a Mutex and written to from both device threads (via post_message) and the VP thread (via flush_messages). This created a race where a device thread could register for deliverability notifications that the VP thread would then clear without processing the corresponding message, leaving it stuck in the queue indefinitely.

Move the deliverability notification register to MshvProcessor so it is owned exclusively by the VP thread. Device threads now enqueue messages and wake the VP task via a stored Waker, following the same pattern used by virt_mshv_vtl. The VP thread checks for pending messages before each run() call and updates the hypervisor's notification register as needed.

As part of this change, unify the virt::Processor implementation and VP run loop across x86_64 and aarch64 in the root module. Each architecture now only provides a handle_exit method for arch-specific exit dispatch. The PostMessage and SignalEvent hypercall trait implementations are also moved to the root module since they are identical across architectures.