### PR TITLE
nvme_driver: no longer drops create io queue request when inspect is called + test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10038,6 +10038,7 @@ dependencies = [
  "get_resources",
  "guid",
  "hyperv_ic_resources",
+ "inspect",
  "jiff",
  "kmsg",
  "memory_range",

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -1308,32 +1308,29 @@ impl<D: DeviceBacking> AsyncRun<WorkerState> for DriverWorkerTask<D> {
         stop: &mut task_control::StopTask<'_>,
         state: &mut WorkerState,
     ) -> Result<(), task_control::Cancelled> {
-        let r = stop
-            .until_stopped(async {
-                loop {
-                    match self.recv.next().await {
-                        Some(NvmeWorkerRequest::CreateIssuer(rpc)) => {
-                            rpc.handle(async |cpu| self.create_io_issuer(state, cpu).await)
-                                .await
-                        }
-                        Some(NvmeWorkerRequest::Save(rpc)) => {
-                            rpc.handle(async |span| {
-                                let child_span = tracing::info_span!(
-                                    parent: &span,
-                                    "nvme_worker_save",
-                                    pci_id = %self.device.id()
-                                );
-                                self.save(state).instrument(child_span).await
-                            })
-                            .await
-                        }
-                        None => break,
-                    }
+        loop {
+            let cmd = stop.until_stopped(self.recv.next()).await?;
+            match cmd {
+                Some(NvmeWorkerRequest::CreateIssuer(rpc)) => {
+                    rpc.handle(async |cpu| self.create_io_issuer(state, cpu).await)
+                        .await
                 }
-            })
-            .await;
-        tracing::info!(pci_id = %self.device.id(), "nvme worker task exiting");
-        r
+                Some(NvmeWorkerRequest::Save(rpc)) => {
+                    rpc.handle(async |span| {
+                        let child_span = tracing::info_span!(
+                            parent: &span,
+                            "nvme_worker_save",
+                            pci_id = %self.device.id()
+                        );
+                        self.save(state).instrument(child_span).await
+                    })
+                    .await
+                }
+                None => break,
+            }
+        }
+        tracing::info!(pci_id = %self.device.id(), "nvme worker task exiting cleanly");
+        Ok(())
     }
 }
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -347,8 +347,8 @@ impl DrainAfterRestore {
 struct QueueHandlerLoop<A: AerHandler, D: DeviceBacking> {
     queue_handler: QueueHandler<A>,
     registers: Arc<DeviceRegisters<D>>,
-    recv_req: mesh::Receiver<Req>,
-    recv_cmd: mesh::Receiver<Cmd>,
+    recv_req: Option<mesh::Receiver<Req>>,
+    recv_cmd: Option<mesh::Receiver<Cmd>>,
     interrupt: DeviceInterrupt,
 }
 
@@ -362,8 +362,8 @@ impl<A: AerHandler, D: DeviceBacking> AsyncRun<()> for QueueHandlerLoop<A, D> {
             self.queue_handler
                 .run(
                     &self.registers,
-                    &mut self.recv_req,
-                    &mut self.recv_cmd,
+                    self.recv_req.take().unwrap(),
+                    self.recv_cmd.take().unwrap(),
                     &mut self.interrupt,
                 )
                 .await;
@@ -523,8 +523,8 @@ impl<A: AerHandler, D: DeviceBacking> QueuePair<A, D> {
         let mut task = TaskControl::new(QueueHandlerLoop {
             queue_handler,
             registers,
-            recv_req,
-            recv_cmd,
+            recv_req: Some(recv_req),
+            recv_cmd: Some(recv_cmd),
             interrupt,
         });
         task.insert(spawner, "nvme-queue", ());
@@ -1159,13 +1159,11 @@ struct QueueStats {
 }
 
 impl<A: AerHandler> QueueHandler<A> {
-    /// Run the queue handler loop. This needs to be cancel safe because the
-    /// task can be stopped at any time and restarted.
     async fn run(
         &mut self,
         registers: &DeviceRegisters<impl DeviceBacking>,
-        recv_req: &mut mesh::Receiver<Req>,
-        recv_cmd: &mut mesh::Receiver<Cmd>,
+        mut recv_req: mesh::Receiver<Req>,
+        mut recv_cmd: mesh::Receiver<Cmd>,
         interrupt: &mut DeviceInterrupt,
     ) {
         if matches!(
@@ -1249,7 +1247,7 @@ impl<A: AerHandler> QueueHandler<A> {
                 Event::Request(req) => match req {
                     Req::Save(queue_state) => {
                         tracing::info!(pci_id = ?self.device_id, qid = ?self.qid, "received save request, shutting down ...");
-                        queue_state.complete(self.save());
+                        queue_state.complete(self.save().await);
                         // Do not allow any more processing after save completed.
                         break;
                     }
@@ -1312,7 +1310,7 @@ impl<A: AerHandler> QueueHandler<A> {
     }
 
     /// Save queue data for servicing.
-    pub fn save(&self) -> anyhow::Result<QueueHandlerSavedState> {
+    pub async fn save(&self) -> anyhow::Result<QueueHandlerSavedState> {
         // Log pending admin command wait durations at save time.
         if self.qid == 0 {
             for (_index, cmd) in self.commands.commands.iter() {

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -347,8 +347,8 @@ impl DrainAfterRestore {
 struct QueueHandlerLoop<A: AerHandler, D: DeviceBacking> {
     queue_handler: QueueHandler<A>,
     registers: Arc<DeviceRegisters<D>>,
-    recv_req: Option<mesh::Receiver<Req>>,
-    recv_cmd: Option<mesh::Receiver<Cmd>>,
+    recv_req: mesh::Receiver<Req>,
+    recv_cmd: mesh::Receiver<Cmd>,
     interrupt: DeviceInterrupt,
 }
 
@@ -362,8 +362,8 @@ impl<A: AerHandler, D: DeviceBacking> AsyncRun<()> for QueueHandlerLoop<A, D> {
             self.queue_handler
                 .run(
                     &self.registers,
-                    self.recv_req.take().unwrap(),
-                    self.recv_cmd.take().unwrap(),
+                    &mut self.recv_req,
+                    &mut self.recv_cmd,
                     &mut self.interrupt,
                 )
                 .await;
@@ -523,8 +523,8 @@ impl<A: AerHandler, D: DeviceBacking> QueuePair<A, D> {
         let mut task = TaskControl::new(QueueHandlerLoop {
             queue_handler,
             registers,
-            recv_req: Some(recv_req),
-            recv_cmd: Some(recv_cmd),
+            recv_req,
+            recv_cmd,
             interrupt,
         });
         task.insert(spawner, "nvme-queue", ());
@@ -1159,11 +1159,13 @@ struct QueueStats {
 }
 
 impl<A: AerHandler> QueueHandler<A> {
+    /// Run the queue handler loop. This needs to be cancel safe because the
+    /// task can be stopped at any time and restarted.
     async fn run(
         &mut self,
         registers: &DeviceRegisters<impl DeviceBacking>,
-        mut recv_req: mesh::Receiver<Req>,
-        mut recv_cmd: mesh::Receiver<Cmd>,
+        recv_req: &mut mesh::Receiver<Req>,
+        recv_cmd: &mut mesh::Receiver<Cmd>,
         interrupt: &mut DeviceInterrupt,
     ) {
         if matches!(
@@ -1247,7 +1249,7 @@ impl<A: AerHandler> QueueHandler<A> {
                 Event::Request(req) => match req {
                     Req::Save(queue_state) => {
                         tracing::info!(pci_id = ?self.device_id, qid = ?self.qid, "received save request, shutting down ...");
-                        queue_state.complete(self.save().await);
+                        queue_state.complete(self.save());
                         // Do not allow any more processing after save completed.
                         break;
                     }
@@ -1310,7 +1312,7 @@ impl<A: AerHandler> QueueHandler<A> {
     }
 
     /// Save queue data for servicing.
-    pub async fn save(&self) -> anyhow::Result<QueueHandlerSavedState> {
+    pub fn save(&self) -> anyhow::Result<QueueHandlerSavedState> {
         // Log pending admin command wait durations at save time.
         if self.qid == 0 {
             for (_index, cmd) in self.commands.commands.iter() {

--- a/vmm_tests/vmm_tests/Cargo.toml
+++ b/vmm_tests/vmm_tests/Cargo.toml
@@ -23,6 +23,7 @@ tmk_tests.workspace = true
 
 petri_artifacts_common.workspace = true
 petri.workspace = true
+inspect.workspace = true
 
 get_resources.workspace = true
 openvmm_defs.workspace = true

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -1277,7 +1277,7 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
             );
         }
     };
-    assert!(entries.len() == 1, "expected only 1 entry, the AER command");
+    assert_eq!(entries.len(), 1, "expected only 1 entry, the AER command");
 
     Ok(())
 }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -1137,45 +1137,6 @@ async fn servicing_keepalive_slow_create_io_queue(
     Ok(())
 }
 
-async fn apply_fault_with_keepalive(
-    config: PetriVmBuilder<OpenVmmPetriBackend>,
-    fault_configuration: FaultConfiguration,
-    mut fault_start_updater: CellUpdater<bool>,
-    igvm_file: ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,
-    new_cmdline: Option<&str>,
-) -> Result<PetriVm<OpenVmmPetriBackend>, anyhow::Error> {
-    let mut flags = config.default_servicing_flags();
-    flags.enable_nvme_keepalive = true;
-    let (mut vm, agent) = create_keepalive_test_config_default(
-        config,
-        fault_configuration,
-        VTL0_NVME_LUN,
-        Guid::new_random(),
-        DEFAULT_DISK_SIZE,
-    )
-    .await?;
-
-    agent.ping().await?;
-    let sh = agent.unix_shell();
-
-    // Make sure the disk showed up.
-    cmd!(sh, "ls /dev/sda").run().await?;
-
-    fault_start_updater.set(true).await;
-
-    if let Some(cmdline) = new_cmdline {
-        vm.update_command_line(cmdline).await?;
-    }
-
-    vm.restart_openhcl(igvm_file.clone(), flags).await?;
-
-    // Ensure the agent is responsive after the restart before returning.
-    agent.ping().await?;
-
-    fault_start_updater.set(false).await;
-    Ok(vm)
-}
-
 /// Verifies that save works correctly when a create_io_queue command
 /// is stuck. The `DriverWorkerTask` run loop should still be able to process
 /// save commands when the stuck create_io_queue command completes, even when
@@ -1185,7 +1146,7 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
     (igvm_file,): (ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,),
 ) -> Result<(), anyhow::Error> {
-    const QUEUE_CREATION_DELAY: Duration = Duration::from_secs(20);
+    const QUEUE_CREATION_DELAY: Duration = Duration::from_secs(200);
     const TRIGGER_CREATE_IO_QUEUE_TIMEOUT: Duration = Duration::from_secs(5);
     const TOTAL_SAVE_TIMEOUT: Duration = Duration::from_secs(50);
 
@@ -1205,7 +1166,7 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
 
     let scsi_controller_guid = Guid::new_random();
     let disk_size = 4 * 1024 * 1024; // 4 MiB — enough for dd reads
-    let vp_count = 6;
+    let vp_count = 4;
 
     let (mut vm, agent) = create_keepalive_test_config_custom_vps(
         config,
@@ -1265,8 +1226,10 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
         "IO command should have timed out. This likely means the create_io_queue command did not get injected correctly."
     );
 
-    let nvme_device_inspect = vm.inspect_openhcl("vm/nvme/devices", None, None).await?;
-    tracing::info!(nvme_device_inspect = ?nvme_device_inspect, "nvme device inspected");
+    for _ in 0..3 {
+        let nvme_device_inspect = vm.inspect_openhcl("vm/nvme/devices", None, None).await?;
+        tracing::info!(nvme_device_inspect = ?nvme_device_inspect, "nvme device inspected");
+    }
 
     CancelContext::new()
         .with_timeout(TOTAL_SAVE_TIMEOUT)
@@ -1275,13 +1238,106 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
         .expect("VM save did not complete within the given timeout, even though it should have. Save is stuck when draining after restore with slow create_io_queue.")
         .expect("Save failed");
 
-    let vm_inspect = vm.inspect_openhcl("", None, None).await?;
-    tracing::info!(vm_inspect = ?vm_inspect, "vm inspected");
-
     fault_start_updater.set(false).await;
+
     vm.restore_openhcl().await?;
     agent.ping().await?;
+
+    let vm_inspect = vm
+        .inspect_openhcl(
+            "vm/nvme/devices/182f:00:00.0/driver/driver/admin/commands/commands",
+            None,
+            None,
+        )
+        .await?;
+
+    tracing::info!("vm inspected {}", vm_inspect.json());
+    let entries = match vm_inspect {
+        inspect::Node::Dir(entries) => entries,
+        _ => {
+            panic!(
+                "expected node for the list of commands but found {}",
+                vm_inspect.json()
+            );
+        }
+    };
+
+    assert!(entries.len() == 1, "expected only 1 entry, the AER command");
+
+    // Helper: descend through a chain of named directory children.
+    fn dir_child<'a>(node: &'a inspect::Node, name: &str) -> &'a inspect::Node {
+        match node {
+            inspect::Node::Dir(children) => {
+                &children
+                    .iter()
+                    .find(|c| c.name == name)
+                    .unwrap_or_else(|| panic!("missing child '{name}' in inspect dir"))
+                    .node
+            }
+            other => panic!("expected dir for '{name}', found {:?}", other),
+        }
+    }
+
+    let create_io_cq_opcode = u64::from(nvme_spec::AdminOpcode::CREATE_IO_COMPLETION_QUEUE.0);
+
+    for e in &entries {
+        let opcode_node = dir_child(dir_child(dir_child(&e.node, "command"), "cdw0"), "opcode");
+        let opcode = match opcode_node {
+            inspect::Node::Value(v) => match v.kind {
+                inspect::ValueKind::Unsigned(n) => n,
+                ref other => panic!("opcode for entry '{}' is not unsigned: {:?}", e.name, other),
+            },
+            other => panic!("opcode for entry '{}' is not a value: {:?}", e.name, other),
+        };
+        tracing::info!(entry = %e.name, opcode, "inspected pending command");
+        assert_ne!(
+            opcode, create_io_cq_opcode,
+            "pending command '{}' has CREATE_IO_COMPLETION_QUEUE opcode (5); \
+             expected the slow create_io_queue command to have completed before save",
+            e.name
+        );
+    }
+
     Ok(())
+}
+
+async fn apply_fault_with_keepalive(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+    fault_configuration: FaultConfiguration,
+    mut fault_start_updater: CellUpdater<bool>,
+    igvm_file: ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,
+    new_cmdline: Option<&str>,
+) -> Result<PetriVm<OpenVmmPetriBackend>, anyhow::Error> {
+    let mut flags = config.default_servicing_flags();
+    flags.enable_nvme_keepalive = true;
+    let (mut vm, agent) = create_keepalive_test_config_default(
+        config,
+        fault_configuration,
+        VTL0_NVME_LUN,
+        Guid::new_random(),
+        DEFAULT_DISK_SIZE,
+    )
+    .await?;
+
+    agent.ping().await?;
+    let sh = agent.unix_shell();
+
+    // Make sure the disk showed up.
+    cmd!(sh, "ls /dev/sda").run().await?;
+
+    fault_start_updater.set(true).await;
+
+    if let Some(cmdline) = new_cmdline {
+        vm.update_command_line(cmdline).await?;
+    }
+
+    vm.restart_openhcl(igvm_file.clone(), flags).await?;
+
+    // Ensure the agent is responsive after the restart before returning.
+    agent.ping().await?;
+
+    fault_start_updater.set(false).await;
+    Ok(vm)
 }
 
 async fn create_keepalive_test_config_default(

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -1176,6 +1176,114 @@ async fn apply_fault_with_keepalive(
     Ok(vm)
 }
 
+/// Verifies that save works correctly when a create_io_queue command
+/// is stuck. The `DriverWorkerTask` run loop should still be able to process
+/// save commands when the stuck create_io_queue command completes, even when
+/// that happens after save has been issued.
+#[openvmm_test(openhcl_linux_direct_x64 [LATEST_LINUX_DIRECT_TEST_X64])]
+async fn servicing_keepalive_slow_create_io_queue_with_inspect(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+    (igvm_file,): (ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,),
+) -> Result<(), anyhow::Error> {
+    const QUEUE_CREATION_DELAY: Duration = Duration::from_secs(20);
+    const TRIGGER_CREATE_IO_QUEUE_TIMEOUT: Duration = Duration::from_secs(5);
+    const TOTAL_SAVE_TIMEOUT: Duration = Duration::from_secs(50);
+
+    let mut flags = config.default_servicing_flags();
+    flags.enable_nvme_keepalive = true;
+    let mut fault_start_updater = CellUpdater::new(false);
+
+    let fault_configuration = FaultConfiguration::new(fault_start_updater.cell())
+        .with_admin_queue_fault(
+            AdminQueueFaultConfig::new().with_submission_queue_fault(
+                CommandMatchBuilder::new()
+                    .match_cdw0_opcode(nvme_spec::AdminOpcode::CREATE_IO_COMPLETION_QUEUE.0)
+                    .build(),
+                AdminQueueFaultBehavior::Delay(QUEUE_CREATION_DELAY),
+            ),
+        );
+
+    let scsi_controller_guid = Guid::new_random();
+    let disk_size = 4 * 1024 * 1024; // 4 MiB — enough for dd reads
+    let vp_count = 6;
+
+    let (mut vm, agent) = create_keepalive_test_config_custom_vps(
+        config,
+        fault_configuration,
+        VTL0_NVME_LUN,
+        scsi_controller_guid,
+        disk_size,
+        vp_count,
+    )
+    .await?;
+    agent.ping().await?;
+
+    let cpus_with_issuers = find_cpus_with_io_issuers(&vm).await?;
+    let target_cpu = (0u32..vp_count)
+        .find(|cpu| !cpus_with_issuers.contains(cpu))
+        .unwrap_or_else(|| {
+            panic!(
+                "all {vp_count} CPUs already have IO issuers after boot — \
+             test cannot exercise create_io_queue. Consider increasing vp_count."
+            )
+        });
+    tracing::info!(
+        target_cpu,
+        existing_issuers = ?cpus_with_issuers,
+        "selected target CPU with no IO issuer"
+    );
+
+    // Resolve the disk path before save. The device might appear as /dev/sda
+    // or /dev/sdb depending on timing.
+    let device_paths = get_device_paths(
+        &agent,
+        scsi_controller_guid,
+        vec![ExpectedGuestDevice {
+            lun: VTL0_NVME_LUN,
+            disk_size_sectors: (disk_size / SCSI_SECTOR_SIZE) as usize,
+            friendly_name: "nvme_disk".to_string(),
+        }],
+    )
+    .await?;
+    assert!(device_paths.len() == 1);
+    let disk_path = &device_paths[0];
+
+    // DEV NOTE: `run_cpu_pinned_io` only needs to be run for a duration that
+    // guarantees the create_io_queue command getting stuck. Ideally this should
+    // be event driven instead of time driven, but the infrastructure for that
+    // is not in place yet.
+    // Even though the dd command will timeout, the run loop will be stuck until
+    // the create_io_queue command completes.
+    fault_start_updater.set(true).await;
+    let io_result = CancelContext::new()
+        .with_timeout(TRIGGER_CREATE_IO_QUEUE_TIMEOUT)
+        .until_cancelled(run_cpu_pinned_io(&agent, disk_path, target_cpu))
+        .await;d
+
+    assert!(
+        io_result.is_err(),
+        "IO command should have timed out. This likely means the create_io_queue command did not get injected correctly."
+    );
+
+    let nvme_device_inspect = vm.inspect_openhcl("vm/nvme/devices", None, None).await?;
+    tracing::info!(nvme_device_inspect = ?nvme_device_inspect, "nvme device inspected");
+
+    CancelContext::new()
+        .with_timeout(TOTAL_SAVE_TIMEOUT)
+        .until_cancelled(vm.save_openhcl(igvm_file.clone(), flags))
+        .await
+        .expect("VM save did not complete within the given timeout, even though it should have. Save is stuck when draining after restore with slow create_io_queue.")
+        .expect("Save failed");
+
+    let vm_inspect = vm.inspect_openhcl("", None, None).await?;
+    tracing::info!(vm_inspect = ?vm_inspect, "vm inspected");
+
+    fault_start_updater.set(false).await;
+    vm.restore_openhcl().await?;
+    agent.ping().await?;
+    Ok(())
+}
+
 async fn create_keepalive_test_config_default(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
     fault_configuration: FaultConfiguration,

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -1229,10 +1229,23 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
     // In previous versions invoking inspect would cause the DriverWorkerTask to
     // just drop the stuck create io queue command and service the save with
     // pending admin commands (not good)
-    for _ in 0..2 {
-        let nvme_device_inspect = vm.inspect_openhcl("vm/nvme/devices", None, None).await?;
-        tracing::info!(nvme_device_inspect = ?nvme_device_inspect, "nvme device inspected");
-    }
+    let nvme_device_inspect = vm.inspect_openhcl("vm/nvme/devices", None, None).await?;
+    tracing::info!(nvme_device_inspect = ?nvme_device_inspect, "nvme device inspected");
+
+    let entries = match &nvme_device_inspect {
+        inspect::Node::Dir(entries) => entries,
+        _ => panic!(
+            "expected dir for 'vm/nvme/devices' but found {}",
+            nvme_device_inspect.json()
+        ),
+    };
+    assert_eq!(
+        entries.len(),
+        1,
+        "expected exactly 1 NVMe device under 'vm/nvme/devices', found {}",
+        entries.len()
+    );
+    let nvme_device_name = entries[0].name.clone();
 
     CancelContext::new()
         .with_timeout(TOTAL_SAVE_TIMEOUT)
@@ -1248,7 +1261,7 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
 
     let vm_inspect = vm
         .inspect_openhcl(
-            "vm/nvme/devices/182f:00:00.0/driver/driver/admin/commands/commands",
+            &format!("vm/nvme/devices/{nvme_device_name}/driver/driver/admin/commands/commands"),
             None,
             None,
         )
@@ -1259,7 +1272,7 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
         inspect::Node::Dir(entries) => entries,
         _ => {
             panic!(
-                "expected node for the list of commands but found {}",
+                "expected list of pending commands but found {}",
                 vm_inspect.json()
             );
         }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -1138,17 +1138,17 @@ async fn servicing_keepalive_slow_create_io_queue(
 }
 
 /// Verifies that save works correctly when a create_io_queue command
-/// is stuck. The `DriverWorkerTask` run loop should still be able to process
-/// save commands when the stuck create_io_queue command completes, even when
-/// that happens after save has been issued.
+/// is still in flight and inspect is called on the device. Previously we saw
+/// inspect calls inadvertently throwing away create_io_issuer futures and then
+/// save being serviced with CREATE_IO_COMPLETION_QUEUE commands still pending.
 #[openvmm_test(openhcl_linux_direct_x64 [LATEST_LINUX_DIRECT_TEST_X64])]
 async fn servicing_keepalive_slow_create_io_queue_with_inspect(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
     (igvm_file,): (ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,),
 ) -> Result<(), anyhow::Error> {
-    const QUEUE_CREATION_DELAY: Duration = Duration::from_secs(200);
+    const QUEUE_CREATION_DELAY: Duration = Duration::from_secs(60);
     const TRIGGER_CREATE_IO_QUEUE_TIMEOUT: Duration = Duration::from_secs(5);
-    const TOTAL_SAVE_TIMEOUT: Duration = Duration::from_secs(50);
+    const TOTAL_SAVE_TIMEOUT: Duration = Duration::from_secs(15);
 
     let mut flags = config.default_servicing_flags();
     flags.enable_nvme_keepalive = true;
@@ -1226,7 +1226,10 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
         "IO command should have timed out. This likely means the create_io_queue command did not get injected correctly."
     );
 
-    for _ in 0..3 {
+    // In previous versions invoking inspect would cause the DriverWorkerTask to
+    // just drop the stuck create io queue command and service the save with
+    // pending admin commands (not good)
+    for _ in 0..2 {
         let nvme_device_inspect = vm.inspect_openhcl("vm/nvme/devices", None, None).await?;
         tracing::info!(nvme_device_inspect = ?nvme_device_inspect, "nvme device inspected");
     }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -1258,7 +1258,7 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
     let io_result = CancelContext::new()
         .with_timeout(TRIGGER_CREATE_IO_QUEUE_TIMEOUT)
         .until_cancelled(run_cpu_pinned_io(&agent, disk_path, target_cpu))
-        .await;d
+        .await;
 
     assert!(
         io_result.is_err(),

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -1261,42 +1261,7 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
             );
         }
     };
-
     assert!(entries.len() == 1, "expected only 1 entry, the AER command");
-
-    // Helper: descend through a chain of named directory children.
-    fn dir_child<'a>(node: &'a inspect::Node, name: &str) -> &'a inspect::Node {
-        match node {
-            inspect::Node::Dir(children) => {
-                &children
-                    .iter()
-                    .find(|c| c.name == name)
-                    .unwrap_or_else(|| panic!("missing child '{name}' in inspect dir"))
-                    .node
-            }
-            other => panic!("expected dir for '{name}', found {:?}", other),
-        }
-    }
-
-    let create_io_cq_opcode = u64::from(nvme_spec::AdminOpcode::CREATE_IO_COMPLETION_QUEUE.0);
-
-    for e in &entries {
-        let opcode_node = dir_child(dir_child(dir_child(&e.node, "command"), "cdw0"), "opcode");
-        let opcode = match opcode_node {
-            inspect::Node::Value(v) => match v.kind {
-                inspect::ValueKind::Unsigned(n) => n,
-                ref other => panic!("opcode for entry '{}' is not unsigned: {:?}", e.name, other),
-            },
-            other => panic!("opcode for entry '{}' is not a value: {:?}", e.name, other),
-        };
-        tracing::info!(entry = %e.name, opcode, "inspected pending command");
-        assert_ne!(
-            opcode, create_io_cq_opcode,
-            "pending command '{}' has CREATE_IO_COMPLETION_QUEUE opcode (5); \
-             expected the slow create_io_queue command to have completed before save",
-            e.name
-        );
-    }
 
     Ok(())
 }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -1300,7 +1300,7 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
         .await?;
 
     tracing::info!("vm inspected {}", vm_inspect.json());
-    let entries = match vm_inspect {
+    let entries = match &vm_inspect {
         inspect::Node::Dir(entries) => entries,
         _ => {
             panic!(


### PR DESCRIPTION
Previously the run loop for the `DriverWorkerTask` would abandon work in progress when TaskControl cancelled the task to service an inspect call. This would cause the `create_nvme_io_queue` span to exit before the queues were properly set up. With this change the task should only be cancelled when waiting on `next()` . However, if active work is being done this won't abandon current work in order to service an inspect call. 
There are downsides to this approach, however. If a device is being really slow to process a create command, we won't be able to service saves AND (with this change) won't be able to inspect system state either.

Added a vmm_test as well that verifies such behavior by calling inspect on nvme driver with a delayed CREATE_IO_COMPLETION_QUEUE and then verifies that save was not serviced before create completion.

# Why inspect causes this task to be canceled/stopped?
Looking at the implementation of `TaskControl` / `StopTask` / `StopTaskInner`, we see that `TaskControl`, once started, invokes `run()` on the underlying task type (in our case `DriverWorkerTask`) and passes in two parameters:

- Task state (provided by the task user via `task.insert()`)
- `StopTask`

Focusing on `StopTask::until_stopped()`, we see that it accepts a future that can be stopped using `TaskControl::stop()`. This function works by polling two futures:

- The future provided to `until_stopped`, which in our case is an async loop (or whatever future the user wants to run)
- `StopTaskInner`

Zooming in further to `StopTaskInner::poll`, we can see that it can return `Poll::Ready()` for two reasons:

- `!shared.calls.is_empty()`  ← This becomes important  
- `shared.stop == true`

The shared calls are important because they allow `TaskControl` to update existing task state while the task is running. This is done by updating the `Vec<>` of function calls and invoking the waker associated with the `StopTask`, which is polling both the user function and `StopTaskInner`. This is, in my understanding, the same waker that the user function `f` would invoke when more work is available.

When this happens, `StopTaskInner::poll` returns `Poll::Ready(Err(Cancelled))`, at which point the entire task exits and yields execution back to the internal components of `TaskControl`. `TaskControl` then executes all the calls accumulated in `shared.calls` and invokes `run()` on the underlying task again, provided the task was not stopped by the user.

The side effect of all of this is that the future the user was awaiting inside `until_stopped` gets discarded. Crucially, this is also the same pathway leveraged by `Inspect` and `InspectMut` to inspect the underlying task. As a result, when the `nvme_driver` is inspected, it causes the task to be cancelled and re-run. In our case, this would discard the `create_nvme_io_queue` future being awaited, putting the system into a bad state.

A simple fix here is to only wrap the `recv.next()` in `until_stopped`, which is also the pattern used elsewhere in the codebase. The downside here is that we can't stop stuck create_nvme_io_queue or save commands anymore ... but we were not doing that previously either. If either of those are stuck, we need to tear everything down anyways.

The relationships between these objects can be mapped out as: 
<img width="6088" height="2824" alt="image" src="https://github.com/user-attachments/assets/9885ad1a-3cce-4c6b-ab7f-7487a5875b26" />
 