### PR TITLE
vmcore: add InterruptTarget trait and lazy irqfd route allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8736,7 +8736,6 @@ dependencies = [
  "vfio-bindings",
  "vfio_assigned_device_resources",
  "vfio_sys",
- "virt",
  "vm_resource",
  "vmcore",
 ]

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2880,7 +2880,10 @@ impl LoadedVm {
                                 })
                                 .ok_or_else(|| anyhow::anyhow!("port '{}' not found in any root complex", port_name))?;
 
-                            let msi_conn = pci_core::msi::MsiConnection::new();
+                            let msi_conn = match self.inner.partition.irqfd() {
+                                Some(fd) => pci_core::msi::MsiConnection::with_irqfd(fd),
+                                None => pci_core::msi::MsiConnection::new(),
+                            };
                             let signal_msi = self.inner.partition.as_signal_msi(Vtl::Vtl0);
 
                             let (unit, device) = self.inner.chipset_devices.add_dyn_device(
@@ -2898,7 +2901,6 @@ impl LoadedVm {
                                                 guest_memory: &self.inner.gm,
                                                 doorbell_registration: self.inner.partition.clone().into_doorbell_registration(Vtl::Vtl0),
                                                 shared_mem_mapper: None,
-                                                irqfd: self.inner.partition.irqfd(),
                                             },
                                         )
                                         .await

--- a/vm/devices/pci/pci_core/src/capabilities/msix.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/msix.rs
@@ -4,18 +4,19 @@
 //! MSI-X Capability.
 
 use super::PciCapability;
+use crate::msi::MsiRoute;
 use crate::msi::MsiTarget;
 use crate::spec::caps::CapabilityId;
 use crate::spec::caps::msix::MsixCapabilityHeader;
 use crate::spec::caps::msix::MsixTableEntryIdx;
 use inspect::Inspect;
 use inspect::InspectMut;
+use pal_event::Event;
 use parking_lot::Mutex;
 use std::fmt::Debug;
 use std::sync::Arc;
 use vmcore::interrupt::Interrupt;
-use vmcore::irqfd::IrqFd;
-use vmcore::irqfd::IrqFdRoute;
+use vmcore::interrupt::InterruptTarget;
 
 #[derive(Debug, Inspect)]
 struct MsiTableLocation {
@@ -123,12 +124,13 @@ pub(crate) struct MsiInterrupt(#[inspect(flatten)] Arc<Mutex<MsiInterruptInner>>
 
 #[derive(Inspect)]
 struct MsiInterruptInner {
+    #[inspect(skip)]
     target: MsiTarget,
-    /// Optional kernel-mediated route for fast interrupt delivery.
+    /// Optional kernel-mediated route for direct interrupt delivery.
     /// When present, `enable()`/`disable()` automatically program the
     /// kernel's MSI routing alongside the userspace `MsiTarget` path.
     #[inspect(skip)]
-    route: Option<Box<dyn IrqFdRoute>>,
+    route: Option<MsiRoute>,
     pending: bool,
     enabled: bool,
     address: u64,
@@ -167,26 +169,8 @@ impl MsiInterrupt {
         state.enabled = true;
 
         // Program the kernel route if present.
-        if state.route.is_some() {
-            let route = state.route.as_ref().unwrap();
-            if route.consume_pending() {
-                state.pending = true;
-            }
-        }
         if let Some(route) = &state.route {
-            if address != 0 || data != 0 {
-                if let Err(e) = route.set_msi(address, data) {
-                    tracelimit::warn_ratelimited!(
-                        error = ?e,
-                        "failed to program MSI-X route on enable"
-                    );
-                }
-            } else if let Err(e) = route.clear_msi() {
-                tracelimit::warn_ratelimited!(
-                    error = ?e,
-                    "failed to clear MSI-X route on enable"
-                );
-            }
+            route.enable(address, data);
         }
 
         if state.pending {
@@ -199,12 +183,7 @@ impl MsiInterrupt {
         let mut state = self.0.lock();
         state.enabled = false;
         if let Some(route) = &state.route {
-            if let Err(e) = route.mask() {
-                tracelimit::warn_ratelimited!(
-                    error = ?e,
-                    "failed to mask MSI-X route on disable"
-                );
-            }
+            route.disable();
         }
     }
 
@@ -218,26 +197,46 @@ impl MsiInterrupt {
         was_pending
     }
 
-    /// Install a kernel-mediated route for fast interrupt delivery.
-    pub(crate) fn set_route(&self, route: Box<dyn IrqFdRoute>) {
-        self.0.lock().route = Some(route);
-    }
-
-    /// Remove the kernel-mediated route.
-    pub(crate) fn clear_route(&self) {
-        self.0.lock().route = None;
-    }
-
     pub fn interrupt(&self) -> Interrupt {
-        let state = self.0.clone();
-        Interrupt::from_fn(move || {
-            let mut state = state.lock();
-            if state.enabled {
-                state.target.signal_msi(0, state.address, state.data);
-            } else {
-                state.pending = true;
+        Interrupt::from_target(MsiInterruptTarget(self.0.clone()))
+    }
+}
+
+/// [`InterruptTarget`] for MSI-X vectors that lazily allocates an irqfd
+/// route when [`event()`](InterruptTarget::event) is first called.
+struct MsiInterruptTarget(Arc<Mutex<MsiInterruptInner>>);
+
+impl InterruptTarget for MsiInterruptTarget {
+    fn deliver(&self) {
+        let mut state = self.0.lock();
+        if state.enabled {
+            state.target.signal_msi(0, state.address, state.data);
+        } else {
+            state.pending = true;
+        }
+    }
+
+    fn event(&self) -> Option<Arc<Event>> {
+        let mut state = self.0.lock();
+        if let Some(route) = &state.route {
+            return Some(Arc::new(route.event().clone()));
+        }
+        let route = match state.target.new_route() {
+            Some(Ok(route)) => route,
+            Some(Err(e)) => {
+                tracelimit::warn_ratelimited!(error = ?e, "failed to allocate MSI route");
+                return None;
             }
-        })
+            None => return None,
+        };
+        if state.enabled {
+            route.enable(state.address, state.data);
+        } else {
+            route.disable();
+        }
+        let event = Arc::new(route.event().clone());
+        state.route = Some(route);
+        Some(event)
     }
 }
 
@@ -492,50 +491,6 @@ impl MsixEmulator {
             );
         }
     }
-
-    /// Enable kernel-mediated interrupt delivery for all vectors.
-    ///
-    /// Creates one irqfd route per vector using the provided [`IrqFd`]
-    /// interface. The `register` callback receives references to the events
-    /// for all vectors. The caller uses this to pass events to the
-    /// interrupt source (e.g., VFIO `map_msix` or vhost-user
-    /// `SET_VRING_CALL`). After the callback returns, the routes are
-    /// installed in the emulator. When the guest programs MSI-X table
-    /// entries, the emulator automatically updates the kernel's MSI routing.
-    ///
-    /// Call [`disable_irqfd`](Self::disable_irqfd) to tear down the routes.
-    pub fn enable_irqfd(
-        &self,
-        irqfd: &dyn IrqFd,
-        register: impl FnOnce(&[&pal_event::Event]) -> anyhow::Result<()>,
-    ) -> anyhow::Result<()> {
-        let state = self.state.lock();
-        let mut routes: Vec<Box<dyn IrqFdRoute>> = Vec::with_capacity(state.vectors.len());
-        for _ in state.vectors.iter() {
-            routes.push(irqfd.new_irqfd_route()?);
-        }
-
-        // Collect event references while routes are still in our local Vec.
-        let events: Vec<&pal_event::Event> = routes.iter().map(|r| r.event()).collect();
-        register(&events)?;
-
-        // Move routes into the emulator's MsiInterrupts.
-        for (entry, route) in state.vectors.iter().zip(routes) {
-            entry.msi.set_route(route);
-        }
-        Ok(())
-    }
-
-    /// Tear down kernel-mediated interrupt delivery.
-    ///
-    /// Drops all irqfd routes, unregistering them from the hypervisor and
-    /// freeing GSI allocations.
-    pub fn disable_irqfd(&self) {
-        let state = self.state.lock();
-        for entry in &state.vectors {
-            entry.msi.clear_route();
-        }
-    }
 }
 
 mod save_restore {
@@ -702,102 +657,81 @@ mod tests {
     use pal_event::Event;
     use parking_lot::Mutex;
 
-    /// Record of a call made to a [`MockIrqFdRoute`].
+    /// Record of a call made to a mock route.
     #[derive(Debug, Clone, PartialEq)]
     enum RouteCall {
         SetMsi { address: u64, data: u32 },
         ClearMsi,
-        Mask,
-        ConsumePending,
     }
 
-    /// Mock irqfd route that records calls.
+    /// Mock IrqFdRoute implementation that records calls.
     struct MockIrqFdRoute {
         event: Event,
         calls: Arc<Mutex<Vec<RouteCall>>>,
-        pending: Arc<Mutex<bool>>,
     }
 
-    impl IrqFdRoute for MockIrqFdRoute {
+    impl vmcore::irqfd::IrqFdRoute for MockIrqFdRoute {
         fn event(&self) -> &Event {
             &self.event
         }
 
-        fn set_msi(&self, address: u64, data: u32) -> anyhow::Result<()> {
+        fn enable(&self, address: u64, data: u32) {
             self.calls.lock().push(RouteCall::SetMsi { address, data });
-            Ok(())
         }
 
-        fn clear_msi(&self) -> anyhow::Result<()> {
+        fn disable(&self) {
             self.calls.lock().push(RouteCall::ClearMsi);
-            Ok(())
-        }
-
-        fn mask(&self) -> anyhow::Result<()> {
-            self.calls.lock().push(RouteCall::Mask);
-            Ok(())
-        }
-
-        fn unmask(&self) -> anyhow::Result<()> {
-            Ok(())
-        }
-
-        fn consume_pending(&self) -> bool {
-            self.calls.lock().push(RouteCall::ConsumePending);
-            let mut p = self.pending.lock();
-            let was = *p;
-            *p = false;
-            was
         }
     }
 
-    /// Mock IrqFd that creates MockIrqFdRoutes and returns shared call logs.
-    struct MockIrqFd {
-        routes: Mutex<Vec<(Arc<Mutex<Vec<RouteCall>>>, Arc<Mutex<bool>>)>>,
-    }
+    /// Build a mock IrqFd and shared call logs.
+    fn mock_irqfd(
+        count: usize,
+    ) -> (
+        Arc<dyn vmcore::irqfd::IrqFd>,
+        Vec<Arc<Mutex<Vec<RouteCall>>>>,
+    ) {
+        let mut call_logs = Vec::new();
+        let route_params = Arc::new(Mutex::new(Vec::new()));
+        for _ in 0..count {
+            let calls = Arc::new(Mutex::new(Vec::new()));
+            call_logs.push(calls.clone());
+            route_params.lock().push(calls);
+        }
 
-    impl MockIrqFd {
-        fn new(count: usize) -> (Self, Vec<Arc<Mutex<Vec<RouteCall>>>>, Vec<Arc<Mutex<bool>>>) {
-            let mut call_logs = Vec::new();
-            let mut pendings = Vec::new();
-            let mut route_params = Vec::new();
-            for _ in 0..count {
-                let calls = Arc::new(Mutex::new(Vec::new()));
-                let pending = Arc::new(Mutex::new(false));
-                call_logs.push(calls.clone());
-                pendings.push(pending.clone());
-                route_params.push((calls, pending));
+        struct MockIrqFd {
+            routes: Mutex<Vec<Arc<Mutex<Vec<RouteCall>>>>>,
+        }
+        impl vmcore::irqfd::IrqFd for MockIrqFd {
+            fn new_irqfd_route(&self) -> anyhow::Result<Box<dyn vmcore::irqfd::IrqFdRoute>> {
+                let calls = self.routes.lock().remove(0);
+                Ok(Box::new(MockIrqFdRoute {
+                    event: Event::new(),
+                    calls,
+                }))
             }
-            (
-                Self {
-                    routes: Mutex::new(route_params),
-                },
-                call_logs,
-                pendings,
-            )
         }
-    }
 
-    impl IrqFd for MockIrqFd {
-        fn new_irqfd_route(&self) -> anyhow::Result<Box<dyn IrqFdRoute>> {
-            let (calls, pending) = self.routes.lock().remove(0);
-            Ok(Box::new(MockIrqFdRoute {
-                event: Event::new(),
-                calls,
-                pending,
-            }))
-        }
+        (
+            Arc::new(MockIrqFd {
+                routes: Mutex::new(call_logs.clone()),
+            }),
+            call_logs,
+        )
     }
 
     #[test]
     fn route_set_msi_on_unmask() {
-        let msi_conn = MsiConnection::new();
+        let (irqfd, calls) = mock_irqfd(2);
+        let msi_conn = MsiConnection::with_irqfd(irqfd);
         let (mut msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
-        let (mock_irqfd, calls, _pendings) = MockIrqFd::new(2);
-        msix.enable_irqfd(&mock_irqfd, |_| Ok(())).unwrap();
+        // Trigger lazy irqfd route creation for all vectors.
+        for i in 0..2 {
+            msix.interrupt(i).unwrap().event();
+        }
 
         // Enable MSI-X globally.
         cap.write_u32(0, 0x80000000);
@@ -819,9 +753,8 @@ mod tests {
         calls[0].lock().clear();
         msix.write_u32(12, 0);
 
-        // Should have called consume_pending then set_msi.
+        // Should have called set_msi to re-establish the route.
         let log = calls[0].lock().clone();
-        assert!(log.contains(&RouteCall::ConsumePending));
         assert!(log.contains(&RouteCall::SetMsi {
             address: 0xFEE00000,
             data: 0x42
@@ -830,13 +763,16 @@ mod tests {
 
     #[test]
     fn route_mask_on_vector_mask() {
-        let msi_conn = MsiConnection::new();
+        let (irqfd, calls) = mock_irqfd(2);
+        let msi_conn = MsiConnection::with_irqfd(irqfd);
         let (mut msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
-        let (mock_irqfd, calls, _pendings) = MockIrqFd::new(2);
-        msix.enable_irqfd(&mock_irqfd, |_| Ok(())).unwrap();
+        // Trigger lazy irqfd route creation for all vectors.
+        for i in 0..2 {
+            msix.interrupt(i).unwrap().event();
+        }
 
         // Enable MSI-X, program and unmask vector 0.
         cap.write_u32(0, 0x80000000);
@@ -850,18 +786,21 @@ mod tests {
         msix.write_u32(12, 1);
 
         let log = calls[0].lock().clone();
-        assert!(log.contains(&RouteCall::Mask));
+        assert!(log.contains(&RouteCall::ClearMsi));
     }
 
     #[test]
     fn route_global_disable_masks_all() {
-        let msi_conn = MsiConnection::new();
+        let (irqfd, calls) = mock_irqfd(2);
+        let msi_conn = MsiConnection::with_irqfd(irqfd);
         let (mut msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
-        let (mock_irqfd, calls, _pendings) = MockIrqFd::new(2);
-        msix.enable_irqfd(&mock_irqfd, |_| Ok(())).unwrap();
+        // Trigger lazy irqfd route creation for all vectors.
+        for i in 0..2 {
+            msix.interrupt(i).unwrap().event();
+        }
 
         // Enable, program, and unmask both vectors.
         cap.write_u32(0, 0x80000000);
@@ -876,45 +815,47 @@ mod tests {
         // Disable MSI-X globally.
         cap.write_u32(0, 0);
 
-        // Both vectors should have been masked.
-        assert!(calls[0].lock().contains(&RouteCall::Mask));
-        assert!(calls[1].lock().contains(&RouteCall::Mask));
+        // Both vectors should have been disabled.
+        assert!(calls[0].lock().contains(&RouteCall::ClearMsi));
+        assert!(calls[1].lock().contains(&RouteCall::ClearMsi));
     }
 
     #[test]
     fn route_consume_pending_on_pba_read() {
-        let msi_conn = MsiConnection::new();
+        let (irqfd, _calls) = mock_irqfd(2);
+        let msi_conn = MsiConnection::with_irqfd(irqfd);
         let (msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
-        let (mock_irqfd, calls, pendings) = MockIrqFd::new(2);
-        msix.enable_irqfd(&mock_irqfd, |_| Ok(())).unwrap();
+        // Trigger lazy irqfd route creation for all vectors.
+        let events: Vec<_> = (0..2)
+            .map(|i| msix.interrupt(i).unwrap().event().unwrap().clone())
+            .collect();
 
         // Enable MSI-X but leave vectors masked (control = 1 by default).
         cap.write_u32(0, 0x80000000);
 
-        // Simulate a pending interrupt on vector 0.
-        *pendings[0].lock() = true;
-        calls[0].lock().clear();
+        // Simulate a pending interrupt on vector 0 by signaling the event.
+        events[0].signal();
 
         // PBA is at offset = vector_count * 16 = 32.
         let pba = msix.read_u32(32);
 
-        // Should have called consume_pending and returned bit 0 set.
-        assert!(calls[0].lock().contains(&RouteCall::ConsumePending));
+        // consume_pending drains the event; PBA bit 0 should be set.
         assert_eq!(pba & 1, 1);
     }
 
     #[test]
     fn route_set_msi_on_addr_data_change_while_unmasked() {
-        let msi_conn = MsiConnection::new();
+        let (irqfd, calls) = mock_irqfd(1);
+        let msi_conn = MsiConnection::with_irqfd(irqfd);
         let (mut msix, mut cap) = MsixEmulator::new(2, 1, msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
-        let (mock_irqfd, calls, _pendings) = MockIrqFd::new(1);
-        msix.enable_irqfd(&mock_irqfd, |_| Ok(())).unwrap();
+        // Trigger lazy irqfd route creation.
+        msix.interrupt(0).unwrap().event();
 
         // Enable, program, unmask.
         cap.write_u32(0, 0x80000000);

--- a/vm/devices/pci/pci_core/src/msi.rs
+++ b/vm/devices/pci/pci_core/src/msi.rs
@@ -3,9 +3,11 @@
 
 //! Traits for working with MSI interrupts.
 
-use inspect::Inspect;
+use pal_event::Event;
 use parking_lot::RwLock;
 use std::sync::Arc;
+use vmcore::irqfd::IrqFd;
+use vmcore::irqfd::IrqFdRoute;
 
 /// An object that can signal MSI interrupts.
 pub trait SignalMsi: Send + Sync {
@@ -13,6 +15,48 @@ pub trait SignalMsi: Send + Sync {
     ///
     /// `rid` is the requester ID of the PCI device sending the interrupt.
     fn signal_msi(&self, rid: u32, address: u64, data: u32);
+}
+
+/// A kernel-mediated MSI interrupt route for a single vector.
+///
+/// Each route has an associated event. Signaling the event causes the
+/// hypervisor to inject the configured MSI into the guest without a
+/// userspace transition. This is used for device passthrough (VFIO)
+/// where the physical device signals the event on interrupt.
+pub struct MsiRoute(Box<dyn IrqFdRoute>);
+
+impl MsiRoute {
+    /// Wraps a boxed [`IrqFdRoute`] into a concrete route.
+    pub fn new(backing: Box<dyn IrqFdRoute>) -> Self {
+        Self(backing)
+    }
+
+    /// Returns the event that triggers interrupt injection when signaled.
+    ///
+    /// Pass this to VFIO `map_msix` or any other interrupt source.
+    pub fn event(&self) -> &Event {
+        self.0.event()
+    }
+
+    /// Configures the MSI address and data for this route.
+    ///
+    /// `address` and `data` are the x86 MSI address and data values that
+    /// the hypervisor will use when injecting the interrupt.
+    pub fn enable(&self, address: u64, data: u32) {
+        self.0.enable(address, data)
+    }
+
+    /// Disables the MSI route, preventing interrupt injection until
+    /// a new configuration is set via [`enable`](Self::enable).
+    pub fn disable(&self) {
+        self.0.disable()
+    }
+
+    /// Drains pending interrupt state and returns whether an interrupt
+    /// was pending while the route was masked.
+    pub fn consume_pending(&self) -> bool {
+        self.event().try_wait()
+    }
 }
 
 struct DisconnectedMsiTarget;
@@ -30,10 +74,18 @@ pub struct MsiConnection {
 }
 
 /// An MSI target that can be used to signal MSI interrupts.
-#[derive(Inspect, Debug, Clone)]
-#[inspect(skip)]
+#[derive(Clone)]
 pub struct MsiTarget {
     inner: Arc<RwLock<MsiTargetInner>>,
+    irqfd: Option<Arc<dyn IrqFd>>,
+}
+
+impl std::fmt::Debug for MsiTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MsiTarget")
+            .field("has_irqfd", &self.irqfd.is_some())
+            .finish()
+    }
 }
 
 struct MsiTargetInner {
@@ -55,6 +107,23 @@ impl MsiConnection {
                 inner: Arc::new(RwLock::new(MsiTargetInner {
                     signal_msi: Arc::new(DisconnectedMsiTarget),
                 })),
+                irqfd: None,
+            },
+        }
+    }
+
+    /// Creates a new disconnected MSI target connection with an
+    /// [`IrqFd`] for kernel-mediated MSI route allocation.
+    ///
+    /// When present, [`MsiTarget::new_route`] can create [`MsiRoute`]
+    /// instances for direct interrupt delivery.
+    pub fn with_irqfd(irqfd: Arc<dyn IrqFd>) -> Self {
+        Self {
+            target: MsiTarget {
+                inner: Arc::new(RwLock::new(MsiTargetInner {
+                    signal_msi: Arc::new(DisconnectedMsiTarget),
+                })),
+                irqfd: Some(irqfd),
             },
         }
     }
@@ -78,5 +147,21 @@ impl MsiTarget {
     pub fn signal_msi(&self, rid: u32, address: u64, data: u32) {
         let inner = self.inner.read();
         inner.signal_msi.signal_msi(rid, address, data);
+    }
+
+    /// Creates a new kernel-mediated MSI route for direct interrupt
+    /// delivery.
+    ///
+    /// Returns `None` if this target was not configured with an
+    /// [`IrqFd`].
+    pub fn new_route(&self) -> Option<anyhow::Result<MsiRoute>> {
+        self.irqfd
+            .as_ref()
+            .map(|fd| Ok(MsiRoute::new(fd.new_irqfd_route()?)))
+    }
+
+    /// Returns whether this target supports direct MSI routes.
+    pub fn supports_direct_msi(&self) -> bool {
+        self.irqfd.is_some()
     }
 }

--- a/vm/devices/pci/pci_core/src/msi.rs
+++ b/vm/devices/pci/pci_core/src/msi.rs
@@ -40,14 +40,16 @@ impl MsiRoute {
 
     /// Configures the MSI address and data for this route.
     ///
-    /// `address` and `data` are the x86 MSI address and data values that
+    /// `address` and `data` are the MSI address and data values that
     /// the hypervisor will use when injecting the interrupt.
     pub fn enable(&self, address: u64, data: u32) {
         self.0.enable(address, data)
     }
 
-    /// Disables the MSI route, preventing interrupt injection until
-    /// a new configuration is set via [`enable`](Self::enable).
+    /// Disables the MSI route. Interrupts that arrive while disabled
+    /// remain pending on the event and will be delivered when
+    /// [`enable`](Self::enable) is called, or can be drained via
+    /// [`consume_pending`](Self::consume_pending).
     pub fn disable(&self) {
         self.0.disable()
     }

--- a/vm/devices/pci/pci_resources/src/lib.rs
+++ b/vm/devices/pci/pci_resources/src/lib.rs
@@ -15,7 +15,6 @@ use pci_core::msi::MsiTarget;
 use std::sync::Arc;
 use vm_resource::CanResolveTo;
 use vm_resource::kind::PciDeviceHandleKind;
-use vmcore::irqfd::IrqFd;
 use vmcore::vm_task::VmTaskDriverSource;
 
 impl CanResolveTo<ResolvedPciDevice> for PciDeviceHandleKind {
@@ -45,8 +44,4 @@ pub struct ResolvePciDeviceHandleParams<'a> {
     pub doorbell_registration: Option<Arc<dyn DoorbellRegistration>>,
     /// An object with which to register shared memory regions.
     pub shared_mem_mapper: Option<&'a dyn MemoryMapper>,
-    /// irqfd interface for kernel-mediated interrupt delivery. Used by
-    /// device passthrough resolvers (VFIO, vhost-user) for irqfd-based
-    /// MSI injection.
-    pub irqfd: Option<Arc<dyn IrqFd>>,
 }

--- a/vm/devices/pci/vfio_assigned_device/Cargo.toml
+++ b/vm/devices/pci/vfio_assigned_device/Cargo.toml
@@ -19,7 +19,6 @@ pci_resources.workspace = true
 vfio_sys.workspace = true
 vfio-bindings.workspace = true
 vfio_assigned_device_resources.workspace = true
-virt.workspace = true
 vm_resource.workspace = true
 vmcore.workspace = true
 

--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -35,8 +35,6 @@ use pci_core::spec::cfg_space;
 use pci_core::spec::cfg_space::HeaderType00;
 use std::ops::Range;
 use std::os::unix::fs::FileExt;
-use std::sync::Arc;
-use virt::irqfd::IrqFd;
 use vmcore::device_state::ChangeDeviceState;
 use vmcore::save_restore::RestoreError;
 use vmcore::save_restore::SaveError;
@@ -118,10 +116,6 @@ pub(crate) struct VfioAssignedPciDevice {
     #[inspect(skip)]
     vfio_device: vfio_sys::Device,
 
-    /// irqfd routing interface for registering eventfds with the hypervisor.
-    #[inspect(skip)]
-    irqfd: Arc<dyn IrqFd>,
-
     /// Offset into the VFIO device fd where the PCI config region starts.
     #[inspect(hex)]
     config_offset: u64,
@@ -188,7 +182,6 @@ impl VfioAssignedPciDevice {
         driver_source: &VmTaskDriverSource,
         register_mmio: &mut (dyn chipset_device::mmio::RegisterMmioIntercept + Send),
         msi_target: &MsiTarget,
-        irqfd: Arc<dyn IrqFd>,
         memory_mapper: &dyn MemoryMapper,
     ) -> anyhow::Result<Self> {
         let driver = driver_source.simple();
@@ -352,7 +345,6 @@ impl VfioAssignedPciDevice {
         Ok(Self {
             pci_id,
             vfio_device,
-            irqfd,
             config_offset,
             config_size,
             bar_masks,
@@ -427,10 +419,11 @@ impl VfioAssignedPciDevice {
 
     /// Set up irqfd-backed MSI-X interrupt delivery when the guest enables MSI-X.
     ///
-    /// Tells the emulator to create irqfd routes and passes the resulting
+    /// Gets an interrupt for each vector and triggers lazy irqfd route
+    /// creation by requesting the backing event. Passes the resulting
     /// events to VFIO so the physical device signals them on interrupt.
     fn msix_enable(&mut self) -> anyhow::Result<()> {
-        let msix = self.msix.as_mut().expect("msix must be present");
+        let msix = self.msix.as_ref().expect("msix must be present");
         let count = msix.vector_count;
 
         // VFIO map_msix has a hard limit of 256 eventfds per call.
@@ -439,12 +432,21 @@ impl VfioAssignedPciDevice {
             "MSI-X vector count ({count}) exceeds VFIO limit of 256"
         );
 
-        let vfio_device = &self.vfio_device;
-        msix.emulator.enable_irqfd(self.irqfd.as_ref(), |events| {
-            vfio_device
-                .map_msix(0, events)
-                .context("VFIO map_msix failed")
-        })?;
+        // Get an interrupt for each vector and trigger lazy irqfd route
+        // creation by requesting the backing event.
+        let interrupts: Vec<_> = (0..count)
+            .map(|i| msix.emulator.interrupt(i).expect("vector in range"))
+            .collect();
+
+        let events: Vec<_> = interrupts
+            .iter()
+            .map(|int| int.event())
+            .collect::<Option<Vec<_>>>()
+            .context("failed to allocate irqfd routes for MSI-X vectors")?;
+
+        self.vfio_device
+            .map_msix(0, &events)
+            .context("VFIO map_msix failed")?;
 
         tracing::info!(
             count,
@@ -456,8 +458,11 @@ impl VfioAssignedPciDevice {
 
     /// Tear down VFIO MSI-X eventfd mapping when the guest disables MSI-X.
     fn msix_disable(&mut self) {
-        let msix = self.msix.as_mut().expect("msix must be present");
-        let count = msix.vector_count;
+        let count = self
+            .msix
+            .as_ref()
+            .expect("msix must be present")
+            .vector_count;
 
         if let Err(e) = self.vfio_device.unmap_msix(0, count as u32) {
             tracing::warn!(
@@ -467,7 +472,6 @@ impl VfioAssignedPciDevice {
             );
         }
 
-        msix.emulator.disable_irqfd();
         tracing::info!(
             pci_id = self.pci_id.as_str(),
             "MSI-X disabled: unmapped vectors"
@@ -778,7 +782,6 @@ impl ChangeDeviceState for VfioAssignedPciDevice {
         let Self {
             pci_id,
             vfio_device,
-            irqfd: _,         // handle — no reset needed
             config_offset: _, // immutable device geometry
             config_size: _,   // immutable device geometry
             bar_masks: _,     // immutable device geometry
@@ -915,7 +918,7 @@ impl PciConfigSpace for VfioAssignedPciDevice {
                             // Install irqfd routes BEFORE writing the
                             // capability, so that when the capability
                             // processes the enable transition it can call
-                            // set_msi() on the already-installed routes.
+                            // enable() on the already-installed routes.
                             match self.msix_enable() {
                                 Ok(()) => {
                                     let msix = self.msix.as_mut().unwrap();

--- a/vm/devices/pci/vfio_assigned_device/src/resolver.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/resolver.rs
@@ -70,10 +70,6 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioDeviceHandle> for VfioDeviceR
             .await
             .context("VFIO container manager failed")?;
 
-        let irqfd = input
-            .irqfd
-            .context("partition does not support irqfd (required for VFIO)")?;
-
         let memory_mapper = input
             .shared_mem_mapper
             .context("memory mapper is required for VFIO device assignment")?;
@@ -84,7 +80,6 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioDeviceHandle> for VfioDeviceR
             input.driver_source,
             input.register_mmio,
             input.msi_target,
-            irqfd,
             memory_mapper,
         )
         .await?;

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -1834,9 +1834,8 @@ impl ServerTaskInner {
 
             (Some(guest_event_port), interrupt)
         } else {
-            // Use a dummy interrupt which does nothing, but make sure it has an event to avoid
-            // proxy_integration from trying to wrap it.
-            (None, Interrupt::null_event())
+            // Use a dummy interrupt which does nothing.
+            (None, Interrupt::null())
         };
 
         // Delete any previously reserved state.

--- a/vm/vmcore/src/interrupt.rs
+++ b/vm/vmcore/src/interrupt.rs
@@ -5,14 +5,19 @@
 
 #![forbid(unsafe_code)]
 
-use crate::local_only::LocalOnly;
 use mesh::MeshPayload;
+use mesh::payload::DefaultEncoding;
+use mesh::payload::FieldDecode;
+use mesh::payload::FieldEncode;
+use mesh::payload::inplace::InplaceOption;
+use mesh::resource::Resource;
 use pal_async::driver::SpawnDriver;
 use pal_async::task::Task;
 use pal_async::wait::PolledWait;
 use pal_event::Event;
 use std::fmt::Debug;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 /// An object representing an interrupt-like signal to notify the guest of
 /// device activity.
@@ -20,12 +25,13 @@ use std::sync::Arc;
 /// This is generally an edge-triggered interrupt, but it could also be a synic
 /// event or similar notification.
 ///
-/// The interrupt can be backed by a [`pal_event::Event`], a
-/// [`mesh::Cell<pal_event::Event>`], or a function. In the former two cases, the
-/// `Interrupt` can be sent across a mesh channel to remote processes.
+/// The interrupt can be backed by a [`pal_event::Event`] or a function. In the
+/// former case, the `Interrupt` can be sent across a mesh channel to remote
+/// processes.
 #[derive(Clone, Debug, MeshPayload)]
 pub struct Interrupt {
-    inner: InterruptInner,
+    #[mesh(encoding = "InterruptEncoding")]
+    inner: Arc<InterruptInner>,
 }
 
 impl Default for Interrupt {
@@ -37,37 +43,23 @@ impl Default for Interrupt {
 impl Interrupt {
     /// An interrupt that does nothing.
     ///
-    /// N.B. If the caller requires the interrupt to have an underlying event, it is recommended to
-    ///      use [`Self::null_event`] instead.
+    /// Note that [`Self::event`] will still return a valid event, which will be
+    /// lazily created on demand. This allows the interrupt to be used with APIs
+    /// that require an event, without actually delivering any notifications.
     pub fn null() -> Self {
-        // Create a dummy event.
-        Self::from_event(Event::new())
-    }
-
-    /// An interrupt that does nothing but is guaranteed to have an underlying event.
-    ///
-    /// N.B. Currently this does the same thing as [`Self::null`], but it allows [`Self::null`] to
-    ///      be optimized in the future, while callers that require an event can use this function.
-    pub fn null_event() -> Self {
-        Self::from_event(Event::new())
+        Self::from_target(NullEventTarget)
     }
 
     /// Creates an interrupt from an event.
     ///
     /// The event will be signaled when [`Self::deliver`] is called.
     pub fn from_event(event: Event) -> Self {
+        let event = Arc::new(event);
         Self {
-            inner: InterruptInner::Event(Arc::new(event)),
-        }
-    }
-
-    /// Creates an interrupt from a mesh cell containing an event.
-    ///
-    /// The current event will be signaled when [`Self::deliver`] is called. The event
-    /// can be transparently changed without interaction from the caller.
-    pub fn from_cell(cell: mesh::Cell<Event>) -> Self {
-        Self {
-            inner: InterruptInner::Cell(Arc::new(cell)),
+            inner: Arc::new(InterruptInner {
+                event: OnceLock::from(Some(event.clone())),
+                t: EventTarget(event),
+            }),
         }
     }
 
@@ -80,34 +72,43 @@ impl Interrupt {
         F: 'static + Send + Sync + Fn(),
     {
         Self {
-            inner: InterruptInner::Fn(LocalOnly(Arc::new(f))),
+            inner: Arc::new(InterruptInner {
+                event: OnceLock::new(),
+                t: FnTarget(f),
+            }),
+        }
+    }
+
+    /// Creates an interrupt from an [`InterruptTarget`] implementation.
+    pub fn from_target(target: impl InterruptTarget + 'static) -> Self {
+        Self {
+            inner: Arc::new(InterruptInner {
+                event: OnceLock::new(),
+                t: target,
+            }),
         }
     }
 
     /// Delivers the interrupt.
     pub fn deliver(&self) {
-        match &self.inner {
-            InterruptInner::Event(event) => event.signal(),
-            InterruptInner::Cell(cell) => cell.with(|event| event.signal()),
-            InterruptInner::Fn(LocalOnly(f)) => f(),
-        }
+        self.inner.t.deliver();
     }
 
     /// Gets a reference to the backing event, if there is one.
+    ///
+    /// This will attempt to lazily create the event via the target if one
+    /// has not already been cached.
     pub fn event(&self) -> Option<&Event> {
-        match &self.inner {
-            InterruptInner::Event(event) => Some(event.as_ref()),
-            _ => None,
-        }
+        self.inner.event().as_deref()
     }
 
     /// Returns an event that, when signaled, will deliver this interrupt.
     ///
-    /// If the interrupt is already event-backed, returns a clone of the
-    /// existing event and no proxy is needed. Otherwise, creates an
-    /// [`EventProxy`] that spawns an async task to bridge a new event to
-    /// [`Interrupt::deliver`]. The caller must keep the returned
-    /// `Option<EventProxy>` alive for as long as the event is in use.
+    /// If [`Self::event`] returns an event, returns a clone of it and no
+    /// proxy is needed. Otherwise, creates an [`EventProxy`] that spawns an
+    /// async task to bridge a new event to [`Interrupt::deliver`]. The caller
+    /// must keep the returned `Option<EventProxy>` alive for as long as the
+    /// event is in use.
     pub fn event_or_proxy(
         &self,
         driver: &impl SpawnDriver,
@@ -121,20 +122,129 @@ impl Interrupt {
     }
 }
 
-#[derive(Clone, MeshPayload)]
-enum InterruptInner {
-    Event(Arc<Event>),
-    Cell(Arc<mesh::Cell<Event>>),
-    Fn(LocalOnly<Arc<dyn Send + Sync + Fn()>>),
+/// A trait for implementing interrupt delivery.
+///
+/// Interrupt targets provide the core behavior for delivering interrupts
+/// and optionally providing a backing OS event.
+pub trait InterruptTarget: Send + Sync {
+    /// Deliver the interrupt.
+    fn deliver(&self);
+
+    /// Called to lazily create an event-backed delivery path for this
+    /// interrupt. If the implementation can provide an event (e.g., by
+    /// allocating an irqfd route), it should do so here and return it.
+    ///
+    /// This will be called at most once per interrupt; the result is cached.
+    fn event(&self) -> Option<Arc<Event>> {
+        None
+    }
+}
+
+struct InterruptInner<T: ?Sized = dyn InterruptTarget> {
+    event: OnceLock<Option<Arc<Event>>>,
+    t: T,
 }
 
 impl Debug for InterruptInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            InterruptInner::Event(_) => f.pad("Event"),
-            InterruptInner::Cell(_) => f.pad("Cell"),
-            InterruptInner::Fn(_) => f.pad("Fn"),
+        f.pad("InterruptInner")
+    }
+}
+
+impl InterruptInner {
+    fn event(&self) -> &Option<Arc<Event>> {
+        self.event.get_or_init(|| self.t.event())
+    }
+}
+
+/// Trivial target that wraps an event.
+struct EventTarget(Arc<Event>);
+
+impl InterruptTarget for EventTarget {
+    fn deliver(&self) {
+        self.0.signal();
+    }
+
+    fn event(&self) -> Option<Arc<Event>> {
+        Some(self.0.clone())
+    }
+}
+
+/// Target that wraps a function callback.
+struct FnTarget<F>(F);
+
+impl<F: Send + Sync + Fn()> InterruptTarget for FnTarget<F> {
+    fn deliver(&self) {
+        (self.0)()
+    }
+}
+
+/// Target for null interrupts that lazily creates an event on demand.
+struct NullEventTarget;
+
+impl InterruptTarget for NullEventTarget {
+    fn deliver(&self) {}
+
+    fn event(&self) -> Option<Arc<Event>> {
+        Some(Arc::new(Event::new()))
+    }
+}
+
+struct InterruptEncoding;
+
+type EventFieldEncoding = <Event as DefaultEncoding>::Encoding;
+
+impl FieldEncode<Arc<InterruptInner>, Resource> for InterruptEncoding {
+    fn write_field(
+        item: Arc<InterruptInner>,
+        writer: mesh::payload::protobuf::FieldWriter<'_, '_, Resource>,
+    ) {
+        if let Some(event) = item.event() {
+            EventFieldEncoding::write_field_in_sequence((**event).clone(), &mut writer.sequence());
+        } else {
+            tracing::warn!("encoding local-only interrupt");
         }
+    }
+
+    fn compute_field_size(
+        item: &mut Arc<InterruptInner>,
+        sizer: mesh::payload::protobuf::FieldSizer<'_>,
+    ) {
+        if item.event().is_some() {
+            sizer.sequence().field().resource();
+        }
+    }
+
+    fn wrap_in_sequence() -> bool {
+        true
+    }
+}
+
+impl FieldDecode<'_, Arc<InterruptInner>, Resource> for InterruptEncoding {
+    fn read_field(
+        item: &mut InplaceOption<'_, Arc<InterruptInner>>,
+        reader: mesh::payload::protobuf::FieldReader<'_, '_, Resource>,
+    ) -> mesh::payload::Result<()> {
+        mesh::payload::inplace_none!(event: Event);
+        EventFieldEncoding::read_field_in_sequence(&mut event, reader)?;
+        let event = Arc::new(event.take().unwrap());
+        item.set(Arc::new(InterruptInner {
+            event: OnceLock::from(Some(event.clone())),
+            t: EventTarget(event),
+        }));
+        Ok(())
+    }
+
+    fn default_field(
+        _item: &mut InplaceOption<'_, Arc<InterruptInner>>,
+    ) -> mesh::payload::Result<()> {
+        Err(mesh::payload::Error::new(
+            "missing event in serialized interrupt",
+        ))
+    }
+
+    fn wrap_in_sequence() -> bool {
+        true
     }
 }
 
@@ -171,37 +281,143 @@ impl EventProxy {
 #[cfg(test)]
 mod tests {
     use super::Interrupt;
+    use super::InterruptTarget;
     use pal_async::DefaultDriver;
     use pal_async::async_test;
+    use pal_event::Event;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn test_interrupt_event() {
-        let event = pal_event::Event::new();
+        let event = Event::new();
         let interrupt = Interrupt::from_event(event.clone());
         interrupt.deliver();
         assert!(event.try_wait());
     }
 
-    #[async_test]
-    async fn test_interrupt_cell() {
-        let mut event = pal_event::Event::new();
-        let (mut updater, cell) = mesh::cell(event.clone());
-        let interrupt = Interrupt::from_cell(cell);
+    #[test]
+    fn test_interrupt_fn() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let count2 = count.clone();
+        let interrupt = Interrupt::from_fn(move || {
+            count2.fetch_add(1, Ordering::SeqCst);
+        });
         interrupt.deliver();
-        assert!(event.try_wait());
-        event = pal_event::Event::new();
         interrupt.deliver();
-        assert!(!event.try_wait());
-        updater.set(event.clone()).await;
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn test_interrupt_null_does_not_signal() {
+        let interrupt = Interrupt::null();
+        // deliver() should not panic on a null interrupt.
+        interrupt.deliver();
+    }
+
+    #[test]
+    fn test_event_backed_has_event() {
+        let event = Event::new();
+        let interrupt = Interrupt::from_event(event.clone());
+        assert!(interrupt.event().is_some());
+    }
+
+    #[test]
+    fn test_fn_backed_has_no_event() {
+        let interrupt = Interrupt::from_fn(|| {});
+        assert!(interrupt.event().is_none());
+    }
+
+    #[test]
+    fn test_null_has_event() {
+        let interrupt = Interrupt::null();
+        // Null interrupts lazily provide an event for APIs that require one.
+        assert!(interrupt.event().is_some());
+    }
+
+    #[test]
+    fn test_null_event_is_stable() {
+        let interrupt = Interrupt::null();
+        let e1 = std::ptr::from_ref::<Event>(interrupt.event().unwrap());
+        let e2 = std::ptr::from_ref::<Event>(interrupt.event().unwrap());
+        assert_eq!(
+            e1, e2,
+            "event() should return the same event on repeated calls"
+        );
+    }
+
+    #[test]
+    fn test_from_target() {
+        struct TestTarget {
+            count: Arc<AtomicUsize>,
+        }
+        impl InterruptTarget for TestTarget {
+            fn deliver(&self) {
+                self.count.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        let count = Arc::new(AtomicUsize::new(0));
+        let interrupt = Interrupt::from_target(TestTarget {
+            count: count.clone(),
+        });
+        interrupt.deliver();
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+        assert!(interrupt.event().is_none());
+    }
+
+    #[test]
+    fn test_from_target_with_event() {
+        struct TestTarget(Arc<Event>);
+        impl InterruptTarget for TestTarget {
+            fn deliver(&self) {
+                self.0.signal();
+            }
+            fn event(&self) -> Option<Arc<Event>> {
+                Some(self.0.clone())
+            }
+        }
+        let event = Arc::new(Event::new());
+        let interrupt = Interrupt::from_target(TestTarget(event.clone()));
+        assert!(interrupt.event().is_some());
         interrupt.deliver();
         assert!(event.try_wait());
     }
 
+    #[test]
+    fn test_clone_shares_state() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let count2 = count.clone();
+        let interrupt = Interrupt::from_fn(move || {
+            count2.fetch_add(1, Ordering::SeqCst);
+        });
+        let cloned = interrupt.clone();
+        interrupt.deliver();
+        cloned.deliver();
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn test_default_is_null() {
+        let interrupt = Interrupt::default();
+        // Should behave like null: deliver doesn't panic, event is available.
+        interrupt.deliver();
+        assert!(interrupt.event().is_some());
+    }
+
+    #[test]
+    fn test_mesh_round_trip_event_backed() {
+        let event = Event::new();
+        let interrupt = Interrupt::from_event(event);
+        let msg = mesh::payload::SerializedMessage::from_message(interrupt);
+        let decoded: Interrupt = msg.into_message().unwrap();
+        // The decoded interrupt should be event-backed.
+        assert!(decoded.event().is_some());
+        decoded.deliver();
+    }
+
     #[async_test]
     async fn test_event_or_proxy_event_backed(driver: DefaultDriver) {
-        let orig_event = pal_event::Event::new();
+        let orig_event = Event::new();
         let interrupt = Interrupt::from_event(orig_event.clone());
         let (event, proxy) = interrupt.event_or_proxy(&driver).unwrap();
         // Event-backed interrupt should return the same event and no proxy.

--- a/vm/vmcore/src/irqfd.rs
+++ b/vm/vmcore/src/irqfd.rs
@@ -49,13 +49,15 @@ pub trait IrqFdRoute: Send + Sync {
 
     /// Sets the MSI routing for this irqfd's GSI.
     ///
-    /// `address` and `data` are the x86 MSI address and data values that the
-    /// kernel will use when injecting the interrupt into the guest.
+    /// `address` and `data` are the MSI address and data values that the
+    /// hypervisor will use when injecting the interrupt into the guest.
     fn enable(&self, address: u64, data: u32);
 
     /// Disables the MSI routing for this irqfd's GSI.
     ///
-    /// The irqfd remains registered but interrupt delivery is disabled until
-    /// a new route is configured via [`enable`](IrqFdRoute::enable).
+    /// Disarms the irqfd so that signaling the event no longer injects an
+    /// interrupt. Interrupts that arrive while disabled remain pending on
+    /// the event and will be delivered when [`enable`](IrqFdRoute::enable)
+    /// is called, or can be drained by waiting on the event directly.
     fn disable(&self);
 }

--- a/vm/vmcore/src/irqfd.rs
+++ b/vm/vmcore/src/irqfd.rs
@@ -36,7 +36,7 @@ pub trait IrqFd: Send + Sync {
 ///
 /// Each route represents a single GSI with an associated event. When the
 /// event is signaled (e.g., by VFIO on a device interrupt), the kernel injects
-/// the MSI configured via [`set_msi`](IrqFdRoute::set_msi) into the guest.
+/// the MSI configured via [`enable`](IrqFdRoute::enable) into the guest.
 ///
 /// Dropping this handle unregisters the irqfd and frees the GSI.
 pub trait IrqFdRoute: Send + Sync {
@@ -51,35 +51,11 @@ pub trait IrqFdRoute: Send + Sync {
     ///
     /// `address` and `data` are the x86 MSI address and data values that the
     /// kernel will use when injecting the interrupt into the guest.
-    fn set_msi(&self, address: u64, data: u32) -> anyhow::Result<()>;
+    fn enable(&self, address: u64, data: u32);
 
-    /// Clears the MSI routing for this irqfd's GSI.
+    /// Disables the MSI routing for this irqfd's GSI.
     ///
     /// The irqfd remains registered but interrupt delivery is disabled until
-    /// a new route is configured via [`set_msi`](IrqFdRoute::set_msi).
-    fn clear_msi(&self) -> anyhow::Result<()>;
-
-    /// Masks the route.
-    ///
-    /// While masked, interrupts arriving on the event are not injected into
-    /// the guest. The caller should use [`consume_pending`](IrqFdRoute::consume_pending)
-    /// to check whether an interrupt arrived while masked and store the
-    /// result in the MSI-X PBA. On unmask, the caller should deliver any
-    /// pending interrupt from the PBA before re-enabling the route.
-    fn mask(&self) -> anyhow::Result<()>;
-
-    /// Unmasks the route and re-enables interrupt injection.
-    fn unmask(&self) -> anyhow::Result<()>;
-
-    /// Drains the pending interrupt state and returns whether an interrupt
-    /// was pending.
-    ///
-    /// This atomically reads and clears the event's counter. The caller
-    /// should store the result in the MSI-X PBA (Pending Bit Array).
-    /// Repeated calls after the first drain will return `false` until a
-    /// new interrupt arrives, so the caller must persist the pending state
-    /// externally (e.g., in the MSI-X emulator's PBA bits).
-    fn consume_pending(&self) -> bool {
-        self.event().try_wait()
-    }
+    /// a new route is configured via [`enable`](IrqFdRoute::enable).
+    fn disable(&self);
 }

--- a/vmm_core/src/device_builder.rs
+++ b/vmm_core/src/device_builder.rs
@@ -138,7 +138,10 @@ pub async fn resolve_and_add_pci_device(
     mapper: Option<&dyn guestmem::MemoryMapper>,
     irqfd: Option<Arc<dyn IrqFd>>,
 ) -> anyhow::Result<(Arc<CloseableMutex<ErasedChipsetDevice>>, MsiConnection)> {
-    let msi_conn = MsiConnection::new();
+    let msi_conn = match irqfd {
+        Some(fd) => MsiConnection::with_irqfd(fd),
+        None => MsiConnection::new(),
+    };
 
     let device = {
         device_builder
@@ -153,7 +156,6 @@ pub async fn resolve_and_add_pci_device(
                             guest_memory,
                             doorbell_registration,
                             shared_mem_mapper: mapper,
-                            irqfd,
                         },
                     )
                     .await

--- a/vmm_core/virt_kvm/src/gsi.rs
+++ b/vmm_core/virt_kvm/src/gsi.rs
@@ -115,7 +115,7 @@ pub struct GsiRoute {
     gsi: u32,
     irqfd_event: Option<Event>,
     enabled: AtomicBool,
-    enable_mutex: Mutex<()>, // used to serialize enable/disable calls
+    enable_mutex: Mutex<()>, // serializes route updates and enable/disable calls
 }
 
 impl Drop for GsiRoute {
@@ -142,8 +142,8 @@ impl GsiRoute {
 
     /// Enables the route and associated irqfd.
     pub fn enable(&self, entry: kvm::RoutingEntry) {
-        let partition = self.set_entry(Some(entry));
         let _lock = self.enable_mutex.lock();
+        let partition = self.set_entry(Some(entry));
         if !self.enabled.load(Ordering::Relaxed) {
             if let (Some(partition), Some(event)) = (&partition, &self.irqfd_event) {
                 partition

--- a/vmm_core/virt_kvm/src/gsi.rs
+++ b/vmm_core/virt_kvm/src/gsi.rs
@@ -226,11 +226,7 @@ impl IrqFd for KvmIrqFdState {
             .partition
             .new_route(Some(event.clone()))
             .context("no free GSIs available for irqfd")?;
-        Ok(Box::new(KvmIrqFdRoute {
-            route,
-            event,
-            last_entry: Mutex::new(None),
-        }))
+        Ok(Box::new(KvmIrqFdRoute { route, event }))
     }
 }
 
@@ -241,9 +237,6 @@ impl IrqFd for KvmIrqFdState {
 struct KvmIrqFdRoute {
     route: GsiRoute,
     event: Event,
-    /// The last routing entry configured via `set_msi`, used to restore
-    /// routing on `unmask`.
-    last_entry: Mutex<Option<kvm::RoutingEntry>>,
 }
 
 impl IrqFdRoute for KvmIrqFdRoute {
@@ -251,7 +244,7 @@ impl IrqFdRoute for KvmIrqFdRoute {
         &self.event
     }
 
-    fn set_msi(&self, address: u64, data: u32) -> anyhow::Result<()> {
+    fn enable(&self, address: u64, data: u32) {
         let crate::arch::KvmMsi {
             address_lo,
             address_hi,
@@ -262,29 +255,14 @@ impl IrqFdRoute for KvmIrqFdRoute {
             address_hi,
             data,
         };
-        *self.last_entry.lock() = Some(entry);
         self.route.enable(entry);
-        Ok(())
     }
 
-    fn clear_msi(&self) -> anyhow::Result<()> {
-        *self.last_entry.lock() = None;
+    fn disable(&self) {
+        // Just disarm the irqfd. The routing entry is inert without an
+        // armed eventfd, so there's no need to remove it and trigger an
+        // expensive KVM_SET_GSI_ROUTING ioctl. On re-enable, if the
+        // address/data haven't changed, set_entry will be a no-op.
         self.route.disable();
-        self.route.set_entry(None);
-        Ok(())
-    }
-
-    fn mask(&self) -> anyhow::Result<()> {
-        // Disable the irqfd but preserve the last routing entry for unmask.
-        self.route.disable();
-        Ok(())
-    }
-
-    fn unmask(&self) -> anyhow::Result<()> {
-        // Re-enable the irqfd with the previously configured routing entry.
-        if let Some(entry) = *self.last_entry.lock() {
-            self.route.enable(entry);
-        }
-        Ok(())
     }
 }

--- a/vmm_core/virt_mshv/src/irqfd.rs
+++ b/vmm_core/virt_mshv/src/irqfd.rs
@@ -217,24 +217,11 @@ struct MshvIrqFdRoute {
     gsi: u32,
     event: Event,
     /// Whether the irqfd is currently armed (registered with the kernel).
-    /// Serializes arm/disarm ioctls and route updates to prevent races.
+    /// Serializes route updates and arm/disarm ioctls to prevent races.
     armed: Mutex<bool>,
 }
 
 impl MshvIrqFdRoute {
-    fn arm(&self) {
-        let mut armed = self.armed.lock();
-        if !*armed {
-            // SAFETY: `self.event` is owned by this struct and will outlive
-            // the registration (unregistered in `disarm` or `Drop`).
-            if let Err(e) = unsafe { self.partition.register_irqfd(&self.event, self.gsi) } {
-                tracelimit::warn_ratelimited!(error = ?e, gsi = self.gsi, "failed to register irqfd");
-                return;
-            }
-            *armed = true;
-        }
-    }
-
     fn disarm(&self) {
         let mut armed = self.armed.lock();
         if *armed {
@@ -254,6 +241,7 @@ impl IrqFdRoute for MshvIrqFdRoute {
     }
 
     fn enable(&self, address: u64, data: u32) {
+        let mut armed = self.armed.lock();
         let route = MsiRoute {
             address_lo: address as u32,
             address_hi: (address >> 32) as u32,
@@ -261,8 +249,17 @@ impl IrqFdRoute for MshvIrqFdRoute {
         };
         if let Err(e) = self.partition.set_gsi_route(self.gsi, Some(route)) {
             tracelimit::warn_ratelimited!(error = ?e, gsi = self.gsi, "failed to set GSI route");
+            return;
         }
-        self.arm();
+        if !*armed {
+            // SAFETY: `self.event` is owned by this struct and will outlive
+            // the registration (unregistered in `disarm` or `Drop`).
+            if let Err(e) = unsafe { self.partition.register_irqfd(&self.event, self.gsi) } {
+                tracelimit::warn_ratelimited!(error = ?e, gsi = self.gsi, "failed to register irqfd");
+                return;
+            }
+            *armed = true;
+        }
     }
 
     fn disable(&self) {

--- a/vmm_core/virt_mshv/src/irqfd.rs
+++ b/vmm_core/virt_mshv/src/irqfd.rs
@@ -204,7 +204,7 @@ impl IrqFd for MshvIrqFd {
             partition: self.partition.clone(),
             gsi,
             event,
-            last_route: Mutex::new(None),
+            armed: Mutex::new(true),
         }))
     }
 }
@@ -216,9 +216,36 @@ struct MshvIrqFdRoute {
     partition: Arc<MshvPartitionInner>,
     gsi: u32,
     event: Event,
-    /// The last MSI route configured via `set_msi`, used to restore routing
-    /// on `unmask`.
-    last_route: Mutex<Option<MsiRoute>>,
+    /// Whether the irqfd is currently armed (registered with the kernel).
+    /// Serializes arm/disarm ioctls and route updates to prevent races.
+    armed: Mutex<bool>,
+}
+
+impl MshvIrqFdRoute {
+    fn arm(&self) {
+        let mut armed = self.armed.lock();
+        if !*armed {
+            // SAFETY: `self.event` is owned by this struct and will outlive
+            // the registration (unregistered in `disarm` or `Drop`).
+            if let Err(e) = unsafe { self.partition.register_irqfd(&self.event, self.gsi) } {
+                tracelimit::warn_ratelimited!(error = ?e, gsi = self.gsi, "failed to register irqfd");
+                return;
+            }
+            *armed = true;
+        }
+    }
+
+    fn disarm(&self) {
+        let mut armed = self.armed.lock();
+        if *armed {
+            // SAFETY: `self.event` is the same event passed to `register_irqfd`.
+            if let Err(e) = unsafe { self.partition.unregister_irqfd(&self.event, self.gsi) } {
+                tracelimit::warn_ratelimited!(error = ?e, gsi = self.gsi, "failed to unregister irqfd");
+                return;
+            }
+            *armed = false;
+        }
+    }
 }
 
 impl IrqFdRoute for MshvIrqFdRoute {
@@ -226,54 +253,34 @@ impl IrqFdRoute for MshvIrqFdRoute {
         &self.event
     }
 
-    fn set_msi(&self, address: u64, data: u32) -> anyhow::Result<()> {
+    fn enable(&self, address: u64, data: u32) {
         let route = MsiRoute {
             address_lo: address as u32,
             address_hi: (address >> 32) as u32,
             data,
         };
-        self.partition.set_gsi_route(self.gsi, Some(route))?;
-        *self.last_route.lock() = Some(route);
-        Ok(())
-    }
-
-    fn clear_msi(&self) -> anyhow::Result<()> {
-        self.partition.set_gsi_route(self.gsi, None)?;
-        *self.last_route.lock() = None;
-        Ok(())
-    }
-
-    fn mask(&self) -> anyhow::Result<()> {
-        // Disable the GSI route so the kernel stops injecting interrupts.
-        // The eventfd remains registered — any signals while masked can be
-        // consumed via consume_pending(). The last route is preserved so it
-        // can be restored on unmask.
-        self.partition.set_gsi_route(self.gsi, None)
-    }
-
-    fn unmask(&self) -> anyhow::Result<()> {
-        // Restore the previously configured MSI route.
-        let route = *self.last_route.lock();
-        if let Some(route) = route {
-            self.partition.set_gsi_route(self.gsi, Some(route))?;
+        if let Err(e) = self.partition.set_gsi_route(self.gsi, Some(route)) {
+            tracelimit::warn_ratelimited!(error = ?e, gsi = self.gsi, "failed to set GSI route");
         }
-        Ok(())
+        self.arm();
+    }
+
+    fn disable(&self) {
+        // Just disarm the irqfd. The routing entry is inert without an
+        // armed eventfd, so there's no need to remove it and trigger an
+        // expensive MSHV_SET_MSI_ROUTING ioctl. On re-enable, if the
+        // address/data haven't changed, set_gsi_route will be a no-op.
+        self.disarm();
     }
 }
 
 impl Drop for MshvIrqFdRoute {
     fn drop(&mut self) {
+        self.disarm();
+
         self.partition
             .set_gsi_route(self.gsi, None)
             .expect("failed to clear GSI route on drop");
-
-        // SAFETY: `self.event` is the same event passed to `register_irqfd`
-        // and is about to be dropped, so this is the last use.
-        unsafe {
-            self.partition
-                .unregister_irqfd(&self.event, self.gsi)
-                .expect("failed to unregister irqfd on drop");
-        }
 
         self.partition.free_gsi(self.gsi);
     }


### PR DESCRIPTION
The Interrupt type previously used an enum of Event/Cell/Fn variants internally. Replace this with a trait-object-based InterruptTarget that allows custom interrupt implementations and, critically, enables lazy event creation via a cached OnceLock. This removes the Cell variant (unused in practice) and the from_cell constructor.

The key motivation is moving irqfd ownership closer to the interrupt source. Previously, the IrqFd interface was threaded through ResolvePciDeviceHandleParams so that device resolvers (VFIO) could explicitly call enable_irqfd/disable_irqfd on the MSI-X emulator. This was awkward: it coupled the PCI resource resolver interface to a hypervisor-specific interrupt mechanism and required bulk route allocation up front.

Now, MsiConnection optionally holds an Arc<dyn IrqFd>, and each MSI-X vector lazily allocates its irqfd route when something first requests the backing event (via InterruptTarget::event). This happens naturally when VFIO calls interrupt(i).event() to collect eventfds for map_msix. The irqfd field is removed from ResolvePciDeviceHandleParams entirely.

The IrqFdRoute trait is also simplified: mask/unmask are removed in favor of using enable/disable (which map to set_msi/clear_msi). The trait methods are made infallible since failures at this level represent broken invariants rather than recoverable errors, and both KVM and MSHV implementations now log-and-continue on the rare ioctl failures.

For both KVM and MSHV, disable no longer removes the GSI routing table entry. Instead it just disarms the irqfd, avoiding an expensive full routing table ioctl (KVM_SET_GSI_ROUTING / MSHV_SET_MSI_ROUTING) on every mask/unmask cycle. The stale routing entry is inert without an armed eventfd. On re-enable with unchanged address/data, the routing table update is skipped entirely, reducing the cost of a mask/unmask cycle from two routing table ioctls to two cheap irqfd arm/disarm calls.