### PR TITLE
virtiofs: remove unnecessary per-entry lookup from plain readdir

### DIFF
--- a/vm/devices/virtio/virtiofs/src/file.rs
+++ b/vm/devices/virtio/virtiofs/src/file.rs
@@ -78,22 +78,6 @@ impl VirtioFsFile {
         let mut file = self.file.write();
         file.read_dir(offset as lx::off_t, |entry| {
             entry_count += 1;
-            let get_child_fuse_entry = || -> lx::Result<Option<fuse_entry_out>> {
-                match fs.lookup_helper(&self.inode, &entry.name) {
-                    Ok(e) => Ok(Some(e)),
-                    Err(err) => {
-                        // Ignore entries that are inaccessible to the user or deleted.
-                        // ENOENT can occur if a file was deleted between enumeration
-                        // and lookup (e.g., when deleting files in a loop while
-                        // enumerating the directory).
-                        if err.value() == lx::EACCES || err.value() == lx::ENOENT {
-                            Ok(None)
-                        } else {
-                            Err(err)
-                        }
-                    }
-                }
-            };
             // If readdirplus is being used, do a lookup on all items except the . and .. entries.
             if plus {
                 let fuse_entry = if entry.name == "." || entry.name == ".." {
@@ -106,18 +90,28 @@ impl VirtioFsFile {
                         return Ok(false);
                     }
 
-                    match get_child_fuse_entry()? {
-                        Some(e) => e,
-                        None => {
-                            // Ignore entries that are inaccessible to the user.
-                            entry_count -= 1;
-                            return Ok(true);
+                    match fs.lookup_helper(&self.inode, &entry.name) {
+                        Ok(e) => e,
+                        Err(err) => {
+                            // Ignore entries that are inaccessible to the
+                            // user or deleted. ENOENT can occur if a file was
+                            // deleted between enumeration and lookup.
+                            if err.value() == lx::EACCES || err.value() == lx::ENOENT {
+                                entry_count -= 1;
+                                return Ok(true);
+                            }
+                            return Err(err);
                         }
                     }
                 };
 
                 Ok(buffer.dir_entry_plus(&entry.name, entry.offset as u64, fuse_entry))
             } else {
+                // For plain readdir, return directory entries directly without
+                // per-entry lookups. Directory read permission is already
+                // checked at opendir time, so the per-entry access check
+                // is unnecessary overhead.
+                //
                 // Use the current file's inode number for . and .. entries.
                 // On Windows inode_nr is 0 for these; on Linux it may be
                 // non-zero, so check by name rather than relying on the
@@ -125,11 +119,6 @@ impl VirtioFsFile {
                 let inode_nr = if entry.name == "." || entry.name == ".." {
                     self_inode_nr
                 } else {
-                    if get_child_fuse_entry()?.is_none() {
-                        // Ignore entries that are inaccessible to the user.
-                        entry_count -= 1;
-                        return Ok(true);
-                    }
                     entry.inode_nr
                 };
 


### PR DESCRIPTION
The plain readdir path was calling `lookup_helper()` on every directory
entry just to check accessibility, then discarding the result. This
caused a full stat round-trip per entry even though the lookup results
were not returned to the guest kernel (unlike readdirplus, where they
pre-populate the dentry cache).

Directory read permission is already verified at opendir time, making
the per-entry access check redundant.

This should improve performance for directory listing workloads where
the kernel uses plain readdir (e.g. via `READDIRPLUS_AUTO` fallback).