### PR TITLE
virtiofs: negotiate FUSE_MAX_PAGES for larger I/O requests

### DIFF
--- a/vm/devices/support/fs/fuse/src/session.rs
+++ b/vm/devices/support/fs/fuse/src/session.rs
@@ -24,6 +24,7 @@ const DEFAULT_FLAGS: u32 = FUSE_ASYNC_READ
     | FUSE_ASYNC_DIO
     | FUSE_ATOMIC_O_TRUNC
     | FUSE_BIG_WRITES
+    | FUSE_MAX_PAGES
     | FUSE_INIT_EXT;
 
 // Default flags2 to negotiate when FUSE_INIT_EXT is supported.


### PR DESCRIPTION
Add `FUSE_MAX_PAGES` to `DEFAULT_FLAGS` so the FUSE server advertises support for larger request sizes during `FUSE_INIT` negotiation.

## Background

Without this flag, the Linux kernel uses `FUSE_DEFAULT_MAX_PAGES_PER_REQ` (32 pages = 128 KiB) as the maximum request size. With the flag, the kernel uses `min(fuse_max_pages_limit, virtqueue_size - FUSE_HEADER_OVERHEAD)` which — for our default virtqueue size of 256 — is 252 pages (~1008 KiB). This is an **8x increase** in max request size, significantly reducing per-request overhead for sequential I/O.

## Benchmark results

burette virtio-fs benchmark, 3 iterations each, comparing with and without `FUSE_MAX_PAGES` flag.

### 6.1 kernel

| Metric | Baseline | With flag | Delta |
|--------|----------|-----------|-------|
| Sequential read | 166 MiB/s | 227 MiB/s | **+37%** |
| Sequential write | 101 MiB/s | 161 MiB/s | **+59%** |
| Random read IOPS | 2231 | 1953 | ~noise |
| Random write IOPS | 2312 | 2376 | ~noise |

### 6.12 kernel

| Metric | Baseline | With flag | Delta |
|--------|----------|-----------|-------|
| Sequential read | 119 MiB/s | 219 MiB/s | **+83%** |
| Sequential write | 93 MiB/s | 156 MiB/s | **+68%** |
| Random read IOPS | 1757 | 1807 | ~noise |
| Random write IOPS | 2416 | 2376 | ~noise |

Random I/O is unaffected as expected — 4K blocks do not benefit from larger request sizes.

## Notes

`DEFAULT_MAX_PAGES` (256) is intentionally left unchanged. The kernel clamps `max_pages` to `min(fuse_max_pages_limit=256, virtqueue_size-4=252)`, so larger values have no effect with the current virtqueue size of 256. The gain comes entirely from negotiating the flag, which moves the kernel from 32 to 252 pages per request.

On Linux 6.18+, `fuse_max_pages_limit` becomes a runtime module parameter (previously a compile-time constant). To benefit from values beyond 252 in the future, we would also need to increase the virtqueue size.