### PR TITLE
virt_support: Add extra tracing on emulation failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9078,6 +9078,7 @@ version = "0.0.0"
 dependencies = [
  "aarch64defs",
  "aarch64emu",
+ "cvm_tracing",
  "guestmem",
  "hvdef",
  "thiserror 2.0.16",
@@ -9123,6 +9124,7 @@ dependencies = [
 name = "virt_support_x86emu"
 version = "0.0.0"
 dependencies = [
+ "cvm_tracing",
  "guestmem",
  "hvdef",
  "iced-x86",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8060,16 +8060,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8079,15 +8069,12 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/support/tracing_helpers/Cargo.toml
+++ b/support/tracing_helpers/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 [dependencies]
 anyhow.workspace = true
 tracing.workspace = true
-tracing-subscriber = { workspace = true, features = ["json"] }
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/vmm_core/virt_support_aarch64emu/Cargo.toml
+++ b/vmm_core/virt_support_aarch64emu/Cargo.toml
@@ -14,6 +14,7 @@ vm_topology.workspace = true
 virt.workspace = true
 aarch64emu.workspace = true
 
+cvm_tracing.workspace = true
 thiserror.workspace = true
 tracelimit.workspace = true
 tracing.workspace = true

--- a/vmm_core/virt_support_aarch64emu/src/emulate.rs
+++ b/vmm_core/virt_support_aarch64emu/src/emulate.rs
@@ -9,6 +9,8 @@ use aarch64defs::FaultStatusCode;
 use aarch64defs::IssInstructionAbort;
 use aarch64emu::AccessCpuState;
 use aarch64emu::InterceptState;
+use cvm_tracing::CVM_ALLOWED;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use guestmem::GuestMemory;
 use guestmem::GuestMemoryError;
 use hvdef::HV_PAGE_SIZE;
@@ -173,7 +175,29 @@ pub async fn emulate<T: EmulatorSupport>(
 ) -> Result<(), VpHaltReason> {
     emulate_core(support, intercept_state, emu_mem, dev)
         .await
-        .map_err(|e| dev.fatal_error(e.into()))
+        .map_err(|e| {
+            let pc = support.pc();
+            let sp = support.sp();
+            let cpsr = support.cpsr();
+            let gpa = support.physical_address();
+            let initial_translation = support.initial_gva_translation();
+            let int_pend = support.interruption_pending();
+            let gpa_mapped = gpa.map(|a| support.is_gpa_mapped(a, false));
+            tracing::warn!(
+                CVM_ALLOWED,
+                pc,
+                sp,
+                ?cpsr,
+                ?gpa,
+                ?initial_translation,
+                ?int_pend,
+                ?gpa_mapped,
+                "emulation failed"
+            );
+            let xs = (0..=30).map(|i| (i, support.x(i))).collect::<Vec<_>>();
+            tracing::warn!(CVM_CONFIDENTIAL, ?xs, "emulation failed");
+            dev.fatal_error(e.into())
+        })
 }
 
 async fn emulate_core<T: EmulatorSupport>(

--- a/vmm_core/virt_support_aarch64emu/src/emulate.rs
+++ b/vmm_core/virt_support_aarch64emu/src/emulate.rs
@@ -188,10 +188,10 @@ pub async fn emulate<T: EmulatorSupport>(
                 pc,
                 sp,
                 ?cpsr,
-                ?gpa,
+                gpa,
                 ?initial_translation,
                 int_pend,
-                ?gpa_mapped,
+                gpa_mapped,
                 "emulation failed"
             );
             let xs = (0..=30).map(|i| (i, support.x(i))).collect::<Vec<_>>();

--- a/vmm_core/virt_support_aarch64emu/src/emulate.rs
+++ b/vmm_core/virt_support_aarch64emu/src/emulate.rs
@@ -190,7 +190,7 @@ pub async fn emulate<T: EmulatorSupport>(
                 ?cpsr,
                 ?gpa,
                 ?initial_translation,
-                ?int_pend,
+                int_pend,
                 ?gpa_mapped,
                 "emulation failed"
             );

--- a/vmm_core/virt_support_x86emu/Cargo.toml
+++ b/vmm_core/virt_support_x86emu/Cargo.toml
@@ -15,6 +15,7 @@ virt.workspace = true
 x86defs.workspace = true
 x86emu.workspace = true
 
+cvm_tracing.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true

--- a/vmm_core/virt_support_x86emu/src/emulate.rs
+++ b/vmm_core/virt_support_x86emu/src/emulate.rs
@@ -312,10 +312,10 @@ pub async fn emulate<T: EmulatorSupport>(
             efer,
             cr0,
             ?rflags,
-            ?gpa,
+            gpa,
             ?initial_translation,
-            ?int_pend,
-            ?gpa_mapped,
+            int_pend,
+            gpa_mapped,
             "emulation failed"
         );
         let gps = [

--- a/vmm_core/virt_support_x86emu/src/emulate.rs
+++ b/vmm_core/virt_support_x86emu/src/emulate.rs
@@ -6,6 +6,8 @@
 use crate::translate::TranslateFlags;
 use crate::translate::TranslatePrivilegeCheck;
 use crate::translate::translate_gva_to_gpa;
+use cvm_tracing::CVM_ALLOWED;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use guestmem::GuestMemory;
 use guestmem::GuestMemoryError;
 use hvdef::HV_PAGE_SIZE;
@@ -293,9 +295,51 @@ pub async fn emulate<T: EmulatorSupport>(
     emu_mem: &EmulatorMemoryAccess<'_>,
     dev: &impl CpuIo,
 ) -> Result<(), VpHaltReason> {
-    emulate_core(support, emu_mem, dev)
-        .await
-        .map_err(|e| dev.fatal_error(e.into()))
+    emulate_core(support, emu_mem, dev).await.map_err(|e| {
+        let rip = support.rip();
+        let efer = support.efer();
+        let cr0 = support.cr0();
+        let rflags = support.rflags();
+        let vendor = support.vendor();
+        let gpa = support.physical_address();
+        let initial_translation = support.initial_gva_translation();
+        let int_pend = support.interruption_pending();
+        let gpa_mapped = gpa.map(|a| support.is_gpa_mapped(a, false));
+        tracing::warn!(
+            CVM_ALLOWED,
+            rip,
+            ?vendor,
+            efer,
+            cr0,
+            ?rflags,
+            ?gpa,
+            ?initial_translation,
+            ?int_pend,
+            ?gpa_mapped,
+            "emulation failed"
+        );
+        let gps = [
+            Gp::RAX,
+            Gp::RCX,
+            Gp::RDX,
+            Gp::RBX,
+            Gp::RSP,
+            Gp::RBP,
+            Gp::RSI,
+            Gp::RDI,
+            Gp::R8,
+            Gp::R9,
+            Gp::R10,
+            Gp::R11,
+            Gp::R12,
+            Gp::R13,
+            Gp::R14,
+            Gp::R15,
+        ]
+        .map(|i| support.gp(i));
+        tracing::warn!(CVM_CONFIDENTIAL, ?gps, "emulation failed");
+        dev.fatal_error(e.into())
+    })
 }
 
 async fn emulate_core<T: EmulatorSupport>(


### PR DESCRIPTION
We're seeing ICMs with weird emulation failures, and unfortunately so much is optimized out of the dumps that we don't have what we need to debug them. Add tracing to ensure important information shows up in our logs.