### PR TITLE
Hypercall to let the VTL0 or VTL1 to retrieve its VMPCK so that it can communicate with the PSP

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -567,6 +567,7 @@ pub(crate) mod ioctls {
     pub const HCL_CAP_VTL_RETURN_ACTION: u32 = 2;
     pub const HCL_CAP_DR6_SHARED: u32 = 3;
     pub const HCL_CAP_LOWER_VTL_TIMER_VIRT: u32 = 4;
+    pub const HCL_CAP_LOWER_VTL_SNP_GUEST_REQUEST: u32 = 5;
 
     ioctl_write_ptr!(
         /// Check for the presence of an extension capability.
@@ -1343,6 +1344,7 @@ pub struct Hcl {
     supports_register_page: bool,
     dr6_shared: bool,
     supports_lower_vtl_timer_virt: bool,
+    supports_lower_vtl_snp_guest_request: bool,
     isolation: IsolationType,
     snp_register_bitmap: [u8; 64],
     sidecar: Option<SidecarClient>,
@@ -1382,6 +1384,12 @@ impl Hcl {
     /// Returns true if timer virtualization for lower VTL is supported.
     pub fn supports_lower_vtl_timer_virt(&self) -> bool {
         self.supports_lower_vtl_timer_virt
+    }
+
+    /// Returns true if SNP guest requests from lower VTLs are intercepted and
+    /// forwarded to VTL2.
+    pub fn supports_lower_vtl_snp_guest_request(&self) -> bool {
+        self.supports_lower_vtl_snp_guest_request
     }
 }
 
@@ -1784,10 +1792,13 @@ impl Hcl {
         let dr6_shared = mshv_fd.check_extension(HCL_CAP_DR6_SHARED)?;
         let supports_lower_vtl_timer_virt =
             mshv_fd.check_extension(HCL_CAP_LOWER_VTL_TIMER_VIRT)?;
+        let supports_lower_vtl_snp_guest_request =
+            mshv_fd.check_extension(HCL_CAP_LOWER_VTL_SNP_GUEST_REQUEST)?;
         tracing::debug!(
             supports_vtl_ret_action,
             supports_register_page,
             supports_lower_vtl_timer_virt,
+            supports_lower_vtl_snp_guest_request,
             "HCL capabilities",
         );
 
@@ -1812,6 +1823,7 @@ impl Hcl {
             supports_register_page,
             dr6_shared,
             supports_lower_vtl_timer_virt,
+            supports_lower_vtl_snp_guest_request,
             isolation,
             snp_register_bitmap,
             sidecar,

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -567,7 +567,6 @@ pub(crate) mod ioctls {
     pub const HCL_CAP_VTL_RETURN_ACTION: u32 = 2;
     pub const HCL_CAP_DR6_SHARED: u32 = 3;
     pub const HCL_CAP_LOWER_VTL_TIMER_VIRT: u32 = 4;
-    pub const HCL_CAP_LOWER_VTL_SNP_GUEST_REQUEST: u32 = 5;
 
     ioctl_write_ptr!(
         /// Check for the presence of an extension capability.
@@ -1386,8 +1385,7 @@ impl Hcl {
         self.supports_lower_vtl_timer_virt
     }
 
-    /// Returns true if SNP guest requests from lower VTLs are intercepted and
-    /// forwarded to VTL2.
+    /// Returns true if the partition supports SNP guest requests from lower VTLs.
     pub fn supports_lower_vtl_snp_guest_request(&self) -> bool {
         self.supports_lower_vtl_snp_guest_request
     }
@@ -1792,8 +1790,29 @@ impl Hcl {
         let dr6_shared = mshv_fd.check_extension(HCL_CAP_DR6_SHARED)?;
         let supports_lower_vtl_timer_virt =
             mshv_fd.check_extension(HCL_CAP_LOWER_VTL_TIMER_VIRT)?;
-        let supports_lower_vtl_snp_guest_request =
-            mshv_fd.check_extension(HCL_CAP_LOWER_VTL_SNP_GUEST_REQUEST)?;
+
+        let supports_lower_vtl_snp_guest_request = if cfg!(guest_arch = "x86_64") {
+            // xtask-fmt allow-target-arch cpu-intrinsic
+            #[cfg(target_arch = "x86_64")]
+            {
+                let result = safe_intrinsics::cpuid(
+                    hvdef::HV_CPUID_FUNCTION_MS_HV_ENLIGHTENMENT_INFORMATION,
+                    0,
+                );
+                let enlightenment_info = hvdef::HvEnlightenmentInformation::from_cpuid([
+                    result.eax, result.ebx, result.ecx, result.edx,
+                ]);
+                enlightenment_info.lower_vtl_guest_request_support()
+            }
+            // xtask-fmt allow-target-arch cpu-intrinsic
+            #[cfg(not(target_arch = "x86_64"))]
+            {
+                unreachable!()
+            }
+        } else {
+            false
+        };
+
         tracing::debug!(
             supports_vtl_ret_action,
             supports_register_page,

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -73,6 +73,9 @@ use vmcore::vmtime::VmTimeAccess;
 use x86defs::RFlags;
 use x86defs::apic::X2APIC_MSR_BASE;
 use x86defs::cpuid::CpuidFunction;
+use x86defs::snp::SNP_NUM_VMPCKS;
+use x86defs::snp::SNP_SECRETS_VMPCK0_OFFSET;
+use x86defs::snp::SNP_VMPCK_KEY_SIZE;
 use x86defs::snp::SevAvicIncompleteIpiInfo1;
 use x86defs::snp::SevAvicIncompleteIpiInfo2;
 use x86defs::snp::SevAvicNoAccelInfo;
@@ -427,11 +430,18 @@ pub struct SnpBackedShared {
     #[inspect(skip)]
     guest_timer: hardware_cvm::VmTimeGuestTimer,
     secure_avic: bool,
+    /// VMPCK keys extracted from the SNP secrets page at partition initialization.
+    /// Indexed by VMPCK index (0-3), where each key is [`SNP_VMPCK_KEY_SIZE`] bytes.
+    #[inspect(skip)]
+    vmpck_keys: [[u8; SNP_VMPCK_KEY_SIZE]; SNP_NUM_VMPCKS],
+    /// Whether the hypervisor supports intercepting SNP guest requests from lower
+    /// VTLs and forwarding them to VTL2.
+    supports_lower_vtl_snp_guest_request: bool,
 }
 
 impl SnpBackedShared {
     pub(crate) fn new(
-        _partition_params: &UhPartitionNewParams<'_>,
+        partition_params: &UhPartitionNewParams<'_>,
         params: BackingSharedParams<'_>,
     ) -> Result<Self, Error> {
         let cvm = params.cvm_state.unwrap();
@@ -460,6 +470,18 @@ impl SnpBackedShared {
         // Configure timer interface for lower VTLs.
         let guest_timer = hardware_cvm::VmTimeGuestTimer;
 
+        // Extract the four VMPCK keys from the SNP secrets page.
+        let vmpck_keys = if let Some(secrets) = partition_params.snp_secrets {
+            let mut keys = [[0u8; SNP_VMPCK_KEY_SIZE]; SNP_NUM_VMPCKS];
+            for (i, key) in keys.iter_mut().enumerate() {
+                let offset = SNP_SECRETS_VMPCK0_OFFSET + i * SNP_VMPCK_KEY_SIZE;
+                key.copy_from_slice(&secrets[offset..offset + SNP_VMPCK_KEY_SIZE]);
+            }
+            keys
+        } else {
+            [[0u8; SNP_VMPCK_KEY_SIZE]; SNP_NUM_VMPCKS]
+        };
+
         Ok(Self {
             sev_status,
             invlpgb_count_max,
@@ -467,6 +489,8 @@ impl SnpBackedShared {
             secure_avic,
             cvm,
             guest_timer,
+            vmpck_keys,
+            supports_lower_vtl_snp_guest_request: params.hcl.supports_lower_vtl_snp_guest_request(),
         })
     }
 }
@@ -954,6 +978,7 @@ impl UhHypercallHandler<'_, '_, SnpBacked> {
             hv1_hypercall::HvSendSyntheticClusterIpiEx,
             hv1_hypercall::HvInstallIntercept,
             hv1_hypercall::HvAssertVirtualInterrupt,
+            hv1_hypercall::HvGetSnpVmpck,
         ],
     );
 
@@ -3120,6 +3145,23 @@ impl TlbFlushLockAccess for SnpTlbLockFlushAccess<'_> {
             }
             .set_wait_for_tlb_locks(vtl);
         }
+    }
+}
+
+impl hv1_hypercall::GetSnpVmpck for UhHypercallHandler<'_, '_, SnpBacked> {
+    fn get_snp_vmpck(&mut self) -> hvdef::HvResult<hvdef::hypercall::GetSnpVmpckOutput> {
+        if !self.vp.shared.supports_lower_vtl_snp_guest_request {
+            return Err(HvError::AccessDenied);
+        }
+
+        // The VMPCK index corresponds to the VMPL of the calling VTL:
+        // VTL0 runs at VMPL2, VTL1 runs at VMPL1.
+        let index = match self.intercepted_vtl {
+            GuestVtl::Vtl0 => 2,
+            GuestVtl::Vtl1 => 1,
+        };
+        let vmpck_key = self.vp.shared.vmpck_keys[index];
+        Ok(hvdef::hypercall::GetSnpVmpckOutput { vmpck_key })
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -433,10 +433,7 @@ pub struct SnpBackedShared {
     /// VMPCK keys extracted from the SNP secrets page at partition initialization.
     /// Indexed by VMPCK index (0-3), where each key is [`SNP_VMPCK_KEY_SIZE`] bytes.
     #[inspect(skip)]
-    vmpck_keys: [[u8; SNP_VMPCK_KEY_SIZE]; SNP_NUM_VMPCKS],
-    /// Whether the hypervisor supports intercepting SNP guest requests from lower
-    /// VTLs and forwarding them to VTL2.
-    supports_lower_vtl_snp_guest_request: bool,
+    vmpck_keys: Option<[[u8; SNP_VMPCK_KEY_SIZE]; SNP_NUM_VMPCKS]>,
 }
 
 impl SnpBackedShared {
@@ -470,16 +467,28 @@ impl SnpBackedShared {
         // Configure timer interface for lower VTLs.
         let guest_timer = hardware_cvm::VmTimeGuestTimer;
 
+        let required_len = SNP_SECRETS_VMPCK0_OFFSET + SNP_NUM_VMPCKS * SNP_VMPCK_KEY_SIZE;
+
         // Extract the four VMPCK keys from the SNP secrets page.
         let vmpck_keys = if let Some(secrets) = partition_params.snp_secrets {
-            let mut keys = [[0u8; SNP_VMPCK_KEY_SIZE]; SNP_NUM_VMPCKS];
-            for (i, key) in keys.iter_mut().enumerate() {
-                let offset = SNP_SECRETS_VMPCK0_OFFSET + i * SNP_VMPCK_KEY_SIZE;
-                key.copy_from_slice(&secrets[offset..offset + SNP_VMPCK_KEY_SIZE]);
+            if secrets.len() < required_len {
+                tracing::error!(
+                    "SNP secrets page too small: got {} bytes, expected at least {} bytes",
+                    secrets.len(),
+                    required_len
+                );
+
+                None
+            } else {
+                let mut keys = [[0u8; SNP_VMPCK_KEY_SIZE]; SNP_NUM_VMPCKS];
+                for (i, key) in keys.iter_mut().enumerate() {
+                    let offset = SNP_SECRETS_VMPCK0_OFFSET + i * SNP_VMPCK_KEY_SIZE;
+                    key.copy_from_slice(&secrets[offset..offset + SNP_VMPCK_KEY_SIZE]);
+                }
+                Some(keys)
             }
-            keys
         } else {
-            [[0u8; SNP_VMPCK_KEY_SIZE]; SNP_NUM_VMPCKS]
+            None
         };
 
         Ok(Self {
@@ -490,7 +499,6 @@ impl SnpBackedShared {
             cvm,
             guest_timer,
             vmpck_keys,
-            supports_lower_vtl_snp_guest_request: params.hcl.supports_lower_vtl_snp_guest_request(),
         })
     }
 }
@@ -3150,9 +3158,14 @@ impl TlbFlushLockAccess for SnpTlbLockFlushAccess<'_> {
 
 impl hv1_hypercall::GetSnpVmpck for UhHypercallHandler<'_, '_, SnpBacked> {
     fn get_snp_vmpck(&mut self) -> hvdef::HvResult<hvdef::hypercall::GetSnpVmpckOutput> {
-        if !self.vp.shared.supports_lower_vtl_snp_guest_request {
+        if !self.vp.partition.hcl.supports_lower_vtl_snp_guest_request() {
             return Err(HvError::AccessDenied);
         }
+
+        let vmpck_keys = match &self.vp.shared.vmpck_keys {
+            Some(keys) => keys,
+            None => return Err(HvError::NotFound),
+        };
 
         // The VMPCK index corresponds to the VMPL of the calling VTL:
         // VTL0 runs at VMPL2, VTL1 runs at VMPL1.
@@ -3160,8 +3173,9 @@ impl hv1_hypercall::GetSnpVmpck for UhHypercallHandler<'_, '_, SnpBacked> {
             GuestVtl::Vtl0 => 2,
             GuestVtl::Vtl1 => 1,
         };
-        let vmpck_key = self.vp.shared.vmpck_keys[index];
-        Ok(hvdef::hypercall::GetSnpVmpckOutput { vmpck_key })
+        Ok(hvdef::hypercall::GetSnpVmpckOutput {
+            vmpck_key: vmpck_keys[index],
+        })
     }
 }
 

--- a/vm/hv1/hv1_hypercall/src/imp.rs
+++ b/vm/hv1/hv1_hypercall/src/imp.rs
@@ -389,6 +389,22 @@ impl<T: TranslateVirtualAddressExAarch64> HypercallDispatch<HvAarch64TranslateVi
     }
 }
 
+/// Defines the `HvGetSnpVmpck` hypercall.
+pub type HvGetSnpVmpck =
+    SimpleHypercall<(), defs::GetSnpVmpckOutput, { HypercallCode::HvCallGetSnpVmpck.0 }>;
+
+/// Implements the `HvGetSnpVmpck` hypercall.
+pub trait GetSnpVmpck {
+    /// Returns the VMPCK (VM Platform Communication Key) for the calling VTL.
+    fn get_snp_vmpck(&mut self) -> HvResult<defs::GetSnpVmpckOutput>;
+}
+
+impl<T: GetSnpVmpck> HypercallDispatch<HvGetSnpVmpck> for T {
+    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HypercallOutput {
+        HvGetSnpVmpck::run(params, |()| self.get_snp_vmpck())
+    }
+}
+
 /// Defines the `HvGetVpRegisters` hypercall.
 pub type HvGetVpRegisters = RepHypercall<
     defs::GetSetVpRegisters,

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -745,6 +745,7 @@ open_enum! {
         HvCallPinGpaPageRanges = 0x0112,
         HvCallUnpinGpaPageRanges = 0x0113,
         HvCallQuerySparseGpaPageHostVisibility = 0x011C,
+        HvCallGetSnpVmpck = 0x0134,
 
         // Extended hypercalls.
         HvExtCallQueryCapabilities = 0x8001,
@@ -2486,6 +2487,15 @@ pub mod hypercall {
         pub reserved: u32,
         pub reference_time_in_100_ns: u64,
         pub tsc: u64,
+    }
+
+    /// The size of a VMPCK key in bytes.
+    pub const SNP_VMPCK_KEY_SIZE: usize = 0x20;
+
+    #[repr(C)]
+    #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+    pub struct GetSnpVmpckOutput {
+        pub vmpck_key: [u8; SNP_VMPCK_KEY_SIZE],
     }
 }
 

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -621,13 +621,20 @@ pub struct HvEnlightenmentInformation {
     pub use_hypercall_for_mmio_access: bool,
     pub use_gpa_pinning_hypercall: bool,
     pub wake_vps: bool,
-    _reserved: u8,
+    pub proxy_interrupt_doorbell_support: bool,
+    pub memory_type_locking_support: bool,
+    pub map_partition_event_log_buffer: bool,
+    pub lower_vtl_guest_request_support: bool,
+    pub heat_hint_beneficial_support: bool,
+    pub ring_buffer_message_port_support: bool,
+    _reserved1: bool,
+    _reserved2: bool,
     pub long_spin_wait_count: u32,
     #[bits(7)]
     pub implemented_physical_address_bits: u32,
     #[bits(25)]
-    _reserved1: u32,
-    _reserved2: u32,
+    _reserved3: u32,
+    _reserved4: u32,
 }
 
 impl HvEnlightenmentInformation {
@@ -2493,7 +2500,7 @@ pub mod hypercall {
     pub const SNP_VMPCK_KEY_SIZE: usize = 0x20;
 
     #[repr(C)]
-    #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+    #[derive(Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
     pub struct GetSnpVmpckOutput {
         pub vmpck_key: [u8; SNP_VMPCK_KEY_SIZE],
     }

--- a/vm/whp/src/abi.rs
+++ b/vm/whp/src/abi.rs
@@ -567,10 +567,6 @@ impl WHV_SYNTHETIC_PROCESSOR_FEATURES {
     /// SPIs are advertised to VTL2.
     #[cfg(target_arch = "aarch64")]
     pub const ManagementVtlSpiSupport: Self = Self(1 << 44);
-
-    // Hypervisor supports for lower VTLs to make guest requests.
-    #[cfg(target_arch = "x86_64")]
-    pub const LowerVtlGuestRequestSupport: Self = Self(1 << 46);
 }
 
 #[repr(C)]

--- a/vm/whp/src/abi.rs
+++ b/vm/whp/src/abi.rs
@@ -567,6 +567,10 @@ impl WHV_SYNTHETIC_PROCESSOR_FEATURES {
     /// SPIs are advertised to VTL2.
     #[cfg(target_arch = "aarch64")]
     pub const ManagementVtlSpiSupport: Self = Self(1 << 44);
+
+    // Hypervisor supports for lower VTLs to make guest requests.
+    #[cfg(target_arch = "x86_64")]
+    pub const LowerVtlGuestRequestSupport: Self = Self(1 << 46);
 }
 
 #[repr(C)]

--- a/vm/x86/x86defs/src/snp.rs
+++ b/vm/x86/x86defs/src/snp.rs
@@ -21,6 +21,15 @@ pub const SEV_INTR_TYPE_SW: u32 = 4;
 pub const REG_TWEAK_BITMAP_OFFSET: usize = 0x100;
 pub const REG_TWEAK_BITMAP_SIZE: usize = 0x40;
 
+// VMPCK key offsets within the SNP secrets page.
+// See AMD SEV-SNP Firmware ABI Specification, Table 11 (Guest-Secrets Page Layout).
+pub const SNP_NUM_VMPCKS: usize = 4;
+pub const SNP_SECRETS_VMPCK0_OFFSET: usize = 0x20;
+pub const SNP_SECRETS_VMPCK1_OFFSET: usize = 0x40;
+pub const SNP_SECRETS_VMPCK2_OFFSET: usize = 0x60;
+pub const SNP_SECRETS_VMPCK3_OFFSET: usize = 0x80;
+pub const SNP_VMPCK_KEY_SIZE: usize = 0x20;
+
 /// Value for the `msg_version` member in [`SNP_GUEST_REQ_MSG_VERSION`].
 /// Use 1 for now.
 pub const SNP_GUEST_REQ_MSG_VERSION: u32 = 1;


### PR DESCRIPTION
Implement the hypercall that allows the VTL0 or VTL1 retrieve the VM Platform Communication Key (VMPCK) for its own VTL, so that it can directly communicate with the PSP. The VMPCK is used to encrypt/decrypt the communication with the PSP.