### PR TITLE
deps: Update mu_msvm to v26.0.1 release

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -24,7 +24,7 @@ pub const GH_CLI: &str = "2.52.0";
 pub const MDBOOK: &str = "0.4.40";
 pub const MDBOOK_ADMONISH: &str = "1.18.0";
 pub const MDBOOK_MERMAID: &str = "0.14.0";
-pub const MU_MSVM: &str = "26.0.2";
+pub const MU_MSVM: &str = "26.0.1";
 pub const NEXTEST: &str = "0.9.101";
 pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -24,7 +24,7 @@ pub const GH_CLI: &str = "2.52.0";
 pub const MDBOOK: &str = "0.4.40";
 pub const MDBOOK_ADMONISH: &str = "1.18.0";
 pub const MDBOOK_MERMAID: &str = "0.14.0";
-pub const MU_MSVM: &str = "26.0.0";
+pub const MU_MSVM: &str = "26.0.2";
 pub const NEXTEST: &str = "0.9.101";
 pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly

--- a/nix/uefi_mu_msvm.nix
+++ b/nix/uefi_mu_msvm.nix
@@ -14,11 +14,11 @@ let
 
 in stdenv.mkDerivation {
   pname = "uefi-mu-msvm-${archToolchain}";
-  version = "26.0.0";
+  version = "26.0.2";
 
   src = fetchzip {
     url =
-      "https://github.com/microsoft/mu_msvm/releases/download/v26.0.0/RELEASE-${archToolchain}-artifacts.tar.gz";
+      "https://github.com/microsoft/mu_msvm/releases/download/v26.0.2/RELEASE-${archToolchain}-artifacts.tar.gz";
     stripRoot = false;
     inherit hash;
   };

--- a/nix/uefi_mu_msvm.nix
+++ b/nix/uefi_mu_msvm.nix
@@ -14,11 +14,11 @@ let
 
 in stdenv.mkDerivation {
   pname = "uefi-mu-msvm-${archToolchain}";
-  version = "26.0.2";
+  version = "26.0.1";
 
   src = fetchzip {
     url =
-      "https://github.com/microsoft/mu_msvm/releases/download/v26.0.2/RELEASE-${archToolchain}-artifacts.tar.gz";
+      "https://github.com/microsoft/mu_msvm/releases/download/v26.0.1/RELEASE-${archToolchain}-artifacts.tar.gz";
     stripRoot = false;
     inherit hash;
   };


### PR DESCRIPTION
mu_msvm release notes: https://github.com/microsoft/mu_msvm/releases/tag/v26.0.1