### PR TITLE
nvme_driver: disable keepalive for a specific class of devices

### DIFF
--- a/openhcl/openhcl_boot/src/cmdline.rs
+++ b/openhcl/openhcl_boot/src/cmdline.rs
@@ -132,7 +132,7 @@ impl BootCommandLineOptions {
             confidential_debug: false,
             enable_vtl2_gpa_pool: Vtl2GpaPoolConfig::Heuristics(Vtl2GpaPoolLookupTable::Release), // use the release config by default
             sidecar: SidecarOptions::default(),
-            disable_nvme_keep_alive: false,
+            disable_nvme_keep_alive: true,
             vtl2_gpa_pool_numa_split: false,
         }
     }
@@ -142,7 +142,7 @@ impl BootCommandLineOptions {
     /// Parse arguments from a command line.
     pub fn parse(&mut self, cmdline: &str) {
         // Workaround for a host side issue: disable NVMe keepalive by default.
-        self.disable_nvme_keep_alive = false;
+        self.disable_nvme_keep_alive = true;
 
         let mut override_vtl2_gpa_pool: Option<Vtl2GpaPoolConfig> = None;
         for arg in cmdline.split_whitespace() {

--- a/openhcl/openhcl_boot/src/cmdline.rs
+++ b/openhcl/openhcl_boot/src/cmdline.rs
@@ -132,7 +132,7 @@ impl BootCommandLineOptions {
             confidential_debug: false,
             enable_vtl2_gpa_pool: Vtl2GpaPoolConfig::Heuristics(Vtl2GpaPoolLookupTable::Release), // use the release config by default
             sidecar: SidecarOptions::default(),
-            disable_nvme_keep_alive: true,
+            disable_nvme_keep_alive: false,
             vtl2_gpa_pool_numa_split: false,
         }
     }
@@ -142,7 +142,7 @@ impl BootCommandLineOptions {
     /// Parse arguments from a command line.
     pub fn parse(&mut self, cmdline: &str) {
         // Workaround for a host side issue: disable NVMe keepalive by default.
-        self.disable_nvme_keep_alive = true;
+        self.disable_nvme_keep_alive = false;
 
         let mut override_vtl2_gpa_pool: Option<Vtl2GpaPoolConfig> = None;
         for arg in cmdline.split_whitespace() {

--- a/openhcl/underhill_core/src/nvme_manager/device.rs
+++ b/openhcl/underhill_core/src/nvme_manager/device.rs
@@ -334,6 +334,7 @@ enum NvmeDriverRequest {
 pub struct NvmeDriverManager {
     task: Task<()>,
     pci_id: String,
+    keepalive_compatible: bool,
     client: NvmeDriverManagerClient,
 }
 
@@ -358,12 +359,18 @@ impl NvmeDriverManager {
         &self.client
     }
 
+    /// Returns whether the underlying device is compatible with NVMe keepalive.
+    pub fn keepalive_compatible(&self) -> bool {
+        self.keepalive_compatible
+    }
+
     /// Creates the [`NvmeDriverManager`].
     pub fn new(
         driver_source: &VmTaskDriverSource,
         pci_id: &str,
         vp_count: u32,
         save_restore_supported: bool,
+        keepalive_compatible: bool,
         device: Option<Box<dyn NvmeDevice>>,
         nvme_driver_spawner: Arc<dyn CreateNvmeDriver>,
     ) -> anyhow::Result<Self> {
@@ -382,6 +389,7 @@ impl NvmeDriverManager {
         Ok(Self {
             task,
             pci_id: pci_id.into(),
+            keepalive_compatible,
             client: NvmeDriverManagerClient {
                 pci_id: pci_id.into(),
                 sender: send,

--- a/openhcl/underhill_core/src/nvme_manager/manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager/manager.rs
@@ -344,6 +344,7 @@ impl NvmeManagerWorker {
         // Note: `client` exists outside of the devices write lock. This is safe:
         // the mesh client will fail appropriately if shutdown comes in between inserting
         // this entry and the call to `load_driver()`.
+        let keepalive_compatible = is_nvme_keepalive_compatible(&pci_id);
         let client = {
             let mut guard = context.devices.write();
 
@@ -361,8 +362,6 @@ impl NvmeManagerWorker {
                 match guard.entry(pci_id.clone()) {
                     hash_map::Entry::Occupied(_) => unreachable!(), // We checked above that this entry does not exist.
                     hash_map::Entry::Vacant(entry) => {
-                        let keepalive_compatible = is_nvme_keepalive_compatible(&pci_id);
-
                         let driver = NvmeDriverManager::new(
                             &context.driver_source,
                             &pci_id,
@@ -496,7 +495,7 @@ impl NvmeManagerWorker {
                     &self.context.driver_source,
                     &pci_id,
                     self.context.vp_count,
-                    keepalive_compatible, // save_restore support is no longer guaraneteed
+                    keepalive_compatible, // save_restore support is no longer guaranteed
                     keepalive_compatible,
                     Some(nvme_driver),
                     self.context.nvme_driver_spawner.clone(),

--- a/openhcl/underhill_core/src/nvme_manager/manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager/manager.rs
@@ -5,6 +5,7 @@ use crate::nvme_manager::CreateNvmeDriver;
 use crate::nvme_manager::device::NvmeDriverManager;
 use crate::nvme_manager::device::NvmeDriverManagerClient;
 use crate::nvme_manager::device::NvmeDriverShutdownOptions;
+use crate::nvme_manager::is_nvme_keepalive_compatible;
 use crate::nvme_manager::save_restore::NvmeManagerSavedState;
 use crate::nvme_manager::save_restore::NvmeSavedDiskConfig;
 use crate::servicing::NvmeSavedState;
@@ -301,12 +302,17 @@ impl NvmeManagerWorker {
 
         async {
             join_all(devices_to_shutdown.into_iter().map(|(pci_id, driver)| {
+                let keepalive_compatible = driver.keepalive_compatible();
                 driver
                     .shutdown(NvmeDriverShutdownOptions {
                         // nvme_keepalive is received from host but it is only valid
                         // when memory pool allocator supports save/restore.
-                        do_not_reset: nvme_keepalive && self.context.save_restore_supported,
-                        skip_device_shutdown: nvme_keepalive && self.context.save_restore_supported,
+                        do_not_reset: nvme_keepalive
+                            && self.context.save_restore_supported
+                            && keepalive_compatible,
+                        skip_device_shutdown: nvme_keepalive
+                            && self.context.save_restore_supported
+                            && keepalive_compatible,
                     })
                     .instrument(tracing::info_span!("shutdown_nvme_driver", %pci_id))
             }))
@@ -355,11 +361,14 @@ impl NvmeManagerWorker {
                 match guard.entry(pci_id.clone()) {
                     hash_map::Entry::Occupied(_) => unreachable!(), // We checked above that this entry does not exist.
                     hash_map::Entry::Vacant(entry) => {
+                        let keepalive_compatible = is_nvme_keepalive_compatible(&pci_id);
+
                         let driver = NvmeDriverManager::new(
                             &context.driver_source,
                             &pci_id,
                             context.vp_count,
-                            context.save_restore_supported,
+                            context.save_restore_supported && keepalive_compatible,
+                            keepalive_compatible,
                             None, // No device yet,
                             context.nvme_driver_spawner.clone(),
                         )?;
@@ -419,12 +428,24 @@ impl NvmeManagerWorker {
     /// Saves NVMe device's states into buffer during servicing.
     pub async fn save(&mut self) -> anyhow::Result<NvmeManagerSavedState> {
         let mut nvme_disks: Vec<NvmeSavedDiskConfig> = Vec::new();
+        // Only save state for devices known to be keepalive-compatible.
         let mut devices_to_save: HashMap<String, NvmeDriverManagerClient> = self
             .context
             .devices
             .write()
             .iter()
-            .map(|(pci_id, driver)| (pci_id.clone(), driver.client().clone()))
+            .filter_map(|(pci_id, driver)| {
+                if driver.keepalive_compatible() {
+                    Some((pci_id.clone(), driver.client().clone()))
+                } else {
+                    tracing::info!(
+                        %pci_id,
+                        "skipping save of nvme device; \
+                         keepalive disabled for this device"
+                    );
+                    None
+                }
+            })
             .collect();
         for (pci_id, client) in devices_to_save.iter_mut() {
             nvme_disks.push(NvmeSavedDiskConfig {
@@ -449,6 +470,14 @@ impl NvmeManagerWorker {
 
         for disk in &saved_state.nvme_disks {
             let pci_id = disk.pci_id.clone();
+
+            // Read the PCI vendor/device IDs once and cache the resulting
+            // keepalive compatibility flag on the `NvmeDriverManager`. We
+            // cannot rely on saved state to determine keepalive compatibility
+            // because previous versions might save devices that are no longer
+            // considered keepalive compatible.
+            let keepalive_compatible = is_nvme_keepalive_compatible(&pci_id);
+
             let nvme_driver = self
                 .context
                 .nvme_driver_spawner
@@ -456,7 +485,7 @@ impl NvmeManagerWorker {
                     &self.context.driver_source,
                     &pci_id,
                     saved_state.cpu_count,
-                    save_restore_supported,
+                    save_restore_supported && keepalive_compatible,
                     Some(&disk.driver_state),
                 )
                 .await?;
@@ -467,7 +496,8 @@ impl NvmeManagerWorker {
                     &self.context.driver_source,
                     &pci_id,
                     self.context.vp_count,
-                    true, // save_restore_supported is always `true` when restoring.
+                    keepalive_compatible, // save_restore support is no longer guaraneteed
+                    keepalive_compatible,
                     Some(nvme_driver),
                     self.context.nvme_driver_spawner.clone(),
                 )?,
@@ -1068,9 +1098,16 @@ mod tests {
         ));
 
         // Create a driver manager
-        let driver_manager =
-            NvmeDriverManager::new(&driver_source, "0000:00:04.0", 4, false, None, spawner)
-                .unwrap();
+        let driver_manager = NvmeDriverManager::new(
+            &driver_source,
+            "0000:00:04.0",
+            4,
+            false,
+            false,
+            None,
+            spawner,
+        )
+        .unwrap();
 
         let client = driver_manager.client().clone();
 
@@ -1154,6 +1191,7 @@ mod tests {
             "0000:00:05.0",
             4,
             true, // save_restore_supported
+            true,
             None,
             spawner,
         )

--- a/openhcl/underhill_core/src/nvme_manager/mod.rs
+++ b/openhcl/underhill_core/src/nvme_manager/mod.rs
@@ -67,6 +67,14 @@ pub struct NamespaceError {
     source: NvmeSpawnerError,
 }
 
+/// PCI vendor ID, as it appears in the sysfs `vendor` file (e.g. `0x0100`),
+/// for NVMe devices that are incompatible with keepalive.
+const KEEPALIVE_INCOMPATIBLE_VENDOR_ID: &str = "0x1414";
+
+/// PCI device ID, as it appears in the sysfs `device` file (e.g. `0x0100`),
+/// for NVMe devices that are incompatible with keepalive.
+const KEEPALIVE_INCOMPATIBLE_DEVICE_ID: &str = "0xb111";
+
 #[derive(Debug, Error)]
 pub enum NvmeSpawnerError {
     #[error("failed to initialize vfio device")]
@@ -110,4 +118,46 @@ pub trait CreateNvmeDriver: Inspect + Send + Sync {
         save_restore_supported: bool,
         saved_state: Option<&nvme_driver::save_restore::NvmeDriverSavedState>,
     ) -> Result<Box<dyn NvmeDevice>, NvmeSpawnerError>;
+}
+
+/// Returns whether the given PCI device is compatible with NVMe keepalive.
+pub(crate) fn is_nvme_keepalive_compatible(pci_id: &str) -> bool {
+    match read_pci_vendor_device_ids(&pci_id) {
+        Ok((vendor_id, device_id)) => {
+            vendor_id != KEEPALIVE_INCOMPATIBLE_VENDOR_ID
+                || device_id != KEEPALIVE_INCOMPATIBLE_DEVICE_ID
+        }
+        Err(err) => {
+            tracing::warn!(
+                pci_id = %pci_id,
+                error = err.as_ref() as &dyn std::error::Error,
+                "failed to read PCI vendor/device IDs; treating device as not keepalive-compatible"
+            );
+            false
+        }
+    }
+}
+
+/// Reads the sysfs `vendor` and `device` files for the given PCI device,
+/// returning the trimmed contents (e.g. `"0x0100"`).
+///
+/// Callers should invoke this once per device and cache the result, since
+/// the values do not change for the lifetime of the device.
+fn read_pci_vendor_device_ids(pci_id: &str) -> anyhow::Result<(String, String)> {
+    let devpath = std::path::Path::new("/sys/bus/pci/devices").join(pci_id);
+    let vendor = fs_err::read_to_string(devpath.join("vendor"))?
+        .trim_end()
+        .to_owned();
+    let device = fs_err::read_to_string(devpath.join("device"))?
+        .trim_end()
+        .to_owned();
+
+    tracing::info!(
+        pci_id = %pci_id,
+        vendor = %vendor,
+        device = %device,
+        "read PCI vendor/device IDs"
+    );
+
+    Ok((vendor, device))
 }

--- a/openhcl/underhill_core/src/nvme_manager/mod.rs
+++ b/openhcl/underhill_core/src/nvme_manager/mod.rs
@@ -122,7 +122,7 @@ pub trait CreateNvmeDriver: Inspect + Send + Sync {
 
 /// Returns whether the given PCI device is compatible with NVMe keepalive.
 pub(crate) fn is_nvme_keepalive_compatible(pci_id: &str) -> bool {
-    match read_pci_vendor_device_ids(&pci_id) {
+    match read_pci_vendor_device_ids(pci_id) {
         Ok((vendor_id, device_id)) => {
             vendor_id != KEEPALIVE_INCOMPATIBLE_VENDOR_ID
                 || device_id != KEEPALIVE_INCOMPATIBLE_DEVICE_ID

--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -315,6 +315,42 @@ pub struct CommandMatch {
     pub mask: [u8; 64],
 }
 
+/// A fault configuration for overriding the device's hardware configuration
+/// (i.e. the values reported in PCI configuration space).
+///
+/// When a field is `Some`, its value replaces the corresponding field reported
+/// by the NVMe fault controller's PCI hardware IDs. When `None`, the real
+/// hardware ID value is used unchanged. Unlike most other faults in this
+/// module, hardware config faults are applied at device construction time
+/// and are therefore not gated by the `fault_active` flag.
+///
+/// # Example
+/// Override the Vendor ID and Device ID reported in PCI config space.
+/// ```no_run
+/// use mesh::CellUpdater;
+/// use nvme_resources::fault::FaultConfiguration;
+/// use nvme_resources::fault::HardwareConfigFaultConfig;
+///
+/// pub fn hardware_config_fault() -> FaultConfiguration {
+///     let mut fault_start_updater = CellUpdater::new(false);
+///     FaultConfiguration::new(fault_start_updater.cell())
+///         .with_hardware_config_fault(
+///             HardwareConfigFaultConfig::new()
+///                 .with_vendor_id(0x1414)
+///                 .with_device_id(0x00a9),
+///         )
+/// }
+/// ```
+#[derive(Debug, Copy, Clone, Default, MeshPayload)]
+pub struct HardwareConfigFaultConfig {
+    /// Override for the device's PCI Vendor ID. When `None`, the real Vendor
+    /// ID is used.
+    pub vendor_id: Option<u16>,
+    /// Override for the device's PCI Device ID. When `None`, the real Device
+    /// ID is used.
+    pub device_id: Option<u16>,
+}
+
 /// Fault configuration for the NVMe fault controller.
 ///
 /// This struct defines behaviors that inject faults into the NVMe fault controller logic,
@@ -390,6 +426,8 @@ pub struct FaultConfiguration {
     pub namespace_fault: NamespaceFaultConfig,
     /// Fault to apply to all IO queues
     pub io_fault: Arc<IoQueueFaultConfig>,
+    /// Fault to apply to the Hardware Configuration
+    pub hardware_config_fault: Option<HardwareConfigFaultConfig>,
 }
 
 impl FaultConfiguration {
@@ -404,6 +442,7 @@ impl FaultConfiguration {
             pci_fault: Some(PciFaultConfig::new()),
             namespace_fault: NamespaceFaultConfig::new(mesh::channel().1),
             io_fault: Arc::new(IoQueueFaultConfig::new(fault_active)),
+            hardware_config_fault: None,
         }
     }
 
@@ -428,6 +467,35 @@ impl FaultConfiguration {
     /// Add a namespace fault configuration to the fault configuration
     pub fn with_namespace_fault(mut self, namespace_fault: NamespaceFaultConfig) -> Self {
         self.namespace_fault = namespace_fault;
+        self
+    }
+
+    /// Add a hardware config fault configuration to the fault configuration
+    pub fn with_hardware_config_fault(
+        mut self,
+        hardware_config_fault: HardwareConfigFaultConfig,
+    ) -> Self {
+        self.hardware_config_fault = Some(hardware_config_fault);
+        self
+    }
+}
+
+impl HardwareConfigFaultConfig {
+    /// Create a new no-op hardware config fault configuration. All fields
+    /// default to `None`, meaning the real hardware values are used.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the PCI Vendor ID reported by the device.
+    pub fn with_vendor_id(mut self, vendor_id: u16) -> Self {
+        self.vendor_id = Some(vendor_id);
+        self
+    }
+
+    /// Override the PCI Device ID reported by the device.
+    pub fn with_device_id(mut self, device_id: u16) -> Self {
+        self.device_id = Some(device_id);
         self
     }
 }

--- a/vm/devices/storage/nvme_test/src/pci.rs
+++ b/vm/devices/storage/nvme_test/src/pci.rs
@@ -137,10 +137,21 @@ impl NvmeFaultController {
                 BarMemoryKind::Intercept(register_mmio.new_io_region("msix", msix.bar_len())),
             );
 
+        // Apply any hardware-config fault overrides for the IDs reported in
+        // PCI configuration space, falling back to the real values when no
+        // override is configured.
+        let hardware_config_fault = fault_configuration.hardware_config_fault.take();
+        let vendor_id = hardware_config_fault
+            .and_then(|f| f.vendor_id)
+            .unwrap_or(VENDOR_ID);
+        let device_id = hardware_config_fault
+            .and_then(|f| f.device_id)
+            .unwrap_or(0x00a9);
+
         let cfg_space = ConfigSpaceType0Emulator::new(
             HardwareIds {
-                vendor_id: VENDOR_ID,
-                device_id: 0x00a9,
+                vendor_id,
+                device_id,
                 revision_id: 0,
                 prog_if: ProgrammingInterface::MASS_STORAGE_CONTROLLER_NON_VOLATILE_MEMORY_NVME,
                 sub_class: Subclass::MASS_STORAGE_CONTROLLER_NON_VOLATILE_MEMORY,

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -19,6 +19,7 @@ use nvme_resources::NvmeFaultControllerHandle;
 use nvme_resources::fault::AdminQueueFaultBehavior;
 use nvme_resources::fault::AdminQueueFaultConfig;
 use nvme_resources::fault::FaultConfiguration;
+use nvme_resources::fault::HardwareConfigFaultConfig;
 use nvme_resources::fault::IoQueueFaultBehavior;
 use nvme_resources::fault::IoQueueFaultConfig;
 use nvme_resources::fault::NamespaceChange;
@@ -1310,6 +1311,189 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
         }
     };
     assert_eq!(entries.len(), 1, "expected only 1 entry, the AER command");
+
+    Ok(())
+}
+
+/// Verifies the per-device NVMe keepalive gate.
+///
+/// Two NVMe controllers are attached to a single VM:
+/// * A keepalive-compatible controller. Keepalive must be honored for
+///   this device — its controller is not reset across servicing, so
+///   `CREATE_IO_COMPLETION_QUEUE` must NOT be issued after servicing.
+///   The fault panics if the opcode is observed.
+/// * A keepalive-incompatible controller with VendorID = 0x1414 and DeviceID =
+///   0xb111. The test forces this path via the hardware-config fault override
+///   used by the compatibility check. Keepalive must be downgraded to
+///   reset-on-servicing for this device, so `CREATE_IO_COMPLETION_QUEUE` must
+///   be issued around servicing.
+///
+/// Keepalive is enabled VM-wide; the gate is expected to apply per
+/// device based on its Vendor/Device IDs.
+#[openvmm_test(openhcl_linux_direct_x64 [LATEST_LINUX_DIRECT_TEST_X64])]
+async fn servicing_keepalive_per_device_gate(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+    (igvm_file,): (ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,),
+) -> Result<(), anyhow::Error> {
+    let mut flags = config.default_servicing_flags();
+    flags.enable_nvme_keepalive = true;
+
+    const WITH_KEEPALIVE_NVME_INSTANCE: Guid = guid::guid!("00000000-c05b-0000-0000-000000000001");
+    const NO_KEEPALIVE_NVME_INSTANCE: Guid = guid::guid!("dce4ebad-182f-46c0-8d30-8446c1c62ab3");
+
+    const WITH_KEEPALIVE_NSID: u32 = KEEPALIVE_VTL2_NSID;
+    const NO_KEEPALIVE_NSID: u32 = KEEPALIVE_VTL2_NSID + 1;
+    const WITH_KEEPALIVE_LUN: u32 = VTL0_NVME_LUN;
+    const NO_KEEPALIVE_LUN: u32 = VTL0_NVME_LUN + 1;
+
+    // Two independent fault start cells — one per device.
+    let mut with_keepalive_fault_updater = CellUpdater::new(false);
+    let mut no_keepalive_fault_updater = CellUpdater::new(false);
+
+    let (no_keepalive_create_seen_send, no_keepalive_create_seen_recv) = mesh::oneshot::<()>();
+
+    // c05b device: keepalive must be honored — fail loudly if any
+    // CREATE_IO_COMPLETION_QUEUE is observed after the fault is armed.
+    let with_keepalive_fault_config = FaultConfiguration::new(with_keepalive_fault_updater.cell())
+        .with_admin_queue_fault(
+            AdminQueueFaultConfig::new().with_submission_queue_fault(
+                CommandMatchBuilder::new()
+                    .match_cdw0_opcode(nvme_spec::AdminOpcode::CREATE_IO_COMPLETION_QUEUE.0)
+                    .build(),
+                AdminQueueFaultBehavior::Panic(
+                    "c05b device received CREATE_IO_COMPLETION_QUEUE after servicing — \
+                     keepalive should have been honored for this device but the controller \
+                     was reset."
+                        .to_string(),
+                ),
+            ),
+        );
+
+    // Non c05b device: keepalive must be downgraded —
+    // verify CREATE_IO_COMPLETION_QUEUE IS issued after servicing.
+    let no_keepalive_fault_config = FaultConfiguration::new(no_keepalive_fault_updater.cell())
+        .with_admin_queue_fault(
+            AdminQueueFaultConfig::new().with_submission_queue_fault(
+                CommandMatchBuilder::new()
+                    .match_cdw0_opcode(nvme_spec::AdminOpcode::CREATE_IO_COMPLETION_QUEUE.0)
+                    .build(),
+                AdminQueueFaultBehavior::Verify(Some(no_keepalive_create_seen_send)),
+            ),
+        )
+        .with_hardware_config_fault(
+            HardwareConfigFaultConfig::new()
+                .with_vendor_id(0x1414)
+                .with_device_id(0xb111),
+        );
+
+    let scsi_instance = Guid::new_random();
+
+    let (mut vm, agent) = config
+        .with_vmbus_redirect(true)
+        .with_openhcl_command_line(
+            "OPENHCL_ENABLE_VTL2_GPA_POOL=512 OPENHCL_DISABLE_NVME_KEEP_ALIVE=0",
+        )
+        .modify_backend(move |b| {
+            b.with_custom_config(move |c| {
+                c.vpci_devices.push(VpciDeviceConfig {
+                    vtl: DeviceVtl::Vtl2,
+                    instance_id: NO_KEEPALIVE_NVME_INSTANCE,
+                    resource: NvmeFaultControllerHandle {
+                        subsystem_id: Guid::new_random(),
+                        msix_count: 10,
+                        max_io_queues: 10,
+                        namespaces: vec![NamespaceDefinition {
+                            nsid: NO_KEEPALIVE_NSID,
+                            read_only: false,
+                            disk: LayeredDiskHandle::single_layer(RamDiskLayerHandle {
+                                len: Some(DEFAULT_DISK_SIZE),
+                                sector_size: None,
+                            })
+                            .into_resource(),
+                        }],
+                        fault_config: no_keepalive_fault_config,
+                        enable_tdisp_tests: false,
+                    }
+                    .into_resource(),
+                });
+                c.vpci_devices.push(VpciDeviceConfig {
+                    vtl: DeviceVtl::Vtl2,
+                    instance_id: WITH_KEEPALIVE_NVME_INSTANCE,
+                    resource: NvmeFaultControllerHandle {
+                        subsystem_id: Guid::new_random(),
+                        msix_count: 10,
+                        max_io_queues: 10,
+                        namespaces: vec![NamespaceDefinition {
+                            nsid: WITH_KEEPALIVE_NSID,
+                            read_only: false,
+                            disk: LayeredDiskHandle::single_layer(RamDiskLayerHandle {
+                                len: Some(DEFAULT_DISK_SIZE),
+                                sector_size: None,
+                            })
+                            .into_resource(),
+                        }],
+                        fault_config: with_keepalive_fault_config,
+                        enable_tdisp_tests: false,
+                    }
+                    .into_resource(),
+                });
+            })
+        })
+        .add_vtl2_storage_controller(
+            Vtl2StorageControllerBuilder::new(ControllerType::Scsi)
+                .with_instance_id(scsi_instance)
+                .add_lun(
+                    Vtl2LunBuilder::disk()
+                        .with_location(NO_KEEPALIVE_LUN)
+                        .with_physical_device(Vtl2StorageBackingDeviceBuilder::new(
+                            ControllerType::Nvme,
+                            NO_KEEPALIVE_NVME_INSTANCE,
+                            NO_KEEPALIVE_NSID,
+                        )),
+                )
+                .add_lun(
+                    Vtl2LunBuilder::disk()
+                        .with_location(WITH_KEEPALIVE_LUN)
+                        .with_physical_device(Vtl2StorageBackingDeviceBuilder::new(
+                            ControllerType::Nvme,
+                            WITH_KEEPALIVE_NVME_INSTANCE,
+                            WITH_KEEPALIVE_NSID,
+                        )),
+                )
+                .build(),
+        )
+        .run()
+        .await?;
+
+    agent.ping().await?;
+
+    // Arm both faults BEFORE servicing so that the post-servicing
+    // CREATE_IO_COMPLETION_QUEUE is what each fault matches.
+    with_keepalive_fault_updater.set(true).await;
+    no_keepalive_fault_updater.set(true).await;
+
+    vm.restart_openhcl(igvm_file.clone(), flags).await?;
+
+    agent.ping().await?;
+
+    // The non-c05b device must issue CREATE_IO_COMPLETION_QUEUE after
+    // servicing because its keepalive was downgraded to reset.
+    CancelContext::new()
+        .with_timeout(Duration::from_secs(60))
+        .until_cancelled(no_keepalive_create_seen_recv)
+        .await
+        .expect(
+            "non-c05b NVMe device did not issue CREATE_IO_COMPLETION_QUEUE within 60s after \
+             servicing — the per-device keepalive gate did not downgrade keepalive for this \
+             device.",
+        )
+        .expect("CREATE_IO_COMPLETION_QUEUE verification on non-c05b device failed");
+
+    // If the c05b device had received CREATE_IO_COMPLETION_QUEUE, the
+    // panic fault would have crashed the VM and failed this test. We
+    // disarm the faults defensively before tearing down.
+    with_keepalive_fault_updater.set(false).await;
+    no_keepalive_fault_updater.set(false).await;
 
     Ok(())
 }


### PR DESCRIPTION
This change is intended to disable keepalive entirely for any devices with VendorId = 0x1414 and DeviceId = 0xb111. Disablement is done in the nvme_manager when the device is first loaded by reading the VendorID and DeviceID from the config space and the manager stores a flag the determines keepalive compatibility for the device (so that we are not repeatedly reading in the config space). 
It also makes sure that even when a device is being restored, it is not automatically assumed to be keepalive compatible.