### PR TITLE
openhcl: strip /var/lib/rpm from openvmm-deps interactive layers

### DIFF
--- a/openhcl/update-rootfs.py
+++ b/openhcl/update-rootfs.py
@@ -64,6 +64,28 @@ def run_and_get_stdout(command: str) -> str:
     return result.stdout.decode("utf-8").strip()
 
 
+def strip_rpmdb_from_layer(layer_path: str, temp_dir: str, layer_idx: int) -> str:
+    """Return a path to a copy of `layer_path` with /var/lib/rpm filtered out.
+
+    The openvmm-deps build intentionally ships /var/lib/rpm inside the
+    interactive cpio.gz layers so its upstream pipeline can run syft against
+    them and emit SPDX SBOMs. The RPM database has no purpose at runtime in
+    the VTL2 initrd and just costs RAM, so filter it on the way in.
+
+    Pipes the gzipped cpio through bsdtar with --exclude in a single pass --
+    no extract/repack to a tempdir. If the layer contains no /var/lib/rpm
+    entries (today's NuGet, which still strips upstream), the output is
+    bit-identical to the input minus gzip framing.
+    """
+    stripped = os.path.join(temp_dir, f"layer_{layer_idx}_stripped.cpio.gz")
+    run_inside_shell_and_check(
+        f'gunzip -c "{layer_path}" '
+        f'| bsdtar -c --format=newc '
+        f'    --exclude="./var/lib/rpm" --exclude="./var/lib/rpm/*" "@-" '
+        f'| {Config.GZIP} > "{stripped}"')
+    return stripped
+
+
 def append_to_rootfs(initial_dir: str, file_to_append: str, existing_cpio_gz_path: str):
     command = f'cd {initial_dir}; ' + \
               f'echo {file_to_append} | ' + \
@@ -120,7 +142,8 @@ def process(temp_dir: str, underhill_path: str, kernel_path: str,
         append_file(underhill_cpio_gz_file_name, temp_file_name)
         os.unlink(temp_file_name)
 
-    for layer in additional_layers:
+    for idx, layer in enumerate(additional_layers):
+        layer = strip_rpmdb_from_layer(layer, temp_dir, idx)
         layer_size = os.path.getsize(layer)
         eprint(f"Adding layer {layer}, size: {layer_size} bytes")
         append_file(underhill_cpio_gz_file_name, layer)


### PR DESCRIPTION
The openvmm-deps build will soon stop deleting `/var/lib/rpm` from the shipped sysroot artifacts (microsoft/openvmm-deps#49) so its upstream pipeline can run syft against them and emit standards-compliant SPDX SBOMs.

The RPM database has no purpose at runtime in the VTL2 initrd and just costs RAM, so `update-rootfs.py` strips it from each appended layer on the way in.

## Behavior today

This is a **no-op against the currently shipping openvmm-deps NuGet** -- those cpio.gz layers don't contain `var/lib/rpm` because the upstream build still strips it. The probe (`cpio -t | grep -q ^var/lib/rpm`) returns nothing, the original layer file is appended unchanged, no extract+repack happens.

Once the new openvmm-deps NuGet ships (post openvmm-deps#49), the probe matches and we do an in-place extract -> `rm -rf var/lib/rpm` -> repack before appending. Adds a few seconds per build, removes a few MB from the final initrd.

Landing this first means we can take the new openvmm-deps NuGet without ever shipping rpmdb in production VTL2 memory.

## Companion PRs

- microsoft/openvmm-deps#49 -- stop stripping rpmdb upstream + emit SPDX SBOMs

## Test

I'd appreciate a CI run. Local syntax-check passes (`python -m py_compile`). The behavior on current cpio.gz layers is unchanged.