### PR TITLE
uh_mem: Convert two warnings to tracelimit

### DIFF
--- a/openhcl/underhill_mem/src/mapping.rs
+++ b/openhcl/underhill_mem/src/mapping.rs
@@ -206,7 +206,7 @@ unsafe impl GuestMemoryAccess for GuestMemoryView {
             if !valid_memory.check_valid(gpn) {
                 match valid_memory.memory_type() {
                     GuestValidMemoryType::Shared => {
-                        tracing::warn!(
+                        tracelimit::warn_ratelimited!(
                             ?address,
                             ?len,
                             ?write,
@@ -218,7 +218,7 @@ unsafe impl GuestMemoryAccess for GuestMemoryView {
                         ))
                     }
                     GuestValidMemoryType::Encrypted => {
-                        tracing::warn!(
+                        tracelimit::warn_ratelimited!(
                             ?address,
                             ?len,
                             ?write,


### PR DESCRIPTION
We are seeing an extraordinarily high volume of these events, and they are technically guest triggerable. Convert them to be ratelimited. Investigation on why we're seeing so many is pending.