### PR TITLE
virt_mshv/vfio: add tracing spans to DMA map/unmap operations

### DIFF
--- a/vm/devices/pci/vfio_assigned_device/src/manager.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/manager.rs
@@ -37,7 +37,7 @@ impl membacking::DmaTarget for VfioType1DmaTarget {
         _file_offset: u64,
     ) -> anyhow::Result<()> {
         let vaddr = host_va.expect("VFIO type1 requires host VA (registered with needs_va=true)");
-        let _span = tracing::info_span!("vfio map", %range, vaddr = vaddr as u64).entered();
+        let _span = tracing::info_span!("vfio map", %range).entered();
         // SAFETY: The caller (DmaMapper in membacking) guarantees that the
         // host VA is backed and stable via ensure_mapped + VaMapper lifetime.
         unsafe {

--- a/vm/devices/pci/vfio_assigned_device/src/manager.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/manager.rs
@@ -37,6 +37,7 @@ impl membacking::DmaTarget for VfioType1DmaTarget {
         _file_offset: u64,
     ) -> anyhow::Result<()> {
         let vaddr = host_va.expect("VFIO type1 requires host VA (registered with needs_va=true)");
+        let _span = tracing::info_span!("vfio map", %range, vaddr = vaddr as u64).entered();
         // SAFETY: The caller (DmaMapper in membacking) guarantees that the
         // host VA is backed and stable via ensure_mapped + VaMapper lifetime.
         unsafe {
@@ -47,6 +48,7 @@ impl membacking::DmaTarget for VfioType1DmaTarget {
     }
 
     fn unmap_dma(&self, range: memory_range::MemoryRange) -> anyhow::Result<()> {
+        let _span = tracing::info_span!("vfio unmap", %range).entered();
         self.container
             .unmap_dma(range.start(), range.len())
             .context("VFIO DMA unmap failed")

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -697,6 +697,14 @@ impl virt::PartitionMemoryMap for MshvPartitionInner {
             rsvd: [0; 7],
         };
 
+        let _span = tracing::info_span!(
+            "mshv map user memory",
+            guest_pfn = mem_region.guest_pfn,
+            size = mem_region.size,
+            writable,
+            exec,
+        )
+        .entered();
         self.vmfd.map_user_memory(mem_region)?;
         state.ranges[slot_to_use] = Some(mem_region);
         Ok(())
@@ -714,6 +722,12 @@ impl virt::PartitionMemoryMap for MshvPartitionInner {
             let region_end = region.guest_pfn + (region.size >> HV_PAGE_SHIFT);
             if unmap_start <= region_start && region_end <= unmap_end {
                 // Region is fully contained in the unmap range.
+                let _span = tracing::info_span!(
+                    "mshv unmap user memory",
+                    guest_pfn = region.guest_pfn,
+                    size = region.size,
+                )
+                .entered();
                 self.vmfd.unmap_user_memory(*region)?;
                 *entry = None;
             } else {


### PR DESCRIPTION
Memory mapping and unmapping operations are some of the most performance-sensitive and difficult-to-debug paths in the VMM. Add tracing info spans around VFIO DMA map/unmap and mshv user memory map/unmap calls so that these operations show up in traces with their key parameters (address ranges, sizes, writability). This makes it straightforward to correlate mapping activity with other VM events during performance analysis or failure diagnosis.