### PR TITLE
petri: retry pipette handshake on stale connections

### DIFF
--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -559,18 +559,30 @@ impl PetriVmInner {
         };
 
         tracing::info!(set_high_vtl, "listening for pipette connection");
-        let (conn, _) = listener
-            .accept()
-            .await
-            .context("failed to accept pipette connection")?;
-        tracing::info!(set_high_vtl, "handshaking with pipette");
-        let client = PipetteClient::new(
-            &self.resources.driver,
-            PolledSocket::new(&self.resources.driver, conn)?,
-            &self.resources.output_dir,
-        )
-        .await
-        .context("failed to connect to pipette")?;
+        let client = loop {
+            let (conn, _) = listener
+                .accept()
+                .await
+                .context("failed to accept pipette connection")?;
+            tracing::info!(set_high_vtl, "handshaking with pipette");
+            let socket = PolledSocket::new(&self.resources.driver, conn)?;
+            match PipetteClient::new(&self.resources.driver, socket, &self.resources.output_dir)
+                .await
+            {
+                Ok(client) => break client,
+                Err(e) => {
+                    // During save/restore cycles, stale connections from
+                    // previous hvsock relay sessions can accumulate in the
+                    // listener backlog. These are already-closed sockets
+                    // that fail during the mesh handshake. Drain them and
+                    // retry until we get a live connection.
+                    tracing::warn!(
+                        error = &e as &dyn std::error::Error,
+                        "pipette handshake failed, retrying"
+                    );
+                }
+            }
+        };
         tracing::info!(set_high_vtl, "completed pipette handshake");
 
         // When pipette runs as PID 1 init and a CIDATA agent disk is

--- a/support/mesh/mesh_remote/src/point_to_point.rs
+++ b/support/mesh/mesh_remote/src/point_to_point.rs
@@ -110,7 +110,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> AsyncReadWrite for T {}
 enum TaskError {
     #[error("cancelled")]
     Cancelled(#[from] CancelReason),
-    #[error("failed to change addresses")]
+    #[error("failed to exchange addresses")]
     Exchange(#[source] io::Error),
     #[error("failed to send data")]
     Send(#[source] io::Error),

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -275,7 +275,7 @@ async fn vpci_relay_tdisp_device(
 }
 
 /// Boot with a virtio-blk disk via virtio-mmio and verify the device appears in the guest.
-#[openvmm_test(unstable_linux_direct_x64)]
+#[openvmm_test(linux_direct_x64)]
 async fn virtio_blk_device(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     use disk_backend_resources::LayeredDiskHandle;
     use disk_backend_resources::layer::RamDiskLayerHandle;


### PR DESCRIPTION
During back-to-back save/restore pulse cycles, the hvsock relay can establish a connection to the pipette listener unix socket, only to have the underlying vmbus channel torn down moments later by the next pulse's reset. This leaves a dead socket in the listener's accept queue. When wait_for_agent subsequently calls accept(), it dequeues this stale connection, and the mesh handshake immediately fails with a broken pipe.

Fix this by retrying the accept+handshake loop when the handshake fails, draining any stale connections until a live one arrives. This also promotes the virtio_blk_device test from unstable to stable, since this was the root cause of its flakiness.