### PR TITLE
net_mana: trace spurious CQE before panicing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4642,6 +4642,7 @@ dependencies = [
  "mana_driver",
  "mesh",
  "net_backend",
+ "page_pool_alloc",
  "pal_async",
  "pci_core",
  "safeatomic",

--- a/vm/devices/net/net_mana/Cargo.toml
+++ b/vm/devices/net/net_mana/Cargo.toml
@@ -32,6 +32,7 @@ zerocopy.workspace = true
 [dev-dependencies]
 chipset_device.workspace = true
 gdma.workspace = true
+page_pool_alloc.workspace = true
 pci_core.workspace = true
 test_with_tracing.workspace = true
 user_driver_emulated_mock.workspace = true

--- a/vm/devices/net/net_mana/src/lib.rs
+++ b/vm/devices/net/net_mana/src/lib.rs
@@ -752,7 +752,7 @@ impl<T: DeviceBacking> ManaQueue<T> {
         &mut self,
         tracing_level: tracing::Level,
         cqe_params: CqeParams,
-        tx_oob: ManaTxCompOob,
+        tx_oob: &ManaTxCompOob,
         done_length: usize,
     ) {
         tracelimit::event_ratelimited!(
@@ -1068,40 +1068,7 @@ impl<T: DeviceBacking + Send> Queue for ManaQueue<T> {
         while i < done.len() {
             let id = if let Some(cqe) = self.tx_cq.pop() {
                 let tx_oob = ManaTxCompOob::read_from_prefix(&cqe.data[..]).unwrap().0; // TODO: zerocopy: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
-                match tx_oob.cqe_hdr.cqe_type() {
-                    CQE_TX_OKAY => {
-                        self.stats.tx_packets.increment();
-                    }
-                    CQE_TX_GDMA_ERR => {
-                        // Hardware hit an error with the packet coming from the Guest.
-                        // CQE_TX_GDMA_ERR is how the Hardware indicates that it has disabled the queue.
-                        self.stats.tx_errors.increment();
-                        self.stats.tx_stuck.increment();
-                        self.trace_tx(tracing::Level::ERROR, cqe.params, tx_oob, done.len());
-                        // Return a TryRestart error to indicate that the queue needs to be restarted.
-                        return Err(TxError::TryRestart(anyhow::anyhow!("TX GDMA error")));
-                    }
-                    CQE_TX_INVALID_OOB => {
-                        // Invalid OOB means the metadata didn't match how the hardware parsed the packet.
-                        // This is somewhat common, usually due to encapsulation, and only affects the specific packet.
-                        self.stats.tx_errors.increment();
-                        self.trace_tx(tracing::Level::WARN, cqe.params, tx_oob, done.len());
-                    }
-                    ty => {
-                        tracelimit::error_ratelimited!(
-                            ty,
-                            vendor_error = tx_oob.cqe_hdr.vendor_err(),
-                            "tx completion error"
-                        );
-                        self.stats.tx_errors.increment();
-                    }
-                }
-                let packet = self.posted_tx.pop_front().unwrap();
-                self.tx_wq.advance_head(packet.wqe_len);
-                if packet.bounced_len_with_padding > 0 {
-                    self.tx_bounce_buffer.free(packet.bounced_len_with_padding);
-                }
-                packet.id
+                self.handle_tx_cqe(&tx_oob, cqe.params, done.len())?
             } else if let Some(id) = self.dropped_tx.pop_front() {
                 self.stats.tx_dropped.increment();
                 id
@@ -1140,6 +1107,60 @@ impl BackendQueueStats for QueueStats {
 }
 
 impl<T: DeviceBacking> ManaQueue<T> {
+    /// Handle a single TX completion entry, or CQE. Advance the TX work queue
+    /// and free the bounce buffer slot for the corresponding posted TX.
+    ///
+    /// Returns the `TxId` of the completed packet on success, or
+    /// `TxError::TryRestart` if the queue must be torn down and rebuilt
+    /// due to a hardware-reported queue-disabling error.
+    /// Explicitly panics if a CQE is received with no matching posted TX.
+    fn handle_tx_cqe(
+        &mut self,
+        tx_oob: &ManaTxCompOob,
+        cqe_params: CqeParams,
+        done_len: usize,
+    ) -> Result<TxId, TxError> {
+        match tx_oob.cqe_hdr.cqe_type() {
+            CQE_TX_OKAY => {
+                self.stats.tx_packets.increment();
+            }
+            CQE_TX_GDMA_ERR => {
+                // Hardware hit an error with the packet coming from the Guest.
+                // CQE_TX_GDMA_ERR is how the Hardware indicates that it has disabled the queue.
+                self.stats.tx_errors.increment();
+                self.stats.tx_stuck.increment();
+                self.trace_tx(tracing::Level::ERROR, cqe_params, tx_oob, done_len);
+                // Return a TryRestart error to indicate that the queue needs to be restarted.
+                return Err(TxError::TryRestart(anyhow::anyhow!("TX GDMA error")));
+            }
+            CQE_TX_INVALID_OOB => {
+                // Invalid OOB means the metadata didn't match how the hardware parsed the packet.
+                // This is somewhat common, usually due to encapsulation, and only affects the specific packet.
+                self.stats.tx_errors.increment();
+                self.trace_tx(tracing::Level::WARN, cqe_params, tx_oob, done_len);
+            }
+            ty => {
+                tracelimit::error_ratelimited!(
+                    ty,
+                    vendor_error = tx_oob.cqe_hdr.vendor_err(),
+                    "tx completion error"
+                );
+                self.stats.tx_errors.increment();
+            }
+        }
+        let Some(packet) = self.posted_tx.pop_front() else {
+            // A CQE arrived with no matching posted TX.
+            // We don't know how far to advance the tx_wq.
+            self.trace_tx(tracing::Level::ERROR, cqe_params, tx_oob, done_len);
+            panic!("TX CQE arrived with no matching posted TX");
+        };
+        self.tx_wq.advance_head(packet.wqe_len);
+        if packet.bounced_len_with_padding > 0 {
+            self.tx_bounce_buffer.free(packet.bounced_len_with_padding);
+        }
+        Ok(packet.id)
+    }
+
     fn handle_tx(
         &mut self,
         segments: &[TxSegment],

--- a/vm/devices/net/net_mana/src/test.rs
+++ b/vm/devices/net/net_mana/src/test.rs
@@ -1038,3 +1038,158 @@ fn get_queue_stats(queue_stats: Option<&dyn net_backend::BackendQueueStats>) -> 
         ..Default::default()
     }
 }
+
+use crate::ManaQueue;
+use gdma_defs::CqeParams;
+use gdma_defs::bnic::ManaTxCompOob;
+use mana_driver::mana::ResourceArena;
+use page_pool_alloc::PagePoolAllocator;
+use zerocopy::FromZeros;
+
+type TestEmulatedDevice = EmulatedDevice<gdma::GdmaDevice, PagePoolAllocator>;
+
+/// Sets up the full device stack and returns a [`ManaQueue`] ready for
+/// direct `handle_tx_cqe` testing along with the resources needed for
+/// teardown.
+async fn new_test_queue(
+    driver: &DefaultDriver,
+) -> (
+    ManaQueue<TestEmulatedDevice>,
+    ResourceArena,
+    ManaEndpoint<TestEmulatedDevice>,
+) {
+    let pages = 256;
+    let mem = DeviceTestMemory::new(pages * 2, true, "test queue");
+    let msi_conn = MsiConnection::new();
+    let device = gdma::GdmaDevice::new(
+        &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
+        mem.guest_memory(),
+        msi_conn.target(),
+        vec![VportConfig {
+            mac_address: [1, 2, 3, 4, 5, 6].into(),
+            endpoint: Box::new(LoopbackEndpoint::new()),
+        }],
+        &mut ExternallyManagedMmioIntercepts,
+    );
+    let device = EmulatedDevice::new(device, msi_conn, mem.dma_client());
+    let dev_config = ManaQueryDeviceCfgResp {
+        pf_cap_flags1: 0.into(),
+        pf_cap_flags2: 0,
+        pf_cap_flags3: 0,
+        pf_cap_flags4: 0,
+        max_num_vports: 1,
+        reserved: 0,
+        max_num_eqs: 64,
+        adapter_mtu: 0,
+        reserved2: 0,
+        adapter_link_speed_mbps: 0,
+    };
+    let thing = ManaDevice::new(driver, device, 1, 1, None).await.unwrap();
+    let vport = thing.new_vport(0, None, &dev_config).await.unwrap();
+    let mut endpoint = ManaEndpoint::new(driver.clone(), vport, GuestDmaMode::DirectDma).await;
+    let tx_config = endpoint.vport.config_tx().await.unwrap();
+
+    let mut arena = ResourceArena::new();
+    let (queue, _resources) = endpoint.new_queue(&tx_config, &mut arena, 0).await.unwrap();
+
+    (queue, arena, endpoint)
+}
+
+#[async_test]
+#[should_panic(expected = "TX CQE arrived with no matching posted TX")]
+async fn tx_spurious_cqe_panics(driver: DefaultDriver) {
+    use gdma_defs::bnic::CQE_TX_OKAY;
+
+    let (mut queue, _arena, _endpoint) = new_test_queue(&driver).await;
+
+    assert!(queue.posted_tx.is_empty());
+    let mut oob = ManaTxCompOob::new_zeroed();
+    oob.cqe_hdr.set_cqe_type(CQE_TX_OKAY);
+
+    let _ = queue.handle_tx_cqe(&oob, CqeParams::new(), 8);
+}
+
+#[async_test]
+async fn tx_cqe_gdma_err_returns_try_restart(driver: DefaultDriver) {
+    use crate::PostedTx;
+    use gdma_defs::bnic::CQE_TX_GDMA_ERR;
+    use net_backend::TxError;
+
+    let (mut queue, arena, endpoint) = new_test_queue(&driver).await;
+
+    queue.posted_tx.push_back(PostedTx {
+        id: TxId(42),
+        wqe_len: 0,
+        bounced_len_with_padding: 0,
+    });
+
+    let mut oob = ManaTxCompOob::new_zeroed();
+    oob.cqe_hdr.set_cqe_type(CQE_TX_GDMA_ERR);
+
+    // CQE_TX_GDMA_ERR returns TryRestart without popping posted_tx.
+    let result = queue.handle_tx_cqe(&oob, CqeParams::new(), 8);
+    assert!(
+        matches!(result, Err(TxError::TryRestart(_))),
+        "expected TryRestart, got {result:?}"
+    );
+    assert_eq!(queue.stats.tx_errors.get(), 1);
+    assert_eq!(queue.stats.tx_stuck.get(), 1);
+    assert_eq!(queue.posted_tx.len(), 1);
+
+    drop(queue);
+    endpoint.vport.destroy(arena).await;
+    endpoint.stop().await;
+}
+
+#[async_test]
+async fn tx_cqe_invalid_oob_completes_packet(driver: DefaultDriver) {
+    use crate::PostedTx;
+    use gdma_defs::bnic::CQE_TX_INVALID_OOB;
+
+    let (mut queue, arena, endpoint) = new_test_queue(&driver).await;
+
+    queue.posted_tx.push_back(PostedTx {
+        id: TxId(7),
+        wqe_len: 0,
+        bounced_len_with_padding: 0,
+    });
+
+    let mut oob = ManaTxCompOob::new_zeroed();
+    oob.cqe_hdr.set_cqe_type(CQE_TX_INVALID_OOB);
+
+    // CQE_TX_INVALID_OOB logs an error but still pops posted_tx.
+    let result = queue.handle_tx_cqe(&oob, CqeParams::new(), 8);
+    assert_eq!(result.unwrap().0, 7);
+    assert_eq!(queue.stats.tx_errors.get(), 1);
+    assert!(queue.posted_tx.is_empty());
+
+    drop(queue);
+    endpoint.vport.destroy(arena).await;
+    endpoint.stop().await;
+}
+
+#[async_test]
+async fn tx_cqe_okay_completes_packet(driver: DefaultDriver) {
+    use crate::PostedTx;
+    use gdma_defs::bnic::CQE_TX_OKAY;
+
+    let (mut queue, arena, endpoint) = new_test_queue(&driver).await;
+
+    queue.posted_tx.push_back(PostedTx {
+        id: TxId(99),
+        wqe_len: 0,
+        bounced_len_with_padding: 0,
+    });
+
+    let mut oob = ManaTxCompOob::new_zeroed();
+    oob.cqe_hdr.set_cqe_type(CQE_TX_OKAY);
+
+    let result = queue.handle_tx_cqe(&oob, CqeParams::new(), 8);
+    assert_eq!(result.unwrap().0, 99);
+    assert_eq!(queue.stats.tx_packets.get(), 1);
+    assert!(queue.posted_tx.is_empty());
+
+    drop(queue);
+    endpoint.vport.destroy(arena).await;
+    endpoint.stop().await;
+}

--- a/vm/devices/net/net_mana/src/test.rs
+++ b/vm/devices/net/net_mana/src/test.rs
@@ -1115,7 +1115,7 @@ async fn tx_cqe_gdma_err_returns_try_restart(driver: DefaultDriver) {
     use gdma_defs::bnic::CQE_TX_GDMA_ERR;
     use net_backend::TxError;
 
-    let (mut queue, arena, endpoint) = new_test_queue(&driver).await;
+    let (mut queue, arena, mut endpoint) = new_test_queue(&driver).await;
 
     queue.posted_tx.push_back(PostedTx {
         id: TxId(42),
@@ -1146,7 +1146,7 @@ async fn tx_cqe_invalid_oob_completes_packet(driver: DefaultDriver) {
     use crate::PostedTx;
     use gdma_defs::bnic::CQE_TX_INVALID_OOB;
 
-    let (mut queue, arena, endpoint) = new_test_queue(&driver).await;
+    let (mut queue, arena, mut endpoint) = new_test_queue(&driver).await;
 
     queue.posted_tx.push_back(PostedTx {
         id: TxId(7),
@@ -1173,7 +1173,7 @@ async fn tx_cqe_okay_completes_packet(driver: DefaultDriver) {
     use crate::PostedTx;
     use gdma_defs::bnic::CQE_TX_OKAY;
 
-    let (mut queue, arena, endpoint) = new_test_queue(&driver).await;
+    let (mut queue, arena, mut endpoint) = new_test_queue(&driver).await;
 
     queue.posted_tx.push_back(PostedTx {
         id: TxId(99),


### PR DESCRIPTION
In the TX completion path in `tx_poll()` a CQE arriving without a matching packet (`posted_tx.pop_front()` is None) causes a panic without enough tracing to help diagnose the CQE. This should not happen, but we have seen it once in the last year. Improving our chances of root causing this next time by:

* Refactoring out the CQE matching logic to a helper.
* Adding a check for a None `posted_tx.pop_front()` and tracing the CQE.
* Adding unit tests for the refactored `handle_tx_cqe()` that validates the behavior for different `CQE_TX_` values.
