### PR TITLE
virtiofs: advertise multiple request queues for parallel I/O

### DIFF
--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1424,6 +1424,7 @@ async fn vm_config_from_command_line(
                 root_path: args.path.clone(),
                 mount_options: args.options.clone(),
             },
+            num_request_queues: None,
         }
         .into_resource();
         if let Some(pcie_port) = &args.pcie_port {
@@ -1442,6 +1443,7 @@ async fn vm_config_from_command_line(
             fs: virtio_resources::fs::VirtioFsBackend::SectionFs {
                 root_path: args.path.clone(),
             },
+            num_request_queues: None,
         }
         .into_resource();
         if let Some(pcie_port) = &args.pcie_port {

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -650,6 +650,7 @@ impl VmService {
                         root_path: virtiofs.root_path,
                         mount_options: String::new(),
                     },
+                    num_request_queues: None,
                 }
                 .into_resource();
                 // Use VPCI when possible (currently only on Windows and macOS due

--- a/vm/devices/virtio/virtio_resources/src/lib.rs
+++ b/vm/devices/virtio/virtio_resources/src/lib.rs
@@ -49,6 +49,9 @@ pub mod fs {
     pub struct VirtioFsHandle {
         pub tag: String,
         pub fs: VirtioFsBackend,
+        /// Number of request queues to advertise. If `None`, defaults to the
+        /// number of available CPUs (capped at 16).
+        pub num_request_queues: Option<u32>,
     }
 
     #[derive(MeshPayload)]

--- a/vm/devices/virtio/virtiofs/src/integration_tests.rs
+++ b/vm/devices/virtio/virtiofs/src/integration_tests.rs
@@ -71,7 +71,7 @@ impl TestHarness {
 
         let fs = VirtioFs::new(tmpdir.path(), None).unwrap();
         let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone()));
-        let device = VirtioFsDevice::new(&driver_source, "testfs", fs, 0, None);
+        let device = VirtioFsDevice::new(&driver_source, "testfs", fs, 0, None, Some(1));
 
         let queue_event = Event::new();
         let interrupt_event = Event::new();

--- a/vm/devices/virtio/virtiofs/src/integration_tests.rs
+++ b/vm/devices/virtio/virtiofs/src/integration_tests.rs
@@ -533,3 +533,44 @@ async fn init_negotiates_direct_io_allow_mmap(driver: DefaultDriver) {
         "VirtioFs should request FUSE_DIRECT_IO_ALLOW_MMAP_FLAG2 when kernel advertises it"
     );
 }
+
+#[async_test]
+async fn num_request_queues_default_is_clamped(driver: DefaultDriver) {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let fs = VirtioFs::new(tmpdir.path(), None).unwrap();
+    let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
+    let device = VirtioFsDevice::new(&driver_source, "testfs", fs, 0, None, None);
+
+    let traits = device.traits();
+    // num_request_queues should be at least 1 and at most MAX (16).
+    // max_queues = num_request_queues + 1 (hiprio queue).
+    assert!(traits.max_queues >= 2, "at least 1 request queue + hiprio");
+    assert!(
+        traits.max_queues <= 17,
+        "at most 16 request queues + hiprio"
+    );
+}
+
+#[async_test]
+async fn num_request_queues_explicit_zero_is_clamped_to_one(driver: DefaultDriver) {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let fs = VirtioFs::new(tmpdir.path(), None).unwrap();
+    let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
+    let device = VirtioFsDevice::new(&driver_source, "testfs", fs, 0, None, Some(0));
+
+    let traits = device.traits();
+    // Some(0) should be clamped to 1 → max_queues = 2
+    assert_eq!(traits.max_queues, 2);
+}
+
+#[async_test]
+async fn num_request_queues_explicit_overflow_is_clamped(driver: DefaultDriver) {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let fs = VirtioFs::new(tmpdir.path(), None).unwrap();
+    let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
+    let device = VirtioFsDevice::new(&driver_source, "testfs", fs, 0, None, Some(100));
+
+    let traits = device.traits();
+    // Some(100) should be clamped to MAX_REQUEST_QUEUES (16) → max_queues = 17
+    assert_eq!(traits.max_queues, 17);
+}

--- a/vm/devices/virtio/virtiofs/src/integration_tests.rs
+++ b/vm/devices/virtio/virtiofs/src/integration_tests.rs
@@ -8,6 +8,7 @@
 //! as a guest kernel would.
 
 use crate::VirtioFs;
+use crate::virtio::MAX_REQUEST_QUEUES;
 use crate::virtio::VirtioFsDevice;
 use fuse::protocol::*;
 use guestmem::GuestMemory;
@@ -542,12 +543,12 @@ async fn num_request_queues_default_is_clamped(driver: DefaultDriver) {
     let device = VirtioFsDevice::new(&driver_source, "testfs", fs, 0, None, None);
 
     let traits = device.traits();
-    // num_request_queues should be at least 1 and at most MAX (16).
+    // num_request_queues should be at least 1 and at most MAX_REQUEST_QUEUES.
     // max_queues = num_request_queues + 1 (hiprio queue).
     assert!(traits.max_queues >= 2, "at least 1 request queue + hiprio");
     assert!(
-        traits.max_queues <= 17,
-        "at most 16 request queues + hiprio"
+        traits.max_queues <= MAX_REQUEST_QUEUES as u16 + 1,
+        "at most MAX_REQUEST_QUEUES request queues + hiprio"
     );
 }
 
@@ -571,6 +572,6 @@ async fn num_request_queues_explicit_overflow_is_clamped(driver: DefaultDriver) 
     let device = VirtioFsDevice::new(&driver_source, "testfs", fs, 0, None, Some(100));
 
     let traits = device.traits();
-    // Some(100) should be clamped to MAX_REQUEST_QUEUES (16) → max_queues = 17
-    assert_eq!(traits.max_queues, 17);
+    // Some(100) should be clamped to MAX_REQUEST_QUEUES → max_queues = MAX + 1
+    assert_eq!(traits.max_queues, MAX_REQUEST_QUEUES as u16 + 1);
 }

--- a/vm/devices/virtio/virtiofs/src/resolver.rs
+++ b/vm/devices/virtio/virtiofs/src/resolver.rs
@@ -44,6 +44,7 @@ impl ResolveResource<VirtioDeviceHandle, VirtioFsHandle> for VirtioFsResolver {
                 )?,
                 0,
                 None,
+                None,
             ),
             #[cfg(windows)]
             VirtioFsBackend::SectionFs { root_path } => {
@@ -52,6 +53,7 @@ impl ResolveResource<VirtioDeviceHandle, VirtioFsHandle> for VirtioFsResolver {
                     &resource.tag,
                     crate::SectionFs::new(root_path)?,
                     8 * 1024 * 1024 * 1024, // 8GB of shared memory,
+                    None,
                     None,
                 )
             }

--- a/vm/devices/virtio/virtiofs/src/resolver.rs
+++ b/vm/devices/virtio/virtiofs/src/resolver.rs
@@ -35,25 +35,29 @@ impl ResolveResource<VirtioDeviceHandle, VirtioFsHandle> for VirtioFsResolver {
             VirtioFsBackend::HostFs {
                 root_path,
                 mount_options,
-            } => VirtioFsDevice::new(
-                input.driver_source,
-                &resource.tag,
-                VirtioFs::new(
-                    root_path,
-                    Some(&LxVolumeOptions::from_option_string(mount_options)),
-                )?,
-                0,
-                None,
-                resource.num_request_queues,
-            ),
+            } => {
+                let notify_corruption = None;
+                VirtioFsDevice::new(
+                    input.driver_source,
+                    &resource.tag,
+                    VirtioFs::new(
+                        root_path,
+                        Some(&LxVolumeOptions::from_option_string(mount_options)),
+                    )?,
+                    0,
+                    notify_corruption,
+                    resource.num_request_queues,
+                )
+            }
             #[cfg(windows)]
             VirtioFsBackend::SectionFs { root_path } => {
+                let notify_corruption = None;
                 VirtioFsDevice::new(
                     input.driver_source,
                     &resource.tag,
                     crate::SectionFs::new(root_path)?,
                     8 * 1024 * 1024 * 1024, // 8GB of shared memory,
-                    None,
+                    notify_corruption,
                     resource.num_request_queues,
                 )
             }

--- a/vm/devices/virtio/virtiofs/src/resolver.rs
+++ b/vm/devices/virtio/virtiofs/src/resolver.rs
@@ -44,7 +44,7 @@ impl ResolveResource<VirtioDeviceHandle, VirtioFsHandle> for VirtioFsResolver {
                 )?,
                 0,
                 None,
-                None,
+                resource.num_request_queues,
             ),
             #[cfg(windows)]
             VirtioFsBackend::SectionFs { root_path } => {
@@ -54,7 +54,7 @@ impl ResolveResource<VirtioDeviceHandle, VirtioFsHandle> for VirtioFsResolver {
                     crate::SectionFs::new(root_path)?,
                     8 * 1024 * 1024 * 1024, // 8GB of shared memory,
                     None,
-                    None,
+                    resource.num_request_queues,
                 )
             }
             #[cfg(not(windows))]

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -77,12 +77,13 @@ impl VirtioFsDevice {
     where
         Fs: 'static + fuse::Fuse + Send + Sync,
     {
-        let num_request_queues = num_request_queues.unwrap_or_else(|| {
-            std::thread::available_parallelism()
-                .map(|n| n.get() as u32)
-                .unwrap_or(1)
-                .clamp(1, MAX_REQUEST_QUEUES)
-        });
+        let num_request_queues = num_request_queues
+            .unwrap_or_else(|| {
+                std::thread::available_parallelism()
+                    .map(|n| n.get() as u32)
+                    .unwrap_or(1)
+            })
+            .clamp(1, MAX_REQUEST_QUEUES);
 
         let mut config = VirtioFsDeviceConfig {
             tag: [0; 36],

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -31,7 +31,7 @@ use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 
 /// Maximum number of request queues to advertise.
-const MAX_REQUEST_QUEUES: u32 = 16;
+pub(crate) const MAX_REQUEST_QUEUES: u32 = 16;
 
 /// PCI configuration space values for virtio-fs devices.
 #[repr(C)]
@@ -66,7 +66,8 @@ impl VirtioFsDevice {
     /// advertises. The Linux guest kernel (≥6.11) distributes I/O across
     /// queues on a per-CPU basis, so this is best set to the guest vCPU count.
     /// If `None`, defaults to the number of host CPUs (capped at
-    /// `MAX_REQUEST_QUEUES`). Values are clamped to `1..=MAX_REQUEST_QUEUES`.
+    /// `MAX_REQUEST_QUEUES`). All values (including `Some(0)`) are clamped
+    /// to `1..=MAX_REQUEST_QUEUES`.
     pub fn new<Fs>(
         driver_source: &VmTaskDriverSource,
         tag: &str,

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -64,8 +64,9 @@ impl VirtioFsDevice {
     ///
     /// `num_request_queues` controls how many virtio request queues the device
     /// advertises. The Linux guest kernel (≥6.11) distributes I/O across
-    /// queues on a per-CPU basis. If `None`, defaults to the number of
-    /// available CPUs (capped at 16).
+    /// queues on a per-CPU basis, so this is best set to the guest vCPU count.
+    /// If `None`, defaults to the number of host CPUs (capped at
+    /// `MAX_REQUEST_QUEUES`). Values are clamped to `1..=MAX_REQUEST_QUEUES`.
     pub fn new<Fs>(
         driver_source: &VmTaskDriverSource,
         tag: &str,

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -30,6 +30,9 @@ use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 
+/// Maximum number of request queues to advertise.
+const MAX_REQUEST_QUEUES: u32 = 16;
+
 /// PCI configuration space values for virtio-fs devices.
 #[repr(C)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
@@ -58,19 +61,32 @@ pub struct VirtioFsDevice {
 
 impl VirtioFsDevice {
     /// Creates a new `VirtioFsDevice` with the specified mount tag.
+    ///
+    /// `num_request_queues` controls how many virtio request queues the device
+    /// advertises. The Linux guest kernel (≥6.11) distributes I/O across
+    /// queues on a per-CPU basis. If `None`, defaults to the number of
+    /// available CPUs (capped at 16).
     pub fn new<Fs>(
         driver_source: &VmTaskDriverSource,
         tag: &str,
         fs: Fs,
         shmem_size: u64,
         notify_corruption: Option<Arc<dyn Fn() + Sync + Send>>,
+        num_request_queues: Option<u32>,
     ) -> Self
     where
         Fs: 'static + fuse::Fuse + Send + Sync,
     {
+        let num_request_queues = num_request_queues.unwrap_or_else(|| {
+            std::thread::available_parallelism()
+                .map(|n| n.get() as u32)
+                .unwrap_or(1)
+                .clamp(1, MAX_REQUEST_QUEUES)
+        });
+
         let mut config = VirtioFsDeviceConfig {
             tag: [0; 36],
-            num_request_queues: 1,
+            num_request_queues,
         };
 
         let notify_corruption = if let Some(notify) = notify_corruption {
@@ -104,7 +120,7 @@ impl VirtioDevice for VirtioFsDevice {
                 .with_ring_event_idx(true)
                 .with_ring_indirect_desc(true)
                 .with_ring_packed(true),
-            max_queues: 2,
+            max_queues: self.config.num_request_queues as u16 + 1,
             device_register_length: self.config.as_bytes().len() as u32,
             shared_memory: DeviceTraitsSharedMemory {
                 id: 0,


### PR DESCRIPTION
Advertise `num_request_queues` based on available host CPUs (capped at 16)
instead of hardcoding 1. The Linux guest kernel (≥6.11) distributes
FUSE requests across queues on a per-CPU basis, eliminating single-queue
lock contention for parallel workloads.

Each queue is serviced by an independent worker task, so requests on
different queues are processed concurrently without contention. Older
kernels that lack multi-queue support (<6.11) will ignore the extra
queues and continue using queue 0 — no behavioral change for them.

The queue count is configurable via the new `num_request_queues` parameter
on `VirtioFsDevice::new()`. Passing `None` uses the host CPU count heuristic.

## Changes

- `virtio.rs`: Add `MAX_REQUEST_QUEUES` constant, compute queue count from `available_parallelism()`, update `max_queues` to `num_request_queues + 1`
- `resolver.rs`: Pass `None` (use default heuristic)
- `integration_tests.rs`: Pass `Some(1)` for deterministic test behavior