### PR TITLE
petri/logview: update postcss to 8.5.12 to fix CVE

### DIFF
--- a/petri/logview/package-lock.json
+++ b/petri/logview/package-lock.json
@@ -2161,9 +2161,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -2179,7 +2179,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",

--- a/petri/logview/package-lock.json
+++ b/petri/logview/package-lock.json
@@ -2179,6 +2179,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",


### PR DESCRIPTION
Fixes Dependabot alert #32 (PostCSS XSS via unescaped `</style>` in CSS stringify output).

Updates the lockfile from postcss 8.5.8 → 8.5.12 (vulnerable range was < 8.5.10). The `package.json` already had `^8.5.6` so only the lockfile needed updating.