### PR TITLE
ci: cleanup gh and ado pools

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -616,7 +616,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -969,7 +969,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3581,7 +3581,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4552,7 +4552,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6140,7 +6140,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6481,7 +6481,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6878,7 +6878,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7227,7 +7227,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -665,7 +665,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -946,7 +946,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3528,7 +3528,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4460,7 +4460,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -5874,7 +5874,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6173,7 +6173,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6528,7 +6528,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6811,7 +6811,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -395,7 +395,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1057,7 +1057,11 @@ jobs:
       shell: bash
   job12:
     name: clippy [x64-windows], unit tests [x64-windows]
-    runs-on: windows-latest
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1325,7 +1329,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1606,7 +1610,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1927,7 +1931,11 @@ jobs:
       shell: bash
   job15:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
-    runs-on: windows-11-arm
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=win-arm64
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2192,7 +2200,11 @@ jobs:
       shell: bash
   job16:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
-    runs-on: ubuntu-24.04-arm
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=ubuntu2404-arm64
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2520,7 +2532,11 @@ jobs:
       shell: bash
   job17:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
-    runs-on: ubuntu-24.04-arm
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=ubuntu2404-arm64
+    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4176,7 +4192,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -5108,7 +5124,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6587,7 +6603,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6886,7 +6902,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7241,7 +7257,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -25,8 +25,8 @@ jobs:
   displayName: quick check [fmt, clippy x64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
   variables:
@@ -216,8 +216,8 @@ jobs:
   displayName: build openhcl (mi-secure) [x64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -475,8 +475,8 @@ jobs:
   displayName: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -770,8 +770,8 @@ jobs:
   displayName: clippy [macos], unit tests [x64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1031,7 +1031,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1282,8 +1282,8 @@ jobs:
   displayName: build openhcl [x64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1715,8 +1715,8 @@ jobs:
   displayName: build openhcl [aarch64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1973,8 +1973,8 @@ jobs:
   displayName: build artifacts [x64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -2286,8 +2286,8 @@ jobs:
   displayName: build artifacts [aarch64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -2548,7 +2548,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -2839,8 +2839,8 @@ jobs:
   displayName: run vmm-tests [x64-linux-amd-kvm]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   - job5
@@ -3338,7 +3338,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   - job5
@@ -3878,7 +3878,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -4079,7 +4079,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -4366,7 +4366,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -4563,7 +4563,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))

--- a/flowey/flowey_hvlite/src/pipelines/build_docs.rs
+++ b/flowey/flowey_hvlite/src/pipelines/build_docs.rs
@@ -121,7 +121,7 @@ impl IntoPipeline for BuildDocsCli {
                 FlowArch::X86_64,
                 "build mdbook guide",
             )
-            .gh_set_pool(crate::pipelines_shared::gh_pools::gh_hosted_x64_linux())
+            .gh_set_pool(crate::pipelines_shared::gh_pools::linux_x64_gh())
             .dep_on(|ctx| flowey_lib_hvlite::build_guide::Request {
                 built_guide: ctx.publish_typed_artifact(pub_guide),
             })
@@ -137,13 +137,13 @@ impl IntoPipeline for BuildDocsCli {
             (
                 CommonTriple::X86_64_WINDOWS_MSVC,
                 FlowPlatform::Windows,
-                crate::pipelines_shared::gh_pools::gh_hosted_x64_windows(),
+                crate::pipelines_shared::gh_pools::windows_x64_gh(),
                 pub_rustdoc_win,
             ),
             (
                 CommonTriple::X86_64_LINUX_GNU,
                 FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
-                crate::pipelines_shared::gh_pools::gh_hosted_x64_linux(),
+                crate::pipelines_shared::gh_pools::linux_x64_gh(),
                 pub_rustdoc_linux,
             ),
         ] {
@@ -174,7 +174,7 @@ impl IntoPipeline for BuildDocsCli {
 
             let job = pipeline
                 .new_job(FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu), FlowArch::X86_64, "publish openvmm.dev")
-                .gh_set_pool(crate::pipelines_shared::gh_pools::gh_hosted_x64_linux())
+                .gh_set_pool(crate::pipelines_shared::gh_pools::linux_x64_gh())
                 .dep_on(
                     |ctx| flowey_lib_hvlite::_jobs::consolidate_and_publish_gh_pages::Params {
                         rustdoc_linux: ctx.use_typed_artifact(&use_rustdoc_linux),
@@ -212,7 +212,7 @@ impl IntoPipeline for BuildDocsCli {
                     FlowArch::X86_64,
                     "openvmm build docs gates",
                 )
-                .gh_set_pool(crate::pipelines_shared::gh_pools::gh_hosted_x64_linux())
+                .gh_set_pool(crate::pipelines_shared::gh_pools::linux_x64_gh())
                 // always run this job, regardless whether or not any previous jobs failed
                 .gh_dangerous_override_if("always() && github.event.pull_request.draft == false")
                 .gh_dangerous_global_env_var("ANY_JOBS_FAILED", "${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}")

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -3,6 +3,8 @@
 
 //! See [`CheckinGatesCli`]
 
+use crate::pipelines_shared::ado_pools;
+use crate::pipelines_shared::gh_pools;
 use flowey::node::prelude::AdoResourcesRepositoryId;
 use flowey::node::prelude::FlowPlatformLinuxDistro;
 use flowey::node::prelude::GhPermission;
@@ -219,7 +221,8 @@ impl IntoPipeline for CheckinGatesCli {
         // <https://github.com/orgs/community/discussions/12395>
         let mut all_jobs = Vec::new();
 
-        // ── Phase 1: quick-check gate ──────────────────────────────────────
+        // Quick check gate
+        //
         // Combined fmt + clippy on one self-hosted linux machine.
         // Catches the most common failures quickly before fanning out expensive jobs.
         let quick_check_job = if matches!(config, PipelineConfig::Pr | PipelineConfig::PrRelease) {
@@ -229,16 +232,12 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     "quick check [fmt, clippy x64-linux]",
                 )
-                .gh_set_pool(crate::pipelines_shared::gh_pools::linux_1es())
-                .ado_set_pool(crate::pipelines_shared::ado_pools::default_x86_pool(
-                    FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
-                ))
-                // 1. xtask fmt (linux)
+                .gh_set_pool(gh_pools::default_linux())
+                .ado_set_pool(ado_pools::default_linux())
                 .dep_on(|ctx| flowey_lib_hvlite::_jobs::check_xtask_fmt::Request {
                     target: CommonTriple::X86_64_LINUX_GNU,
                     done: ctx.new_done_handle(),
                 })
-                // 2. clippy for x64-linux-gnu
                 .dep_on(|ctx| flowey_lib_hvlite::_jobs::check_clippy::Request {
                     target: target_lexicon::triple!("x86_64-unknown-linux-gnu"),
                     profile: CommonProfile::from_release(release),
@@ -249,7 +248,7 @@ impl IntoPipeline for CheckinGatesCli {
 
             Some(job)
         } else {
-            // CI (post-merge) keeps full fan-out — no phase-1 gate
+            // skip in CI
             None
         };
 
@@ -261,10 +260,8 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     "xtask fmt (windows)",
                 )
-                .gh_set_pool(crate::pipelines_shared::gh_pools::gh_hosted_x64_windows())
-                .ado_set_pool(crate::pipelines_shared::ado_pools::default_x86_pool(
-                    FlowPlatform::Windows,
-                ))
+                .gh_set_pool(gh_pools::windows_x64_gh())
+                .ado_set_pool(ado_pools::default_windows())
                 .dep_on(|ctx| flowey_lib_hvlite::_jobs::check_xtask_fmt::Request {
                     target: CommonTriple::X86_64_WINDOWS_MSVC,
                     done: ctx.new_done_handle(),
@@ -282,10 +279,8 @@ impl IntoPipeline for CheckinGatesCli {
                         FlowArch::X86_64,
                         "xtask fmt (linux)",
                     )
-                    .gh_set_pool(crate::pipelines_shared::gh_pools::gh_hosted_x64_linux())
-                    .ado_set_pool(crate::pipelines_shared::ado_pools::default_x86_pool(
-                        FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
-                    ))
+                    .gh_set_pool(gh_pools::linux_x64_gh())
+                    .ado_set_pool(ado_pools::default_linux())
                     .dep_on(|ctx| flowey_lib_hvlite::_jobs::check_xtask_fmt::Request {
                         target: CommonTriple::X86_64_LINUX_GNU,
                         done: ctx.new_done_handle(),
@@ -381,10 +376,8 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     format!("build artifacts (not for VMM tests) [{arch_tag}-windows]"),
                 )
-                .gh_set_pool(crate::pipelines_shared::gh_pools::windows_amd_1es())
-                .ado_set_pool(crate::pipelines_shared::ado_pools::default_x86_pool(
-                    FlowPlatform::Windows,
-                ))
+                .gh_set_pool(gh_pools::default_windows())
+                .ado_set_pool(ado_pools::default_windows())
                 .dep_on(|ctx| flowey_lib_hvlite::build_hypestv::Request {
                     target: CommonTriple::Common {
                         arch,
@@ -440,10 +433,8 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     format!("build artifacts (for VMM tests) [{arch_tag}-windows]"),
                 )
-                .gh_set_pool(crate::pipelines_shared::gh_pools::windows_amd_1es())
-                .ado_set_pool(crate::pipelines_shared::ado_pools::default_x86_pool(
-                    FlowPlatform::Windows,
-                ))
+                .gh_set_pool(gh_pools::default_windows())
+                .ado_set_pool(ado_pools::default_windows())
                 .dep_on(|ctx| {
                     flowey_lib_hvlite::build_openvmm::Request {
                         params: flowey_lib_hvlite::build_openvmm::OpenvmmBuildParams {
@@ -621,10 +612,8 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     format!("build artifacts [{arch_tag}-linux]"),
                 )
-                .gh_set_pool(crate::pipelines_shared::gh_pools::linux_1es())
-                .ado_set_pool(crate::pipelines_shared::ado_pools::default_x86_pool(
-                    FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
-                ))
+                .gh_set_pool(gh_pools::default_linux())
+                .ado_set_pool(ado_pools::default_linux())
                 .dep_on(|ctx| {
                     flowey_lib_hvlite::build_openvmm::Request {
                         params: flowey_lib_hvlite::build_openvmm::OpenvmmBuildParams {
@@ -823,10 +812,8 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     build_openhcl_job_tag(arch_tag),
                 )
-                .gh_set_pool(crate::pipelines_shared::gh_pools::linux_1es())
-                .ado_set_pool(crate::pipelines_shared::ado_pools::default_x86_pool(
-                    FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
-                ))
+                .gh_set_pool(gh_pools::default_linux())
+                .ado_set_pool(ado_pools::default_linux())
                 .dep_on(|ctx| {
                     let publish_baseline_artifact = pub_openhcl_baseline
                         .map(|baseline_artifact| ctx.publish_artifact(baseline_artifact));
@@ -922,7 +909,7 @@ impl IntoPipeline for CheckinGatesCli {
                         FlowArch::X86_64,
                         format!("verify openhcl binary size [{}]", arch_tag),
                     )
-                    .gh_set_pool(crate::pipelines_shared::gh_pools::gh_hosted_x64_linux())
+                    .gh_set_pool(gh_pools::linux_x64_gh())
                     .dep_on(
                         |ctx| flowey_lib_hvlite::_jobs::check_openvmm_hcl_size::Request {
                             target: CommonTriple::Common {
@@ -947,6 +934,7 @@ impl IntoPipeline for CheckinGatesCli {
             platform: FlowPlatform,
             arch: FlowArch,
             gh_pool: GhRunner,
+            ado_pool: Option<AdoPool>,
             clippy_targets: Option<(&'a str, &'a [(Triple, bool)])>,
             unit_test_target: Option<(&'a str, Triple)>,
         }
@@ -961,17 +949,15 @@ impl IntoPipeline for CheckinGatesCli {
             platform,
             arch,
             gh_pool,
+            ado_pool,
             clippy_targets,
             unit_test_target,
         } in [
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: if release {
-                    crate::pipelines_shared::gh_pools::windows_amd_1es()
-                } else {
-                    crate::pipelines_shared::gh_pools::gh_hosted_x64_windows()
-                },
+                gh_pool: gh_pools::windows_amd_1es(),
+                ado_pool: Some(ado_pools::windows_amd_1es()),
                 clippy_targets: Some((
                     "x64-windows",
                     &[(target_lexicon::triple!("x86_64-pc-windows-msvc"), false)],
@@ -984,11 +970,10 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
-                // This job fails on github runners for an unknown reason, so
-                // use self-hosted runners for now.
-                gh_pool: crate::pipelines_shared::gh_pools::linux_1es(),
+                gh_pool: gh_pools::linux_amd_1es(),
+                ado_pool: Some(ado_pools::linux_amd_1es()),
                 clippy_targets: if quick_check_job.is_some() {
-                    // Phase 1 already ran clippy for x64-linux;
+                    // quick check already ran clippy for x64-linux;
                     // still need macos cross-clippy here.
                     Some(("macos", macos_clippy_targets.as_slice()))
                 } else {
@@ -1005,9 +990,8 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
-                // This job fails on github runners due to disk space exhaustion, so
-                // use self-hosted runners for now.
-                gh_pool: crate::pipelines_shared::gh_pools::linux_1es(),
+                gh_pool: gh_pools::linux_amd_1es(),
+                ado_pool: Some(ado_pools::linux_amd_1es()),
                 clippy_targets: Some((
                     "x64-linux-musl, misc nostd",
                     &[(openhcl_musl_target(CommonArch::X86_64), true)],
@@ -1017,11 +1001,8 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::Aarch64,
-                gh_pool: if release {
-                    crate::pipelines_shared::gh_pools::windows_arm_1es()
-                } else {
-                    crate::pipelines_shared::gh_pools::gh_hosted_arm_windows()
-                },
+                gh_pool: gh_pools::windows_arm_1es(),
+                ado_pool: None,
                 clippy_targets: Some((
                     "aarch64-windows",
                     &[(target_lexicon::triple!("aarch64-pc-windows-msvc"), false)],
@@ -1034,11 +1015,8 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::Aarch64,
-                gh_pool: if release {
-                    crate::pipelines_shared::gh_pools::linux_arm_1es()
-                } else {
-                    crate::pipelines_shared::gh_pools::gh_hosted_arm_linux()
-                },
+                gh_pool: gh_pools::linux_arm_1es(),
+                ado_pool: None,
                 clippy_targets: Some((
                     "aarch64-linux",
                     &[(target_lexicon::triple!("aarch64-unknown-linux-gnu"), false)],
@@ -1051,11 +1029,8 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::Aarch64,
-                gh_pool: if release {
-                    crate::pipelines_shared::gh_pools::linux_arm_1es()
-                } else {
-                    crate::pipelines_shared::gh_pools::gh_hosted_arm_linux()
-                },
+                gh_pool: gh_pools::linux_arm_1es(),
+                ado_pool: None,
                 clippy_targets: Some((
                     "aarch64-linux-musl, misc nostd",
                     &[(openhcl_musl_target(CommonArch::Aarch64), true)],
@@ -1066,9 +1041,8 @@ impl IntoPipeline for CheckinGatesCli {
                 )),
             },
         ] {
-            // Skip ARM64 jobs entirely for ADO backend (there is no native ARM64 pool ADO)
-            if matches!(arch, FlowArch::Aarch64) && matches!(backend_hint, PipelineBackendHint::Ado)
-            {
+            // Skip unsupported jobs on ADO backend
+            if matches!(backend_hint, PipelineBackendHint::Ado) && ado_pool.is_none() {
                 continue;
             }
 
@@ -1094,18 +1068,11 @@ impl IntoPipeline for CheckinGatesCli {
 
             let mut clippy_unit_test_job = pipeline
                 .new_job(platform, arch, job_name)
-                .gh_set_pool(gh_pool)
-                .ado_set_pool(match platform {
-                    FlowPlatform::Windows => {
-                        crate::pipelines_shared::ado_pools::default_x86_pool(FlowPlatform::Windows)
-                    }
-                    FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu) => {
-                        crate::pipelines_shared::ado_pools::default_x86_pool(FlowPlatform::Linux(
-                            FlowPlatformLinuxDistro::Ubuntu,
-                        ))
-                    }
-                    _ => anyhow::bail!("unsupported platform"),
-                });
+                .gh_set_pool(gh_pool);
+
+            if let Some(pool) = ado_pool {
+                clippy_unit_test_job = clippy_unit_test_job.ado_set_pool(pool);
+            }
 
             if let Some((_, targets)) = clippy_targets {
                 for (target, also_check_misc_nostd_crates) in targets {
@@ -1190,6 +1157,7 @@ impl IntoPipeline for CheckinGatesCli {
             platform: FlowPlatform,
             arch: FlowArch,
             gh_pool: GhRunner,
+            ado_pool: Option<AdoPool>,
             label: &'a str,
             target: CommonTriple,
             resolve_vmm_tests_artifacts: vmm_tests_artifact_builders::ResolveVmmTestsDepArtifacts,
@@ -1286,6 +1254,7 @@ impl IntoPipeline for CheckinGatesCli {
             platform,
             arch,
             gh_pool,
+            ado_pool,
             label,
             target,
             resolve_vmm_tests_artifacts,
@@ -1296,7 +1265,8 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: crate::pipelines_shared::gh_pools::windows_intel_1es(),
+                gh_pool: gh_pools::windows_intel_1es(),
+                ado_pool: Some(ado_pools::windows_intel_1es()),
                 label: "x64-windows-intel",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_x86,
@@ -1307,7 +1277,8 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: crate::pipelines_shared::gh_pools::windows_tdx_self_hosted_baremetal(),
+                gh_pool: gh_pools::windows_tdx_self_hosted_baremetal(),
+                ado_pool: None,
                 label: "x64-windows-intel-tdx",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_tdx_x86,
@@ -1318,7 +1289,8 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: crate::pipelines_shared::gh_pools::windows_amd_1es(),
+                gh_pool: gh_pools::windows_amd_1es(),
+                ado_pool: Some(ado_pools::windows_amd_1es()),
                 label: "x64-windows-amd",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_amd_x86,
@@ -1329,7 +1301,8 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: crate::pipelines_shared::gh_pools::windows_snp_self_hosted_baremetal(),
+                gh_pool: gh_pools::windows_snp_self_hosted_baremetal(),
+                ado_pool: None,
                 label: "x64-windows-amd-snp",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_amd_snp_x86,
@@ -1340,7 +1313,8 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
-                gh_pool: crate::pipelines_shared::gh_pools::linux_1es(),
+                gh_pool: gh_pools::linux_amd_1es(),
+                ado_pool: Some(ado_pools::linux_amd_1es()),
                 label: "x64-linux-amd-kvm",
                 target: CommonTriple::X86_64_LINUX_GNU,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_linux_x86,
@@ -1352,7 +1326,8 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::AzureLinux),
                 arch: FlowArch::X86_64,
-                gh_pool: crate::pipelines_shared::gh_pools::linux_mshv_1es(),
+                gh_pool: gh_pools::linux_mshv_1es(),
+                ado_pool: None,
                 label: "x64-linux-intel-mshv",
                 target: CommonTriple::X86_64_LINUX_MUSL,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_linux_mshv_x86,
@@ -1364,7 +1339,8 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::Aarch64,
-                gh_pool: crate::pipelines_shared::gh_pools::windows_arm_self_hosted_baremetal(),
+                gh_pool: gh_pools::windows_arm_self_hosted_baremetal(),
+                ado_pool: None,
                 label: "aarch64-windows",
                 target: CommonTriple::AARCH64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_aarch64,
@@ -1379,16 +1355,11 @@ impl IntoPipeline for CheckinGatesCli {
                 needs_prep_run: false,
             },
         ] {
-            // Skip ARM64/CVM/MSHV jobs entirely for ADO backend (no native ARM64/CVM/MSHV pools in ADO)
-            if matches!(backend_hint, PipelineBackendHint::Ado) {
-                if matches!(arch, FlowArch::Aarch64)
-                    || label.contains("tdx")
-                    || label.contains("snp")
-                    || label.contains("mshv")
-                {
-                    continue;
-                }
+            // Skip unsupported jobs on ADO backend
+            if matches!(backend_hint, PipelineBackendHint::Ado) && ado_pool.is_none() {
+                continue;
             }
+
             let test_label = format!("{label}-vmm-tests");
 
             let pub_vmm_tests_results = if matches!(backend_hint, PipelineBackendHint::Local) {
@@ -1409,24 +1380,8 @@ impl IntoPipeline for CheckinGatesCli {
                 .new_job(platform, arch, format!("run vmm-tests [{label}]"))
                 .gh_set_pool(gh_pool);
 
-            // Only add ADO pool for x86_64 jobs that have a matching ADO pool
-            if matches!(arch, FlowArch::X86_64) {
-                let ado_pool = match platform {
-                    FlowPlatform::Windows => Some(
-                        crate::pipelines_shared::ado_pools::default_x86_pool(FlowPlatform::Windows),
-                    ),
-                    FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu) => {
-                        Some(crate::pipelines_shared::ado_pools::default_x86_pool(
-                            FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
-                        ))
-                    }
-                    // No ADO pool for AzureLinux (MSHV jobs are GH-only)
-                    FlowPlatform::Linux(FlowPlatformLinuxDistro::AzureLinux) => None,
-                    _ => anyhow::bail!("unsupported platform"),
-                };
-                if let Some(pool) = ado_pool {
-                    vmm_tests_run_job = vmm_tests_run_job.ado_set_pool(pool);
-                }
+            if let Some(pool) = ado_pool {
+                vmm_tests_run_job = vmm_tests_run_job.ado_set_pool(pool);
             }
 
             vmm_tests_run_job = vmm_tests_run_job.dep_on(|ctx| {
@@ -1466,7 +1421,7 @@ impl IntoPipeline for CheckinGatesCli {
                         FlowArch::X86_64,
                         "test flowey local backend",
                     )
-                    .gh_set_pool(crate::pipelines_shared::gh_pools::gh_hosted_x64_linux())
+                    .gh_set_pool(gh_pools::linux_x64_gh())
                     .dep_on(
                         |ctx| flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm::Request {
                             base_recipe: OpenhclIgvmRecipe::X64,
@@ -1507,10 +1462,8 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     "build openhcl (mi-secure) [x64-linux]",
                 )
-                .gh_set_pool(crate::pipelines_shared::gh_pools::linux_1es())
-                .ado_set_pool(crate::pipelines_shared::ado_pools::default_x86_pool(
-                    FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
-                ))
+                .gh_set_pool(gh_pools::default_linux())
+                .ado_set_pool(ado_pools::default_linux())
                 .dep_on(|ctx| {
                     flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe::Params {
                         igvm_files: [
@@ -1568,10 +1521,8 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     "run vmm-tests [x64-windows-intel-mi-secure]",
                 )
-                .gh_set_pool(crate::pipelines_shared::gh_pools::windows_intel_1es())
-                .ado_set_pool(crate::pipelines_shared::ado_pools::default_x86_pool(
-                    FlowPlatform::Windows,
-                ))
+                .gh_set_pool(gh_pools::windows_intel_1es())
+                .ado_set_pool(ado_pools::windows_intel_1es())
                 .dep_on(|ctx| {
                     flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive::Params {
                         junit_test_label: mi_secure_test_label,
@@ -1628,7 +1579,7 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     "openvmm checkin gates",
                 )
-                .gh_set_pool(crate::pipelines_shared::gh_pools::gh_hosted_x64_linux())
+                .gh_set_pool(gh_pools::linux_x64_gh())
                 // always run this job, regardless whether or not any previous jobs failed
                 .gh_dangerous_override_if("always() && github.event.pull_request.draft == false")
                 .gh_dangerous_global_env_var("ANY_JOBS_FAILED", "${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}")
@@ -1656,7 +1607,7 @@ impl IntoPipeline for CheckinGatesCli {
                     GhPermission::Contents,
                     GhPermissionValue::Write,
                 )])
-                .gh_set_pool(crate::pipelines_shared::gh_pools::gh_hosted_x64_linux())
+                .gh_set_pool(gh_pools::linux_x64_gh())
                 .dep_on(
                     |ctx| flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release::Request {
                         vmgstools: vmgstools

--- a/flowey/flowey_hvlite/src/pipelines_shared/ado_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/ado_pools.rs
@@ -3,24 +3,37 @@
 
 //! Centralized list of constants enumerating available ADO build pools.
 
-use flowey::node::prelude::FlowPlatformLinuxDistro;
 use flowey::pipeline::prelude::*;
 
-pub const INTEL_POOL: &str = "openvmm-ado-intel-centralus";
+use super::gh_pools::LINUX_IMAGE_AMD64;
+use super::gh_pools::WINDOWS_IMAGE_AMD64;
 
-fn intel_pool_with_image(image: &str) -> AdoPool {
+pub const AMD_POOL_1ES: &str = "openvmm-ado-amd-westus2";
+pub const INTEL_POOL_1ES: &str = "openvmm-ado-intel-centralus";
+
+fn ado_pool_with_image_1es(pool: &str, image: &str) -> AdoPool {
     AdoPool {
-        name: INTEL_POOL.into(),
+        name: pool.into(),
         demands: vec![format!("ImageOverride -equals {image}")],
     }
 }
 
-pub fn default_x86_pool(platform: FlowPlatform) -> AdoPool {
-    match platform {
-        FlowPlatform::Windows => intel_pool_with_image("win-amd64"),
-        FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu) => {
-            intel_pool_with_image("ubuntu2404-amd64-256gb")
-        }
-        platform => panic!("unsupported platform {platform}"),
-    }
+pub fn windows_amd_1es() -> AdoPool {
+    ado_pool_with_image_1es(AMD_POOL_1ES, WINDOWS_IMAGE_AMD64)
+}
+
+pub fn windows_intel_1es() -> AdoPool {
+    ado_pool_with_image_1es(INTEL_POOL_1ES, WINDOWS_IMAGE_AMD64)
+}
+
+pub fn linux_amd_1es() -> AdoPool {
+    ado_pool_with_image_1es(AMD_POOL_1ES, LINUX_IMAGE_AMD64)
+}
+
+pub fn default_windows() -> AdoPool {
+    windows_amd_1es()
+}
+
+pub fn default_linux() -> AdoPool {
+    linux_amd_1es()
 }

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -5,67 +5,61 @@
 
 use flowey::pipeline::prelude::*;
 
-pub fn windows_amd_1es() -> GhRunner {
+pub const AMD_POOL_1ES: &str = "openvmm-gh-amd-westus3";
+pub const INTEL_POOL_1ES: &str = "openvmm-gh-intel-westus3";
+pub const ARM_POOL_1ES: &str = "openvmm-gh-arm-westus2";
+
+pub const WINDOWS_IMAGE_AMD64: &str = "win-amd64";
+pub const WINDOWS_IMAGE_ARM64: &str = "win-arm64";
+pub const LINUX_IMAGE_AMD64: &str = "ubuntu2404-amd64";
+pub const LINUX_IMAGE_ARM64: &str = "ubuntu2404-arm64";
+pub const MSHV_IMAGE_AMD64: &str = "azurelinux3-amd64-dom0";
+
+fn gh_pool_with_image_1es(pool: &str, image: &str) -> GhRunner {
     GhRunner::SelfHosted(vec![
         "self-hosted".to_string(),
-        "1ES.Pool=openvmm-gh-amd-westus3".to_string(),
-        "1ES.ImageOverride=win-amd64".to_string(),
+        format!("1ES.Pool={pool}"),
+        format!("1ES.ImageOverride={image}"),
     ])
+}
+
+pub fn windows_amd_1es() -> GhRunner {
+    gh_pool_with_image_1es(AMD_POOL_1ES, WINDOWS_IMAGE_AMD64)
 }
 
 pub fn windows_intel_1es() -> GhRunner {
-    GhRunner::SelfHosted(vec![
-        "self-hosted".to_string(),
-        "1ES.Pool=openvmm-gh-intel-westus3".to_string(),
-        "1ES.ImageOverride=win-amd64".to_string(),
-    ])
+    gh_pool_with_image_1es(INTEL_POOL_1ES, WINDOWS_IMAGE_AMD64)
 }
 
 pub fn windows_arm_1es() -> GhRunner {
-    GhRunner::SelfHosted(vec![
-        "self-hosted".to_string(),
-        "1ES.Pool=openvmm-gh-arm-westus2".to_string(),
-        "1ES.ImageOverride=win-arm64".to_string(),
-    ])
+    gh_pool_with_image_1es(ARM_POOL_1ES, WINDOWS_IMAGE_ARM64)
 }
 
 pub fn linux_arm_1es() -> GhRunner {
-    GhRunner::SelfHosted(vec![
-        "self-hosted".to_string(),
-        "1ES.Pool=openvmm-gh-arm-westus2".to_string(),
-        "1ES.ImageOverride=ubuntu2404-arm64".to_string(),
-    ])
+    gh_pool_with_image_1es(ARM_POOL_1ES, LINUX_IMAGE_ARM64)
 }
 
-pub fn linux_1es() -> GhRunner {
-    GhRunner::SelfHosted(vec![
-        "self-hosted".to_string(),
-        "1ES.Pool=openvmm-gh-amd-westus3".to_string(),
-        "1ES.ImageOverride=ubuntu2404-amd64-256gb".to_string(),
-    ])
+pub fn linux_amd_1es() -> GhRunner {
+    gh_pool_with_image_1es(AMD_POOL_1ES, LINUX_IMAGE_AMD64)
 }
 
 pub fn linux_mshv_1es() -> GhRunner {
-    GhRunner::SelfHosted(vec![
-        "self-hosted".to_string(),
-        "1ES.Pool=openvmm-gh-intel-westus3".to_string(),
-        "1ES.ImageOverride=azurelinux3-amd64-dom0".to_string(),
-    ])
+    gh_pool_with_image_1es(INTEL_POOL_1ES, MSHV_IMAGE_AMD64)
 }
 
-pub fn gh_hosted_x64_windows() -> GhRunner {
+pub fn windows_x64_gh() -> GhRunner {
     GhRunner::GhHosted(GhRunnerOsLabel::WindowsLatest)
 }
 
-pub fn gh_hosted_x64_linux() -> GhRunner {
+pub fn linux_x64_gh() -> GhRunner {
     GhRunner::GhHosted(GhRunnerOsLabel::UbuntuLatest)
 }
 
-pub fn gh_hosted_arm_windows() -> GhRunner {
+pub fn windows_arm_gh() -> GhRunner {
     GhRunner::GhHosted(GhRunnerOsLabel::Windows11Arm)
 }
 
-pub fn gh_hosted_arm_linux() -> GhRunner {
+pub fn linux_arm_gh() -> GhRunner {
     GhRunner::GhHosted(GhRunnerOsLabel::Ubuntu2404Arm)
 }
 
@@ -96,4 +90,12 @@ pub fn windows_snp_self_hosted_baremetal() -> GhRunner {
         "SNP".to_string(),
         "Baremetal".to_string(),
     ])
+}
+
+pub fn default_windows() -> GhRunner {
+    windows_amd_1es()
+}
+
+pub fn default_linux() -> GhRunner {
+    linux_amd_1es()
 }

--- a/flowey/flowey_lib_hvlite/src/build_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_nextest_vmm_tests.rs
@@ -72,11 +72,30 @@ impl FlowNode for Node {
         ctx.import::<crate::init_openvmm_magicpath_openhcl_sysroot::Node>();
         ctx.import::<crate::init_cross_build::Node>();
         ctx.import::<flowey_lib_common::run_cargo_nextest_archive::Node>();
+        ctx.import::<flowey_lib_common::install_dist_pkg::Node>();
     }
 
     fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
-        // base requirements for building crates in the hvlite tree
-        let ambient_deps = vec![ctx.reqv(crate::install_openvmm_rust_build_essential::Request)];
+        let mut ambient_deps = vec![ctx.reqv(crate::install_openvmm_rust_build_essential::Request)];
+
+        // TODO: install build tools for other platforms
+        if matches!(
+            ctx.platform(),
+            FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu)
+        ) {
+            ambient_deps.push(ctx.reqv(|v| {
+                flowey_lib_common::install_dist_pkg::Request::Install {
+                    package_names: vec![
+                        "libssl-dev".into(),
+                        "pkg-config".into(),
+                        "build-essential".into(),
+                    ],
+                    done: v,
+                }
+            }));
+        }
+
+        let ambient_deps = ambient_deps;
 
         for Request {
             target,


### PR DESCRIPTION
Refactor and standardize naming of pools and images in flowey. Moves all ubuntu jobs to a clean, updated ubuntu image with nothing preinstalled and uses the 1es pools for all clippy/unit test jobs.