### PR TITLE
crypto: Create a pure-Rust backend

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1141,7 +1141,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 12 flowey_lib_common::git_checkout 0
-        flowey.exe v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
         flowey.exe v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1149,7 +1149,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar7 }}
+        persist-credentials: ${{ env.floweyvar8 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1169,14 +1169,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 12 flowey_lib_common::cache 4
-        flowey.exe v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1212,6 +1212,9 @@ jobs:
     - name: cargo clippy
       run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 1
       shell: bash
+    - name: cargo clippy
+      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey.exe e 12 flowey_lib_common::download_cargo_nextest 0
@@ -1222,14 +1225,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 12 flowey_lib_common::cache 0
-        flowey.exe v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1245,28 +1248,17 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey.exe e 12 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 12 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: |-
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
         flowey.exe e 12 flowey_lib_hvlite::init_cross_build 1
         flowey.exe e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
         flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 2
         flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 12 flowey_lib_common::publish_test_results 5
         flowey.exe e 12 flowey_lib_common::publish_test_results 6
         flowey.exe e 12 flowey_lib_common::publish_test_results 4
@@ -1276,8 +1268,39 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-unit-tests-unit-tests-junit-xml
+        name: x64-windows-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 12 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 12 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 4
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 5
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 12 flowey_lib_common::publish_test_results 8
+        flowey.exe e 12 flowey_lib_common::publish_test_results 9
+        flowey.exe e 12 flowey_lib_common::publish_test_results 10
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
@@ -1303,7 +1326,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
@@ -1404,11 +1427,12 @@ jobs:
       run: |-
         flowey e 13 flowey_lib_common::install_rust 2
         flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 13 flowey_lib_common::git_checkout 0
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1416,7 +1440,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1436,14 +1460,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 4
-        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1481,15 +1505,16 @@ jobs:
         flowey e 13 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: |-
-        flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 1
-        flowey e 13 flowey_lib_hvlite::init_cross_build 0
+      run: flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 1
       shell: bash
     - name: cargo clippy
       run: flowey e 13 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
       run: flowey e 13 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
       run: flowey e 13 flowey_lib_common::run_cargo_clippy 3
@@ -1514,10 +1539,13 @@ jobs:
       run: flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 5
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 6
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -1529,14 +1557,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1556,13 +1584,13 @@ jobs:
         flowey e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 13 flowey_lib_common::publish_test_results 5
         flowey e 13 flowey_lib_common::publish_test_results 6
         flowey e 13 flowey_lib_common::publish_test_results 4
@@ -1572,18 +1600,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 13 flowey_lib_common::publish_test_results 8
         flowey e 13 flowey_lib_common::publish_test_results 9
         flowey e 13 flowey_lib_common::publish_test_results 10
@@ -1593,8 +1621,50 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 13 flowey_lib_common::publish_test_results 12
+        flowey e 13 flowey_lib_common::publish_test_results 13
+        flowey e 13 flowey_lib_common::publish_test_results 14
+        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 13 flowey_lib_common::publish_test_results 16
+        flowey e 13 flowey_lib_common::publish_test_results 17
+        flowey e 13 flowey_lib_common::publish_test_results 18
+        flowey v 13 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 13 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -1613,34 +1683,13 @@ jobs:
       run: flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 13 flowey_lib_common::publish_test_results 12
-        flowey e 13 flowey_lib_common::publish_test_results 13
-        flowey e 13 flowey_lib_common::publish_test_results 14
-        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 13 flowey_lib_common::publish_test_results 0
         flowey e 13 flowey_lib_common::publish_test_results 1
         flowey e 13 flowey_lib_common::publish_test_results 2
@@ -1650,13 +1699,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
@@ -1761,7 +1810,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
         flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1769,7 +1818,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar11 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1793,14 +1842,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1828,17 +1877,20 @@ jobs:
         flowey e 14 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_clippy 5
+        flowey e 14 flowey_lib_common::run_cargo_clippy 6
         flowey e 14 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -1862,7 +1914,7 @@ jobs:
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -1874,14 +1926,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1922,12 +1974,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 14 flowey_lib_common::publish_test_results 8
         flowey e 14 flowey_lib_common::publish_test_results 9
@@ -1938,17 +1990,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 14 flowey_lib_common::publish_test_results 12
         flowey e 14 flowey_lib_common::publish_test_results 13
@@ -1959,17 +2011,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 14 flowey_lib_common::publish_test_results 16
         flowey e 14 flowey_lib_common::publish_test_results 17
@@ -1980,8 +2032,29 @@ jobs:
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 14 flowey_lib_common::publish_test_results 20
+        flowey e 14 flowey_lib_common::publish_test_results 21
+        flowey e 14 flowey_lib_common::publish_test_results 22
+        flowey v 14 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -2000,12 +2073,12 @@ jobs:
       run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 5
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 11
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
@@ -2022,7 +2095,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 7
         flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
@@ -2127,7 +2200,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 15 flowey_lib_common::git_checkout 0
-        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
         flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2135,7 +2208,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar7 }}
+        persist-credentials: ${{ env.floweyvar8 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2155,14 +2228,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 15 flowey_lib_common::cache 4
-        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2198,6 +2271,9 @@ jobs:
     - name: cargo clippy
       run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
+    - name: cargo clippy
+      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey.exe e 15 flowey_lib_common::download_cargo_nextest 0
@@ -2208,14 +2284,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 15 flowey_lib_common::cache 0
-        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2231,28 +2307,17 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey.exe e 15 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: |-
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
         flowey.exe e 15 flowey_lib_hvlite::init_cross_build 1
         flowey.exe e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 2
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 15 flowey_lib_common::publish_test_results 5
         flowey.exe e 15 flowey_lib_common::publish_test_results 6
         flowey.exe e 15 flowey_lib_common::publish_test_results 4
@@ -2262,8 +2327,39 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-unit-tests-unit-tests-junit-xml
+        name: aarch64-windows-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
+      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 15 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 4
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 5
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 15 flowey_lib_common::publish_test_results 8
+        flowey.exe e 15 flowey_lib_common::publish_test_results 9
+        flowey.exe e 15 flowey_lib_common::publish_test_results 10
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
@@ -2289,7 +2385,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
@@ -2400,7 +2496,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2408,7 +2504,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2428,14 +2524,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2454,6 +2550,10 @@ jobs:
       run: |-
         flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 16 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_clippy 1
         flowey e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
@@ -2477,10 +2577,10 @@ jobs:
       run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2492,14 +2592,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2519,13 +2619,13 @@ jobs:
         flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 16 flowey_lib_common::publish_test_results 5
         flowey e 16 flowey_lib_common::publish_test_results 6
         flowey e 16 flowey_lib_common::publish_test_results 4
@@ -2535,18 +2635,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 16 flowey_lib_common::publish_test_results 8
         flowey e 16 flowey_lib_common::publish_test_results 9
         flowey e 16 flowey_lib_common::publish_test_results 10
@@ -2556,8 +2656,50 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey e 16 flowey_lib_common::publish_test_results 13
+        flowey e 16 flowey_lib_common::publish_test_results 14
+        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 16 flowey_lib_common::publish_test_results 16
+        flowey e 16 flowey_lib_common::publish_test_results 17
+        flowey e 16 flowey_lib_common::publish_test_results 18
+        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -2576,34 +2718,13 @@ jobs:
       run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 16 flowey_lib_common::publish_test_results 0
         flowey e 16 flowey_lib_common::publish_test_results 1
         flowey e 16 flowey_lib_common::publish_test_results 2
@@ -2613,13 +2734,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
@@ -2724,7 +2845,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
         flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2732,7 +2853,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar11 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2756,14 +2877,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2791,17 +2912,20 @@ jobs:
         flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_clippy 5
+        flowey e 17 flowey_lib_common::run_cargo_clippy 6
         flowey e 17 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2825,7 +2949,7 @@ jobs:
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2837,14 +2961,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2885,12 +3009,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 17 flowey_lib_common::publish_test_results 8
         flowey e 17 flowey_lib_common::publish_test_results 9
@@ -2901,17 +3025,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 17 flowey_lib_common::publish_test_results 12
         flowey e 17 flowey_lib_common::publish_test_results 13
@@ -2922,17 +3046,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 17 flowey_lib_common::publish_test_results 16
         flowey e 17 flowey_lib_common::publish_test_results 17
@@ -2943,8 +3067,29 @@ jobs:
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 17 flowey_lib_common::publish_test_results 20
+        flowey e 17 flowey_lib_common::publish_test_results 21
+        flowey e 17 flowey_lib_common::publish_test_results 22
+        flowey v 17 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -2963,12 +3108,12 @@ jobs:
       run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 5
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 11
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
@@ -2985,7 +3130,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 7
         flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -194,6 +194,10 @@ jobs:
       run: |-
         flowey e 0 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
         flowey e 0 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 0 flowey_lib_common::run_cargo_clippy 1
         flowey e 0 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
@@ -217,10 +221,10 @@ jobs:
       run: flowey e 0 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 0 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 0 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 0 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 0 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 0 flowey_lib_common::cache 3
@@ -1058,7 +1062,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 12 flowey_lib_common::git_checkout 0
-        flowey.exe v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
         flowey.exe v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1066,7 +1070,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar7 }}
+        persist-credentials: ${{ env.floweyvar8 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1086,14 +1090,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 12 flowey_lib_common::cache 4
-        flowey.exe v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1129,6 +1133,9 @@ jobs:
     - name: cargo clippy
       run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 1
       shell: bash
+    - name: cargo clippy
+      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey.exe e 12 flowey_lib_common::download_cargo_nextest 0
@@ -1139,14 +1146,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 12 flowey_lib_common::cache 0
-        flowey.exe v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1162,28 +1169,17 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey.exe e 12 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 12 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: |-
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
         flowey.exe e 12 flowey_lib_hvlite::init_cross_build 1
         flowey.exe e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
         flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 2
         flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 12 flowey_lib_common::publish_test_results 5
         flowey.exe e 12 flowey_lib_common::publish_test_results 6
         flowey.exe e 12 flowey_lib_common::publish_test_results 4
@@ -1193,8 +1189,39 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-unit-tests-unit-tests-junit-xml
+        name: x64-windows-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 12 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 12 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 4
+        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 5
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 12 flowey_lib_common::publish_test_results 8
+        flowey.exe e 12 flowey_lib_common::publish_test_results 9
+        flowey.exe e 12 flowey_lib_common::publish_test_results 10
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
@@ -1220,7 +1247,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
@@ -1289,7 +1316,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 13 flowey_lib_common::git_checkout 0
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1297,7 +1324,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1317,14 +1344,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 4
-        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1364,6 +1391,9 @@ jobs:
     - name: cargo clippy
       run: flowey e 13 flowey_lib_common::run_cargo_clippy 1
       shell: bash
+    - name: cargo clippy
+      run: flowey e 13 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey e 13 flowey_lib_common::download_cargo_nextest 0
@@ -1374,14 +1404,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1401,13 +1431,13 @@ jobs:
         flowey e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 13 flowey_lib_common::publish_test_results 5
         flowey e 13 flowey_lib_common::publish_test_results 6
         flowey e 13 flowey_lib_common::publish_test_results 4
@@ -1417,18 +1447,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 13 flowey_lib_common::publish_test_results 8
         flowey e 13 flowey_lib_common::publish_test_results 9
         flowey e 13 flowey_lib_common::publish_test_results 10
@@ -1438,8 +1468,50 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 13 flowey_lib_common::publish_test_results 12
+        flowey e 13 flowey_lib_common::publish_test_results 13
+        flowey e 13 flowey_lib_common::publish_test_results 14
+        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 13 flowey_lib_common::publish_test_results 16
+        flowey e 13 flowey_lib_common::publish_test_results 17
+        flowey e 13 flowey_lib_common::publish_test_results 18
+        flowey v 13 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 13 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -1458,34 +1530,13 @@ jobs:
       run: flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 13 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 13 flowey_lib_common::publish_test_results 12
-        flowey e 13 flowey_lib_common::publish_test_results 13
-        flowey e 13 flowey_lib_common::publish_test_results 14
-        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 13 flowey_lib_common::publish_test_results 0
         flowey e 13 flowey_lib_common::publish_test_results 1
         flowey e 13 flowey_lib_common::publish_test_results 2
@@ -1495,13 +1546,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
@@ -1564,7 +1615,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
         flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1572,7 +1623,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar11 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1596,14 +1647,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1631,17 +1682,20 @@ jobs:
         flowey e 14 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_clippy 5
+        flowey e 14 flowey_lib_common::run_cargo_clippy 6
         flowey e 14 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -1665,7 +1719,7 @@ jobs:
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -1677,14 +1731,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1725,12 +1779,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 14 flowey_lib_common::publish_test_results 8
         flowey e 14 flowey_lib_common::publish_test_results 9
@@ -1741,17 +1795,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 14 flowey_lib_common::publish_test_results 12
         flowey e 14 flowey_lib_common::publish_test_results 13
@@ -1762,17 +1816,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 14 flowey_lib_common::publish_test_results 16
         flowey e 14 flowey_lib_common::publish_test_results 17
@@ -1783,8 +1837,29 @@ jobs:
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 14 flowey_lib_common::publish_test_results 20
+        flowey e 14 flowey_lib_common::publish_test_results 21
+        flowey e 14 flowey_lib_common::publish_test_results 22
+        flowey v 14 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -1803,12 +1878,12 @@ jobs:
       run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 5
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 11
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
@@ -1825,7 +1900,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 7
         flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
@@ -1932,7 +2007,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 15 flowey_lib_common::git_checkout 0
-        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
         flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1940,7 +2015,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar7 }}
+        persist-credentials: ${{ env.floweyvar8 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1960,14 +2035,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 15 flowey_lib_common::cache 4
-        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2003,6 +2078,9 @@ jobs:
     - name: cargo clippy
       run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
+    - name: cargo clippy
+      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey.exe e 15 flowey_lib_common::download_cargo_nextest 0
@@ -2013,14 +2091,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 15 flowey_lib_common::cache 0
-        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2036,28 +2114,17 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey.exe e 15 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: |-
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
         flowey.exe e 15 flowey_lib_hvlite::init_cross_build 1
         flowey.exe e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 2
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 15 flowey_lib_common::publish_test_results 5
         flowey.exe e 15 flowey_lib_common::publish_test_results 6
         flowey.exe e 15 flowey_lib_common::publish_test_results 4
@@ -2067,8 +2134,39 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-unit-tests-unit-tests-junit-xml
+        name: aarch64-windows-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
+      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 15 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 4
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 5
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 15 flowey_lib_common::publish_test_results 8
+        flowey.exe e 15 flowey_lib_common::publish_test_results 9
+        flowey.exe e 15 flowey_lib_common::publish_test_results 10
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
@@ -2094,7 +2192,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
@@ -2207,7 +2305,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2215,7 +2313,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2235,14 +2333,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2261,6 +2359,10 @@ jobs:
       run: |-
         flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 16 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_clippy 1
         flowey e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
@@ -2284,10 +2386,10 @@ jobs:
       run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2299,14 +2401,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2326,13 +2428,13 @@ jobs:
         flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 16 flowey_lib_common::publish_test_results 5
         flowey e 16 flowey_lib_common::publish_test_results 6
         flowey e 16 flowey_lib_common::publish_test_results 4
@@ -2342,18 +2444,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 16 flowey_lib_common::publish_test_results 8
         flowey e 16 flowey_lib_common::publish_test_results 9
         flowey e 16 flowey_lib_common::publish_test_results 10
@@ -2363,8 +2465,50 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey e 16 flowey_lib_common::publish_test_results 13
+        flowey e 16 flowey_lib_common::publish_test_results 14
+        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 16 flowey_lib_common::publish_test_results 16
+        flowey e 16 flowey_lib_common::publish_test_results 17
+        flowey e 16 flowey_lib_common::publish_test_results 18
+        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -2383,34 +2527,13 @@ jobs:
       run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 16 flowey_lib_common::publish_test_results 0
         flowey e 16 flowey_lib_common::publish_test_results 1
         flowey e 16 flowey_lib_common::publish_test_results 2
@@ -2420,13 +2543,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
@@ -2533,7 +2656,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
         flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2541,7 +2664,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar11 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2565,14 +2688,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2600,17 +2723,20 @@ jobs:
         flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_clippy 5
+        flowey e 17 flowey_lib_common::run_cargo_clippy 6
         flowey e 17 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2634,7 +2760,7 @@ jobs:
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2646,14 +2772,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2694,12 +2820,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 17 flowey_lib_common::publish_test_results 8
         flowey e 17 flowey_lib_common::publish_test_results 9
@@ -2710,17 +2836,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 17 flowey_lib_common::publish_test_results 12
         flowey e 17 flowey_lib_common::publish_test_results 13
@@ -2731,17 +2857,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 17 flowey_lib_common::publish_test_results 16
         flowey e 17 flowey_lib_common::publish_test_results 17
@@ -2752,8 +2878,29 @@ jobs:
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 17 flowey_lib_common::publish_test_results 20
+        flowey e 17 flowey_lib_common::publish_test_results 21
+        flowey e 17 flowey_lib_common::publish_test_results 22
+        flowey v 17 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -2772,12 +2919,12 @@ jobs:
       run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 5
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 11
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
@@ -2794,7 +2941,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 7
         flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -193,6 +193,10 @@ jobs:
       run: |-
         flowey e 0 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
         flowey e 0 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 0 flowey_lib_common::run_cargo_clippy 1
         flowey e 0 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
@@ -216,10 +220,10 @@ jobs:
       run: flowey e 0 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 0 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 0 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 0 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 0 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 0 flowey_lib_common::cache 3
@@ -1449,7 +1453,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 14 flowey_lib_common::git_checkout 0
-        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
         flowey.exe v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1457,7 +1461,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar7 }}
+        persist-credentials: ${{ env.floweyvar8 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1477,14 +1481,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 14 flowey_lib_common::cache 4
-        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1520,6 +1524,9 @@ jobs:
     - name: cargo clippy
       run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
+    - name: cargo clippy
+      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey.exe e 14 flowey_lib_common::download_cargo_nextest 0
@@ -1530,14 +1537,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 14 flowey_lib_common::cache 0
-        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1553,28 +1560,17 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey.exe e 14 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 14 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: |-
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
         flowey.exe e 14 flowey_lib_hvlite::init_cross_build 1
         flowey.exe e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
         flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 2
         flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 14 flowey_lib_common::publish_test_results 5
         flowey.exe e 14 flowey_lib_common::publish_test_results 6
         flowey.exe e 14 flowey_lib_common::publish_test_results 4
@@ -1584,8 +1580,39 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-unit-tests-unit-tests-junit-xml
+        name: x64-windows-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 14 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 14 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 4
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 5
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 14 flowey_lib_common::publish_test_results 8
+        flowey.exe e 14 flowey_lib_common::publish_test_results 9
+        flowey.exe e 14 flowey_lib_common::publish_test_results 10
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
@@ -1611,7 +1638,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
@@ -1680,7 +1707,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1688,7 +1715,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1708,14 +1735,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1755,6 +1782,9 @@ jobs:
     - name: cargo clippy
       run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey e 15 flowey_lib_common::download_cargo_nextest 0
@@ -1765,14 +1795,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1792,13 +1822,13 @@ jobs:
         flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 15 flowey_lib_common::publish_test_results 5
         flowey e 15 flowey_lib_common::publish_test_results 6
         flowey e 15 flowey_lib_common::publish_test_results 4
@@ -1808,18 +1838,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 15 flowey_lib_common::publish_test_results 8
         flowey e 15 flowey_lib_common::publish_test_results 9
         flowey e 15 flowey_lib_common::publish_test_results 10
@@ -1829,8 +1859,50 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 15 flowey_lib_common::publish_test_results 12
+        flowey e 15 flowey_lib_common::publish_test_results 13
+        flowey e 15 flowey_lib_common::publish_test_results 14
+        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 15 flowey_lib_common::publish_test_results 16
+        flowey e 15 flowey_lib_common::publish_test_results 17
+        flowey e 15 flowey_lib_common::publish_test_results 18
+        flowey v 15 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -1849,34 +1921,13 @@ jobs:
       run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 15 flowey_lib_common::publish_test_results 12
-        flowey e 15 flowey_lib_common::publish_test_results 13
-        flowey e 15 flowey_lib_common::publish_test_results 14
-        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
         flowey e 15 flowey_lib_common::publish_test_results 2
@@ -1886,13 +1937,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
@@ -1955,7 +2006,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
         flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1963,7 +2014,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar11 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1987,14 +2038,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2022,17 +2073,20 @@ jobs:
         flowey e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
       run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_clippy 5
+        flowey e 16 flowey_lib_common::run_cargo_clippy 6
         flowey e 16 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2056,7 +2110,7 @@ jobs:
       run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2068,14 +2122,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2116,12 +2170,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 16 flowey_lib_common::publish_test_results 8
         flowey e 16 flowey_lib_common::publish_test_results 9
@@ -2132,17 +2186,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 16 flowey_lib_common::publish_test_results 12
         flowey e 16 flowey_lib_common::publish_test_results 13
@@ -2153,17 +2207,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 16 flowey_lib_common::publish_test_results 16
         flowey e 16 flowey_lib_common::publish_test_results 17
@@ -2174,8 +2228,29 @@ jobs:
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 16 flowey_lib_common::publish_test_results 20
+        flowey e 16 flowey_lib_common::publish_test_results 21
+        flowey e 16 flowey_lib_common::publish_test_results 22
+        flowey v 16 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 16 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -2194,12 +2269,12 @@ jobs:
       run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 5
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 11
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 16 flowey_lib_common::publish_test_results 0
         flowey e 16 flowey_lib_common::publish_test_results 1
@@ -2216,7 +2291,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 7
         flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
@@ -2323,7 +2398,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 17 flowey_lib_common::git_checkout 0
-        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar7
+        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
         flowey.exe v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2331,7 +2406,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar7 }}
+        persist-credentials: ${{ env.floweyvar8 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2351,14 +2426,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 17 flowey_lib_common::cache 4
-        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2394,6 +2469,9 @@ jobs:
     - name: cargo clippy
       run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
+    - name: cargo clippy
+      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey.exe e 17 flowey_lib_common::download_cargo_nextest 0
@@ -2404,14 +2482,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 17 flowey_lib_common::cache 0
-        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2427,28 +2505,17 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey.exe e 17 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 17 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: |-
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
         flowey.exe e 17 flowey_lib_hvlite::init_cross_build 1
         flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
         flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 2
         flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 17 flowey_lib_common::publish_test_results 5
         flowey.exe e 17 flowey_lib_common::publish_test_results 6
         flowey.exe e 17 flowey_lib_common::publish_test_results 4
@@ -2458,8 +2525,39 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-unit-tests-unit-tests-junit-xml
+        name: aarch64-windows-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
+      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 17 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 17 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 4
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 5
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 17 flowey_lib_common::publish_test_results 8
+        flowey.exe e 17 flowey_lib_common::publish_test_results 9
+        flowey.exe e 17 flowey_lib_common::publish_test_results 10
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-windows-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
@@ -2485,7 +2583,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
@@ -2598,7 +2696,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2606,7 +2704,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2626,14 +2724,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2652,6 +2750,10 @@ jobs:
       run: |-
         flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 18 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_clippy 1
         flowey e 18 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
@@ -2675,10 +2777,10 @@ jobs:
       run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2690,14 +2792,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2717,13 +2819,13 @@ jobs:
         flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 18 flowey_lib_common::publish_test_results 5
         flowey e 18 flowey_lib_common::publish_test_results 6
         flowey e 18 flowey_lib_common::publish_test_results 4
@@ -2733,18 +2835,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 18 flowey_lib_common::publish_test_results 8
         flowey e 18 flowey_lib_common::publish_test_results 9
         flowey e 18 flowey_lib_common::publish_test_results 10
@@ -2754,8 +2856,50 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 18 flowey_lib_common::publish_test_results 12
+        flowey e 18 flowey_lib_common::publish_test_results 13
+        flowey e 18 flowey_lib_common::publish_test_results 14
+        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 18 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 18 flowey_lib_common::publish_test_results 16
+        flowey e 18 flowey_lib_common::publish_test_results 17
+        flowey e 18 flowey_lib_common::publish_test_results 18
+        flowey v 18 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 18 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -2774,34 +2918,13 @@ jobs:
       run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 18 flowey_lib_common::publish_test_results 12
-        flowey e 18 flowey_lib_common::publish_test_results 13
-        flowey e 18 flowey_lib_common::publish_test_results 14
-        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 18 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 18 flowey_lib_common::publish_test_results 0
         flowey e 18 flowey_lib_common::publish_test_results 1
         flowey e 18 flowey_lib_common::publish_test_results 2
@@ -2811,13 +2934,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
@@ -2924,7 +3047,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 19 flowey_lib_common::git_checkout 0
-        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
         flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2932,7 +3055,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar11 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2956,14 +3079,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 19 flowey_lib_common::cache 4
-        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2991,17 +3114,20 @@ jobs:
         flowey e 19 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
       run: flowey e 19 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_clippy 5
+        flowey e 19 flowey_lib_common::run_cargo_clippy 6
         flowey e 19 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -3025,7 +3151,7 @@ jobs:
       run: flowey e 19 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -3037,14 +3163,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 19 flowey_lib_common::cache 0
-        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -3085,12 +3211,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 19 flowey_lib_common::publish_test_results 8
         flowey e 19 flowey_lib_common::publish_test_results 9
@@ -3101,17 +3227,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 19 flowey_lib_common::publish_test_results 12
         flowey e 19 flowey_lib_common::publish_test_results 13
@@ -3122,17 +3248,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 19 flowey_lib_common::publish_test_results 16
         flowey e 19 flowey_lib_common::publish_test_results 17
@@ -3143,8 +3269,29 @@ jobs:
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 19 flowey_lib_common::publish_test_results 20
+        flowey e 19 flowey_lib_common::publish_test_results 21
+        flowey e 19 flowey_lib_common::publish_test_results 22
+        flowey v 19 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 19 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
@@ -3163,12 +3310,12 @@ jobs:
       run: flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 5
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 11
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 19 flowey_lib_common::publish_test_results 0
         flowey e 19 flowey_lib_common::publish_test_results 1
@@ -3185,7 +3332,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 7
         flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6622,7 +6622,6 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core",
- "sha1",
  "sha2",
  "signature",
  "spki",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.0.0"
 dependencies = [
  "aarch64defs",
  "futures",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "inspect",
  "pal_async",
  "parking_lot",
@@ -833,7 +833,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "futures",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "pal_async",
  "term",
  "tracing",
@@ -847,7 +847,7 @@ dependencies = [
  "blocking",
  "cfg-if",
  "futures",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "heapless",
  "inspect",
  "inspect_counters",
@@ -1041,10 +1041,15 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "der",
+ "getrandom 0.4.2",
  "hex",
  "openssl",
  "openssl_kdf",
+ "pkcs1",
+ "pkcs8",
  "rsa",
+ "sha1",
+ "sha2",
  "symcrypt",
  "thiserror 2.0.16",
  "wchar",
@@ -1956,7 +1961,7 @@ version = "0.0.0"
 dependencies = [
  "chipset_device",
  "generation_id",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guestmem",
  "guid",
  "inspect",
@@ -1983,7 +1988,7 @@ dependencies = [
  "der",
  "firmware_uefi_custom_vars",
  "generation_id",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guestmem",
  "guid",
  "inspect",
@@ -2676,7 +2681,7 @@ dependencies = [
 name = "generation_id"
 version = "0.0.0"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guestmem",
  "inspect",
  "mesh",
@@ -2751,8 +2756,22 @@ checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -2918,7 +2937,7 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "get_protocol",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guest_emulation_device",
  "guestmem",
  "guid",
@@ -2990,7 +3009,7 @@ dependencies = [
 name = "guid"
 version = "0.0.0"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "inspect",
  "mesh_protobuf",
  "thiserror 2.0.16",
@@ -3069,7 +3088,7 @@ dependencies = [
  "build_rs_guest_arch",
  "cvm_tracing",
  "fs-err",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "hv1_structs",
  "hvdef",
  "inspect",
@@ -3484,6 +3503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ide"
 version = "0.0.0"
 dependencies = [
@@ -3625,6 +3650,7 @@ checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -3848,6 +3874,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -4110,7 +4142,7 @@ dependencies = [
  "futures",
  "gdma",
  "gdma_defs",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "inspect",
  "mesh",
  "net_backend",
@@ -4155,7 +4187,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "futures",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guestmem",
  "hvdef",
  "inspect",
@@ -4265,7 +4297,7 @@ version = "0.0.0"
 dependencies = [
  "bitfield-struct 0.11.0",
  "futures",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "mesh_derive",
  "mesh_protobuf",
  "open_enum",
@@ -4325,7 +4357,7 @@ dependencies = [
  "event-listener",
  "futures",
  "futures-concurrency",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "libc",
  "mesh_channel",
  "mesh_node",
@@ -4711,7 +4743,7 @@ dependencies = [
  "event-listener",
  "futures",
  "futures-concurrency",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guestmem",
  "guid",
  "hvdef",
@@ -5271,7 +5303,7 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "get_resources",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guestmem",
  "guid",
  "hcl_compat_uefi_nvram_storage",
@@ -5387,7 +5419,7 @@ dependencies = [
  "futures-concurrency",
  "gdma_resources",
  "get_resources",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guid",
  "hyperv_ic_resources",
  "hyperv_secure_boot_templates",
@@ -5677,7 +5709,7 @@ version = "0.0.0"
 dependencies = [
  "caps",
  "fs-err",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "headervec",
  "landlock",
  "libc",
@@ -5702,7 +5734,7 @@ dependencies = [
  "async-task",
  "cfg-if",
  "futures",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "headervec",
  "io-uring",
  "libc",
@@ -5736,7 +5768,7 @@ dependencies = [
 name = "pal_event"
 version = "0.0.0"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "libc",
  "mesh_protobuf",
  "windows-sys 0.61.0",
@@ -6301,6 +6333,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6368,7 +6410,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph 0.6.5",
- "prettyplease",
+ "prettyplease 0.1.25",
  "prost",
  "prost-types",
  "regex",
@@ -6433,6 +6475,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -6574,6 +6622,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core",
+ "sha1",
  "sha2",
  "signature",
  "spki",
@@ -6797,7 +6846,7 @@ dependencies = [
  "disk_backend",
  "disk_prwrap",
  "futures",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guestmem",
  "guid",
  "hvdef",
@@ -7274,7 +7323,7 @@ dependencies = [
 name = "sparse_mmap"
 version = "0.0.0"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "libc",
  "pal",
  "parking_lot",
@@ -7948,7 +7997,7 @@ dependencies = [
  "chipset_device",
  "chipset_device_resources",
  "cvm_tracing",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guestmem",
  "guid",
  "inspect",
@@ -7987,7 +8036,7 @@ name = "tpm_lib"
 version = "0.0.0"
 dependencies = [
  "cvm_tracing",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "inspect",
  "ms-tpm-20-ref",
  "thiserror 2.0.16",
@@ -8290,7 +8339,7 @@ dependencies = [
  "disk_backend",
  "disklayer_ram",
  "get_protocol",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guest_emulation_device",
  "guest_emulation_transport",
  "guid",
@@ -8369,7 +8418,7 @@ dependencies = [
  "gdma_defs",
  "get_helpers",
  "get_protocol",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guest_emulation_transport",
  "guestmem",
  "guid",
@@ -8613,6 +8662,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unicycle"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8634,7 +8689,7 @@ checksum = "40789245bbff5f31eb773c9ac4ee5c4e15eab9640d975e124d6ce4c34a6410d7"
 name = "unix_socket"
 version = "0.0.0"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "mesh_protobuf",
  "socket2",
  "windows-sys 0.61.0",
@@ -9341,7 +9396,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "futures",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guestmem",
  "inspect",
  "mesh",
@@ -9373,7 +9428,7 @@ dependencies = [
  "anyhow",
  "bitfield-struct 0.11.0",
  "futures",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guestmem",
  "guid",
  "hybrid_vsock",
@@ -9567,7 +9622,7 @@ dependencies = [
  "anyhow",
  "futures",
  "futures-concurrency",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guid",
  "inspect",
  "mesh",
@@ -9770,7 +9825,7 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-concurrency",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guestmem",
  "guid",
  "hvdef",
@@ -9861,7 +9916,7 @@ dependencies = [
  "cvm_tracing",
  "disk_backend",
  "disklayer_ram",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guestmem",
  "inspect",
  "inspect_counters",
@@ -9937,7 +9992,7 @@ dependencies = [
  "disk_backend",
  "disk_vhd1",
  "fs-err",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guid",
  "hcl_compat_uefi_nvram_storage",
  "hex",
@@ -10169,7 +10224,7 @@ name = "vmswitch"
 version = "0.0.0"
 dependencies = [
  "futures",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "guid",
  "pal",
  "pal_async",
@@ -10400,6 +10455,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.9.3",
+ "hashbrown",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -10945,12 +11052,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.3",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease 0.2.37",
+ "syn 2.0.106",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease 0.2.37",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.3",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -513,11 +513,14 @@ flate2 = "1.1"
 # --- Cryptography & secure computing ---
 constant_time_eq = "0.3"
 der = "0.8"
-getrandom = "0.3"
+getrandom = "0.4"
 ms-tpm-20-ref = { version = "0.1", git = "https://github.com/microsoft/ms-tpm-20-ref-rs.git", branch = "main" }
 openssl = "0.10.72"
 openssl-sys = "0.9"
-rsa = { version = "0.10.0-rc.18", default-features = false }
+pkcs1 = "0.8.0-rc.4"
+pkcs8 = "0.11.0"
+rsa = "0.10.0-rc.18"
+sha1 = "0.11.0"
 sha2 = { version = "0.11.0", default-features = false }
 symcrypt = { version = "0.6.0", git = "https://github.com/microsoft/rust-symcrypt.git", branch = "release/0.6.0" }
 x509-cert = { version = "0.3.0-rc.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -519,8 +519,8 @@ openssl = "0.10.72"
 openssl-sys = "0.9"
 pkcs1 = "0.8.0-rc.4"
 pkcs8 = "0.11.0"
-rsa = "0.10.0-rc.18"
-sha1 = "0.11.0"
+rsa = { version = "0.10.0-rc.18", default-features = false }
+sha1 = { version = "0.11.0", default-features = false }
 sha2 = { version = "0.11.0", default-features = false }
 symcrypt = { version = "0.6.0", git = "https://github.com/microsoft/rust-symcrypt.git", branch = "release/0.6.0" }
 x509-cert = { version = "0.3.0-rc.4", default-features = false }

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -182,8 +182,12 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 0 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
       $(FLOWEY_BIN) e 0 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 0 flowey_lib_hvlite::init_cross_build 1
     displayName: run xtask fmt
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 1
+      $(FLOWEY_BIN) e 0 flowey_lib_hvlite::init_cross_build 1
+    displayName: cargo clippy
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_build 0
@@ -201,9 +205,9 @@ jobs:
     displayName: cargo clippy
   - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 2
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 3
+  - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 4
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 1
+  - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 3
     displayName: cargo clippy
   - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
@@ -518,14 +522,14 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar11
       $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar10)
+    persistCredentials: $(floweyvar11)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
@@ -544,13 +548,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar9
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar10
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar9)
-      path: $(floweyvar8)
+      key: $(floweyvar10)
+      path: $(floweyvar9)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
@@ -575,15 +579,17 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 2
     displayName: symlink protoc
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 4
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 3
+    displayName: cargo clippy
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 5
     displayName: cargo clippy
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 6
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 7
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 5
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 6
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 0
     displayName: cargo clippy
   - bash: |-
@@ -603,7 +609,7 @@ jobs:
     displayName: cargo clippy
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 2
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 3
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 4
     displayName: cargo clippy
   - bash: |-
       set -e
@@ -615,13 +621,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar7)
-      path: $(floweyvar6)
+      key: $(floweyvar8)
+      path: $(floweyvar7)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
@@ -641,18 +647,38 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 3
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+    displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 6
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 7
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 8
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 4
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (rust)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar5)
+      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (rust)
+    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
     displayName: generate nextest command
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 4
       $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 5
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 7
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 6
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 6
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (openssl)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -661,23 +687,23 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (openssl)
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 6
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 7
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 7
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 8
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 8
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 9
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 9
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 10
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 8
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:10:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar6
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (symcrypt)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar5)
+      testResultsFiles: $(floweyvar6)
       testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
@@ -687,12 +713,12 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 9
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 11
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 8
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 10
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (all)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -715,12 +741,12 @@ jobs:
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 5
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 8
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 9
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 10
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 11
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 0
@@ -757,7 +783,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 7
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -817,14 +843,14 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar9
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
       $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar9)
+    persistCredentials: $(floweyvar10)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
@@ -840,13 +866,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 13 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar8)
-      path: $(floweyvar7)
+      key: $(floweyvar9)
+      path: $(floweyvar8)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
@@ -885,6 +911,8 @@ jobs:
     displayName: cargo clippy
   - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_clippy 2
+    displayName: cargo clippy
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 0
@@ -895,13 +923,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 13 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar6)
-      path: $(floweyvar5)
+      key: $(floweyvar7)
+      path: $(floweyvar6)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
@@ -921,18 +949,58 @@ jobs:
       $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 0
       $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+    displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 6
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 7
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 8
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 4
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (rust)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar5)
+      testRunTitle: x64-linux-unit-tests-unit-tests crypto (rust)
+    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+    displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 4
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 7
+      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 6
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 6
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (openssl)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar4)
+      testRunTitle: x64-linux-unit-tests-unit-tests crypto (openssl)
+    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 9
       $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 8
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (all)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -955,18 +1023,18 @@ jobs:
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 4
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 6
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 7
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 8
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 9
       $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 7
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -982,11 +1050,11 @@ jobs:
       $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 2
       $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 3
       $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 3
       $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 4
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 2
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (none)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -995,29 +1063,9 @@ jobs:
       testRunTitle: x64-linux-unit-tests-unit-tests crypto (none)
     displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-    displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 4
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 5
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 6
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (openssl)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar4)
-      testRunTitle: x64-linux-unit-tests-unit-tests crypto (openssl)
-    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 6
       $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -1118,14 +1166,14 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar7
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar8
       $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar7)
+    persistCredentials: $(floweyvar8)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
@@ -1141,13 +1189,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar6)
-      path: $(floweyvar5)
+      key: $(floweyvar7)
+      path: $(floweyvar6)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
@@ -1182,6 +1230,8 @@ jobs:
     displayName: cargo clippy
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 2
+    displayName: cargo clippy
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 0
@@ -1192,13 +1242,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar4)
-      path: $(floweyvar3)
+      key: $(floweyvar5)
+      path: $(floweyvar4)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
@@ -1215,9 +1265,40 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 3
+    displayName: installing cargo-nextest
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_xtask 1
+    displayName: cargo build xtask
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 1
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
-    displayName: installing cargo-nextest
+    displayName: determine unit test exclusions
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+    displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 4
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 4
+      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar1)
+      testRunTitle: x64-windows-unit-tests-unit-tests
+    displayName: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
@@ -1238,38 +1319,29 @@ jobs:
       testRunTitle: x64-windows-unit-tests-unit-tests crypto (none)
     displayName: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 3
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_xtask 1
-    displayName: cargo build xtask
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
-    displayName: determine unit test exclusions
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 2
       $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 3
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
       $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 4
       $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
       $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests' nextest tests
+    displayName: run 'unit-tests crypto (rust)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar1)
-      testRunTitle: x64-windows-unit-tests-unit-tests
-    displayName: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
+      testResultsFiles: $(floweyvar3)
+      testRunTitle: x64-windows-unit-tests-unit-tests crypto (rust)
+    displayName: 'publish test results: x64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0

--- a/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
@@ -216,6 +216,21 @@ impl SimpleFlowNode for Node {
             done: v,
         }));
 
+        // Always test the pure rust backend.
+        reqs.push(ctx.reqv(|v| flowey_lib_common::run_cargo_clippy::Request {
+            in_folder: openvmm_repo_path.clone(),
+            package: CargoPackage::Crate("crypto".into()),
+            profile: profile.clone(),
+            features: CargoFeatureSet::Specific(vec!["rust".into()]),
+            target: target.clone(),
+            extra_env: None,
+            exclude: ReadVar::from_static(None),
+            keep_going: true,
+            all_targets: true,
+            pre_build_deps: pre_build_deps.clone(),
+            done: v,
+        }));
+
         // Then on linux test the openssl & symcrypt backends, and ensure that --all-features works properly.
         // We could test openssl on non-linux targets too, but setting up builds for them is a pain.
         if matches!(

--- a/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
@@ -204,11 +204,16 @@ impl FlowNode for Node {
 
             // crypto has non-additive features, so it gets its own runs to
             // ensure full coverage of different backends. Always test the
-            // 'native' no-feature backend. On linux additionally test the
-            // openssl & symcrypt backends and --all-features (we could test
-            // openssl on non-linux targets too, but setting up builds for
-            // them is a pain).
-            let mut crypto_feature_sets = vec![("none", CargoFeatureSet::None)];
+            // 'native' no-feature and pure-rust backends. On linux additionally
+            // test the openssl & symcrypt backends and --all-features fallback.
+            // We could test openssl on non-linux targets too, but setting up
+            // builds for them is a pain. We could test Symcrypt on non-musl
+            // linux targets too, but we don't currently have a prebuilt
+            // library for them.
+            let mut crypto_feature_sets = vec![
+                ("none", CargoFeatureSet::None),
+                ("rust", CargoFeatureSet::Specific(vec!["rust".into()])),
+            ];
             if matches!(
                 target.operating_system,
                 target_lexicon::OperatingSystem::Linux

--- a/openhcl/underhill_attestation/src/jwt.rs
+++ b/openhcl/underhill_attestation/src/jwt.rs
@@ -55,7 +55,7 @@ pub(crate) enum CertificateChainValidationError {
     #[error("failed to get public key from the certificate")]
     GetPublicKeyFromCertificate(#[source] crypto::x509::X509Error),
     #[error("failed to verify the child certificate signature with parent public key")]
-    VerifyChildSignatureWithParentPublicKey(#[source] crypto::x509::X509Error),
+    VerifyChildSignatureWithParentPublicKey(#[source] crypto::rsa::RsaError),
     #[error("cert chain validation failed -- signature mismatch")]
     CertChainSignatureMismatch,
     #[error("failed to check if the certificate was issued by the issuer")]

--- a/support/crypto/Cargo.toml
+++ b/support/crypto/Cargo.toml
@@ -53,11 +53,7 @@ der = { workspace = true, optional = true }
 getrandom = { workspace = true, optional = true, features = ["sys_rng"] }
 pkcs1 = { workspace = true, optional = true }
 pkcs8 = { workspace = true, optional = true }
-rsa = { workspace = true, optional = true, features = [
-    "encoding",
-    "sha1",
-    "sha2",
-] }
+rsa = { workspace = true, optional = true, features = ["encoding", "sha2"] }
 sha1 = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 x509-cert = { workspace = true, optional = true, features = ["builder"] }

--- a/support/crypto/Cargo.toml
+++ b/support/crypto/Cargo.toml
@@ -23,7 +23,23 @@ symcrypt = [
     "symcrypt/sha1",
     # The Symcrypt backend uses RustCrypto crates for de/serialization only.
     "dep:der",
+    "dep:pkcs1",
+    "dep:pkcs8",
     "dep:rsa",
+    "dep:x509-cert",
+]
+
+# Use RustCrypto crates instead of any native backend.
+# Note that some of these crates have known security issues.
+# This backend should not be used in production scenarios.
+rust = [
+    "dep:der",
+    "dep:getrandom",
+    "dep:pkcs1",
+    "dep:pkcs8",
+    "dep:rsa",
+    "dep:sha1",
+    "dep:sha2",
     "dep:x509-cert",
 ]
 
@@ -34,7 +50,16 @@ openssl = { workspace = true, optional = true }
 symcrypt = { workspace = true, optional = true }
 
 der = { workspace = true, optional = true }
-rsa = { workspace = true, optional = true, features = ["encoding", "sha2"] }
+getrandom = { workspace = true, optional = true, features = ["sys_rng"] }
+pkcs1 = { workspace = true, optional = true }
+pkcs8 = { workspace = true, optional = true }
+rsa = { workspace = true, optional = true, features = [
+    "encoding",
+    "sha1",
+    "sha2",
+] }
+sha1 = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
 x509-cert = { workspace = true, optional = true, features = ["builder"] }
 
 anyhow.workspace = true

--- a/support/crypto/Cargo.toml
+++ b/support/crypto/Cargo.toml
@@ -54,7 +54,7 @@ getrandom = { workspace = true, optional = true, features = ["sys_rng"] }
 pkcs1 = { workspace = true, optional = true }
 pkcs8 = { workspace = true, optional = true }
 rsa = { workspace = true, optional = true, features = ["encoding", "sha2"] }
-sha1 = { workspace = true, optional = true }
+sha1 = { workspace = true, optional = true, features = ["oid"] }
 sha2 = { workspace = true, optional = true }
 x509-cert = { workspace = true, optional = true, features = ["builder"] }
 

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -5,35 +5,51 @@
 
 fn main() {
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_OPENSSL");
+    println!("cargo::rerun-if-env-changed=CARGO_FEATURE_RUST");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_SYMCRYPT");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_VENDORED");
     println!("cargo::rerun-if-env-changed=CARGO_CFG_TARGET_OS");
 
     println!("cargo::rustc-check-cfg=cfg(native)");
     println!("cargo::rustc-check-cfg=cfg(openssl)");
+    println!("cargo::rustc-check-cfg=cfg(rust)");
     println!("cargo::rustc-check-cfg=cfg(symcrypt)");
 
     let openssl = std::env::var_os("CARGO_FEATURE_OPENSSL").is_some();
+    let rust = std::env::var_os("CARGO_FEATURE_RUST").is_some();
     let symcrypt = std::env::var_os("CARGO_FEATURE_SYMCRYPT").is_some();
     let vendored = std::env::var_os("CARGO_FEATURE_VENDORED").is_some();
     let linux = std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "linux";
 
+    let all_features = openssl && rust && symcrypt && vendored;
+    let backend_count = openssl as u8 + rust as u8 + symcrypt as u8;
+
+    // If we see multiple backends enabled that's an error. However if we see every
+    // backend, and vendoring, enabled, it's likely we're in an --all-features session.
+    // Since this is a common rust-analyzer configuration, allow it and fall back to
+    // platform defaults.
+    if backend_count > 1 && !all_features {
+        panic!("Multiple crypto backends enabled, but only one can be selected");
+    } else if backend_count == 0 || all_features {
+        // Default to openssl on linux, the dependencies are also marked
+        // non-optional and there is no native backend available
+        if linux {
+            println!("cargo::rustc-cfg=openssl");
+        } else {
+            println!("cargo::rustc-cfg=native");
+        }
+    }
     // Symcrypt does not support vendoring, so fail early if the user tries to
-    // enable both the symcrypt backend and the vendored feature. However if
-    // openssl is also enabled then the user likely passed --all-features, so we
-    // allow this combination to succeed with the openssl backend.
-    if vendored && symcrypt && !openssl {
+    // enable both the symcrypt backend and the vendored feature.
+    else if vendored && symcrypt {
         panic!("The symcrypt backend does not support vendoring");
     }
-
     // Output a single config flag to indicate which backend should be used.
-    match (openssl, symcrypt) {
-        // For now prefer OpenSSL if both backend features are enabled. This allows
-        // compilation with --all-features to still succeed.
-        (true, true) | (true, false) => println!("cargo::rustc-cfg=openssl"),
-        (false, true) => println!("cargo::rustc-cfg=symcrypt"),
-        // Default to openssl on linux, the dependencies are also marked non-optional
-        (false, false) if linux => println!("cargo::rustc-cfg=openssl"),
-        (false, false) => println!("cargo::rustc-cfg=native"),
+    else if openssl {
+        println!("cargo::rustc-cfg=openssl");
+    } else if symcrypt {
+        println!("cargo::rustc-cfg=symcrypt");
+    } else if rust {
+        println!("cargo::rustc-cfg=rust");
     }
 }

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -34,7 +34,7 @@ fn main() {
         // Default to openssl on linux, the dependencies are also marked
         // non-optional and there is no native backend available
         if linux {
-            println!("cargo::rustc-cfg=openssl");
+            println!("cargo::rustc-cfg=rust");
         } else {
             println!("cargo::rustc-cfg=native");
         }

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -34,7 +34,7 @@ fn main() {
         // Default to openssl on linux, the dependencies are also marked
         // non-optional and there is no native backend available
         if linux {
-            println!("cargo::rustc-cfg=rust");
+            println!("cargo::rustc-cfg=openssl");
         } else {
             println!("cargo::rustc-cfg=native");
         }

--- a/support/crypto/src/aes_256_cbc/ossl.rs
+++ b/support/crypto/src/aes_256_cbc/ossl.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! AES-256-CBC implementation using OpenSSL.
+
 use super::*;
 
 pub struct Aes256CbcInner {

--- a/support/crypto/src/aes_256_cbc/symcrypt.rs
+++ b/support/crypto/src/aes_256_cbc/symcrypt.rs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use super::*;
-use ::symcrypt::cipher::AesExpandedKey;
+use super::Aes256CbcError;
+use super::IV_LEN;
+use super::KEY_LEN;
+use symcrypt::cipher::AesExpandedKey;
 
 pub struct Aes256CbcInner {
     key: AesExpandedKey,
@@ -16,7 +18,7 @@ pub struct Aes256CbcDecCtxInner<'a> {
     key: &'a AesExpandedKey,
 }
 
-fn err(e: ::symcrypt::errors::SymCryptError, op: &'static str) -> Aes256CbcError {
+fn err(e: symcrypt::errors::SymCryptError, op: &'static str) -> Aes256CbcError {
     Aes256CbcError(crate::BackendError::SymCrypt(e, op))
 }
 

--- a/support/crypto/src/aes_256_cbc/symcrypt.rs
+++ b/support/crypto/src/aes_256_cbc/symcrypt.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! AES-256-CBC implementation using SymCrypt.
+
 use super::Aes256CbcError;
 use super::IV_LEN;
 use super::KEY_LEN;

--- a/support/crypto/src/aes_256_gcm/ossl.rs
+++ b/support/crypto/src/aes_256_gcm/ossl.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! AES-256-GCM implementation using OpenSSL.
+
 use super::*;
 
 pub struct Aes256GcmInner {

--- a/support/crypto/src/aes_256_gcm/symcrypt.rs
+++ b/support/crypto/src/aes_256_gcm/symcrypt.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! AES-256-GCM implementation using SymCrypt.
+
 use super::Aes256GcmError;
 use super::IV_LEN;
 use super::KEY_LEN;

--- a/support/crypto/src/aes_256_gcm/symcrypt.rs
+++ b/support/crypto/src/aes_256_gcm/symcrypt.rs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use super::*;
-use ::symcrypt::gcm::GcmExpandedKey;
+use super::Aes256GcmError;
+use super::IV_LEN;
+use super::KEY_LEN;
+use symcrypt::gcm::GcmExpandedKey;
 
 pub struct Aes256GcmInner {
     key: GcmExpandedKey,
@@ -16,13 +18,13 @@ pub struct Aes256GcmDecCtxInner<'a> {
     key: &'a GcmExpandedKey,
 }
 
-fn err(e: ::symcrypt::errors::SymCryptError, op: &'static str) -> Aes256GcmError {
+fn err(e: symcrypt::errors::SymCryptError, op: &'static str) -> Aes256GcmError {
     Aes256GcmError(crate::BackendError::SymCrypt(e, op))
 }
 
 impl Aes256GcmInner {
     pub fn new(key: &[u8; KEY_LEN]) -> Result<Self, Aes256GcmError> {
-        let key = GcmExpandedKey::new(key, ::symcrypt::cipher::BlockCipherType::AesBlock)
+        let key = GcmExpandedKey::new(key, symcrypt::cipher::BlockCipherType::AesBlock)
             .map_err(|e| err(e, "expanding gcm key"))?;
         Ok(Self { key })
     }

--- a/support/crypto/src/aes_256_gcm/win.rs
+++ b/support/crypto/src/aes_256_gcm/win.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! AES-256-GCM implementation using Windows Bcrypt APIs.
+
 use super::*;
 use crate::win::*;
 use std::sync::LazyLock;

--- a/support/crypto/src/aes_key_wrap/mod.rs
+++ b/support/crypto/src/aes_key_wrap/mod.rs
@@ -20,6 +20,7 @@ pub enum AesKeyWrapError {
     InvalidKeySize(usize),
     /// A backend cryptographic error occurred.
     #[error("AES key wrap error")]
+    #[expect(private_interfaces)] // Will go away after refactoring this algo
     Backend(#[source] super::BackendError),
 }
 

--- a/support/crypto/src/hmac_sha_256/ossl.rs
+++ b/support/crypto/src/hmac_sha_256/ossl.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! HMAC-SHA-256 implementation using OpenSSL.
+
 use super::HmacSha256Error;
 
 fn err(err: openssl::error::ErrorStack, op: &'static str) -> HmacSha256Error {

--- a/support/crypto/src/hmac_sha_256/symcrypt.rs
+++ b/support/crypto/src/hmac_sha_256/symcrypt.rs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 use super::HmacSha256Error;
-use ::symcrypt::errors::SymCryptError;
-use ::symcrypt::hmac::hmac_sha256;
+use symcrypt::errors::SymCryptError;
+use symcrypt::hmac::hmac_sha256;
 
 fn err(e: SymCryptError, op: &'static str) -> HmacSha256Error {
     HmacSha256Error(crate::BackendError::SymCrypt(e, op))

--- a/support/crypto/src/hmac_sha_256/symcrypt.rs
+++ b/support/crypto/src/hmac_sha_256/symcrypt.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! HMAC-SHA-256 implementation using SymCrypt.
+
 use super::HmacSha256Error;
 use symcrypt::errors::SymCryptError;
 use symcrypt::hmac::hmac_sha256;

--- a/support/crypto/src/lib.rs
+++ b/support/crypto/src/lib.rs
@@ -32,28 +32,28 @@ pub(crate) mod win;
 #[cfg(openssl)]
 #[derive(Clone, Debug, thiserror::Error)]
 #[error("openssl error during {1}")]
-pub struct BackendError(#[source] openssl::error::ErrorStack, &'static str);
+pub(crate) struct BackendError(#[source] openssl::error::ErrorStack, &'static str);
 
 /// An error that occurred in the crypto backend, with a description of the
 /// operation being performed when the error occurred.
 #[cfg(all(native, windows))]
 #[derive(Clone, Debug, thiserror::Error)]
 #[error("windows crypto error during {1}")]
-pub struct BackendError(#[source] windows_result::Error, &'static str);
+pub(crate) struct BackendError(#[source] windows_result::Error, &'static str);
 
 /// An error that occurred in the crypto backend, with a description of the
 /// operation being performed when the error occurred.
 #[cfg(symcrypt)]
 #[derive(Clone, Debug, thiserror::Error)]
 #[error("symcrypt backend error during {1}")]
-pub enum BackendError {
+pub(crate) enum BackendError {
     /// An error from the SymCrypt library, with the operation being performed when the error occurred.
     SymCrypt(#[source] symcrypt::errors::SymCryptError, &'static str),
     /// An error from encoding or decoding PKCS#8, with the operation being performed when the error occurred.
-    Pkcs8Encoding(#[source] ::rsa::pkcs8::Error, &'static str),
+    Pkcs8Encoding(#[source] pkcs8::Error, &'static str),
     /// An error from DER encoding or decoding, with the operation being performed when the error occurred.
-    Der(#[source] ::der::Error, &'static str),
+    Der(#[source] der::Error, &'static str),
 }
 
 #[cfg(all(native, target_os = "macos"))]
-pub use mac::BackendError;
+pub(crate) use mac::BackendError;

--- a/support/crypto/src/mac.rs
+++ b/support/crypto/src/mac.rs
@@ -87,7 +87,7 @@ impl std::error::Error for OsStatusCode {}
 /// An error that occurred in the crypto backend.
 #[derive(Clone, Debug, thiserror::Error)]
 #[error("{0}")]
-pub struct BackendError(BackendErrorKind);
+pub(crate) struct BackendError(BackendErrorKind);
 
 #[derive(Clone, Debug, thiserror::Error)]
 enum BackendErrorKind {

--- a/support/crypto/src/mac.rs
+++ b/support/crypto/src/mac.rs
@@ -3,7 +3,7 @@
 
 //! Helpers for macOS operations, used by multiple algorithms.
 
-#![cfg(target_os = "macos")]
+#![cfg(all(native, target_os = "macos"))]
 
 use std::ffi::c_void;
 use std::fmt;

--- a/support/crypto/src/pkcs7/ossl.rs
+++ b/support/crypto/src/pkcs7/ossl.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! PKCS#7 signature verification using OpenSSL.
+
 use super::*;
 
 pub struct Pkcs7SignedDataInner(openssl::pkcs7::Pkcs7);

--- a/support/crypto/src/pkcs7/win.rs
+++ b/support/crypto/src/pkcs7/win.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! PKCS#7 signature verification using the Windows CryptoAPI.
+
 use super::*;
 use std::ptr;
 use windows::Win32::Foundation::CRYPT_E_NOT_FOUND;

--- a/support/crypto/src/rsa/mod.rs
+++ b/support/crypto/src/rsa/mod.rs
@@ -3,24 +3,39 @@
 
 //! RSA cryptographic operations.
 
-#![cfg(any(openssl, symcrypt))]
+#![cfg(any(openssl, rust, symcrypt))]
 
 #[cfg(openssl)]
 pub(crate) mod ossl;
 #[cfg(openssl)]
 use ossl as sys;
 
+#[cfg(rust)]
+pub(crate) mod rust;
+#[cfg(rust)]
+pub(crate) use rust as sys;
+
 #[cfg(symcrypt)]
 pub(crate) mod symcrypt;
 #[cfg(symcrypt)]
-use symcrypt as sys;
+pub(crate) use symcrypt as sys;
 
 use thiserror::Error;
 
 /// An error for RSA operations.
+#[cfg(not(rust))]
 #[derive(Debug, Error)]
 #[error("RSA error")]
 pub struct RsaError(#[source] pub(crate) super::BackendError);
+
+/// An error for RSA operations.
+#[cfg(rust)]
+#[derive(Debug, Error)]
+#[error("RSA error during {1}")]
+pub struct RsaError(
+    #[source] pub(crate) rsa::errors::Error,
+    pub(crate) &'static str,
+);
 
 /// Hash algorithm for RSA operations.
 #[derive(Debug, Clone, Copy)]

--- a/support/crypto/src/rsa/ossl.rs
+++ b/support/crypto/src/rsa/ossl.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! RSA implementation using OpenSSL.
+
 use super::HashAlgorithm;
 use super::RsaError;
 

--- a/support/crypto/src/rsa/rust.rs
+++ b/support/crypto/src/rsa/rust.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! RSA implementation using the `rsa` RustCrypto crate.
+
 use super::RsaError;
 use getrandom::SysRng;
 use pkcs8::DecodePrivateKey;

--- a/support/crypto/src/rsa/rust.rs
+++ b/support/crypto/src/rsa/rust.rs
@@ -1,0 +1,153 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::RsaError;
+use getrandom::SysRng;
+use pkcs8::DecodePrivateKey;
+use pkcs8::EncodePrivateKey;
+use rsa::Oaep;
+use rsa::Pkcs1v15Sign;
+use rsa::RsaPrivateKey;
+use rsa::RsaPublicKey;
+use rsa::rand_core;
+use rsa::rand_core::UnwrapErr;
+use rsa::traits::PublicKeyParts;
+use sha2::Digest;
+
+fn rng() -> impl rand_core::CryptoRng {
+    UnwrapErr(SysRng)
+}
+
+#[repr(transparent)] // Needed for the transmute in as_pub.
+pub struct RsaKeyPairInner(pub(crate) RsaPrivateKey);
+
+impl RsaKeyPairInner {
+    pub fn generate(bits: u32) -> Result<Self, RsaError> {
+        let rsa = RsaPrivateKey::new(&mut rng(), bits as usize)
+            .map_err(|e| RsaError(e, "generating RSA key"))?;
+        Ok(Self(rsa))
+    }
+
+    pub fn from_pkcs8_der(der: &[u8]) -> Result<Self, RsaError> {
+        let parsed = RsaPrivateKey::from_pkcs8_der(der)
+            .map_err(|e| RsaError(e.into(), "parsing PKCS#8 DER"))?;
+        Ok(Self(parsed))
+    }
+
+    pub fn to_pkcs8_der(&self) -> Result<Vec<u8>, RsaError> {
+        Ok(self
+            .0
+            .to_pkcs8_der()
+            .map_err(|e| RsaError(e.into(), "converting to DER"))?
+            .as_bytes()
+            .to_vec())
+    }
+
+    pub fn oaep_decrypt(
+        &self,
+        input: &[u8],
+        hash_algorithm: super::HashAlgorithm,
+    ) -> Result<Vec<u8>, RsaError> {
+        match hash_algorithm {
+            super::HashAlgorithm::Sha1 => {
+                self.0
+                    .decrypt_blinded(&mut rng(), Oaep::<sha1::Sha1>::new(), input)
+            }
+            super::HashAlgorithm::Sha256 => {
+                self.0
+                    .decrypt_blinded(&mut rng(), Oaep::<sha2::Sha256>::new(), input)
+            }
+        }
+        .map_err(|e| RsaError(e, "OAEP decryption"))
+    }
+
+    pub fn pkcs1_sign(
+        &self,
+        data: &[u8],
+        hash_algorithm: super::HashAlgorithm,
+    ) -> Result<Vec<u8>, RsaError> {
+        // rsa's `sign` expects the caller-supplied buffer to already
+        // be the hash digest of the message. Other backends take the raw
+        // message and hash internally. Do the hash here before handing off.
+        match hash_algorithm {
+            super::HashAlgorithm::Sha1 => {
+                let data = sha1::Sha1::digest(data);
+                self.0
+                    .sign_with_rng(&mut rng(), Pkcs1v15Sign::new::<sha1::Sha1>(), &data)
+            }
+            super::HashAlgorithm::Sha256 => {
+                let data = sha2::Sha256::digest(data);
+                self.0
+                    .sign_with_rng(&mut rng(), Pkcs1v15Sign::new::<sha2::Sha256>(), &data)
+            }
+        }
+        .map_err(|e| RsaError(e, "PKCS#1 signing"))
+    }
+
+    pub(crate) fn as_pub(&self) -> &RsaPublicKeyInner {
+        // SAFETY: RsaPublicKeyInner is just a wrapper around an RsaPublicKey.
+        unsafe { std::mem::transmute::<&RsaPublicKey, &RsaPublicKeyInner>(self.0.as_public_key()) }
+    }
+}
+
+#[repr(transparent)] // Needed for the transmute in as_pub.
+pub struct RsaPublicKeyInner(pub(crate) RsaPublicKey);
+
+impl RsaPublicKeyInner {
+    pub fn oaep_encrypt(
+        &self,
+        input: &[u8],
+        hash_algorithm: super::HashAlgorithm,
+    ) -> Result<Vec<u8>, RsaError> {
+        match hash_algorithm {
+            super::HashAlgorithm::Sha1 => {
+                self.0.encrypt(&mut rng(), Oaep::<sha1::Sha1>::new(), input)
+            }
+            super::HashAlgorithm::Sha256 => {
+                self.0
+                    .encrypt(&mut rng(), Oaep::<sha2::Sha256>::new(), input)
+            }
+        }
+        .map_err(|e| RsaError(e, "OAEP encryption"))
+    }
+
+    pub fn pkcs1_verify(
+        &self,
+        data: &[u8],
+        signature: &[u8],
+        hash_algorithm: super::HashAlgorithm,
+    ) -> Result<bool, RsaError> {
+        // SymCrypt's `pkcs1_verify` expects the caller-supplied buffer to already
+        // be the hash digest of the message. Other backends take the raw
+        // message and hash internally. Do the hash here before handing off.
+        let result = match hash_algorithm {
+            super::HashAlgorithm::Sha1 => {
+                let data = sha1::Sha1::digest(data);
+                self.0
+                    .verify(Pkcs1v15Sign::new::<sha1::Sha1>(), &data, signature)
+            }
+            super::HashAlgorithm::Sha256 => {
+                let data = sha2::Sha256::digest(data);
+                self.0
+                    .verify(Pkcs1v15Sign::new::<sha2::Sha256>(), &data, signature)
+            }
+        };
+        match result {
+            Ok(()) => Ok(true),
+            Err(rsa::Error::Verification) => Ok(false),
+            Err(e) => Err(RsaError(e, "PKCS#1 signature verification")),
+        }
+    }
+
+    pub fn modulus_size(&self) -> usize {
+        self.0.size()
+    }
+
+    pub fn modulus(&self) -> Vec<u8> {
+        self.0.n().to_be_bytes_trimmed_vartime().to_vec()
+    }
+
+    pub fn public_exponent(&self) -> Vec<u8> {
+        self.0.e().to_be_bytes_trimmed_vartime().to_vec()
+    }
+}

--- a/support/crypto/src/rsa/rust.rs
+++ b/support/crypto/src/rsa/rust.rs
@@ -117,7 +117,7 @@ impl RsaPublicKeyInner {
         signature: &[u8],
         hash_algorithm: super::HashAlgorithm,
     ) -> Result<bool, RsaError> {
-        // SymCrypt's `pkcs1_verify` expects the caller-supplied buffer to already
+        // rsa's `pkcs1_verify` expects the caller-supplied buffer to already
         // be the hash digest of the message. Other backends take the raw
         // message and hash internally. Do the hash here before handing off.
         let result = match hash_algorithm {

--- a/support/crypto/src/rsa/symcrypt.rs
+++ b/support/crypto/src/rsa/symcrypt.rs
@@ -131,7 +131,17 @@ impl RsaPublicKeyInner {
             .pkcs1_verify(&digest, signature, conv_hash(hash_algorithm))
         {
             Ok(()) => Ok(true),
-            Err(symcrypt::errors::SymCryptError::SignatureVerificationFailure) => Ok(false),
+            // `SignatureVerificationFailure` is the expected error for an
+            // invalid signature. `InvalidArgument` can also occur when the
+            // signature bytes, interpreted as an integer, are >= the modulus
+            // or otherwise don't decode to a valid PKCS#1 v1.5 encoding —
+            // which happens probabilistically when verifying a signature
+            // against the wrong public key. Both indicate "signature does
+            // not verify", not a backend bug.
+            Err(
+                symcrypt::errors::SymCryptError::SignatureVerificationFailure
+                | symcrypt::errors::SymCryptError::InvalidArgument,
+            ) => Ok(false),
             Err(e) => Err(err(e, "PKCS#1 signature verification")),
         }
     }

--- a/support/crypto/src/rsa/symcrypt.rs
+++ b/support/crypto/src/rsa/symcrypt.rs
@@ -2,10 +2,6 @@
 // Licensed under the MIT License.
 
 use super::RsaError;
-use rsa::pkcs8::DecodePrivateKey;
-use rsa::pkcs8::EncodePrivateKey;
-use rsa::traits::PrivateKeyParts;
-use rsa::traits::PublicKeyParts;
 use symcrypt::rsa::RsaKey;
 use symcrypt::rsa::RsaKeyUsage;
 
@@ -13,7 +9,7 @@ fn err(err: symcrypt::errors::SymCryptError, op: &'static str) -> RsaError {
     RsaError(crate::BackendError::SymCrypt(err, op))
 }
 
-fn pkcs8_err(err: rsa::pkcs8::Error, op: &'static str) -> RsaError {
+fn pkcs8_err(err: pkcs8::Error, op: &'static str) -> RsaError {
     RsaError(crate::BackendError::Pkcs8Encoding(err, op))
 }
 
@@ -28,12 +24,16 @@ impl RsaKeyPairInner {
     }
 
     pub fn from_pkcs8_der(der: &[u8]) -> Result<Self, RsaError> {
+        use pkcs8::DecodePrivateKey;
+        use rsa::traits::PrivateKeyParts;
+        use rsa::traits::PublicKeyParts;
+
         let parsed = rsa::RsaPrivateKey::from_pkcs8_der(der)
             .map_err(|e| pkcs8_err(e, "parsing PKCS#8 DER"))?;
         let primes = parsed.primes();
         if primes.len() != 2 {
             return Err(RsaError(crate::BackendError::Pkcs8Encoding(
-                rsa::pkcs8::Error::KeyMalformed(rsa::pkcs8::KeyError::Invalid),
+                pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid),
                 "multiprime RSA keys not supported",
             )));
         }
@@ -49,6 +49,8 @@ impl RsaKeyPairInner {
     }
 
     pub fn to_pkcs8_der(&self) -> Result<Vec<u8>, RsaError> {
+        use pkcs8::EncodePrivateKey;
+
         let blob = self
             .0
             .export_key_pair_blob()

--- a/support/crypto/src/rsa/symcrypt.rs
+++ b/support/crypto/src/rsa/symcrypt.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! RSA implementation using SymCrypt.
+
 use super::RsaError;
 use symcrypt::rsa::RsaKey;
 use symcrypt::rsa::RsaKeyUsage;

--- a/support/crypto/src/sha_256/mod.rs
+++ b/support/crypto/src/sha_256/mod.rs
@@ -3,12 +3,17 @@
 
 //! SHA-256 hashing.
 
-#![cfg(any(openssl, symcrypt))]
+#![cfg(any(openssl, rust, symcrypt))]
 
 #[cfg(openssl)]
 mod ossl;
 #[cfg(openssl)]
 use ossl as sys;
+
+#[cfg(rust)]
+mod rust;
+#[cfg(rust)]
+use rust as sys;
 
 #[cfg(symcrypt)]
 mod symcrypt;

--- a/support/crypto/src/sha_256/ossl.rs
+++ b/support/crypto/src/sha_256/ossl.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! SHA-256 implementation using OpenSSL.
+
 pub fn sha_256(data: &[u8]) -> [u8; 32] {
     let mut hasher = openssl::sha::Sha256::new();
     hasher.update(data);

--- a/support/crypto/src/sha_256/rust.rs
+++ b/support/crypto/src/sha_256/rust.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use sha2::Digest;
+
+pub fn sha_256(data: &[u8]) -> [u8; 32] {
+    sha2::Sha256::digest(data).into()
+}

--- a/support/crypto/src/sha_256/rust.rs
+++ b/support/crypto/src/sha_256/rust.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! SHA-256 implementation using the `sha2` RustCrypto crate.
+
 use sha2::Digest;
 
 pub fn sha_256(data: &[u8]) -> [u8; 32] {

--- a/support/crypto/src/sha_256/symcrypt.rs
+++ b/support/crypto/src/sha_256/symcrypt.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! SHA-256 implementation using SymCrypt.
+
 pub fn sha_256(data: &[u8]) -> [u8; 32] {
     symcrypt::hash::sha256(data)
 }

--- a/support/crypto/src/win.rs
+++ b/support/crypto/src/win.rs
@@ -3,7 +3,7 @@
 
 //! Helpers for Windows operations, used by multiple algorithms.
 
-#![cfg(windows)]
+#![cfg(all(native, windows))]
 
 use windows::Win32::Security::Cryptography::BCRYPT_ALG_HANDLE;
 use windows::Win32::Security::Cryptography::BCRYPT_KEY_HANDLE;

--- a/support/crypto/src/x509/mod.rs
+++ b/support/crypto/src/x509/mod.rs
@@ -3,24 +3,31 @@
 
 //! X.509 certificate operations.
 
-#![cfg(any(openssl, symcrypt))]
+#![cfg(any(openssl, rust, symcrypt))]
 
 #[cfg(openssl)]
 mod ossl;
 #[cfg(openssl)]
 use ossl as sys;
 
-#[cfg(symcrypt)]
-mod symcrypt;
-#[cfg(symcrypt)]
-use symcrypt as sys;
+#[cfg(any(rust, symcrypt))]
+mod symcrypt_rust;
+#[cfg(any(rust, symcrypt))]
+use symcrypt_rust as sys;
 
 use thiserror::Error;
 
 /// An error for X.509 operations.
+#[cfg(not(rust))]
 #[derive(Debug, Error)]
 #[error("X.509 error")]
 pub struct X509Error(#[source] super::BackendError);
+
+/// An error for X.509 operations.
+#[cfg(rust)]
+#[derive(Debug, Error)]
+#[error("X.509 error during {1}")]
+pub struct X509Error(#[source] der::Error, &'static str);
 
 /// An X.509 certificate.
 pub struct X509Certificate(pub(crate) sys::X509CertificateInner);
@@ -40,7 +47,10 @@ impl X509Certificate {
     /// public key.
     /// Returns `Ok(true)` if the signature is valid, `Ok(false)` if the
     /// signature is invalid, or an error for other failures.
-    pub fn verify(&self, issuer_public_key: &crate::rsa::RsaPublicKey) -> Result<bool, X509Error> {
+    pub fn verify(
+        &self,
+        issuer_public_key: &crate::rsa::RsaPublicKey,
+    ) -> Result<bool, crate::rsa::RsaError> {
         self.0.verify(issuer_public_key)
     }
 

--- a/support/crypto/src/x509/ossl.rs
+++ b/support/crypto/src/x509/ossl.rs
@@ -31,10 +31,13 @@ impl X509CertificateInner {
         ))
     }
 
-    pub fn verify(&self, issuer_public_key: &crate::rsa::RsaPublicKey) -> Result<bool, X509Error> {
-        self.0
-            .verify(&issuer_public_key.0.0)
-            .map_err(|e| err(e, "verifying certificate signature"))
+    pub fn verify(
+        &self,
+        issuer_public_key: &crate::rsa::RsaPublicKey,
+    ) -> Result<bool, crate::rsa::RsaError> {
+        self.0.verify(&issuer_public_key.0.0).map_err(|e| {
+            crate::rsa::RsaError(crate::BackendError(e, "verifying certificate signature"))
+        })
     }
 
     pub fn issued(&self, subject: &X509CertificateInner) -> Result<bool, X509Error> {

--- a/support/crypto/src/x509/ossl.rs
+++ b/support/crypto/src/x509/ossl.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! X.509 certificate parsing and verification using OpenSSL.
+
 use super::X509Error;
 
 fn err(err: openssl::error::ErrorStack, op: &'static str) -> X509Error {

--- a/support/crypto/src/x509/symcrypt_rust.rs
+++ b/support/crypto/src/x509/symcrypt_rust.rs
@@ -72,7 +72,7 @@ impl X509CertificateInner {
         &self,
         issuer_public_key: &crate::rsa::RsaPublicKey,
     ) -> Result<bool, crate::rsa::RsaError> {
-        use pkcs8::AssociatedOid;
+        use rsa::pkcs1v15::RsaSignatureAssociatedOid;
 
         let oid = self.0.signature_algorithm().oid;
         let hash = match oid {

--- a/support/crypto/src/x509/symcrypt_rust.rs
+++ b/support/crypto/src/x509/symcrypt_rust.rs
@@ -4,16 +4,33 @@
 use super::X509Error;
 use der::Decode;
 use der::Encode;
-use rsa::pkcs1v15::RsaSignatureAssociatedOid;
-use symcrypt::rsa::RsaKeyUsage;
+#[cfg(symcrypt)]
+use rsa::sha2;
 use x509_cert::Certificate;
 
+#[cfg(symcrypt)]
 fn err(err: symcrypt::errors::SymCryptError, op: &'static str) -> X509Error {
     X509Error(crate::BackendError::SymCrypt(err, op))
 }
 
+#[cfg(symcrypt)]
 fn der_err(err: der::Error, op: &'static str) -> X509Error {
     X509Error(crate::BackendError::Der(err, op))
+}
+
+#[cfg(symcrypt)]
+fn rsa_der_err(err: der::Error, op: &'static str) -> crate::rsa::RsaError {
+    crate::rsa::RsaError(crate::BackendError::Der(err, op))
+}
+
+#[cfg(rust)]
+fn der_err(err: der::Error, op: &'static str) -> X509Error {
+    X509Error(err, op)
+}
+
+#[cfg(rust)]
+fn rsa_der_err(err: der::Error, op: &'static str) -> crate::rsa::RsaError {
+    crate::rsa::RsaError(rsa::Error::Pkcs1(pkcs1::Error::Asn1(err)), op)
 }
 
 pub struct X509CertificateInner(Certificate);
@@ -29,7 +46,7 @@ impl X509CertificateInner {
         // Currently we only expect RSA public keys.
         // If someday we need to support other public key types, the return
         // type of this function will need to change.
-        let parsed = ::rsa::pkcs1::RsaPublicKey::from_der(
+        let key = pkcs1::RsaPublicKey::from_der(
             self.0
                 .tbs_certificate()
                 .subject_public_key_info()
@@ -37,23 +54,31 @@ impl X509CertificateInner {
                 .raw_bytes(),
         )
         .map_err(|e| der_err(e, "parsing PKCS#1 RSA public key"))?;
-        let key = ::symcrypt::rsa::RsaKey::set_public_key(
-            parsed.modulus.as_bytes(),
-            parsed.public_exponent.as_bytes(),
-            RsaKeyUsage::SignAndEncrypt,
+        #[cfg(symcrypt)]
+        let key = symcrypt::rsa::RsaKey::set_public_key(
+            key.modulus.as_bytes(),
+            key.public_exponent.as_bytes(),
+            symcrypt::rsa::RsaKeyUsage::SignAndEncrypt,
         )
         .map_err(|e| err(e, "constructing RSA public key"))?;
+        #[cfg(rust)]
+        let key = key.try_into().unwrap();
         Ok(crate::rsa::RsaPublicKey(
-            crate::rsa::symcrypt::RsaPublicKeyInner(key),
+            crate::rsa::sys::RsaPublicKeyInner(key),
         ))
     }
 
-    pub fn verify(&self, issuer_public_key: &crate::rsa::RsaPublicKey) -> Result<bool, X509Error> {
+    pub fn verify(
+        &self,
+        issuer_public_key: &crate::rsa::RsaPublicKey,
+    ) -> Result<bool, crate::rsa::RsaError> {
+        use pkcs8::AssociatedOid;
+
         let oid = self.0.signature_algorithm().oid;
         let hash = match oid {
-            ::rsa::sha2::Sha256::OID => crate::rsa::HashAlgorithm::Sha256,
+            sha2::Sha256::OID => crate::rsa::HashAlgorithm::Sha256,
             _ => {
-                return Err(der_err(
+                return Err(rsa_der_err(
                     der::ErrorKind::OidUnknown { oid }.to_error(),
                     "unrecognized signature algorithm OID",
                 ));
@@ -64,12 +89,10 @@ impl X509CertificateInner {
             .0
             .tbs_certificate()
             .to_der()
-            .map_err(|e| der_err(e, "encoding TBS certificate"))?;
+            .map_err(|e| rsa_der_err(e, "encoding TBS certificate"))?;
         let signature = self.0.signature().raw_bytes();
 
-        issuer_public_key
-            .pkcs1_verify(&tbs_der, signature, hash)
-            .map_err(|e| X509Error(e.0))
+        issuer_public_key.pkcs1_verify(&tbs_der, signature, hash)
     }
 
     pub fn issued(&self, subject: &X509CertificateInner) -> Result<bool, X509Error> {
@@ -188,17 +211,17 @@ impl X509CertificateInner {
 
         let modulus = key.modulus();
         let exponent = key.public_exponent();
-        let pkcs1_pub = ::rsa::pkcs1::RsaPublicKey {
-            modulus: ::der::asn1::UintRef::new(&modulus)?,
-            public_exponent: ::der::asn1::UintRef::new(&exponent)?,
+        let pkcs1_pub = pkcs1::RsaPublicKey {
+            modulus: der::asn1::UintRef::new(&modulus)?,
+            public_exponent: der::asn1::UintRef::new(&exponent)?,
         };
         let pkcs1_der = pkcs1_pub.to_der()?;
         let spki = x509_cert::spki::SubjectPublicKeyInfoOwned {
             algorithm: x509_cert::spki::AlgorithmIdentifierOwned {
-                oid: ::rsa::pkcs1::ALGORITHM_OID,
-                parameters: Some(::der::asn1::Any::null()),
+                oid: pkcs1::ALGORITHM_OID,
+                parameters: Some(der::asn1::Any::null()),
             },
-            subject_public_key: ::der::asn1::BitString::from_bytes(&pkcs1_der)?,
+            subject_public_key: der::asn1::BitString::from_bytes(&pkcs1_der)?,
         };
 
         let serial_number = x509_cert::serial_number::SerialNumber::from(1u32);
@@ -212,17 +235,21 @@ impl X509CertificateInner {
         let builder =
             x509_cert::builder::CertificateBuilder::new(profile, serial_number, validity, spki)?;
 
+        #[cfg(symcrypt)]
         let blob = key.0.0.export_key_pair_blob()?;
-        let priv_key = ::rsa::RsaPrivateKey::from_components(
-            ::rsa::BoxedUint::from_be_slice_vartime(&blob.modulus),
-            ::rsa::BoxedUint::from_be_slice_vartime(&blob.pub_exp),
-            ::rsa::BoxedUint::from_be_slice_vartime(&blob.private_exp),
+        #[cfg(symcrypt)]
+        let key = rsa::RsaPrivateKey::from_components(
+            rsa::BoxedUint::from_be_slice_vartime(&blob.modulus),
+            rsa::BoxedUint::from_be_slice_vartime(&blob.pub_exp),
+            rsa::BoxedUint::from_be_slice_vartime(&blob.private_exp),
             vec![
-                ::rsa::BoxedUint::from_be_slice_vartime(&blob.p),
-                ::rsa::BoxedUint::from_be_slice_vartime(&blob.q),
+                rsa::BoxedUint::from_be_slice_vartime(&blob.p),
+                rsa::BoxedUint::from_be_slice_vartime(&blob.q),
             ],
         )?;
-        let signer = ::rsa::pkcs1v15::SigningKey::<::rsa::sha2::Sha256>::new(priv_key);
+        #[cfg(rust)]
+        let key = key.0.0.clone();
+        let signer = rsa::pkcs1v15::SigningKey::<sha2::Sha256>::new(key);
 
         let cert = builder.build(&signer)?;
         Ok(Self(cert))

--- a/support/crypto/src/x509/symcrypt_rust.rs
+++ b/support/crypto/src/x509/symcrypt_rust.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! X.509 certificate parsing and verification using the `x509-cert` RustCrypto crate.
+
 use super::X509Error;
 use der::Decode;
 use der::Encode;

--- a/support/crypto/src/xts_aes_256/ossl.rs
+++ b/support/crypto/src/xts_aes_256/ossl.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! XTS-AES-256 implementation using OpenSSL.
+
 use super::*;
 
 pub struct XtsAes256Inner {

--- a/support/crypto/src/xts_aes_256/win.rs
+++ b/support/crypto/src/xts_aes_256/win.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! XTS-AES-256 implementation using Windows Bcrypt APIs.
+
 use super::*;
 use crate::win::*;
 use std::sync::LazyLock;


### PR DESCRIPTION
Add a pure-Rust backend to the crypto crate. Rewrite the build script to support this, and add checks for it to CI. Clean up some misc stuff along the way.

The new backend isn't suitable for use in production scenarios, but is handy to have for test scenarios and fuzzers, as it can build anywhere.