### PR TITLE
openvmm: Add hugetlb memory backing

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -616,7 +616,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -969,7 +969,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1057,7 +1057,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1065,7 +1065,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1089,14 +1089,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 4
-        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1124,17 +1124,14 @@ jobs:
         flowey e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
       run: flowey e 12 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 12 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_clippy 5
+        flowey e 12 flowey_lib_common::run_cargo_clippy 4
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -1170,14 +1167,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1239,12 +1236,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 12 flowey_lib_common::publish_test_results 12
         flowey e 12 flowey_lib_common::publish_test_results 13
@@ -1255,29 +1252,8 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 12 flowey_lib_common::publish_test_results 16
-        flowey e 12 flowey_lib_common::publish_test_results 17
-        flowey e 12 flowey_lib_common::publish_test_results 18
-        flowey v 12 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 12 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -1296,12 +1272,12 @@ jobs:
       run: flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 12 flowey_lib_common::publish_test_results 0
         flowey e 12 flowey_lib_common::publish_test_results 1
@@ -1318,7 +1294,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
@@ -2020,7 +1996,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2028,7 +2004,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2052,14 +2028,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2087,17 +2063,14 @@ jobs:
         flowey e 15 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
       run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_clippy 5
+        flowey e 15 flowey_lib_common::run_cargo_clippy 4
         flowey e 15 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2133,14 +2106,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2202,12 +2175,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 15 flowey_lib_common::publish_test_results 12
         flowey e 15 flowey_lib_common::publish_test_results 13
@@ -2218,29 +2191,8 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 15 flowey_lib_common::publish_test_results 16
-        flowey e 15 flowey_lib_common::publish_test_results 17
-        flowey e 15 flowey_lib_common::publish_test_results 18
-        flowey v 15 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -2259,12 +2211,12 @@ jobs:
       run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
@@ -2281,7 +2233,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
@@ -3581,7 +3533,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3722,7 +3674,10 @@ jobs:
       run: flowey e 20 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: ensure 2 MiB hugetlb pages are available
+      run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -3773,9 +3728,10 @@ jobs:
         flowey e 20 flowey_lib_common::git_checkout 3
         flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
         flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey e 20 flowey_core::pipeline::artifact::resolve 5
-        flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
     - name: generate nextest command
       run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
@@ -4552,7 +4508,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6140,7 +6096,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6481,7 +6437,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6878,7 +6834,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7227,7 +7183,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -616,7 +616,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -969,7 +969,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1057,7 +1057,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1065,7 +1065,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1089,14 +1089,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 4
-        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1124,14 +1124,17 @@ jobs:
         flowey e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
+      run: flowey e 12 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
       run: flowey e 12 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 5
+      run: flowey e 12 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_clippy 4
+        flowey e 12 flowey_lib_common::run_cargo_clippy 5
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -1167,14 +1170,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1236,12 +1239,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 12 flowey_lib_common::publish_test_results 12
         flowey e 12 flowey_lib_common::publish_test_results 13
@@ -1252,8 +1255,29 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 12 flowey_lib_common::publish_test_results 16
+        flowey e 12 flowey_lib_common::publish_test_results 17
+        flowey e 12 flowey_lib_common::publish_test_results 18
+        flowey v 12 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 12 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -1272,12 +1296,12 @@ jobs:
       run: flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 12 flowey_lib_common::publish_test_results 0
         flowey e 12 flowey_lib_common::publish_test_results 1
@@ -1294,7 +1318,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
@@ -1996,7 +2020,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2004,7 +2028,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2028,14 +2052,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2063,14 +2087,17 @@ jobs:
         flowey e 15 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
       run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 5
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_clippy 4
+        flowey e 15 flowey_lib_common::run_cargo_clippy 5
         flowey e 15 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2106,14 +2133,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2175,12 +2202,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 15 flowey_lib_common::publish_test_results 12
         flowey e 15 flowey_lib_common::publish_test_results 13
@@ -2191,8 +2218,29 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 15 flowey_lib_common::publish_test_results 16
+        flowey e 15 flowey_lib_common::publish_test_results 17
+        flowey e 15 flowey_lib_common::publish_test_results 18
+        flowey v 15 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -2211,12 +2259,12 @@ jobs:
       run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
@@ -2233,7 +2281,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
@@ -3533,7 +3581,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4508,7 +4556,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6096,7 +6144,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6437,7 +6485,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6834,7 +6882,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7183,7 +7231,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -665,7 +665,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -946,7 +946,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -992,7 +992,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1000,7 +1000,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1024,14 +1024,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 4
-        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1059,14 +1059,17 @@ jobs:
         flowey e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
+      run: flowey e 12 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
       run: flowey e 12 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 5
+      run: flowey e 12 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_clippy 4
+        flowey e 12 flowey_lib_common::run_cargo_clippy 5
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -1102,14 +1105,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1171,12 +1174,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 12 flowey_lib_common::publish_test_results 12
         flowey e 12 flowey_lib_common::publish_test_results 13
@@ -1187,8 +1190,29 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 12 flowey_lib_common::publish_test_results 16
+        flowey e 12 flowey_lib_common::publish_test_results 17
+        flowey e 12 flowey_lib_common::publish_test_results 18
+        flowey v 12 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 12 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -1207,12 +1231,12 @@ jobs:
       run: flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 12 flowey_lib_common::publish_test_results 0
         flowey e 12 flowey_lib_common::publish_test_results 1
@@ -1229,7 +1253,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
@@ -1937,7 +1961,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1945,7 +1969,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1969,14 +1993,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2004,14 +2028,17 @@ jobs:
         flowey e 15 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
       run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 5
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_clippy 4
+        flowey e 15 flowey_lib_common::run_cargo_clippy 5
         flowey e 15 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2047,14 +2074,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2116,12 +2143,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 15 flowey_lib_common::publish_test_results 12
         flowey e 15 flowey_lib_common::publish_test_results 13
@@ -2132,8 +2159,29 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 15 flowey_lib_common::publish_test_results 16
+        flowey e 15 flowey_lib_common::publish_test_results 17
+        flowey e 15 flowey_lib_common::publish_test_results 18
+        flowey v 15 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -2152,12 +2200,12 @@ jobs:
       run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
@@ -2174,7 +2222,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
@@ -3480,7 +3528,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4416,7 +4464,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -5830,7 +5878,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6129,7 +6177,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6484,7 +6532,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6767,7 +6815,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -665,7 +665,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -946,7 +946,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -992,7 +992,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1000,7 +1000,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1024,14 +1024,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 4
-        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1059,17 +1059,14 @@ jobs:
         flowey e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
       run: flowey e 12 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 12 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 12 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_clippy 5
+        flowey e 12 flowey_lib_common::run_cargo_clippy 4
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -1105,14 +1102,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1174,12 +1171,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 12 flowey_lib_common::publish_test_results 12
         flowey e 12 flowey_lib_common::publish_test_results 13
@@ -1190,29 +1187,8 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 12 flowey_lib_common::publish_test_results 16
-        flowey e 12 flowey_lib_common::publish_test_results 17
-        flowey e 12 flowey_lib_common::publish_test_results 18
-        flowey v 12 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 12 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -1231,12 +1207,12 @@ jobs:
       run: flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 12 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 12 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 12 flowey_lib_common::publish_test_results 0
         flowey e 12 flowey_lib_common::publish_test_results 1
@@ -1253,7 +1229,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
@@ -1961,7 +1937,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1969,7 +1945,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1993,14 +1969,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2028,17 +2004,14 @@ jobs:
         flowey e 15 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
       run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_clippy 5
+        flowey e 15 flowey_lib_common::run_cargo_clippy 4
         flowey e 15 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2074,14 +2047,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2143,12 +2116,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 15 flowey_lib_common::publish_test_results 12
         flowey e 15 flowey_lib_common::publish_test_results 13
@@ -2159,29 +2132,8 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 15 flowey_lib_common::publish_test_results 16
-        flowey e 15 flowey_lib_common::publish_test_results 17
-        flowey e 15 flowey_lib_common::publish_test_results 18
-        flowey v 15 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -2200,12 +2152,12 @@ jobs:
       run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
@@ -2222,7 +2174,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
@@ -3528,7 +3480,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3670,7 +3622,10 @@ jobs:
       run: flowey e 20 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: ensure 2 MiB hugetlb pages are available
+      run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -3721,9 +3676,10 @@ jobs:
         flowey e 20 flowey_lib_common::git_checkout 3
         flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
         flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey e 20 flowey_core::pipeline::artifact::resolve 5
-        flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
     - name: generate nextest command
       run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
@@ -4460,7 +4416,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -5874,7 +5830,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6173,7 +6129,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6528,7 +6484,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6811,7 +6767,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -395,7 +395,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1057,11 +1057,7 @@ jobs:
       shell: bash
   job12:
     name: clippy [x64-windows], unit tests [x64-windows]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    runs-on: windows-latest
     permissions:
       contents: read
       id-token: write
@@ -1329,7 +1325,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1610,7 +1606,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1656,7 +1652,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1664,7 +1660,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1688,14 +1684,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1723,17 +1719,14 @@ jobs:
         flowey e 14 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_clippy 5
+        flowey e 14 flowey_lib_common::run_cargo_clippy 4
         flowey e 14 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -1769,14 +1762,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1838,12 +1831,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 14 flowey_lib_common::publish_test_results 12
         flowey e 14 flowey_lib_common::publish_test_results 13
@@ -1854,29 +1847,8 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 14 flowey_lib_common::publish_test_results 16
-        flowey e 14 flowey_lib_common::publish_test_results 17
-        flowey e 14 flowey_lib_common::publish_test_results 18
-        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -1895,12 +1867,12 @@ jobs:
       run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
@@ -1917,7 +1889,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
@@ -1931,11 +1903,7 @@ jobs:
       shell: bash
   job15:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=win-arm64
-    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    runs-on: windows-11-arm
     permissions:
       contents: read
       id-token: write
@@ -2200,11 +2168,7 @@ jobs:
       shell: bash
   job16:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       id-token: write
@@ -2532,11 +2496,7 @@ jobs:
       shell: bash
   job17:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       id-token: write
@@ -2625,7 +2585,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2633,7 +2593,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2657,14 +2617,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2692,17 +2652,14 @@ jobs:
         flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_clippy 5
+        flowey e 17 flowey_lib_common::run_cargo_clippy 4
         flowey e 17 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2738,14 +2695,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2807,12 +2764,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 17 flowey_lib_common::publish_test_results 12
         flowey e 17 flowey_lib_common::publish_test_results 13
@@ -2823,29 +2780,8 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 17 flowey_lib_common::publish_test_results 16
-        flowey e 17 flowey_lib_common::publish_test_results 17
-        flowey e 17 flowey_lib_common::publish_test_results 18
-        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -2864,12 +2800,12 @@ jobs:
       run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
@@ -2886,7 +2822,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
@@ -4192,7 +4128,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4334,7 +4270,10 @@ jobs:
       run: flowey e 22 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: ensure 2 MiB hugetlb pages are available
+      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -4385,9 +4324,10 @@ jobs:
         flowey e 22 flowey_lib_common::git_checkout 3
         flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
         flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey e 22 flowey_core::pipeline::artifact::resolve 5
-        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
     - name: generate nextest command
       run: flowey e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
@@ -5124,7 +5064,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6603,7 +6543,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6902,7 +6842,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7257,7 +7197,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
+    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -395,7 +395,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1057,7 +1057,11 @@ jobs:
       shell: bash
   job12:
     name: clippy [x64-windows], unit tests [x64-windows]
-    runs-on: windows-latest
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1325,7 +1329,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1606,7 +1610,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1652,7 +1656,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1660,7 +1664,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1684,14 +1688,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1719,14 +1723,17 @@ jobs:
         flowey e 14 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 5
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_clippy 4
+        flowey e 14 flowey_lib_common::run_cargo_clippy 5
         flowey e 14 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -1762,14 +1769,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1831,12 +1838,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 14 flowey_lib_common::publish_test_results 12
         flowey e 14 flowey_lib_common::publish_test_results 13
@@ -1847,8 +1854,29 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 14 flowey_lib_common::publish_test_results 16
+        flowey e 14 flowey_lib_common::publish_test_results 17
+        flowey e 14 flowey_lib_common::publish_test_results 18
+        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -1867,12 +1895,12 @@ jobs:
       run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
@@ -1889,7 +1917,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
@@ -1903,7 +1931,11 @@ jobs:
       shell: bash
   job15:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
-    runs-on: windows-11-arm
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=win-arm64
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2168,7 +2200,11 @@ jobs:
       shell: bash
   job16:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
-    runs-on: ubuntu-24.04-arm
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=ubuntu2404-arm64
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2496,7 +2532,11 @@ jobs:
       shell: bash
   job17:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
-    runs-on: ubuntu-24.04-arm
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=ubuntu2404-arm64
+    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2585,7 +2625,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2593,7 +2633,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2617,14 +2657,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2652,14 +2692,17 @@ jobs:
         flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 5
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_clippy 4
+        flowey e 17 flowey_lib_common::run_cargo_clippy 5
         flowey e 17 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2695,14 +2738,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2764,12 +2807,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 17 flowey_lib_common::publish_test_results 12
         flowey e 17 flowey_lib_common::publish_test_results 13
@@ -2780,8 +2823,29 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 17 flowey_lib_common::publish_test_results 16
+        flowey e 17 flowey_lib_common::publish_test_results 17
+        flowey e 17 flowey_lib_common::publish_test_results 18
+        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -2800,12 +2864,12 @@ jobs:
       run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
@@ -2822,7 +2886,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
@@ -4128,7 +4192,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -5064,7 +5128,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6543,7 +6607,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6842,7 +6906,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7197,7 +7261,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/Guide/src/dev_guide/snapshot_format.md
+++ b/Guide/src/dev_guide/snapshot_format.md
@@ -42,10 +42,10 @@ file inside the snapshot directory.
 
 ### Same-file detection
 
-If the user passes `--memory-backing-file <snapshot_dir>/memory.bin`, the
-source and target of the hard link are the same file. The code detects this
-by canonicalizing both paths and comparing them. When they match, the
-hard-link step is skipped.
+If the user passes `--memory file=<snapshot_dir>/memory.bin`, the source and
+target of the hard link are the same file. The code detects this by
+canonicalizing both paths and comparing them. When they match, the hard-link
+step is skipped.
 
 ## Code references
 

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -8,7 +8,39 @@ as well as the generated CLI help (via `cargo run -- --help`).
 ```
 
 * `--processors <COUNT>`: The number of processors. Defaults to 1.
-* `--memory <SIZE>`: The VM's memory size. Defaults to 1GB.
+* `--memory <SPEC>`: Configure guest RAM. Defaults to `size=1G`.
+  `SPEC` can be a size-only shorthand, such as `--memory 4G`, or a
+  comma-separated key/value list:
+
+  ```bash
+  --memory size=4G,shared=on,prefetch=off
+  ```
+
+  Supported keys:
+  * `size=<SIZE>` - guest RAM size. Sizes accept `K`, `M`, `G`, and
+    `T` suffixes, optionally followed by `B`.
+  * `shared=on|off` - use shared file-backed guest RAM. The default is
+    `on`; `off` uses private anonymous memory.
+  * `prefetch=on|off` - pre-populate shared guest RAM mappings.
+  * `thp=on|off` - mark private guest RAM as Transparent Huge Page
+    eligible. Requires `shared=off`.
+  * `hugepages=on|off` - allocate guest RAM from Linux hugetlb pages.
+    This is Linux-only, requires shared memory, and cannot be combined
+    with file-backed memory or PCAT/legacy x86 RAM splitting.
+  * `hugepage_size=<SIZE>` - request a specific hugetlb page size, such
+    as `2MB` or `1GB`. Requires `hugepages=on`; if omitted,
+    OpenVMM uses 2 MB pages.
+  * `file=<PATH>` - use an existing file as the guest RAM backing file.
+    This is used by snapshots.
+
+  Examples:
+
+  ```bash
+  --memory 4G
+  --memory size=64GB,hugepages=on,hugepage_size=2MB
+  --memory size=4G,file=path/to/memory.bin
+  --memory size=4G,shared=off,thp=on
+  ```
 * `--hv`: Exposes Hyper-V enlightenments and VMBus support.
 * `--hypervisor <SPEC>`: Select a specific hypervisor backend, optionally with
   backend-specific parameters. The format is `name` or `name:key=val,key,...`.
@@ -40,10 +72,10 @@ as well as the generated CLI help (via `cargo run -- --help`).
   On Linux, raw files and block devices use the `disk_blockdevice` backend
   (io_uring-based async I/O) by default. Append `;direct` to the path to
   bypass the OS page cache, e.g. `--disk file:/dev/sdb;direct`.
-* `--private-memory`: Use private anonymous memory for guest RAM
-  instead of shared file-backed sections.
-* `--thp`: Enable Transparent Huge Pages for guest RAM (Linux only).
-  Requires `--private-memory`.
+* `--private-memory`, `--prefetch`, `--thp`, and
+  `--memory-backing-file <PATH>`: Deprecated aliases for `--memory`
+  parameters. Prefer `shared=off`, `prefetch=on`, `thp=on`, and
+  `file=<PATH>`.
 * `--pidfile <PATH>`: Write the process ID to the specified file on startup,
   and remove it on clean exit. If the process is killed with `SIGKILL` or
   crashes, the pidfile is not removed — consumers should verify the PID is

--- a/Guide/src/user_guide/openvmm/snapshots.md
+++ b/Guide/src/user_guide/openvmm/snapshots.md
@@ -22,9 +22,9 @@ These are stored as three files in a snapshot directory:
 
 ## Prerequisites
 
-Snapshots require **file-backed guest memory**. You must pass
-`--memory-backing-file` when launching the VM so that guest RAM is written
-to a file on disk rather than held in anonymous memory.
+Snapshots require **file-backed guest memory**. Pass `file=<PATH>` in the
+`--memory` option when launching the VM so that guest RAM is written to a
+file on disk rather than held in anonymous memory.
 
 ```admonish warning
 The memory backing file and the snapshot directory must be on the **same
@@ -41,8 +41,7 @@ Start a VM with file-backed memory:
 cargo run -- \
   --uefi \
   --disk memdiff:file:path/to/disk.vhdx \
-  --memory-backing-file path/to/memory.bin \
-  --memory 4096
+  --memory size=4096M,file=path/to/memory.bin
 ```
 
 Once the VM is running, open the interactive console and issue a save command,
@@ -69,13 +68,13 @@ To restore, pass the snapshot directory with `--restore-snapshot`:
 cargo run -- \
   --uefi \
   --disk memdiff:file:path/to/disk.vhdx \
-  --memory 4096 \
+  --memory size=4096M \
   --processors 4 \
   --restore-snapshot path/to/snapshot-dir
 ```
 
 `--restore-snapshot` automatically opens `memory.bin` from the snapshot
-directory, so `--memory-backing-file` should not be specified (the two
+directory, so `file=...` should not be specified in `--memory` (the two
 options are mutually exclusive).
 
 ```admonish note

--- a/Guide/src/user_guide/openvmm/vfio.md
+++ b/Guide/src/user_guide/openvmm/vfio.md
@@ -131,6 +131,51 @@ lspci
 
 The device will appear with its real vendor and device ID from the physical hardware.
 
+## Optional: use hugetlb-backed guest RAM
+
+For large VMs, VFIO DMA setup can be much faster when guest RAM is backed by
+Linux hugetlb pages. Without hugetlb backing, the kernel may have to pin each
+4 KB page individually during `VFIO_IOMMU_MAP_DMA`. With 2 MB or 1 GB hugetlb
+pages, the same mapping work is performed over far fewer pages.
+
+Hugetlb pages must be reserved on the host before starting OpenVMM. For
+example, reserve enough 2 MB pages for a 64 GB VM:
+
+```bash
+echo 32768 | sudo tee /proc/sys/vm/nr_hugepages
+```
+
+For 1 GB pages, reserve pages through the size-specific sysfs pool:
+
+```bash
+echo 64 | sudo tee \
+  /sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages
+```
+
+Then request hugepage-backed RAM with the `--memory` option:
+
+```bash
+sudo openvmm \
+  --pcie-root-complex rc0 \
+  --pcie-root-port rc0:rp0 \
+  --vfio rp0:0000:01:00.0 \
+  --kernel /path/to/vmlinux \
+  --initrd /path/to/initrd \
+  --cmdline "console=ttyS0" \
+  --com1 console \
+  --memory size=64GB,hugepages=on,hugepage_size=2MB \
+  --processors 16
+```
+
+Use `hugepage_size=1GB` to request 1 GB pages. If `hugepage_size` is omitted,
+OpenVMM uses 2 MB pages.
+
+```admonish note
+Hugepage-backed RAM is Linux-only. It cannot be combined with file-backed
+memory, private memory (`shared=off`), or legacy x86 RAM splitting such as
+PCAT firmware.
+```
+
 ## Troubleshooting
 
 ### "No such file or directory" for `/dev/vfio/*`
@@ -151,6 +196,21 @@ Run OpenVMM with `sudo`, or add your user to the `vfio` group and set appropriat
 - Verify the VFIO group exists in `/dev/vfio/` (Step 4)
 - Verify the `--vfio` port name matches a `--pcie-root-port` name
 - Check OpenVMM log output for errors during VFIO device initialization
+
+### Hugepage allocation fails
+
+If OpenVMM fails while allocating guest RAM with `hugepages=on`, verify that
+the host has enough free pages in the requested hugetlb pool:
+
+```bash
+grep -i Huge /proc/meminfo
+```
+
+For 1 GB pages, also check the size-specific pool:
+
+```bash
+grep . /sys/kernel/mm/hugepages/hugepages-1048576kB/*
+```
 
 ## Current Limitations
 

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -25,8 +25,8 @@ jobs:
   displayName: quick check [fmt, clippy x64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
   variables:
@@ -216,8 +216,8 @@ jobs:
   displayName: build openhcl (mi-secure) [x64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -475,8 +475,8 @@ jobs:
   displayName: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -518,14 +518,14 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar9
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
       $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar9)
+    persistCredentials: $(floweyvar10)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
@@ -544,13 +544,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar8)
-      path: $(floweyvar7)
+      key: $(floweyvar9)
+      path: $(floweyvar8)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
@@ -575,13 +575,15 @@ jobs:
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 2
     displayName: symlink protoc
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 4
+    displayName: cargo clippy
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 5
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 6
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 4
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 5
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 0
     displayName: cargo clippy
   - bash: |-
@@ -613,13 +615,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar6)
-      path: $(floweyvar5)
+      key: $(floweyvar7)
+      path: $(floweyvar6)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
@@ -659,18 +661,38 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (openssl)
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+    displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 6
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 7
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 7
+      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 8
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 6
+      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
+      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (symcrypt)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar5)
+      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)
+    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 7
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 9
       $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 8
+      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (all)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -693,12 +715,12 @@ jobs:
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 4
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 6
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 7
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 8
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 9
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
       $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 0
@@ -735,7 +757,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 6
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -748,8 +770,8 @@ jobs:
   displayName: clippy [macos], unit tests [x64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1009,7 +1031,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1260,8 +1282,8 @@ jobs:
   displayName: build openhcl [x64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1693,8 +1715,8 @@ jobs:
   displayName: build openhcl [aarch64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1951,8 +1973,8 @@ jobs:
   displayName: build artifacts [x64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -2264,8 +2286,8 @@ jobs:
   displayName: build artifacts [aarch64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -2526,7 +2548,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -2817,8 +2839,8 @@ jobs:
   displayName: run vmm-tests [x64-linux-amd-kvm]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64-256gb
-    name: openvmm-ado-intel-centralus
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   - job5
@@ -3319,7 +3341,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   - job5
@@ -3859,7 +3881,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -4060,7 +4082,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -4347,7 +4369,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -4544,7 +4566,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -25,8 +25,8 @@ jobs:
   displayName: quick check [fmt, clippy x64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    - ImageOverride -equals ubuntu2404-amd64-256gb
+    name: openvmm-ado-intel-centralus
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
   variables:
@@ -216,8 +216,8 @@ jobs:
   displayName: build openhcl (mi-secure) [x64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    - ImageOverride -equals ubuntu2404-amd64-256gb
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -475,8 +475,8 @@ jobs:
   displayName: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    - ImageOverride -equals ubuntu2404-amd64-256gb
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -518,14 +518,14 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar9
       $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar10)
+    persistCredentials: $(floweyvar9)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
@@ -544,13 +544,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar9)
-      path: $(floweyvar8)
+      key: $(floweyvar8)
+      path: $(floweyvar7)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
@@ -575,15 +575,13 @@ jobs:
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 2
     displayName: symlink protoc
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 4
-    displayName: cargo clippy
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 6
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 5
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 5
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 4
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 0
     displayName: cargo clippy
   - bash: |-
@@ -615,13 +613,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar7)
-      path: $(floweyvar6)
+      key: $(floweyvar6)
+      path: $(floweyvar5)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
@@ -661,38 +659,18 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (openssl)
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-    displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 6
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 7
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 7
-      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 8
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
-      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (symcrypt)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar5)
-      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)
-    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 9
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 7
       $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 8
-      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 6
+      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (all)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -715,12 +693,12 @@ jobs:
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 3
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 8
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 9
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 6
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 7
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
       $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 0
@@ -757,7 +735,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 6
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 5
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -770,8 +748,8 @@ jobs:
   displayName: clippy [macos], unit tests [x64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    - ImageOverride -equals ubuntu2404-amd64-256gb
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1031,7 +1009,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1282,8 +1260,8 @@ jobs:
   displayName: build openhcl [x64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    - ImageOverride -equals ubuntu2404-amd64-256gb
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1715,8 +1693,8 @@ jobs:
   displayName: build openhcl [aarch64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    - ImageOverride -equals ubuntu2404-amd64-256gb
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1973,8 +1951,8 @@ jobs:
   displayName: build artifacts [x64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    - ImageOverride -equals ubuntu2404-amd64-256gb
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -2286,8 +2264,8 @@ jobs:
   displayName: build artifacts [aarch64-linux]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    - ImageOverride -equals ubuntu2404-amd64-256gb
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -2548,7 +2526,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -2839,8 +2817,8 @@ jobs:
   displayName: run vmm-tests [x64-linux-amd-kvm]
   pool:
     demands:
-    - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    - ImageOverride -equals ubuntu2404-amd64-256gb
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   - job5
@@ -2923,8 +2901,10 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 15 'artifact_use_from_x64-tmks' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-pipette' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
     displayName: ensure hypervisor device is accessible
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+    displayName: ensure 2 MiB hugetlb pages are available
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 0
@@ -3025,9 +3005,10 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_vmm_tests_env 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 1
       $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
     displayName: setting up vmm_tests env
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
@@ -3338,7 +3319,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   - job5
@@ -3878,7 +3859,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -4079,7 +4060,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -4366,7 +4347,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -4563,7 +4544,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -26,6 +26,10 @@ use std::path::PathBuf;
 use target_lexicon::Triple;
 use vmm_test_images::KnownTestArtifacts;
 
+// This is a cap for surplus 2 MiB hugetlb pages, not a reservation. Keep it
+// generous enough for VMM tests without tying CI provisioning to one test's RAM.
+const HUGETLB_2MB_OVERCOMMIT_PAGES: u64 = 4096;
+
 #[derive(Copy, Clone, clap::ValueEnum)]
 enum PipelineConfig {
     /// Run on all PRs targeting the OpenVMM GitHub repo.
@@ -1206,6 +1210,7 @@ impl IntoPipeline for CheckinGatesCli {
             nextest_filter_expr: String,
             test_artifacts: Vec<KnownTestArtifacts>,
             needs_prep_run: bool,
+            hugetlb_2mb_overcommit_pages: Option<u64>,
         }
 
         let standard_filter = {
@@ -1303,6 +1308,7 @@ impl IntoPipeline for CheckinGatesCli {
             nextest_filter_expr,
             test_artifacts,
             needs_prep_run,
+            hugetlb_2mb_overcommit_pages,
         } in [
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
@@ -1315,6 +1321,7 @@ impl IntoPipeline for CheckinGatesCli {
                 nextest_filter_expr: standard_filter.clone(),
                 test_artifacts: standard_x64_test_artifacts.clone(),
                 needs_prep_run: false,
+                hugetlb_2mb_overcommit_pages: None,
             },
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
@@ -1327,6 +1334,7 @@ impl IntoPipeline for CheckinGatesCli {
                 nextest_filter_expr: cvm_filter("tdx"),
                 test_artifacts: cvm_x64_test_artifacts.clone(),
                 needs_prep_run: true,
+                hugetlb_2mb_overcommit_pages: None,
             },
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
@@ -1339,6 +1347,7 @@ impl IntoPipeline for CheckinGatesCli {
                 nextest_filter_expr: standard_filter.clone(),
                 test_artifacts: standard_x64_test_artifacts.clone(),
                 needs_prep_run: false,
+                hugetlb_2mb_overcommit_pages: None,
             },
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
@@ -1351,6 +1360,7 @@ impl IntoPipeline for CheckinGatesCli {
                 nextest_filter_expr: cvm_filter("snp"),
                 test_artifacts: cvm_x64_test_artifacts,
                 needs_prep_run: true,
+                hugetlb_2mb_overcommit_pages: None,
             },
             VmmTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
@@ -1364,6 +1374,7 @@ impl IntoPipeline for CheckinGatesCli {
                 nextest_filter_expr: format!("{standard_filter} & !test(pcat_x64)"),
                 test_artifacts: standard_x64_test_artifacts.clone(),
                 needs_prep_run: false,
+                hugetlb_2mb_overcommit_pages: Some(HUGETLB_2MB_OVERCOMMIT_PAGES),
             },
             VmmTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::AzureLinux),
@@ -1377,6 +1388,7 @@ impl IntoPipeline for CheckinGatesCli {
                 nextest_filter_expr: format!("{standard_filter} & !test(pcat_x64)"),
                 test_artifacts: standard_x64_test_artifacts.clone(),
                 needs_prep_run: false,
+                hugetlb_2mb_overcommit_pages: None,
             },
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
@@ -1395,6 +1407,7 @@ impl IntoPipeline for CheckinGatesCli {
                     KnownTestArtifacts::VmgsWith16kTpm,
                 ],
                 needs_prep_run: false,
+                hugetlb_2mb_overcommit_pages: None,
             },
         ] {
             // Skip unsupported jobs on ADO backend
@@ -1438,6 +1451,7 @@ impl IntoPipeline for CheckinGatesCli {
                     fail_job_on_test_fail: true,
                     artifact_dir: pub_vmm_tests_results.map(|x| ctx.publish_artifact(x)),
                     needs_prep_run,
+                    hugetlb_2mb_overcommit_pages,
                     done: ctx.new_done_handle(),
                 }
             });
@@ -1579,6 +1593,7 @@ impl IntoPipeline for CheckinGatesCli {
                         fail_job_on_test_fail: true,
                         artifact_dir: pub_mi_secure_test_results.map(|x| ctx.publish_artifact(x)),
                         needs_prep_run: false,
+                        hugetlb_2mb_overcommit_pages: None,
                         done: ctx.new_done_handle(),
                     }
                 });

--- a/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
@@ -56,6 +56,8 @@ flowey_request! {
         pub test_artifacts: Vec<KnownTestArtifacts>,
         /// Whether the prep steps should be run before the tests
         pub needs_prep_run: bool,
+        /// If set, configure this 2 MiB hugetlb surplus page overcommit limit before running tests.
+        pub hugetlb_2mb_overcommit_pages: Option<u64>,
 
         /// Whether the job should fail if any test has failed
         pub fail_job_on_test_fail: bool,
@@ -96,6 +98,7 @@ impl SimpleFlowNode for Node {
             test_artifacts,
             fail_job_on_test_fail,
             needs_prep_run,
+            hugetlb_2mb_overcommit_pages,
             artifact_dir,
             done,
         } = request;
@@ -223,6 +226,7 @@ impl SimpleFlowNode for Node {
             target: None,
             extra_env,
             pre_run_deps,
+            hugetlb_2mb_overcommit_pages,
             results: v,
         });
 

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -863,6 +863,7 @@ impl SimpleFlowNode for Node {
                 target: Some(ReadVar::from_static(target_triple.clone())),
                 extra_env,
                 pre_run_deps: side_effects,
+                hugetlb_2mb_overcommit_pages: None,
                 results: v,
             });
 

--- a/flowey/flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs
@@ -98,14 +98,6 @@ impl SimpleFlowNode for Node {
                         move |rt| {
                             let hugepages_dir =
                                 Path::new("/sys/kernel/mm/hugepages/hugepages-2048kB");
-                            let overcommit_path = hugepages_dir.join("nr_overcommit_hugepages");
-
-                            if !overcommit_path.exists() {
-                                anyhow::bail!(
-                                    "missing {}; host does not expose 2 MiB hugetlb overcommit configuration",
-                                    overcommit_path.display()
-                                );
-                            }
 
                             let read_counter = |name: &str| -> anyhow::Result<u64> {
                                 let path = hugepages_dir.join(name);
@@ -113,20 +105,15 @@ impl SimpleFlowNode for Node {
                                 Ok(value.trim().parse()?)
                             };
 
-                            let current_overcommit = read_counter("nr_overcommit_hugepages")?;
-                            if current_overcommit < overcommit_pages {
-                                flowey::shell_cmd!(
-                                    rt,
-                                    "sudo tee {overcommit_path}"
-                                )
-                                .stdin(format!("{overcommit_pages}\n"))
-                                .run()?;
-                            }
+                            let write_overcommit_script = format!(
+                                "echo {overcommit_pages} | sudo tee {path}",
+                                path = hugepages_dir.join("nr_overcommit_hugepages").display(),
+                            );
+                            flowey::shell_cmd!(rt, "sh -c {write_overcommit_script}").run()?;
 
                             let nr_hugepages = read_counter("nr_hugepages")?;
                             let free_hugepages = read_counter("free_hugepages")?;
-                            let nr_overcommit_hugepages =
-                                read_counter("nr_overcommit_hugepages")?;
+                            let nr_overcommit_hugepages = read_counter("nr_overcommit_hugepages")?;
                             let surplus_hugepages = read_counter("surplus_hugepages")?;
 
                             log::info!("2 MiB hugetlb nr_hugepages={nr_hugepages}");
@@ -138,7 +125,9 @@ impl SimpleFlowNode for Node {
 
                             if nr_overcommit_hugepages < overcommit_pages {
                                 anyhow::bail!(
-                                    "2 MiB hugetlb overcommit remains {nr_overcommit_hugepages}, below requested {overcommit_pages}"
+                                    "2 MiB hugetlb overcommit remains {}, below requested {}",
+                                    nr_overcommit_hugepages,
+                                    overcommit_pages
                                 );
                             }
 

--- a/flowey/flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs
@@ -115,11 +115,11 @@ impl SimpleFlowNode for Node {
 
                             let current_overcommit = read_counter("nr_overcommit_hugepages")?;
                             if current_overcommit < overcommit_pages {
-                                let overcommit_pages_arg = overcommit_pages.to_string();
                                 flowey::shell_cmd!(
                                     rt,
-                                    "echo {overcommit_pages_arg} | sudo tee {overcommit_path}"
+                                    "sudo tee {overcommit_path}"
                                 )
+                                .stdin(format!("{overcommit_pages}\n"))
                                 .run()?;
                             }
 

--- a/flowey/flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs
@@ -35,6 +35,8 @@ flowey_request! {
         /// any tests. (e.g: to allow for some ambient packages / dependencies
         /// to get installed).
         pub pre_run_deps: Vec<ReadVar<SideEffect>>,
+        /// If set, configure this 2 MiB hugetlb surplus page overcommit limit before running tests.
+        pub hugetlb_2mb_overcommit_pages: Option<u64>,
         /// Results of running the tests
         pub results: WriteVar<TestResults>,
     }
@@ -58,10 +60,18 @@ impl SimpleFlowNode for Node {
             nextest_config_file,
             nextest_bin,
             target,
-            extra_env,
+            mut extra_env,
             mut pre_run_deps,
+            hugetlb_2mb_overcommit_pages,
             results,
         } = request;
+
+        if hugetlb_2mb_overcommit_pages.is_some() {
+            extra_env = extra_env.map(ctx, |mut env| {
+                env.insert("OPENVMM_REQUIRE_2MB_HUGETLB".into(), "1".into());
+                env
+            });
+        }
 
         if !matches!(ctx.backend(), FlowBackend::Local)
             && matches!(ctx.platform(), FlowPlatform::Linux(_))
@@ -81,6 +91,62 @@ impl SimpleFlowNode for Node {
                     }
                 })
             });
+
+            if let Some(overcommit_pages) = hugetlb_2mb_overcommit_pages {
+                pre_run_deps.push({
+                    ctx.emit_rust_step("ensure 2 MiB hugetlb pages are available", move |_| {
+                        move |rt| {
+                            let hugepages_dir =
+                                Path::new("/sys/kernel/mm/hugepages/hugepages-2048kB");
+                            let overcommit_path = hugepages_dir.join("nr_overcommit_hugepages");
+
+                            if !overcommit_path.exists() {
+                                anyhow::bail!(
+                                    "missing {}; host does not expose 2 MiB hugetlb overcommit configuration",
+                                    overcommit_path.display()
+                                );
+                            }
+
+                            let read_counter = |name: &str| -> anyhow::Result<u64> {
+                                let path = hugepages_dir.join(name);
+                                let value = fs_err::read_to_string(&path)?;
+                                Ok(value.trim().parse()?)
+                            };
+
+                            let current_overcommit = read_counter("nr_overcommit_hugepages")?;
+                            if current_overcommit < overcommit_pages {
+                                let overcommit_pages_arg = overcommit_pages.to_string();
+                                flowey::shell_cmd!(
+                                    rt,
+                                    "echo {overcommit_pages_arg} | sudo tee {overcommit_path}"
+                                )
+                                .run()?;
+                            }
+
+                            let nr_hugepages = read_counter("nr_hugepages")?;
+                            let free_hugepages = read_counter("free_hugepages")?;
+                            let nr_overcommit_hugepages =
+                                read_counter("nr_overcommit_hugepages")?;
+                            let surplus_hugepages = read_counter("surplus_hugepages")?;
+
+                            log::info!("2 MiB hugetlb nr_hugepages={nr_hugepages}");
+                            log::info!("2 MiB hugetlb free_hugepages={free_hugepages}");
+                            log::info!(
+                                "2 MiB hugetlb nr_overcommit_hugepages={nr_overcommit_hugepages}"
+                            );
+                            log::info!("2 MiB hugetlb surplus_hugepages={surplus_hugepages}");
+
+                            if nr_overcommit_hugepages < overcommit_pages {
+                                anyhow::bail!(
+                                    "2 MiB hugetlb overcommit remains {nr_overcommit_hugepages}, below requested {overcommit_pages}"
+                                );
+                            }
+
+                            Ok(())
+                        }
+                    })
+                });
+            }
         }
 
         let nextest_archive = nextest_archive_file.map(ctx, |x| x.archive_file);

--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -41,7 +41,12 @@ impl MappingManager {
     /// If `private_ram` is true, mappers created from this manager will use
     /// anonymous private memory for guest RAM instead of shared file-backed
     /// memory.
-    pub fn new(spawn: impl Spawn, max_addr: u64, private_ram: bool) -> Self {
+    pub fn new(
+        spawn: impl Spawn,
+        max_addr: u64,
+        private_ram: bool,
+        minimum_va_alignment: Option<usize>,
+    ) -> Self {
         let (req_send, mut req_recv) = mesh::mpsc_channel();
         spawn
             .spawn("mapping_manager", {
@@ -57,6 +62,7 @@ impl MappingManager {
                 req_send,
                 max_addr,
                 private_ram,
+                minimum_va_alignment,
             },
         }
     }
@@ -75,6 +81,7 @@ pub struct MappingManagerClient {
     id: ObjectId,
     max_addr: u64,
     private_ram: bool,
+    minimum_va_alignment: Option<usize>,
 }
 
 static MAPPER_CACHE: ObjectCache<VaMapper> = ObjectCache::new();
@@ -91,7 +98,14 @@ impl MappingManagerClient {
         let private_ram = self.private_ram;
         MAPPER_CACHE
             .get_or_insert_with(&self.id, async {
-                VaMapper::new(self.req_send.clone(), self.max_addr, None, private_ram).await
+                VaMapper::new(
+                    self.req_send.clone(),
+                    self.max_addr,
+                    None,
+                    private_ram,
+                    self.minimum_va_alignment,
+                )
+                .await
             })
             .await
     }
@@ -112,7 +126,14 @@ impl MappingManagerClient {
             return Err(VaMapperError::RemoteWithPrivateMemory);
         }
         Ok(Arc::new(
-            VaMapper::new(self.req_send.clone(), self.max_addr, Some(process), false).await?,
+            VaMapper::new(
+                self.req_send.clone(),
+                self.max_addr,
+                Some(process),
+                false,
+                self.minimum_va_alignment,
+            )
+            .await?,
         ))
     }
 
@@ -404,7 +425,7 @@ mod tests {
 
     #[pal_async::async_test]
     async fn test_dma_target_regions_returned(spawn: impl Spawn) {
-        let mm = MappingManager::new(&spawn, 0x200000, false);
+        let mm = MappingManager::new(&spawn, 0x200000, false, None);
         let client = mm.client().clone();
 
         let ram: Mappable = sparse_mmap::alloc_shared_memory(0x100000, "test-ram")
@@ -448,7 +469,7 @@ mod tests {
 
     #[pal_async::async_test]
     async fn test_no_dma_targets_returns_empty(spawn: impl Spawn) {
-        let mm = MappingManager::new(&spawn, 0x100000, false);
+        let mm = MappingManager::new(&spawn, 0x100000, false, None);
         let client = mm.client().clone();
 
         let mappable: Mappable = sparse_mmap::alloc_shared_memory(0x1000, "test")

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -206,9 +206,13 @@ impl VaMapper {
         len: u64,
         remote_process: Option<RemoteProcess>,
         private_ram: bool,
+        minimum_alignment: Option<usize>,
     ) -> Result<Self, VaMapperError> {
         let mapping = match &remote_process {
-            None => SparseMapping::new(len as usize),
+            None => SparseMapping::new_with_minimum_alignment(
+                len as usize,
+                minimum_alignment.unwrap_or(1),
+            ),
             Some(process) => match process {
                 #[cfg(not(windows))]
                 _ => unreachable!(),

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -165,6 +165,12 @@ pub enum MemoryBuildError {
 
 const DEFAULT_HUGEPAGE_SIZE: u64 = 2 * 1024 * 1024;
 
+/// Explicit hugetlb memfd backing configuration.
+#[derive(Debug, Copy, Clone)]
+struct HugepageConfig {
+    size: Option<u64>,
+}
+
 fn validate_hugepage_size(size: u64) -> Result<usize, MemoryBuildError> {
     if !size.is_power_of_two() || size < SparseMapping::page_size() as u64 {
         return Err(MemoryBuildError::InvalidHugepageSize(MemorySize(size)));
@@ -231,8 +237,7 @@ pub struct GuestMemoryBuilder {
     x86_legacy_support: bool,
     private_memory: bool,
     transparent_hugepages: bool,
-    hugepages: bool,
-    hugepage_size: Option<u64>,
+    hugepages: Option<HugepageConfig>,
 }
 
 impl GuestMemoryBuilder {
@@ -246,8 +251,7 @@ impl GuestMemoryBuilder {
             x86_legacy_support: false,
             private_memory: false,
             transparent_hugepages: false,
-            hugepages: false,
-            hugepage_size: None,
+            hugepages: None,
         }
     }
 
@@ -323,9 +327,8 @@ impl GuestMemoryBuilder {
     }
 
     /// Enables explicit hugetlb memfd backing for guest RAM.
-    pub fn hugepages(mut self, enable: bool, hugepage_size: Option<u64>) -> Self {
-        self.hugepages = enable;
-        self.hugepage_size = hugepage_size;
+    pub fn hugepages(mut self, size: Option<u64>) -> Self {
+        self.hugepages = Some(HugepageConfig { size });
         self
     }
 
@@ -364,7 +367,7 @@ impl GuestMemoryBuilder {
             .chain(mem_layout.vtl2_range())
             .collect::<Vec<_>>();
 
-        let hugepage_size = if self.hugepages {
+        let hugepage_size = if let Some(hugepages) = self.hugepages {
             if !cfg!(target_os = "linux") {
                 return Err(MemoryBuildError::HugepagesUnsupportedPlatform);
             }
@@ -377,13 +380,10 @@ impl GuestMemoryBuilder {
             if self.x86_legacy_support {
                 return Err(MemoryBuildError::HugepagesWithLegacy);
             }
-            let size = validate_hugepage_size(self.hugepage_size.unwrap_or(DEFAULT_HUGEPAGE_SIZE))?;
+            let size = validate_hugepage_size(hugepages.size.unwrap_or(DEFAULT_HUGEPAGE_SIZE))?;
             validate_hugepage_ram_alignment(ram_size, &ram_ranges, size as u64)?;
             Some(size)
         } else {
-            if let Some(size) = self.hugepage_size {
-                return Err(MemoryBuildError::HugepageSizeTooLarge(MemorySize(size)));
-            }
             None
         };
 
@@ -398,7 +398,7 @@ impl GuestMemoryBuilder {
                 .try_into()
                 .map_err(|_| MemoryBuildError::RamTooLarge(MemorySize(ram_size)))?;
             Some(
-                if self.hugepages {
+                if hugepage_size.is_some() {
                     let hugepage_size = hugepage_size.unwrap();
                     sparse_mmap::alloc_shared_memory_hugetlb(
                         ram_size,
@@ -759,6 +759,7 @@ impl RamVisibilityControl {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error as _;
 
     #[test]
     fn test_validate_hugepage_size() {
@@ -840,6 +841,10 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "failed to reserve 512 hugetlb pages of 2 MB each (1 GB total); increase the hugetlb pool or reduce guest memory size"
+        );
+        assert_eq!(
+            error.source().unwrap().to_string(),
+            "Cannot allocate memory"
         );
     }
 }

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -23,6 +23,8 @@ use inspect::Inspect;
 use memory_range::MemoryRange;
 use mesh::MeshPayload;
 use pal_async::DefaultPool;
+use sparse_mmap::SparseMapping;
+use std::io;
 use std::sync::Arc;
 use std::thread::JoinHandle;
 use thiserror::Error;
@@ -76,10 +78,25 @@ pub enum PartitionAttachError {
 pub enum MemoryBuildError {
     /// RAM too large.
     #[error("ram size {0} is too large")]
-    RamTooLarge(u64),
+    RamTooLarge(MemorySize),
     /// Couldn't allocate RAM.
     #[error("failed to allocate memory")]
-    AllocationFailed(#[source] std::io::Error),
+    AllocationFailed(#[source] io::Error),
+    /// Couldn't allocate hugetlb-backed RAM.
+    #[error(
+        "failed to reserve {page_count} hugetlb pages of {hugepage_size} each ({size} total); increase the hugetlb pool or reduce guest memory size"
+    )]
+    HugepageAllocationFailed {
+        /// Total RAM backing size.
+        size: MemorySize,
+        /// Requested or default hugepage size.
+        hugepage_size: MemorySize,
+        /// Number of hugepages required.
+        page_count: usize,
+        /// The allocation error.
+        #[source]
+        error: io::Error,
+    },
     /// Couldn't allocate VA mapper.
     #[error("failed to create VA mapper")]
     VaMapper(#[source] VaMapperError),
@@ -97,13 +114,112 @@ pub enum MemoryBuildError {
     PrivateMemoryWithExistingBacking,
     /// Failed to allocate private RAM range.
     #[error("failed to allocate private RAM range {1}")]
-    PrivateRamAlloc(#[source] std::io::Error, MemoryRange),
+    PrivateRamAlloc(#[source] io::Error, MemoryRange),
     /// THP requires private memory mode.
     #[error("transparent huge pages requires private memory mode")]
     ThpWithoutPrivateMemory,
     /// THP is only supported on Linux.
     #[error("transparent huge pages is only supported on Linux")]
     ThpUnsupportedPlatform,
+    /// Hugepage size is too large.
+    #[error("hugepage size {0} is too large")]
+    HugepageSizeTooLarge(MemorySize),
+    /// Hugepages are only supported on Linux.
+    #[error("hugepages are only supported on Linux")]
+    HugepagesUnsupportedPlatform,
+    /// Hugepages require shared memory mode.
+    #[error("hugepages require shared memory mode")]
+    HugepagesWithPrivateMemory,
+    /// Hugepages are incompatible with existing memory backing.
+    #[error("hugepages are incompatible with existing memory backing")]
+    HugepagesWithExistingBacking,
+    /// Hugepages are incompatible with x86 legacy RAM splitting.
+    #[error("hugepages are incompatible with x86 legacy RAM splitting")]
+    HugepagesWithLegacy,
+    /// Invalid hugepage size.
+    #[error("hugepage size {0} must be a power of two and at least the host page size")]
+    InvalidHugepageSize(MemorySize),
+    /// RAM size is not aligned to the hugepage size.
+    #[error(
+        "RAM size {ram_size} is not aligned to {hugepage_size} hugepages; choose a memory size that is a multiple of the hugepage size"
+    )]
+    HugepageRamSizeUnaligned {
+        /// Total RAM backing size.
+        ram_size: MemorySize,
+        /// Required hugepage alignment.
+        hugepage_size: MemorySize,
+    },
+    /// A RAM range is not aligned to the hugepage size.
+    #[error(
+        "RAM range {range} ({range_size}) is not aligned to {hugepage_size} hugepages; range start and size must both be multiples of the hugepage size"
+    )]
+    HugepageRamRangeUnaligned {
+        /// The unaligned RAM range.
+        range: MemoryRange,
+        /// The RAM range size.
+        range_size: MemorySize,
+        /// Required hugepage alignment.
+        hugepage_size: MemorySize,
+    },
+}
+
+const DEFAULT_HUGEPAGE_SIZE: u64 = 2 * 1024 * 1024;
+
+fn validate_hugepage_size(size: u64) -> Result<usize, MemoryBuildError> {
+    if !size.is_power_of_two() || size < SparseMapping::page_size() as u64 {
+        return Err(MemoryBuildError::InvalidHugepageSize(MemorySize(size)));
+    }
+    size.try_into()
+        .map_err(|_| MemoryBuildError::HugepageSizeTooLarge(MemorySize(size)))
+}
+
+/// A byte count displayed using the same binary units accepted by the CLI.
+#[derive(Debug, Copy, Clone)]
+pub struct MemorySize(
+    /// The size in bytes.
+    pub u64,
+);
+
+impl std::fmt::Display for MemorySize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        const KB: u64 = 1024;
+        const MB: u64 = 1024 * KB;
+        const GB: u64 = 1024 * MB;
+        const TB: u64 = 1024 * GB;
+
+        for (unit, suffix) in [(TB, "TB"), (GB, "GB"), (MB, "MB"), (KB, "KB")] {
+            if self.0 != 0 && self.0.is_multiple_of(unit) {
+                return write!(f, "{} {suffix}", self.0 / unit);
+            }
+        }
+
+        write!(f, "{} bytes", self.0)
+    }
+}
+
+fn validate_hugepage_ram_alignment(
+    ram_size: u64,
+    ram_ranges: &[MemoryRange],
+    hugepage_size: u64,
+) -> Result<(), MemoryBuildError> {
+    if !ram_size.is_multiple_of(hugepage_size) {
+        return Err(MemoryBuildError::HugepageRamSizeUnaligned {
+            ram_size: MemorySize(ram_size),
+            hugepage_size: MemorySize(hugepage_size),
+        });
+    }
+    for &range in ram_ranges {
+        if !range.start().is_multiple_of(hugepage_size)
+            || !range.len().is_multiple_of(hugepage_size)
+        {
+            return Err(MemoryBuildError::HugepageRamRangeUnaligned {
+                range,
+                range_size: MemorySize(range.len()),
+                hugepage_size: MemorySize(hugepage_size),
+            });
+        }
+    }
+    Ok(())
 }
 
 /// A builder for [`GuestMemoryManager`].
@@ -115,6 +231,8 @@ pub struct GuestMemoryBuilder {
     x86_legacy_support: bool,
     private_memory: bool,
     transparent_hugepages: bool,
+    hugepages: bool,
+    hugepage_size: Option<u64>,
 }
 
 impl GuestMemoryBuilder {
@@ -128,6 +246,8 @@ impl GuestMemoryBuilder {
             x86_legacy_support: false,
             private_memory: false,
             transparent_hugepages: false,
+            hugepages: false,
+            hugepage_size: None,
         }
     }
 
@@ -202,6 +322,13 @@ impl GuestMemoryBuilder {
         self
     }
 
+    /// Enables explicit hugetlb memfd backing for guest RAM.
+    pub fn hugepages(mut self, enable: bool, hugepage_size: Option<u64>) -> Self {
+        self.hugepages = enable;
+        self.hugepage_size = hugepage_size;
+        self
+    }
+
     /// Builds the memory backing, allocating memory if existing memory was not
     /// provided by [`existing_backing`](Self::existing_backing).
     pub async fn build(
@@ -230,6 +357,36 @@ impl GuestMemoryBuilder {
 
         let ram_size = mem_layout.ram_size() + mem_layout.vtl2_range().map_or(0, |r| r.len());
 
+        let mut ram_ranges = mem_layout
+            .ram()
+            .iter()
+            .map(|x| x.range)
+            .chain(mem_layout.vtl2_range())
+            .collect::<Vec<_>>();
+
+        let hugepage_size = if self.hugepages {
+            if !cfg!(target_os = "linux") {
+                return Err(MemoryBuildError::HugepagesUnsupportedPlatform);
+            }
+            if self.private_memory {
+                return Err(MemoryBuildError::HugepagesWithPrivateMemory);
+            }
+            if self.existing_mapping.is_some() {
+                return Err(MemoryBuildError::HugepagesWithExistingBacking);
+            }
+            if self.x86_legacy_support {
+                return Err(MemoryBuildError::HugepagesWithLegacy);
+            }
+            let size = validate_hugepage_size(self.hugepage_size.unwrap_or(DEFAULT_HUGEPAGE_SIZE))?;
+            validate_hugepage_ram_alignment(ram_size, &ram_ranges, size as u64)?;
+            Some(size)
+        } else {
+            if let Some(size) = self.hugepage_size {
+                return Err(MemoryBuildError::HugepageSizeTooLarge(MemorySize(size)));
+            }
+            None
+        };
+
         let memory: Option<Mappable> = if self.private_memory {
             // Private memory mode: no shared file-backed allocation.
             // RAM will be backed by anonymous pages in the VaMapper's SparseMapping.
@@ -237,14 +394,29 @@ impl GuestMemoryBuilder {
         } else if let Some(memory) = self.existing_mapping {
             Some(memory.guest_ram)
         } else {
+            let ram_size = ram_size
+                .try_into()
+                .map_err(|_| MemoryBuildError::RamTooLarge(MemorySize(ram_size)))?;
             Some(
-                sparse_mmap::alloc_shared_memory(
-                    ram_size
-                        .try_into()
-                        .map_err(|_| MemoryBuildError::RamTooLarge(ram_size))?,
-                    "guest-ram",
-                )
-                .map_err(MemoryBuildError::AllocationFailed)?
+                if self.hugepages {
+                    let hugepage_size = hugepage_size.unwrap();
+                    sparse_mmap::alloc_shared_memory_hugetlb(
+                        ram_size,
+                        "guest-ram",
+                        Some(hugepage_size),
+                    )
+                    .map_err(|error| {
+                        MemoryBuildError::HugepageAllocationFailed {
+                            size: MemorySize(ram_size as u64),
+                            hugepage_size: MemorySize(hugepage_size as u64),
+                            page_count: ram_size / hugepage_size,
+                            error,
+                        }
+                    })
+                } else {
+                    sparse_mmap::alloc_shared_memory(ram_size, "guest-ram")
+                        .map_err(MemoryBuildError::AllocationFailed)
+                }?
                 .into(),
             )
         };
@@ -266,7 +438,8 @@ impl GuestMemoryBuilder {
             None
         };
 
-        let mapping_manager = MappingManager::new(&spawner, max_addr, self.private_memory);
+        let mapping_manager =
+            MappingManager::new(&spawner, max_addr, self.private_memory, hugepage_size);
         let va_mapper = mapping_manager
             .client()
             .new_mapper()
@@ -274,13 +447,6 @@ impl GuestMemoryBuilder {
             .map_err(MemoryBuildError::VaMapper)?;
 
         let region_manager = RegionManager::new(&spawner, mapping_manager.client().clone());
-
-        let mut ram_ranges = mem_layout
-            .ram()
-            .iter()
-            .map(|x| x.range)
-            .chain(mem_layout.vtl2_range())
-            .collect::<Vec<_>>();
 
         if self.x86_legacy_support {
             if ram_ranges[0].start() != 0 || ram_ranges[0].end() < 0x100000 {
@@ -587,5 +753,93 @@ impl RamVisibilityControl {
             RamVisibility::Unmapped => region.handle.unmap().await,
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_hugepage_size() {
+        let page_size = SparseMapping::page_size() as u64;
+        assert!(validate_hugepage_size(page_size).is_ok());
+        assert!(matches!(
+            validate_hugepage_size(page_size / 2),
+            Err(MemoryBuildError::InvalidHugepageSize(_))
+        ));
+        assert!(matches!(
+            validate_hugepage_size(3 * 1024 * 1024),
+            Err(MemoryBuildError::InvalidHugepageSize(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_hugepage_ram_alignment() {
+        const HUGEPAGE_SIZE: u64 = 2 * 1024 * 1024;
+
+        validate_hugepage_ram_alignment(
+            4 * 1024 * 1024,
+            &[
+                MemoryRange::new(0..HUGEPAGE_SIZE),
+                MemoryRange::new(2 * HUGEPAGE_SIZE..3 * HUGEPAGE_SIZE),
+            ],
+            HUGEPAGE_SIZE,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            validate_hugepage_ram_alignment(3 * 1024 * 1024, &[], HUGEPAGE_SIZE),
+            Err(MemoryBuildError::HugepageRamSizeUnaligned { .. })
+        ));
+        assert!(matches!(
+            validate_hugepage_ram_alignment(
+                HUGEPAGE_SIZE,
+                &[MemoryRange::new(0..1024 * 1024)],
+                HUGEPAGE_SIZE,
+            ),
+            Err(MemoryBuildError::HugepageRamRangeUnaligned { .. })
+        ));
+    }
+
+    #[test]
+    fn test_hugepage_ram_size_alignment_error_message() {
+        let error =
+            validate_hugepage_ram_alignment(257 * 1024 * 1024, &[], 2 * 1024 * 1024).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "RAM size 257 MB is not aligned to 2 MB hugepages; choose a memory size that is a multiple of the hugepage size"
+        );
+    }
+
+    #[test]
+    fn test_hugepage_ram_range_alignment_error_message() {
+        let error = validate_hugepage_ram_alignment(
+            2 * 1024 * 1024,
+            &[MemoryRange::new(0..1024 * 1024)],
+            2 * 1024 * 1024,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "RAM range 0x0-0x100000 (1 MB) is not aligned to 2 MB hugepages; range start and size must both be multiples of the hugepage size"
+        );
+    }
+
+    #[test]
+    fn test_hugepage_allocation_error_message() {
+        let error = MemoryBuildError::HugepageAllocationFailed {
+            size: MemorySize(1024 * 1024 * 1024),
+            hugepage_size: MemorySize(2 * 1024 * 1024),
+            page_count: 512,
+            error: io::Error::new(io::ErrorKind::OutOfMemory, "Cannot allocate memory"),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "failed to reserve 512 hugetlb pages of 2 MB each (1 GB total); increase the hugetlb pool or reduce guest memory size"
+        );
     }
 }

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -397,28 +397,19 @@ impl GuestMemoryBuilder {
             let ram_size = ram_size
                 .try_into()
                 .map_err(|_| MemoryBuildError::RamTooLarge(MemorySize(ram_size)))?;
-            Some(
-                if hugepage_size.is_some() {
-                    let hugepage_size = hugepage_size.unwrap();
-                    sparse_mmap::alloc_shared_memory_hugetlb(
-                        ram_size,
-                        "guest-ram",
-                        Some(hugepage_size),
-                    )
-                    .map_err(|error| {
-                        MemoryBuildError::HugepageAllocationFailed {
-                            size: MemorySize(ram_size as u64),
-                            hugepage_size: MemorySize(hugepage_size as u64),
-                            page_count: ram_size / hugepage_size,
-                            error,
-                        }
-                    })
-                } else {
-                    sparse_mmap::alloc_shared_memory(ram_size, "guest-ram")
-                        .map_err(MemoryBuildError::AllocationFailed)
-                }?
-                .into(),
-            )
+            let guest_ram = if let Some(hugepage_size) = hugepage_size {
+                sparse_mmap::alloc_shared_memory_hugetlb(ram_size, "guest-ram", Some(hugepage_size))
+                    .map_err(|error| MemoryBuildError::HugepageAllocationFailed {
+                        size: MemorySize(ram_size as u64),
+                        hugepage_size: MemorySize(hugepage_size as u64),
+                        page_count: ram_size / hugepage_size,
+                        error,
+                    })?
+            } else {
+                sparse_mmap::alloc_shared_memory(ram_size, "guest-ram")
+                    .map_err(MemoryBuildError::AllocationFailed)?
+            };
+            Some(guest_ram.into())
         };
 
         // Spawn a thread to handle memory requests.

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -179,7 +179,7 @@ fn validate_hugepage_size(size: u64) -> Result<usize, MemoryBuildError> {
         .map_err(|_| MemoryBuildError::HugepageSizeTooLarge(MemorySize(size)))
 }
 
-/// A byte count displayed using the same binary units accepted by the CLI.
+/// A byte count displayed in a human-readable format in error messages.
 #[derive(Debug, Copy, Clone)]
 pub struct MemorySize(
     /// The size in bytes.

--- a/openvmm/membacking/src/region_manager.rs
+++ b/openvmm/membacking/src/region_manager.rs
@@ -1057,7 +1057,7 @@ mod tests {
             }
         }
 
-        let mm = MappingManager::new(spawn, 0x200000, false);
+        let mm = MappingManager::new(spawn, 0x200000, false, None);
         let mut task = TestTask(RegionManagerTask::new(mm.client().clone()));
 
         let high = task.add(1, 0x1000..0x3000).await.unwrap();
@@ -1088,7 +1088,7 @@ mod tests {
 
     impl DmaTestTask {
         fn new(spawn: impl Spawn) -> Self {
-            let mm = MappingManager::new(spawn, 0x200000, false);
+            let mm = MappingManager::new(spawn, 0x200000, false, None);
             Self {
                 task: RegionManagerTask::new(mm.client().clone()),
                 mappable: test_mappable(),

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -919,6 +919,12 @@ impl InitializedVm {
                 .then_some(1 << (physical_address_size - 1))
         });
 
+        if let Some(size) = cfg.memory.hugepage_size
+            && !cfg.memory.hugepages
+        {
+            anyhow::bail!("hugepage_size={size} requires hugepages=on");
+        }
+
         let mut memory_builder = GuestMemoryBuilder::new();
         memory_builder = memory_builder
             .existing_backing(shared_memory)
@@ -926,10 +932,12 @@ impl InitializedVm {
             .prefetch_ram(cfg.memory.prefetch_memory)
             .private_memory(cfg.memory.private_memory)
             .transparent_hugepages(cfg.memory.transparent_hugepages)
-            .hugepages(cfg.memory.hugepages, cfg.memory.hugepage_size)
             .x86_legacy_support(
                 matches!(cfg.load_mode, LoadMode::Pcat { .. }) || cfg.chipset.with_hyperv_vga,
             );
+        if cfg.memory.hugepages {
+            memory_builder = memory_builder.hugepages(cfg.memory.hugepage_size);
+        }
 
         #[cfg(all(windows, feature = "virt_whp"))]
         if !cfg.vpci_resources.is_empty() {

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -926,6 +926,7 @@ impl InitializedVm {
             .prefetch_ram(cfg.memory.prefetch_memory)
             .private_memory(cfg.memory.private_memory)
             .transparent_hugepages(cfg.memory.transparent_hugepages)
+            .hugepages(cfg.memory.hugepages, cfg.memory.hugepage_size)
             .x86_legacy_support(
                 matches!(cfg.load_mode, LoadMode::Pcat { .. }) || cfg.chipset.with_hyperv_vga,
             );

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -335,6 +335,8 @@ pub struct MemoryConfig {
     pub prefetch_memory: bool,
     pub private_memory: bool,
     pub transparent_hugepages: bool,
+    pub hugepages: bool,
+    pub hugepage_size: Option<u64>,
     pub mmio_gaps: Vec<MemoryRange>,
     pub pci_ecam_gaps: Vec<MemoryRange>,
     pub pci_mmio_gaps: Vec<MemoryRange>,

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -32,6 +32,27 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use thiserror::Error;
 
+const DEFAULT_MEMORY_SIZE: u64 = 1024 * 1024 * 1024;
+
+/// Guest memory configuration parsed from `--memory`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryCli {
+    /// Guest RAM size in bytes.
+    pub mem_size: u64,
+    /// Whether shared file-backed memory was explicitly requested.
+    pub shared: Option<bool>,
+    /// Whether to prefetch guest RAM.
+    pub prefetch: bool,
+    /// Whether to use transparent huge pages for private guest RAM.
+    pub transparent_hugepages: bool,
+    /// Whether to use explicit hugetlb memfd backing for guest RAM.
+    pub hugepages: bool,
+    /// Explicit hugetlb page size in bytes.
+    pub hugepage_size: Option<u64>,
+    /// File used to back guest RAM.
+    pub file: Option<PathBuf>,
+}
+
 /// OpenVMM virtual machine monitor.
 ///
 /// This is not yet a stable interface and may change radically between
@@ -42,16 +63,36 @@ pub struct Options {
     #[clap(short = 'p', long, value_name = "COUNT", default_value = "1")]
     pub processors: u32,
 
-    /// guest RAM size
+    /// guest RAM configuration (`SIZE` or `key=value[,key=value...]`)
     #[clap(
         short = 'm',
         long,
-        value_name = "SIZE",
+        value_name = "PARAMS",
         default_value = "1GB",
-        value_parser = parse_memory,
-        conflicts_with = "numa_memory"
+        value_parser = parse_memory_config,
+        conflicts_with = "numa_memory",
+        long_help = r#"Configure guest RAM.
+
+Syntax: SIZE | key=value[,key=value...]
+
+Size suffixes accept K, M, G, and T, optionally followed by B.
+
+Options:
+    size=<SIZE>              guest RAM size, default 1GB
+    shared=on|off            use shared file-backed RAM, default on
+    prefetch=on|off          pre-populate shared RAM mappings
+    thp=on|off               mark private RAM as THP-eligible; requires shared=off
+    hugepages=on|off         allocate RAM from Linux hugetlb pages
+    hugepage_size=<SIZE>     hugetlb page size, default 2MB; requires hugepages=on
+    file=<PATH>              use an existing file as guest RAM backing
+
+Examples:
+    --memory 4G
+    --memory size=64GB,hugepages=on,hugepage_size=2MB
+    --memory size=4G,file=path/to/memory.bin
+    --memory size=4G,shared=off,thp=on"#
     )]
-    pub memory: u64,
+    pub memory: MemoryCli,
 
     /// per-NUMA-node guest RAM sizes (comma-separated, e.g. "2G,2G").
     /// Distributes memory across vNUMA nodes reported to the guest. Mutually
@@ -63,31 +104,40 @@ pub struct Options {
     pub numa_memory: Option<Vec<u64>>,
 
     /// use shared memory segment
-    #[clap(short = 'M', long)]
+    #[clap(short = 'M', long, hide = true)]
     pub shared_memory: bool,
 
     /// prefetch guest RAM
-    #[clap(long)]
-    pub prefetch: bool,
+    #[clap(long = "prefetch", hide = true)]
+    pub deprecated_prefetch: bool,
 
     /// back guest RAM with a file instead of anonymous memory.
     /// The file is created/opened and sized to the guest RAM size.
     /// Enables snapshot save (fsync) and restore (open + mmap).
-    #[clap(long, value_name = "FILE", conflicts_with = "private_memory")]
-    pub memory_backing_file: Option<PathBuf>,
+    #[clap(
+        long = "memory-backing-file",
+        value_name = "FILE",
+        hide = true,
+        conflicts_with = "deprecated_private_memory"
+    )]
+    pub deprecated_memory_backing_file: Option<PathBuf>,
 
     /// Restore VM from a snapshot directory (implies file-backed memory from
     /// the snapshot's memory.bin). Cannot be used with --memory-backing-file.
-    #[clap(long, value_name = "DIR", conflicts_with = "memory_backing_file")]
+    #[clap(
+        long,
+        value_name = "DIR",
+        conflicts_with = "deprecated_memory_backing_file"
+    )]
     pub restore_snapshot: Option<PathBuf>,
 
     /// use private anonymous memory for guest RAM
-    #[clap(long, conflicts_with_all = ["memory_backing_file", "restore_snapshot"])]
-    pub private_memory: bool,
+    #[clap(long = "private-memory", hide = true, conflicts_with_all = ["deprecated_memory_backing_file", "restore_snapshot"])]
+    pub deprecated_private_memory: bool,
 
     /// enable transparent huge pages for guest RAM (Linux only, requires --private-memory)
-    #[clap(long, requires("private_memory"))]
-    pub thp: bool,
+    #[clap(long = "thp", hide = true)]
+    pub deprecated_thp: bool,
 
     /// start in paused state
     #[clap(short = 'P', long)]
@@ -861,6 +911,70 @@ Syntax: <port_name>:<pci_bdf>
     pub vfio: Vec<VfioDeviceCli>,
 }
 
+impl Options {
+    /// Returns the effective guest RAM size.
+    pub fn memory_size(&self) -> u64 {
+        self.memory.mem_size
+    }
+
+    /// Returns whether guest RAM should be prefetched.
+    pub fn prefetch_memory(&self) -> bool {
+        self.memory.prefetch || self.deprecated_prefetch
+    }
+
+    /// Returns whether guest RAM should use private anonymous backing.
+    pub fn private_memory(&self) -> bool {
+        self.memory.shared == Some(false) || self.deprecated_private_memory
+    }
+
+    /// Returns whether guest RAM should be marked THP-eligible.
+    pub fn transparent_hugepages(&self) -> bool {
+        self.memory.transparent_hugepages || self.deprecated_thp
+    }
+
+    /// Returns the effective file backing path for guest RAM.
+    pub fn memory_backing_file(&self) -> Option<&PathBuf> {
+        self.memory
+            .file
+            .as_ref()
+            .or(self.deprecated_memory_backing_file.as_ref())
+    }
+
+    /// Validates combinations that span the new `--memory` parser and legacy aliases.
+    pub fn validate_memory_options(&self) -> anyhow::Result<()> {
+        if self.memory.file.is_some() && self.deprecated_memory_backing_file.is_some() {
+            anyhow::bail!("--memory file=... conflicts with --memory-backing-file");
+        }
+        if self.memory.file.is_some() && self.restore_snapshot.is_some() {
+            anyhow::bail!("--memory file=... conflicts with --restore-snapshot");
+        }
+        if self.memory.shared == Some(true) && self.deprecated_private_memory {
+            anyhow::bail!("--memory shared=on conflicts with --private-memory");
+        }
+        if self.memory_backing_file().is_some() && self.private_memory() {
+            anyhow::bail!("file-backed memory conflicts with private memory");
+        }
+        if self.transparent_hugepages() && !self.private_memory() {
+            anyhow::bail!("transparent huge pages requires private memory mode");
+        }
+        if self.memory.hugepages {
+            if !cfg!(target_os = "linux") {
+                anyhow::bail!("hugepages are only supported on Linux");
+            }
+            if self.private_memory() {
+                anyhow::bail!("hugepages conflict with private memory");
+            }
+            if self.memory_backing_file().is_some() || self.restore_snapshot.is_some() {
+                anyhow::bail!("hugepages conflict with file-backed memory");
+            }
+            if self.pcat {
+                anyhow::bail!("hugepages conflict with x86 legacy RAM splitting");
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct FsArgs {
     pub tag: String,
@@ -989,10 +1103,122 @@ fn parse_memory(s: &str) -> anyhow::Result<u64> {
                 b = &b[..b.len() - 1]
             }
             let n: u64 = std::str::from_utf8(b).ok()?.parse().ok()?;
-            Some(n * multi.unwrap_or(1))
+            n.checked_mul(multi.unwrap_or(1))
         }()
         .with_context(|| format!("invalid memory size '{0}'", s))
     }
+}
+
+fn parse_memory_toggle(key: &str, value: &str) -> anyhow::Result<bool> {
+    match value {
+        "on" => Ok(true),
+        "off" => Ok(false),
+        _ => anyhow::bail!("invalid {key} value '{value}', expected 'on' or 'off'"),
+    }
+}
+
+fn parse_memory_config(s: &str) -> anyhow::Result<MemoryCli> {
+    if !s.contains('=') && !s.contains(',') {
+        return Ok(MemoryCli {
+            mem_size: parse_memory(s)?,
+            shared: None,
+            prefetch: false,
+            transparent_hugepages: false,
+            hugepages: false,
+            hugepage_size: None,
+            file: None,
+        });
+    }
+
+    let mut mem_size = DEFAULT_MEMORY_SIZE;
+    let mut saw_size = false;
+    let mut shared = None;
+    let mut prefetch = None;
+    let mut transparent_hugepages = None;
+    let mut hugepages = None;
+    let mut hugepage_size = None;
+    let mut file = None;
+
+    for part in s.split(',') {
+        let (key, value) = part
+            .split_once('=')
+            .with_context(|| format!("invalid memory option '{part}', expected key=value"))?;
+        if key.is_empty() || value.is_empty() {
+            anyhow::bail!("invalid memory option '{part}', expected key=value");
+        }
+
+        match key {
+            "size" => {
+                if saw_size {
+                    anyhow::bail!("duplicate memory option 'size'");
+                }
+                mem_size = parse_memory(value)?;
+                saw_size = true;
+            }
+            "shared" => {
+                if shared.is_some() {
+                    anyhow::bail!("duplicate memory option 'shared'");
+                }
+                shared = Some(parse_memory_toggle(key, value)?);
+            }
+            "prefetch" => {
+                if prefetch.is_some() {
+                    anyhow::bail!("duplicate memory option 'prefetch'");
+                }
+                prefetch = Some(parse_memory_toggle(key, value)?);
+            }
+            "thp" => {
+                if transparent_hugepages.is_some() {
+                    anyhow::bail!("duplicate memory option 'thp'");
+                }
+                transparent_hugepages = Some(parse_memory_toggle(key, value)?);
+            }
+            "hugepages" => {
+                if hugepages.is_some() {
+                    anyhow::bail!("duplicate memory option 'hugepages'");
+                }
+                hugepages = Some(parse_memory_toggle(key, value)?);
+            }
+            "hugepage_size" => {
+                if hugepage_size.is_some() {
+                    anyhow::bail!("duplicate memory option 'hugepage_size'");
+                }
+                hugepage_size = Some(parse_memory(value)?);
+            }
+            "file" => {
+                if file.is_some() {
+                    anyhow::bail!("duplicate memory option 'file'");
+                }
+                file = Some(PathBuf::from(value));
+            }
+            _ => anyhow::bail!("unknown memory option '{key}'"),
+        }
+    }
+
+    if transparent_hugepages == Some(true) && shared != Some(false) {
+        anyhow::bail!("memory thp=on requires shared=off");
+    }
+    if hugepage_size.is_some() && hugepages != Some(true) {
+        anyhow::bail!("memory hugepage_size requires hugepages=on");
+    }
+    if hugepages == Some(true) {
+        if shared == Some(false) {
+            anyhow::bail!("memory hugepages=on conflicts with shared=off");
+        }
+        if file.is_some() {
+            anyhow::bail!("memory hugepages=on conflicts with file=...");
+        }
+    }
+
+    Ok(MemoryCli {
+        mem_size,
+        shared,
+        prefetch: prefetch.unwrap_or(false),
+        transparent_hugepages: transparent_hugepages.unwrap_or(false),
+        hugepages: hugepages.unwrap_or(false),
+        hugepage_size,
+        file,
+    })
 }
 
 /// Parse a number from a string that could be prefixed with 0x to indicate hex.
@@ -3355,6 +3581,142 @@ mod tests {
         assert!(PcieRemoteCli::from_str("port,controller=").is_err());
         assert!(PcieRemoteCli::from_str("port,controller=bad").is_err());
         assert!(PcieRemoteCli::from_str("port,unknown=value").is_err());
+    }
+
+    #[test]
+    fn test_parse_memory_units() {
+        assert_eq!(parse_memory("64G").unwrap(), 64 * 1024 * 1024 * 1024);
+        assert_eq!(parse_memory("64GB").unwrap(), 64 * 1024 * 1024 * 1024);
+        assert_eq!(parse_memory("3MB").unwrap(), 3 * 1024 * 1024);
+        assert_eq!(parse_memory("512KB").unwrap(), 512 * 1024);
+        assert!(parse_memory("3MiB").is_err());
+    }
+
+    #[test]
+    fn test_memory_config_size_only() {
+        assert_eq!(
+            parse_memory_config("64G").unwrap(),
+            MemoryCli {
+                mem_size: 64 * 1024 * 1024 * 1024,
+                shared: None,
+                prefetch: false,
+                transparent_hugepages: false,
+                hugepages: false,
+                hugepage_size: None,
+                file: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_memory_config_key_value() {
+        assert_eq!(
+            parse_memory_config("size=2G,shared=off,prefetch=on,thp=on").unwrap(),
+            MemoryCli {
+                mem_size: 2 * 1024 * 1024 * 1024,
+                shared: Some(false),
+                prefetch: true,
+                transparent_hugepages: true,
+                hugepages: false,
+                hugepage_size: None,
+                file: None,
+            }
+        );
+
+        assert_eq!(
+            parse_memory_config("size=4GB,hugepages=on,hugepage_size=2MB").unwrap(),
+            MemoryCli {
+                mem_size: 4 * 1024 * 1024 * 1024,
+                shared: None,
+                prefetch: false,
+                transparent_hugepages: false,
+                hugepages: true,
+                hugepage_size: Some(2 * 1024 * 1024),
+                file: None,
+            }
+        );
+
+        assert_eq!(
+            parse_memory_config("file=/tmp/memory.bin").unwrap(),
+            MemoryCli {
+                mem_size: DEFAULT_MEMORY_SIZE,
+                shared: None,
+                prefetch: false,
+                transparent_hugepages: false,
+                hugepages: false,
+                hugepage_size: None,
+                file: Some(PathBuf::from("/tmp/memory.bin")),
+            }
+        );
+    }
+
+    #[test]
+    fn test_memory_config_rejects_invalid_combinations() {
+        assert!(parse_memory_config("thp=on").is_err());
+        assert!(parse_memory_config("size=1G,size=2G").is_err());
+        assert!(parse_memory_config("hugepage_size=2M").is_err());
+        assert!(parse_memory_config("hugepages=on,shared=off").is_err());
+        assert!(parse_memory_config("hugepages=on,file=/tmp/memory.bin").is_err());
+
+        // Semantic validation of the hugepage size happens in the memory
+        // builder, not in CLI parsing.
+        assert_eq!(
+            parse_memory_config("hugepages=on,hugepage_size=3MB")
+                .unwrap()
+                .hugepage_size,
+            Some(3 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn test_memory_options_merge_legacy_aliases() {
+        let opt = Options::try_parse_from([
+            "openvmm",
+            "--memory",
+            "2G",
+            "--prefetch",
+            "--private-memory",
+            "--thp",
+        ])
+        .unwrap();
+        opt.validate_memory_options().unwrap();
+        assert_eq!(opt.memory_size(), 2 * 1024 * 1024 * 1024);
+        assert!(opt.prefetch_memory());
+        assert!(opt.private_memory());
+        assert!(opt.transparent_hugepages());
+    }
+
+    #[test]
+    fn test_memory_options_allow_legacy_thp_with_new_private_memory() {
+        let opt = Options::try_parse_from(["openvmm", "--memory", "shared=off", "--thp"]).unwrap();
+        opt.validate_memory_options().unwrap();
+        assert!(opt.private_memory());
+        assert!(opt.transparent_hugepages());
+    }
+
+    #[test]
+    fn test_memory_options_reject_conflicting_legacy_aliases() {
+        let opt = Options::try_parse_from(["openvmm", "--memory", "shared=on", "--private-memory"])
+            .unwrap();
+        assert!(opt.validate_memory_options().is_err());
+    }
+
+    #[test]
+    fn test_memory_options_reject_hugepage_legacy_conflicts() {
+        let opt =
+            Options::try_parse_from(["openvmm", "--memory", "hugepages=on", "--private-memory"])
+                .unwrap();
+        assert!(opt.validate_memory_options().is_err());
+
+        let opt = Options::try_parse_from([
+            "openvmm",
+            "--memory",
+            "hugepages=on",
+            "--memory-backing-file",
+            "/tmp/memory.bin",
+        ])
+        .unwrap();
+        assert!(opt.validate_memory_options().is_err());
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -409,6 +409,20 @@ async fn vm_config_from_command_line(
     if opt.shared_memory {
         tracing::warn!("--shared-memory/-M flag has no effect and will be removed");
     }
+    if opt.deprecated_prefetch {
+        tracing::warn!("--prefetch is deprecated; use --memory prefetch=on");
+    }
+    if opt.deprecated_private_memory {
+        tracing::warn!("--private-memory is deprecated; use --memory shared=off");
+    }
+    if opt.deprecated_thp {
+        tracing::warn!("--thp is deprecated; use --memory shared=off,thp=on");
+    }
+    if opt.deprecated_memory_backing_file.is_some() {
+        tracing::warn!("--memory-backing-file is deprecated; use --memory file=<path>");
+    }
+
+    opt.validate_memory_options()?;
 
     const MAX_PROCESSOR_COUNT: u32 = 1024;
 
@@ -1589,12 +1603,14 @@ async fn vm_config_from_command_line(
                     .try_fold(0u64, |acc, &s| acc.checked_add(s))
                     .context("numa memory sizes overflow")?
             } else {
-                opt.memory
+                opt.memory_size()
             },
             mmio_gaps,
-            prefetch_memory: opt.prefetch,
-            private_memory: opt.private_memory,
-            transparent_hugepages: opt.thp,
+            prefetch_memory: opt.prefetch_memory(),
+            private_memory: opt.private_memory(),
+            transparent_hugepages: opt.transparent_hugepages(),
+            hugepages: opt.memory.hugepages,
+            hugepage_size: opt.memory.hugepage_size,
             pci_ecam_gaps,
             pci_mmio_gaps,
             numa_mem_sizes: opt.numa_memory.clone(),
@@ -2057,7 +2073,7 @@ fn prepare_snapshot_restore(
     openvmm_helpers::snapshot::validate_manifest(
         &manifest,
         GUEST_ARCH,
-        opt.memory,
+        opt.memory_size(),
         opt.processors,
         system_page_size(),
     )?;
@@ -2258,10 +2274,12 @@ async fn run_control_inner(
             (Some(fd), Some(state_msg))
         } else {
             let shared_memory = opt
-                .memory_backing_file
-                .as_ref()
+                .memory_backing_file()
                 .map(|path| {
-                    openvmm_helpers::shared_memory::open_memory_backing_file(path, opt.memory)
+                    openvmm_helpers::shared_memory::open_memory_backing_file(
+                        path,
+                        opt.memory_size(),
+                    )
                 })
                 .transpose()?;
             (shared_memory, None)
@@ -2325,8 +2343,8 @@ async fn run_control_inner(
         vm_rpc: vm_rpc.clone(),
         paravisor_diag: Some(paravisor_diag),
         igvm_path: opt.igvm.clone(),
-        memory_backing_file: opt.memory_backing_file.clone(),
-        memory: opt.memory,
+        memory_backing_file: opt.memory_backing_file().cloned(),
+        memory: opt.memory_size(),
         processors: opt.processors,
         log_file: opt.log_file.clone(),
     };

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -575,6 +575,8 @@ impl VmService {
                 prefetch_memory: false,
                 private_memory: false,
                 transparent_hugepages: false,
+                hugepages: false,
+                hugepage_size: None,
                 numa_mem_sizes: None,
             },
             chipset: chipset.chipset,

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -397,6 +397,8 @@ impl PetriVmConfigOpenVmm {
                 prefetch_memory: false,
                 private_memory: false,
                 transparent_hugepages: false,
+                hugepages: false,
+                hugepage_size: None,
                 numa_mem_sizes,
             }
         };

--- a/petri/src/vm/openvmm/hugetlb.rs
+++ b/petri/src/vm/openvmm/hugetlb.rs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Helpers for OpenVMM hugetlb-backed memory tests.
+
+use anyhow::Context;
+
+/// Size of a 2 MiB hugetlb page.
+pub const HUGETLB_2MB_PAGE_SIZE: u64 = 2 * 1024 * 1024;
+
+const REQUIRE_2MB_HUGETLB_ENV: &str = "OPENVMM_REQUIRE_2MB_HUGETLB";
+
+fn require_2mb_hugetlb() -> bool {
+    std::env::var_os(REQUIRE_2MB_HUGETLB_ENV).is_some()
+}
+
+fn read_hugetlb_counter(name: &str) -> anyhow::Result<Option<u64>> {
+    let path = format!("/sys/kernel/mm/hugepages/hugepages-2048kB/{name}");
+    let value = match std::fs::read_to_string(&path) {
+        Ok(value) => value,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).with_context(|| format!("failed to read {path}")),
+    };
+    Ok(Some(
+        value
+            .trim()
+            .parse()
+            .with_context(|| format!("failed to parse {path}"))?,
+    ))
+}
+
+/// Returns whether the host appears to have enough 2 MiB hugetlb pages available.
+///
+/// By default, missing or insufficient host support returns `Ok(false)` after
+/// logging a clear warning so local developer runs can skip tests cleanly. If
+/// `OPENVMM_REQUIRE_2MB_HUGETLB` is set, missing or insufficient host support is
+/// an error.
+pub fn ensure_2mb_hugetlb_pages(required_pages: u64) -> anyhow::Result<bool> {
+    let missing_message = "host does not have 2 MiB hugetlb support configured";
+
+    let Some(free_pages) = read_hugetlb_counter("free_hugepages")? else {
+        if require_2mb_hugetlb() {
+            anyhow::bail!(missing_message);
+        }
+        tracing::warn!(missing_message);
+        return Ok(false);
+    };
+    let Some(overcommit_pages) = read_hugetlb_counter("nr_overcommit_hugepages")? else {
+        if require_2mb_hugetlb() {
+            anyhow::bail!(missing_message);
+        }
+        tracing::warn!(missing_message);
+        return Ok(false);
+    };
+    let Some(surplus_pages) = read_hugetlb_counter("surplus_hugepages")? else {
+        if require_2mb_hugetlb() {
+            anyhow::bail!(missing_message);
+        }
+        tracing::warn!(missing_message);
+        return Ok(false);
+    };
+
+    let available_pages = free_pages + overcommit_pages.saturating_sub(surplus_pages);
+    if available_pages < required_pages {
+        let message = format!(
+            "host has {available_pages} available 2 MiB hugetlb pages, but {required_pages} are required; configure /sys/kernel/mm/hugepages/hugepages-2048kB/nr_overcommit_hugepages before running this test"
+        );
+        if require_2mb_hugetlb() {
+            anyhow::bail!(message);
+        }
+        tracing::warn!(message);
+        return Ok(false);
+    }
+
+    Ok(true)
+}

--- a/petri/src/vm/openvmm/hugetlb.rs
+++ b/petri/src/vm/openvmm/hugetlb.rs
@@ -29,6 +29,22 @@ fn read_hugetlb_counter(name: &str) -> anyhow::Result<Option<u64>> {
     ))
 }
 
+fn available_2mb_hugetlb_pages() -> anyhow::Result<Option<u64>> {
+    let Some(free_pages) = read_hugetlb_counter("free_hugepages")? else {
+        return Ok(None);
+    };
+    let Some(overcommit_pages) = read_hugetlb_counter("nr_overcommit_hugepages")? else {
+        return Ok(None);
+    };
+    let Some(surplus_pages) = read_hugetlb_counter("surplus_hugepages")? else {
+        return Ok(None);
+    };
+
+    Ok(Some(
+        free_pages + overcommit_pages.saturating_sub(surplus_pages),
+    ))
+}
+
 /// Returns whether the host appears to have enough 2 MiB hugetlb pages available.
 ///
 /// By default, missing or insufficient host support returns `Ok(false)` after
@@ -36,41 +52,19 @@ fn read_hugetlb_counter(name: &str) -> anyhow::Result<Option<u64>> {
 /// `OPENVMM_REQUIRE_2MB_HUGETLB` is set, missing or insufficient host support is
 /// an error.
 pub fn ensure_2mb_hugetlb_pages(required_pages: u64) -> anyhow::Result<bool> {
-    let missing_message = "host does not have 2 MiB hugetlb support configured";
-
-    let Some(free_pages) = read_hugetlb_counter("free_hugepages")? else {
-        if require_2mb_hugetlb() {
-            anyhow::bail!(missing_message);
+    let message = match available_2mb_hugetlb_pages()? {
+        Some(available_pages) if available_pages >= required_pages => return Ok(true),
+        Some(available_pages) => {
+            format!(
+                "host has {available_pages} available 2 MiB hugetlb pages, but {required_pages} are required; configure /sys/kernel/mm/hugepages/hugepages-2048kB/nr_overcommit_hugepages before running this test"
+            )
         }
-        tracing::warn!(missing_message);
-        return Ok(false);
-    };
-    let Some(overcommit_pages) = read_hugetlb_counter("nr_overcommit_hugepages")? else {
-        if require_2mb_hugetlb() {
-            anyhow::bail!(missing_message);
-        }
-        tracing::warn!(missing_message);
-        return Ok(false);
-    };
-    let Some(surplus_pages) = read_hugetlb_counter("surplus_hugepages")? else {
-        if require_2mb_hugetlb() {
-            anyhow::bail!(missing_message);
-        }
-        tracing::warn!(missing_message);
-        return Ok(false);
+        None => "host does not have 2 MiB hugetlb support configured".into(),
     };
 
-    let available_pages = free_pages + overcommit_pages.saturating_sub(surplus_pages);
-    if available_pages < required_pages {
-        let message = format!(
-            "host has {available_pages} available 2 MiB hugetlb pages, but {required_pages} are required; configure /sys/kernel/mm/hugepages/hugepages-2048kB/nr_overcommit_hugepages before running this test"
-        );
-        if require_2mb_hugetlb() {
-            anyhow::bail!(message);
-        }
-        tracing::warn!(message);
-        return Ok(false);
+    if require_2mb_hugetlb() {
+        anyhow::bail!(message);
     }
-
-    Ok(true)
+    tracing::warn!(message);
+    Ok(false)
 }

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -9,10 +9,16 @@
 //! * The VM is either shut down by the code in `runtime`, or gets dropped and cleaned up automatically.
 
 mod construct;
+#[cfg(target_os = "linux")]
+mod hugetlb;
 mod modify;
 mod runtime;
 mod start;
 
+#[cfg(target_os = "linux")]
+pub use hugetlb::HUGETLB_2MB_PAGE_SIZE;
+#[cfg(target_os = "linux")]
+pub use hugetlb::ensure_2mb_hugetlb_pages;
 pub use runtime::OpenVmmFramebufferAccess;
 pub use runtime::OpenVmmInspector;
 pub use runtime::PetriVmOpenVmm;

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -224,6 +224,13 @@ impl PetriVmConfigOpenVmm {
         self
     }
 
+    /// Use explicit hugetlb-backed guest memory.
+    pub fn with_hugepages(mut self, hugepage_size: Option<u64>) -> Self {
+        self.config.memory.hugepages = true;
+        self.config.memory.hugepage_size = hugepage_size;
+        self
+    }
+
     /// Add a symmetric PCIe topology to the VM based on some basic scale factors
     ///
     /// All root ports are named according to their index within their parent

--- a/support/sparse_mmap/src/lib.rs
+++ b/support/sparse_mmap/src/lib.rs
@@ -17,6 +17,7 @@ pub use sys::Mappable;
 pub use sys::MappableRef;
 pub use sys::SparseMapping;
 pub use sys::alloc_shared_memory;
+pub use sys::alloc_shared_memory_hugetlb;
 pub use sys::new_mappable_from_file;
 
 use std::mem::MaybeUninit;
@@ -195,6 +196,21 @@ mod tests {
         test_with(0x200000 + SparseMapping::page_size());
         test_with(0x40000000);
         test_with(0x40000000 + SparseMapping::page_size());
+    }
+
+    #[test]
+    fn test_sparse_mapping_minimum_alignment() {
+        SparseMapping::new_with_minimum_alignment(SparseMapping::page_size(), 0).unwrap_err();
+
+        let mapping =
+            SparseMapping::new_with_minimum_alignment(SparseMapping::page_size(), 1).unwrap();
+        assert_eq!(mapping.as_ptr() as usize % SparseMapping::page_size(), 0);
+
+        let alignment = 0x200000;
+        let mapping =
+            SparseMapping::new_with_minimum_alignment(SparseMapping::page_size(), alignment)
+                .unwrap();
+        assert_eq!(mapping.as_ptr() as usize % alignment, 0);
     }
 
     #[test]

--- a/support/sparse_mmap/src/lib.rs
+++ b/support/sparse_mmap/src/lib.rs
@@ -206,11 +206,29 @@ mod tests {
             SparseMapping::new_with_minimum_alignment(SparseMapping::page_size(), 1).unwrap();
         assert_eq!(mapping.as_ptr() as usize % SparseMapping::page_size(), 0);
 
-        let alignment = 0x200000;
+        let alignment = 0x10000;
         let mapping =
             SparseMapping::new_with_minimum_alignment(SparseMapping::page_size(), alignment)
                 .unwrap();
         assert_eq!(mapping.as_ptr() as usize % alignment, 0);
+
+        let alignment = 0x200000;
+
+        #[cfg(unix)]
+        {
+            let mapping =
+                SparseMapping::new_with_minimum_alignment(SparseMapping::page_size(), alignment)
+                    .unwrap();
+            assert_eq!(mapping.as_ptr() as usize % alignment, 0);
+        }
+
+        #[cfg(windows)]
+        {
+            let error =
+                SparseMapping::new_with_minimum_alignment(SparseMapping::page_size(), alignment)
+                    .unwrap_err();
+            assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
+        }
     }
 
     #[test]

--- a/support/sparse_mmap/src/unix.rs
+++ b/support/sparse_mmap/src/unix.rs
@@ -95,6 +95,11 @@ impl SparseMapping {
     /// The range will be aligned to the largest system page size that's smaller
     /// or equal to `len`.
     pub fn new(len: usize) -> Result<Self, Error> {
+        Self::new_with_minimum_alignment(len, 1)
+    }
+
+    /// Reserves a sparse mapping range with at least the requested alignment.
+    pub fn new_with_minimum_alignment(len: usize, minimum_alignment: usize) -> Result<Self, Error> {
         trycopy::initialize_try_copy();
 
         // Length of 0 return an OS error, so we need to handle it explicitly.
@@ -104,17 +109,24 @@ impl SparseMapping {
                 "length must be greater than 0",
             ));
         }
+        if !minimum_alignment.is_power_of_two() {
+            return Err(Error::new(
+                io::ErrorKind::InvalidInput,
+                "alignment must be a power of two",
+            ));
+        }
 
         let size_4k = 4096;
         let size_2m = 0x200000;
         let size_1g = 0x40000000;
-        let alignment = if len < size_2m {
+        let default_alignment = if len < size_2m {
             size_4k
         } else if len < size_1g {
             size_2m
         } else {
             size_1g
         };
+        let alignment = default_alignment.max(minimum_alignment);
 
         let len = len
             .checked_add(alignment - 1)
@@ -455,13 +467,13 @@ impl Drop for SparseMapping {
     }
 }
 #[cfg(target_os = "linux")]
-fn new_memfd(name: &str) -> io::Result<File> {
+fn new_memfd(name: &str, flags: libc::c_uint) -> io::Result<File> {
     let name =
         std::ffi::CString::new(name).map_err(|e| Error::new(io::ErrorKind::InvalidInput, e))?;
     // SAFETY: creating and truncating a new file descriptor according to
     // the documented contract.
     unsafe {
-        let fd = libc::memfd_create(name.as_ptr(), libc::MFD_CLOEXEC).syscall_result()?;
+        let fd = libc::memfd_create(name.as_ptr(), flags).syscall_result()?;
         Ok(File::from_raw_fd(fd))
     }
 }
@@ -492,7 +504,61 @@ fn new_memfd(_name: &str) -> io::Result<File> {
 /// `name` labels the memfd so it appears as `/memfd:<name>` in
 /// `/proc/{pid}/smaps` on Linux.
 pub fn alloc_shared_memory(size: usize, name: &str) -> io::Result<OwnedFd> {
+    #[cfg(target_os = "linux")]
+    let fd = new_memfd(name, libc::MFD_CLOEXEC)?;
+    #[cfg(not(target_os = "linux"))]
     let fd = new_memfd(name)?;
     fd.set_len(size as u64)?;
     Ok(fd.into())
+}
+
+/// Allocates a hugetlb mappable shared memory object of `size` bytes.
+///
+/// If `hugepage_size` is specified, it is encoded in the memfd flags using
+/// the Linux `MFD_HUGE_*` convention.
+#[cfg(target_os = "linux")]
+pub fn alloc_shared_memory_hugetlb(
+    size: usize,
+    name: &str,
+    hugepage_size: Option<usize>,
+) -> io::Result<OwnedFd> {
+    const MFD_HUGE_SHIFT: libc::c_uint = 26;
+
+    let mut flags = libc::MFD_CLOEXEC | libc::MFD_HUGETLB;
+    if let Some(hugepage_size) = hugepage_size {
+        if !hugepage_size.is_power_of_two() {
+            return Err(Error::new(
+                io::ErrorKind::InvalidInput,
+                "hugepage size must be a power of two",
+            ));
+        }
+        flags |= (hugepage_size.trailing_zeros() as libc::c_uint) << MFD_HUGE_SHIFT;
+    }
+
+    let fd = new_memfd(name, flags)?;
+    let size = libc::off_t::try_from(size).map_err(|_| {
+        Error::new(
+            io::ErrorKind::InvalidInput,
+            "hugetlb allocation size is too large",
+        )
+    })?;
+
+    // Unlike ftruncate, fallocate forces hugetlb page reservation now, so
+    // insufficient hugepage pools fail during guest RAM allocation instead of
+    // later when the lazy VA mapper first mmaps the memfd.
+    unsafe { libc::fallocate(fd.as_raw_fd(), 0, 0, size).syscall_result()? };
+    Ok(fd.into())
+}
+
+/// Allocates a hugetlb mappable shared memory object of `size` bytes.
+#[cfg(not(target_os = "linux"))]
+pub fn alloc_shared_memory_hugetlb(
+    _size: usize,
+    _name: &str,
+    _hugepage_size: Option<usize>,
+) -> io::Result<OwnedFd> {
+    Err(Error::new(
+        io::ErrorKind::Unsupported,
+        "hugetlb shared memory is only supported on Linux",
+    ))
 }

--- a/support/sparse_mmap/src/windows.rs
+++ b/support/sparse_mmap/src/windows.rs
@@ -293,6 +293,23 @@ impl SparseMapping {
         Self::new_inner(None, None, len)
     }
 
+    /// Reserves a sparse mapping range with at least the requested alignment.
+    pub fn new_with_minimum_alignment(len: usize, minimum_alignment: usize) -> Result<Self, Error> {
+        if !minimum_alignment.is_power_of_two() {
+            return Err(Error::new(
+                io::ErrorKind::InvalidInput,
+                "alignment must be a power of two",
+            ));
+        }
+        if minimum_alignment > page_size() {
+            return Err(Error::new(
+                io::ErrorKind::Unsupported,
+                "over-aligned sparse mappings are not supported on Windows",
+            ));
+        }
+        Self::new(len)
+    }
+
     /// Reserves a sparse mapping range with the given address and size in a
     /// remote process.
     pub fn new_remote(
@@ -735,6 +752,18 @@ pub fn alloc_shared_memory(size: usize, _name: &str) -> io::Result<OwnedHandle> 
         }
         Ok(OwnedHandle::from_raw_handle(h))
     }
+}
+
+/// Allocates a hugetlb mappable shared memory object of `size` bytes.
+pub fn alloc_shared_memory_hugetlb(
+    _size: usize,
+    _name: &str,
+    _hugepage_size: Option<usize>,
+) -> io::Result<OwnedHandle> {
+    Err(Error::new(
+        io::ErrorKind::Unsupported,
+        "hugetlb shared memory is only supported on Linux",
+    ))
 }
 
 #[cfg(test)]

--- a/support/sparse_mmap/src/windows.rs
+++ b/support/sparse_mmap/src/windows.rs
@@ -39,6 +39,7 @@ use windows_sys::Win32::System::Memory;
 use windows_sys::Win32::System::Threading::GetCurrentProcess;
 
 const PAGE_SIZE: usize = 4096;
+const ALLOCATION_GRANULARITY: usize = 0x10000;
 
 pub(crate) fn page_size() -> usize {
     PAGE_SIZE
@@ -294,6 +295,9 @@ impl SparseMapping {
     }
 
     /// Reserves a sparse mapping range with at least the requested alignment.
+    ///
+    /// Windows virtual address reservations are aligned to the system
+    /// allocation granularity.
     pub fn new_with_minimum_alignment(len: usize, minimum_alignment: usize) -> Result<Self, Error> {
         if !minimum_alignment.is_power_of_two() {
             return Err(Error::new(
@@ -301,10 +305,10 @@ impl SparseMapping {
                 "alignment must be a power of two",
             ));
         }
-        if minimum_alignment > page_size() {
+        if minimum_alignment > ALLOCATION_GRANULARITY {
             return Err(Error::new(
                 io::ErrorKind::Unsupported,
-                "over-aligned sparse mappings are not supported on Windows",
+                "sparse mapping alignment greater than the Windows allocation granularity is not supported",
             ));
         }
         Self::new(len)

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -112,6 +112,34 @@ async fn boot_private_memory(config: PetriVmBuilder<OpenVmmPetriBackend>) -> any
     Ok(())
 }
 
+/// Boot Linux with guest memory backed by explicit 2 MiB hugetlb pages.
+#[cfg(target_os = "linux")]
+#[openvmm_test(linux_direct_x64)]
+#[openvmm_test(linux_direct_aarch64)]
+async fn hugetlb_memory_boot(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    const RAM_BYTES: u64 = 1024 * 1024 * 1024;
+
+    let required_pages = RAM_BYTES / petri::openvmm::HUGETLB_2MB_PAGE_SIZE;
+    if !petri::openvmm::ensure_2mb_hugetlb_pages(required_pages)? {
+        return Ok(());
+    }
+
+    let (vm, agent) = config
+        .with_memory(MemoryConfig {
+            startup_bytes: RAM_BYTES,
+            ..Default::default()
+        })
+        .modify_backend(|b| b.with_hugepages(Some(petri::openvmm::HUGETLB_2MB_PAGE_SIZE)))
+        .run()
+        .await?;
+
+    agent.ping().await?;
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+
+    Ok(())
+}
+
 /// Basic boot test for images that require small amounts of ram, like alpine.
 #[vmm_test(
     openvmm_uefi_x64(vhd(alpine_3_23_x64)),


### PR DESCRIPTION
Large VFIO guests can spend significant time pinning and mapping guest RAM when memory is backed by normal 4 KB pages. Add explicit hugetlb-backed shared memory support so OpenVMM can reserve guest RAM from a host hugepage pool and keep the VM address space aligned for those mappings.

This teaches the memory builder to validate hugepage-compatible layouts, allocate Linux hugetlb memfds, and surface actionable errors when the requested hugepage pool cannot satisfy the guest size. The OpenVMM command line now accepts a richer --memory key/value form for size, sharing, prefetch, transparent huge pages, hugetlb pages, and file backing while preserving the old flags as deprecated aliases. The configuration plumbing and docs are updated so the new memory mode is available through normal OpenVMM construction paths.