### PR TITLE
CI: Only test Symcrypt on musl runs

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -704,7 +704,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -712,7 +712,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -732,14 +732,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 4
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -791,9 +791,6 @@ jobs:
       run: flowey e 11 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
       run: |-
         flowey e 11 flowey_lib_common::run_cargo_clippy 1
         flowey e 11 flowey_lib_hvlite::init_cross_build 4
@@ -813,10 +810,10 @@ jobs:
       run: flowey e 11 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 5
+      run: flowey e 11 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 11 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 11 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -828,14 +825,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -855,13 +852,13 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 11 flowey_lib_common::publish_test_results 5
         flowey e 11 flowey_lib_common::publish_test_results 6
         flowey e 11 flowey_lib_common::publish_test_results 4
@@ -871,18 +868,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 11 flowey_lib_common::publish_test_results 8
         flowey e 11 flowey_lib_common::publish_test_results 9
         flowey e 11 flowey_lib_common::publish_test_results 10
@@ -892,50 +889,8 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 11 flowey_lib_common::publish_test_results 12
-        flowey e 11 flowey_lib_common::publish_test_results 13
-        flowey e 11 flowey_lib_common::publish_test_results 14
-        flowey v 11 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 11 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 11 flowey_lib_common::publish_test_results 16
-        flowey e 11 flowey_lib_common::publish_test_results 17
-        flowey e 11 flowey_lib_common::publish_test_results 18
-        flowey v 11 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 11 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
         name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -954,13 +909,34 @@ jobs:
       run: flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 11 flowey_lib_common::publish_test_results 12
+        flowey e 11 flowey_lib_common::publish_test_results 13
+        flowey e 11 flowey_lib_common::publish_test_results 14
+        flowey v 11 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 11 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 11 flowey_lib_common::publish_test_results 0
         flowey e 11 flowey_lib_common::publish_test_results 1
         flowey e 11 flowey_lib_common::publish_test_results 2
@@ -970,13 +946,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 11 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
@@ -1720,7 +1696,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1728,7 +1704,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1748,14 +1724,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1774,10 +1750,6 @@ jobs:
       run: |-
         flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 14 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_clippy 1
         flowey e 14 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
@@ -1804,7 +1776,7 @@ jobs:
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -1816,14 +1788,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1843,13 +1815,13 @@ jobs:
         flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 14 flowey_lib_common::publish_test_results 5
         flowey e 14 flowey_lib_common::publish_test_results 6
         flowey e 14 flowey_lib_common::publish_test_results 4
@@ -1859,18 +1831,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 14 flowey_lib_common::publish_test_results 8
         flowey e 14 flowey_lib_common::publish_test_results 9
         flowey e 14 flowey_lib_common::publish_test_results 10
@@ -1880,50 +1852,8 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 14 flowey_lib_common::publish_test_results 12
-        flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey e 14 flowey_lib_common::publish_test_results 14
-        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 14 flowey_lib_common::publish_test_results 16
-        flowey e 14 flowey_lib_common::publish_test_results 17
-        flowey e 14 flowey_lib_common::publish_test_results 18
-        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
         name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -1942,13 +1872,34 @@ jobs:
       run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 14 flowey_lib_common::publish_test_results 12
+        flowey e 14 flowey_lib_common::publish_test_results 13
+        flowey e 14 flowey_lib_common::publish_test_results 14
+        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
         flowey e 14 flowey_lib_common::publish_test_results 2
@@ -1958,13 +1909,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1623,7 +1623,11 @@ jobs:
       shell: bash
   job14:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
-    runs-on: ubuntu-24.04-arm
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=ubuntu2404-arm64
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1974,7 +1978,11 @@ jobs:
       shell: bash
   job15:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
-    runs-on: ubuntu-24.04-arm
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=ubuntu2404-arm64
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -1561,7 +1561,11 @@ jobs:
       shell: bash
   job14:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
-    runs-on: ubuntu-24.04-arm
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=ubuntu2404-arm64
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1914,7 +1918,11 @@ jobs:
       shell: bash
   job15:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
-    runs-on: ubuntu-24.04-arm
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=ubuntu2404-arm64
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -194,10 +194,6 @@ jobs:
       run: |-
         flowey e 0 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
         flowey e 0 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 0 flowey_lib_common::run_cargo_clippy 1
         flowey e 0 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
@@ -224,7 +220,7 @@ jobs:
       run: flowey e 0 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 0 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 0 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 0 flowey_lib_common::cache 3
@@ -721,7 +717,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -729,7 +725,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -749,14 +745,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 4
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -806,14 +802,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -833,13 +829,13 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 11 flowey_lib_common::publish_test_results 5
         flowey e 11 flowey_lib_common::publish_test_results 6
         flowey e 11 flowey_lib_common::publish_test_results 4
@@ -849,18 +845,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 11 flowey_lib_common::publish_test_results 8
         flowey e 11 flowey_lib_common::publish_test_results 9
         flowey e 11 flowey_lib_common::publish_test_results 10
@@ -870,50 +866,8 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 11 flowey_lib_common::publish_test_results 12
-        flowey e 11 flowey_lib_common::publish_test_results 13
-        flowey e 11 flowey_lib_common::publish_test_results 14
-        flowey v 11 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 11 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 11 flowey_lib_common::publish_test_results 16
-        flowey e 11 flowey_lib_common::publish_test_results 17
-        flowey e 11 flowey_lib_common::publish_test_results 18
-        flowey v 11 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 11 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
         name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -932,13 +886,34 @@ jobs:
       run: flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 11 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 11 flowey_lib_common::publish_test_results 12
+        flowey e 11 flowey_lib_common::publish_test_results 13
+        flowey e 11 flowey_lib_common::publish_test_results 14
+        flowey v 11 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 11 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 11 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 11 flowey_lib_common::publish_test_results 0
         flowey e 11 flowey_lib_common::publish_test_results 1
         flowey e 11 flowey_lib_common::publish_test_results 2
@@ -948,13 +923,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 11 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 11 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
@@ -1660,7 +1635,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1668,7 +1643,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1688,14 +1663,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1714,10 +1689,6 @@ jobs:
       run: |-
         flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 14 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_clippy 1
         flowey e 14 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
@@ -1744,7 +1715,7 @@ jobs:
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -1756,14 +1727,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1783,13 +1754,13 @@ jobs:
         flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 14 flowey_lib_common::publish_test_results 5
         flowey e 14 flowey_lib_common::publish_test_results 6
         flowey e 14 flowey_lib_common::publish_test_results 4
@@ -1799,18 +1770,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 14 flowey_lib_common::publish_test_results 8
         flowey e 14 flowey_lib_common::publish_test_results 9
         flowey e 14 flowey_lib_common::publish_test_results 10
@@ -1820,50 +1791,8 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 14 flowey_lib_common::publish_test_results 12
-        flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey e 14 flowey_lib_common::publish_test_results 14
-        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 14 flowey_lib_common::publish_test_results 16
-        flowey e 14 flowey_lib_common::publish_test_results 17
-        flowey e 14 flowey_lib_common::publish_test_results 18
-        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
         name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -1882,13 +1811,34 @@ jobs:
       run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 14 flowey_lib_common::publish_test_results 12
+        flowey e 14 flowey_lib_common::publish_test_results 13
+        flowey e 14 flowey_lib_common::publish_test_results 14
+        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
         flowey e 14 flowey_lib_common::publish_test_results 2
@@ -1898,13 +1848,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -193,10 +193,6 @@ jobs:
       run: |-
         flowey e 0 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
         flowey e 0 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 0 flowey_lib_common::run_cargo_clippy 1
         flowey e 0 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
@@ -223,7 +219,7 @@ jobs:
       run: flowey e 0 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 0 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 0 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 0 flowey_lib_common::cache 3
@@ -1381,7 +1377,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 13 flowey_lib_common::git_checkout 0
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1389,7 +1385,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1409,14 +1405,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 4
-        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1466,14 +1462,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1493,13 +1489,13 @@ jobs:
         flowey e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 13 flowey_lib_common::publish_test_results 5
         flowey e 13 flowey_lib_common::publish_test_results 6
         flowey e 13 flowey_lib_common::publish_test_results 4
@@ -1509,18 +1505,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 13 flowey_lib_common::publish_test_results 8
         flowey e 13 flowey_lib_common::publish_test_results 9
         flowey e 13 flowey_lib_common::publish_test_results 10
@@ -1530,50 +1526,8 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 13 flowey_lib_common::publish_test_results 12
-        flowey e 13 flowey_lib_common::publish_test_results 13
-        flowey e 13 flowey_lib_common::publish_test_results 14
-        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 13 flowey_lib_common::publish_test_results 16
-        flowey e 13 flowey_lib_common::publish_test_results 17
-        flowey e 13 flowey_lib_common::publish_test_results 18
-        flowey v 13 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 13 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
         name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -1592,13 +1546,34 @@ jobs:
       run: flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 13 flowey_lib_common::publish_test_results 12
+        flowey e 13 flowey_lib_common::publish_test_results 13
+        flowey e 13 flowey_lib_common::publish_test_results 14
+        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 13 flowey_lib_common::publish_test_results 0
         flowey e 13 flowey_lib_common::publish_test_results 1
         flowey e 13 flowey_lib_common::publish_test_results 2
@@ -1608,13 +1583,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
@@ -2312,7 +2287,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2320,7 +2295,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2340,14 +2315,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2366,10 +2341,6 @@ jobs:
       run: |-
         flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 16 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_clippy 1
         flowey e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
@@ -2396,7 +2367,7 @@ jobs:
       run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2408,14 +2379,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2435,13 +2406,13 @@ jobs:
         flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 16 flowey_lib_common::publish_test_results 5
         flowey e 16 flowey_lib_common::publish_test_results 6
         flowey e 16 flowey_lib_common::publish_test_results 4
@@ -2451,18 +2422,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 16 flowey_lib_common::publish_test_results 8
         flowey e 16 flowey_lib_common::publish_test_results 9
         flowey e 16 flowey_lib_common::publish_test_results 10
@@ -2472,50 +2443,8 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 16 flowey_lib_common::publish_test_results 16
-        flowey e 16 flowey_lib_common::publish_test_results 17
-        flowey e 16 flowey_lib_common::publish_test_results 18
-        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
         name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -2534,13 +2463,34 @@ jobs:
       run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey e 16 flowey_lib_common::publish_test_results 13
+        flowey e 16 flowey_lib_common::publish_test_results 14
+        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 16 flowey_lib_common::publish_test_results 0
         flowey e 16 flowey_lib_common::publish_test_results 1
         flowey e 16 flowey_lib_common::publish_test_results 2
@@ -2550,13 +2500,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -182,12 +182,8 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 0 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
       $(FLOWEY_BIN) e 0 flowey_lib_hvlite::init_cross_build 0
-    displayName: run xtask fmt
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 1
       $(FLOWEY_BIN) e 0 flowey_lib_hvlite::init_cross_build 1
-    displayName: cargo clippy
+    displayName: run xtask fmt
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_build 0
@@ -207,7 +203,7 @@ jobs:
     displayName: cargo clippy
   - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 3
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 4
+  - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
   - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
@@ -821,14 +817,14 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar9
       $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar10)
+    persistCredentials: $(floweyvar9)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
@@ -844,13 +840,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar9)
-      path: $(floweyvar8)
+      key: $(floweyvar8)
+      path: $(floweyvar7)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
@@ -899,13 +895,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar7)
-      path: $(floweyvar6)
+      key: $(floweyvar6)
+      path: $(floweyvar5)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
@@ -925,58 +921,18 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-    displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 4
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 5
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 5
-      $(FLOWEY_BIN) e 11 flowey_lib_common::ado_task_publish_test_results 6
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 11 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
-      $FLOWEY_BIN v 11 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (openssl)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar4)
-      testRunTitle: x64-linux-unit-tests-unit-tests crypto (openssl)
-    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-    displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 6
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 7
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 4
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 7
-      $(FLOWEY_BIN) e 11 flowey_lib_common::ado_task_publish_test_results 8
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 11 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
-      $FLOWEY_BIN v 11 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (symcrypt)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar5)
-      testRunTitle: x64-linux-unit-tests-unit-tests crypto (symcrypt)
-    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 5
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 9
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 5
       $(FLOWEY_BIN) e 11 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 8
-      $FLOWEY_BIN v 11 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 11 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 4
+      $FLOWEY_BIN v 11 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 11 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (all)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -999,18 +955,18 @@ jobs:
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 3
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 8
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 9
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 6
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 7
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 1
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 7
       $(FLOWEY_BIN) e 11 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 11 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 6
+      $FLOWEY_BIN v 11 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 11 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1026,11 +982,11 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 2
       $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 3
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 2
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 11 flowey_lib_common::ado_task_publish_test_results 4
-      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 11 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 11 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 11 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 11 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (none)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1039,9 +995,29 @@ jobs:
       testRunTitle: x64-linux-unit-tests-unit-tests crypto (none)
     displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+    displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 6
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 4
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 11 flowey_lib_common::ado_task_publish_test_results 6
+      $(FLOWEY_BIN) e 11 flowey_lib_common::publish_test_results 2
+      $FLOWEY_BIN v 11 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 11 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (openssl)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar4)
+      testRunTitle: x64-linux-unit-tests-unit-tests crypto (openssl)
+    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_nextest_unit_tests 5
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1035,10 +1035,7 @@ impl IntoPipeline for CheckinGatesCli {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::Aarch64,
                 gh_pool: if release {
-                    // TODO: go back to 1es once we understand why the image is
-                    // missing package lists
-                    // crate::pipelines_shared::gh_pools::linux_arm_1es()
-                    crate::pipelines_shared::gh_pools::gh_hosted_arm_linux()
+                    crate::pipelines_shared::gh_pools::linux_arm_1es()
                 } else {
                     crate::pipelines_shared::gh_pools::gh_hosted_arm_linux()
                 },
@@ -1055,10 +1052,7 @@ impl IntoPipeline for CheckinGatesCli {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::Aarch64,
                 gh_pool: if release {
-                    // TODO: go back to 1es once we understand why the image is
-                    // missing package lists
-                    // crate::pipelines_shared::gh_pools::linux_arm_1es()
-                    crate::pipelines_shared::gh_pools::gh_hosted_arm_linux()
+                    crate::pipelines_shared::gh_pools::linux_arm_1es()
                 } else {
                     crate::pipelines_shared::gh_pools::gh_hosted_arm_linux()
                 },

--- a/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
@@ -92,7 +92,7 @@ impl SimpleFlowNode for Node {
                 flowey_lib_common::install_dist_pkg::Request::Install {
                     package_names: vec![
                         "libssl-dev".into(),
-                        "symcrypt".into(),
+                        "pkg-config".into(),
                         "build-essential".into(),
                     ],
                     done: v,
@@ -235,19 +235,22 @@ impl SimpleFlowNode for Node {
                 pre_build_deps: pre_build_deps.clone(),
                 done: v,
             }));
-            reqs.push(ctx.reqv(|v| flowey_lib_common::run_cargo_clippy::Request {
-                in_folder: openvmm_repo_path.clone(),
-                package: CargoPackage::Crate("crypto".into()),
-                profile: profile.clone(),
-                features: CargoFeatureSet::Specific(vec!["symcrypt".into()]),
-                target: target.clone(),
-                extra_env: None,
-                exclude: ReadVar::from_static(None),
-                keep_going: true,
-                all_targets: true,
-                pre_build_deps: pre_build_deps.clone(),
-                done: v,
-            }));
+            // Only test the symcrypt backend on musl targets with our prebuilt lib
+            if matches!(target.environment, target_lexicon::Environment::Musl) {
+                reqs.push(ctx.reqv(|v| flowey_lib_common::run_cargo_clippy::Request {
+                    in_folder: openvmm_repo_path.clone(),
+                    package: CargoPackage::Crate("crypto".into()),
+                    profile: profile.clone(),
+                    features: CargoFeatureSet::Specific(vec!["symcrypt".into()]),
+                    target: target.clone(),
+                    extra_env: None,
+                    exclude: ReadVar::from_static(None),
+                    keep_going: true,
+                    all_targets: true,
+                    pre_build_deps: pre_build_deps.clone(),
+                    done: v,
+                }));
+            }
             reqs.push(ctx.reqv(|v| flowey_lib_common::run_cargo_clippy::Request {
                 in_folder: openvmm_repo_path.clone(),
                 package: CargoPackage::Crate("crypto".into()),

--- a/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
@@ -215,10 +215,13 @@ impl FlowNode for Node {
             ) {
                 crypto_feature_sets
                     .push(("openssl", CargoFeatureSet::Specific(vec!["openssl".into()])));
-                crypto_feature_sets.push((
-                    "symcrypt",
-                    CargoFeatureSet::Specific(vec!["symcrypt".into()]),
-                ));
+                // Only test the symcrypt backend on musl targets with our prebuilt lib
+                if matches!(target.environment, target_lexicon::Environment::Musl) {
+                    crypto_feature_sets.push((
+                        "symcrypt",
+                        CargoFeatureSet::Specific(vec!["symcrypt".into()]),
+                    ));
+                }
                 crypto_feature_sets.push(("all", CargoFeatureSet::All));
             }
             for (name, features) in crypto_feature_sets {


### PR DESCRIPTION
Rather than requiring a glibc-compatible symcrypt for gnu-targeted runs, only test the symcrypt backend on musl runs. This will use the prebuilt symcrypt from openvmm-deps, sidestepping the repository availability issue. Then ensure pkg-config is installed to fix compatibility with our 1ES arm runners, and restore them.