### PR TITLE
virtio: advertise VIRTIO_F_ACCESS_PLATFORM for IOMMU support

### DIFF
--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -65,6 +65,7 @@ const VIRTIO_F_RING_INDIRECT_DESC: u32 = 0x10000000;
 const VIRTIO_F_RING_EVENT_IDX: u32 = 0x20000000;
 // Device features - second bank
 const VIRTIO_F_VERSION_1: u32 = 1;
+const VIRTIO_F_ACCESS_PLATFORM: u32 = 2;
 const VIRTIO_F_RING_PACKED: u32 = 4;
 
 // Device status
@@ -1486,7 +1487,10 @@ async fn verify_chipset_config(driver: DefaultDriver) {
     // device feature (bank 1)
     dev.write_u32(20, 1);
     assert_eq!(dev.read_u32(20), 1);
-    assert_eq!(dev.read_u32(16), VIRTIO_F_VERSION_1 | VIRTIO_F_RING_PACKED);
+    assert_eq!(
+        dev.read_u32(16),
+        VIRTIO_F_VERSION_1 | VIRTIO_F_ACCESS_PLATFORM | VIRTIO_F_RING_PACKED
+    );
     // device feature (bank 2)
     dev.write_u32(20, 2);
     assert_eq!(dev.read_u32(16), 0);
@@ -1506,7 +1510,10 @@ async fn verify_chipset_config(driver: DefaultDriver) {
     // driver feature (bank 1)
     assert_eq!(dev.read_u32(32), 0);
     dev.write_u32(32, 0xffffffff);
-    assert_eq!(dev.read_u32(32), VIRTIO_F_VERSION_1 | VIRTIO_F_RING_PACKED);
+    assert_eq!(
+        dev.read_u32(32),
+        VIRTIO_F_VERSION_1 | VIRTIO_F_ACCESS_PLATFORM | VIRTIO_F_RING_PACKED
+    );
     // driver feature (bank 2)
     dev.write_u32(36, 2);
     assert_eq!(dev.read_u32(32), 0);
@@ -1793,7 +1800,7 @@ async fn verify_pci_registers(driver: DefaultDriver) {
     assert_eq!(pci_test_device.read_u32(bar_address1), 1);
     assert_eq!(
         pci_test_device.read_u32(bar_address1 + 4),
-        VIRTIO_F_VERSION_1 | VIRTIO_F_RING_PACKED
+        VIRTIO_F_VERSION_1 | VIRTIO_F_ACCESS_PLATFORM | VIRTIO_F_RING_PACKED
     );
     // device feature (bank 2)
     pci_test_device.write_u32(bar_address1, 2);
@@ -1817,7 +1824,7 @@ async fn verify_pci_registers(driver: DefaultDriver) {
     pci_test_device.write_u32(bar_address1 + 12, 0xffffffff);
     assert_eq!(
         pci_test_device.read_u32(bar_address1 + 12),
-        VIRTIO_F_VERSION_1 | VIRTIO_F_RING_PACKED
+        VIRTIO_F_VERSION_1 | VIRTIO_F_ACCESS_PLATFORM | VIRTIO_F_RING_PACKED
     );
     // driver feature (bank 2)
     pci_test_device.write_u32(bar_address1 + 8, 2);

--- a/vm/devices/virtio/virtio/src/transport/core.rs
+++ b/vm/devices/virtio/virtio/src/transport/core.rs
@@ -121,7 +121,13 @@ impl VirtioTransportCore {
             })
             .collect::<std::io::Result<Vec<_>>>()?;
 
-        let device_feature = traits.device_features.with_version_1(true);
+        // Always turn on version 1 (we don't support legacy devices) and
+        // access_platform (if the device is behind an IOMMU, DMAs will be
+        // translated).
+        let device_feature = traits
+            .device_features
+            .with_version_1(true)
+            .with_access_platform(true);
         let supports_save_restore = device.supports_save_restore();
 
         let (sender, receiver) = mesh::channel();


### PR DESCRIPTION
Unconditionally set the ACCESS_PLATFORM feature bit on all virtio devices. This tells the guest driver that DMA addresses may go through platform-level translation (e.g., an IOMMU) and must use the DMA API rather than assuming identity-mapped physical addresses.

When no IOMMU is present the feature bit is harmless -- the guest's DMA API still works with identity mappings. When an IOMMU is present (such as the SMMUv3 emulator on aarch64), this bit is required: without it, Linux's virtio driver bypasses the DMA API and programs raw GPAs into virtqueues, which the SMMU will reject as untranslated IOVAs.