### PR TITLE
openvmm: Add consomme, virtio-console and serial connect to ttrpc interface

### DIFF
--- a/openvmm/openvmm_entry/src/serial_io.rs
+++ b/openvmm/openvmm_entry/src/serial_io.rs
@@ -67,6 +67,27 @@ pub fn bind_serial(path: &Path) -> io::Result<Resource<SerialBackendHandle>> {
     Ok(OpenSocketSerialConfig::from(UnixListener::bind(path)?).into_resource())
 }
 
+/// Connect to an existing named pipe or Unix domain socket as a client.
+///
+/// Unlike [`bind_serial`], which creates a new server, this function connects
+/// to a pipe or socket that already exists.
+pub fn connect_serial(path: &Path) -> io::Result<Resource<SerialBackendHandle>> {
+    #[cfg(windows)]
+    {
+        use serial_socket::windows::OpenWindowsPipeSerialConfig;
+
+        if path.starts_with("//./pipe") {
+            let pipe = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(path)?;
+            return Ok(OpenWindowsPipeSerialConfig::from(pipe).into_resource());
+        }
+    }
+
+    Ok(OpenSocketSerialConfig::from(unix_socket::UnixStream::connect(path)?).into_resource())
+}
+
 pub fn bind_tcp_serial(addr: &SocketAddr) -> anyhow::Result<Resource<SerialBackendHandle>> {
     let listener = std::net::TcpListener::bind(addr)
         .with_context(|| format!("failed to bind tcp address {addr}"))?;

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -533,11 +533,12 @@ impl VmService {
             let pc = ports
                 .get_mut(port.port as usize)
                 .context("invalid serial port")?;
-            let (serial_fn, serial_action) = if port.connect {
-                (connect_serial, "connect to")
+            let serial_fn = if port.connect {
+                connect_serial
             } else {
-                (bind_serial, "bind to")
+                bind_serial
             };
+            let serial_action = if port.connect { "connect to" } else { "bind" };
             *pc = Some(serial_fn(port.socket_path.as_ref()).with_context(|| {
                 format!(
                     "failed to {} serial socket: {}",
@@ -898,16 +899,6 @@ impl VmService {
     }
 }
 
-// On platforms without platform-specific NIC backends (e.g., macOS), the
-// platform-gated match arms are unreachable. Consomme is always available.
-#[cfg_attr(
-    not(any(windows, target_os = "linux")),
-    expect(
-        unreachable_code,
-        unused_variables,
-        reason = "platform-specific NIC backends not available"
-    )
-)]
 fn parse_nic_config(
     nic: vmservice::NicConfig,
 ) -> anyhow::Result<(DeviceVtl, Resource<VmbusDeviceHandleKind>)> {

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -536,10 +536,7 @@ impl VmService {
                 .context("invalid serial port")?;
             let (serial_fn, action) = open_socket_backend(port.connect);
             *pc = Some(serial_fn(port.socket_path.as_ref()).with_context(|| {
-                format!(
-                    "failed to {} serial socket: {}",
-                    action, port.socket_path
-                )
+                format!("failed to {} serial socket: {}", action, port.socket_path)
             })?);
         }
 

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -7,6 +7,7 @@
 
 use crate::meshworker::VmmMesh;
 use crate::serial_io::bind_serial;
+use crate::serial_io::connect_serial;
 use crate::vm_controller::InspectTarget;
 use crate::vm_controller::VmController;
 use crate::vm_controller::VmControllerEvent;
@@ -64,6 +65,7 @@ use virtio_resources::VirtioPciDeviceHandle;
 use vm_manifest_builder::VmManifestBuilder;
 use vm_resource::IntoResource;
 use vm_resource::Resource;
+use vm_resource::kind::VirtioDeviceHandle;
 use vm_resource::kind::VmbusDeviceHandleKind;
 
 #[derive(mesh::MeshPayload)]
@@ -531,7 +533,12 @@ impl VmService {
             let pc = ports
                 .get_mut(port.port as usize)
                 .context("invalid serial port")?;
-            *pc = Some(bind_serial(port.socket_path.as_ref()).with_context(|| {
+            let serial_fn = if port.connect {
+                connect_serial
+            } else {
+                bind_serial
+            };
+            *pc = Some(serial_fn(port.socket_path.as_ref()).with_context(|| {
                 format!("failed to bind to serial socket: {}", port.socket_path)
             })?);
         }
@@ -662,6 +669,34 @@ impl VmService {
                     });
                 } else {
                     config.virtio_devices.push((VirtioBus::Pci, resource));
+                }
+            }
+
+            if let Some(virtio_console) = devices_config.virtio_console {
+                if !virtio_console.socket_path.is_empty() {
+                    let serial_fn = if virtio_console.connect {
+                        connect_serial
+                    } else {
+                        bind_serial
+                    };
+                    let backend =
+                        serial_fn(virtio_console.socket_path.as_ref()).with_context(|| {
+                            format!(
+                                "failed to bind virtio console socket: {}",
+                                virtio_console.socket_path
+                            )
+                        })?;
+                    let resource: Resource<VirtioDeviceHandle> =
+                        virtio_resources::console::VirtioConsoleHandle { backend }.into_resource();
+                    if cfg!(windows) || cfg!(target_os = "macos") {
+                        config.vpci_devices.push(VpciDeviceConfig {
+                            vtl: DeviceVtl::Vtl0,
+                            instance_id: Guid::new_random(),
+                            resource: VirtioPciDeviceHandle(resource).into_resource(),
+                        });
+                    } else {
+                        config.virtio_devices.push((VirtioBus::Pci, resource));
+                    }
                 }
             }
         }
@@ -855,19 +890,19 @@ impl VmService {
     }
 }
 
-// On platforms without NIC backends (e.g., macOS), every match arm diverges.
+// On platforms without platform-specific NIC backends (e.g., macOS), the
+// platform-gated match arms are unreachable. Consomme is always available.
 #[cfg_attr(
     not(any(windows, target_os = "linux")),
     expect(
         unreachable_code,
         unused_variables,
-        reason = "no NIC backends available on this platform"
+        reason = "platform-specific NIC backends not available"
     )
 )]
 fn parse_nic_config(
     nic: vmservice::NicConfig,
 ) -> anyhow::Result<(DeviceVtl, Resource<VmbusDeviceHandleKind>)> {
-    #[cfg(any(windows, target_os = "linux"))]
     use self::vmservice::nic_config::Backend;
 
     let endpoint = match nic.backend.context("missing backend")? {
@@ -893,6 +928,15 @@ fn parse_nic_config(
                 .with_context(|| format!("failed to open TAP device '{}'", tap.name))?;
             net_backend_resources::tap::TapHandle { fd }.into_resource()
         }
+        Backend::Consomme(consomme) => net_backend_resources::consomme::ConsommeHandle {
+            cidr: if consomme.cidr.is_empty() {
+                None
+            } else {
+                Some(consomme.cidr)
+            },
+            ports: Vec::new(),
+        }
+        .into_resource(),
         _ => anyhow::bail!("unsupported backend"),
     };
     let cfg = NetvspHandle {

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -65,6 +65,7 @@ use virtio_resources::VirtioPciDeviceHandle;
 use vm_manifest_builder::VmManifestBuilder;
 use vm_resource::IntoResource;
 use vm_resource::Resource;
+use vm_resource::kind::SerialBackendHandle;
 use vm_resource::kind::VirtioDeviceHandle;
 use vm_resource::kind::VmbusDeviceHandleKind;
 
@@ -533,16 +534,11 @@ impl VmService {
             let pc = ports
                 .get_mut(port.port as usize)
                 .context("invalid serial port")?;
-            let serial_fn = if port.connect {
-                connect_serial
-            } else {
-                bind_serial
-            };
-            let serial_action = if port.connect { "connect to" } else { "bind" };
+            let (serial_fn, action) = open_socket_backend(port.connect);
             *pc = Some(serial_fn(port.socket_path.as_ref()).with_context(|| {
                 format!(
                     "failed to {} serial socket: {}",
-                    serial_action, port.socket_path
+                    action, port.socket_path
                 )
             })?);
         }
@@ -678,21 +674,12 @@ impl VmService {
 
             if let Some(virtio_console) = devices_config.virtio_console {
                 if !virtio_console.socket_path.is_empty() {
-                    let serial_fn = if virtio_console.connect {
-                        connect_serial
-                    } else {
-                        bind_serial
-                    };
-                    let operation = if virtio_console.connect {
-                        "connect to"
-                    } else {
-                        "bind"
-                    };
+                    let (serial_fn, action) = open_socket_backend(virtio_console.connect);
                     let backend =
                         serial_fn(virtio_console.socket_path.as_ref()).with_context(|| {
                             format!(
                                 "failed to {} virtio console socket: {}",
-                                operation, virtio_console.socket_path
+                                action, virtio_console.socket_path
                             )
                         })?;
                     let resource: Resource<VirtioDeviceHandle> =
@@ -896,6 +883,22 @@ impl VmService {
                 anyhow::bail!("processor and memory resources not supported")
             }
         }
+    }
+}
+
+/// Returns the appropriate serial backend open function and a human-readable
+/// action verb for error messages, based on whether we should connect to an
+/// existing socket or bind a new listener.
+fn open_socket_backend(
+    connect: bool,
+) -> (
+    fn(&std::path::Path) -> std::io::Result<Resource<SerialBackendHandle>>,
+    &'static str,
+) {
+    if connect {
+        (connect_serial, "connect to")
+    } else {
+        (bind_serial, "bind")
     }
 }
 

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -533,13 +533,16 @@ impl VmService {
             let pc = ports
                 .get_mut(port.port as usize)
                 .context("invalid serial port")?;
-            let serial_fn = if port.connect {
-                connect_serial
+            let (serial_fn, serial_action) = if port.connect {
+                (connect_serial, "connect to")
             } else {
-                bind_serial
+                (bind_serial, "bind to")
             };
             *pc = Some(serial_fn(port.socket_path.as_ref()).with_context(|| {
-                format!("failed to bind to serial socket: {}", port.socket_path)
+                format!(
+                    "failed to {} serial socket: {}",
+                    serial_action, port.socket_path
+                )
             })?);
         }
 
@@ -679,11 +682,16 @@ impl VmService {
                     } else {
                         bind_serial
                     };
+                    let operation = if virtio_console.connect {
+                        "connect to"
+                    } else {
+                        "bind"
+                    };
                     let backend =
                         serial_fn(virtio_console.socket_path.as_ref()).with_context(|| {
                             format!(
-                                "failed to bind virtio console socket: {}",
-                                virtio_console.socket_path
+                                "failed to {} virtio console socket: {}",
+                                operation, virtio_console.socket_path
                             )
                         })?;
                     let resource: Resource<VirtioDeviceHandle> =

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -665,7 +665,7 @@ impl VmService {
                         resource: VirtioPciDeviceHandle(resource).into_resource(),
                     });
                 } else {
-                    config.virtio_devices.push((VirtioBus::Pci, resource));
+                    config.virtio_devices.push((VirtioBus::Mmio, resource));
                 }
             }
 
@@ -688,7 +688,7 @@ impl VmService {
                             resource: VirtioPciDeviceHandle(resource).into_resource(),
                         });
                     } else {
-                        config.virtio_devices.push((VirtioBus::Pci, resource));
+                        config.virtio_devices.push((VirtioBus::Mmio, resource));
                     }
                 }
             }

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -100,7 +100,7 @@ message VirtioConsoleConfig {
     string socket_path = 1;
     // When true, connect to an existing pipe/socket at socket_path as a client
     // instead of creating a new server listener. Used when the host has already
-    // created the pipe (e.g., for DmesgCollector integration).
+    // created the socket/pipe.
     bool connect = 2;
 }
 

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -92,6 +92,16 @@ message DevicesConfig {
     // housed.
     repeated WindowsPCIDevice windows_device = 4;
     repeated VirtioFSConfig virtiofs_config = 5;
+    VirtioConsoleConfig virtio_console = 6;
+}
+
+message VirtioConsoleConfig {
+    // Path to a named pipe or Unix domain socket for the console backend.
+    string socket_path = 1;
+    // When true, connect to an existing pipe/socket at socket_path as a client
+    // instead of creating a new server listener. Used when the host has already
+    // created the pipe (e.g., for DmesgCollector integration).
+    bool connect = 2;
 }
 
 message VMConfig {
@@ -119,6 +129,9 @@ message SerialConfig {
         uint32 port = 1;
         // Uds to relay serial console output to.
         string socket_path = 2;
+        // When true, connect to an existing pipe/socket as a client instead of
+        // creating a new server listener.
+        bool connect = 3;
     }
     repeated Config ports = 3;
 }
@@ -224,6 +237,7 @@ message NICConfig {
         string legacy_port_id = 2; // legacy, GUID, Windows only
         DioBackend dio = 6;
         TapBackend tap = 7;
+        ConsommeBackend consomme = 8;
     }
 }
 
@@ -234,6 +248,12 @@ message DioBackend {
 
 message TapBackend {
     string name = 1;
+}
+
+message ConsommeBackend {
+    // Optional CIDR for the guest network (e.g. "10.0.0.0/24").
+    // If empty, a default is used.
+    string cidr = 1;
 }
 
 message WindowsPCIDevice {

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -90,12 +90,18 @@ fn test_ttrpc_interface(
             let virtiofs_root = std::env::temp_dir().join(Guid::new_random().to_string());
             std::fs::create_dir_all(&virtiofs_root).unwrap();
 
-            // On iteration 0, test serial `connect: true` by pre-creating a
-            // listener that the VM will connect to. On other iterations, test
-            // the default `connect: false` (VM creates the socket).
-            let use_serial_connect = i == 0;
-            let com1_listener = if use_serial_connect {
+            // On iteration 0, test `connect: true` for both serial and
+            // virtio console by pre-creating listeners that the VM will
+            // connect to. On other iterations, test the default
+            // `connect: false` (VM creates the socket).
+            let use_connect = i == 0;
+            let com1_listener = if use_connect {
                 Some(UnixListener::bind(&com1_path).unwrap())
+            } else {
+                None
+            };
+            let console_listener = if use_connect {
+                Some(UnixListener::bind(&console_path).unwrap())
             } else {
                 None
             };
@@ -127,7 +133,7 @@ fn test_ttrpc_interface(
                                 ports: vec![vmservice::serial_config::Config {
                                     port: 0,
                                     socket_path: com1_path.to_string_lossy().into(),
-                                    connect: use_serial_connect,
+                                    connect: use_connect,
                                 }],
                             }),
                             devices_config: Some(vmservice::DevicesConfig {
@@ -143,7 +149,7 @@ fn test_ttrpc_interface(
                                 }],
                                 virtio_console: Some(vmservice::VirtioConsoleConfig {
                                     socket_path: console_path.to_string_lossy().into(),
-                                    connect: false,
+                                    connect: use_connect,
                                 }),
                                 virtiofs_config: vec![vmservice::VirtioFsConfig {
                                     tag: "testfs".to_string(),
@@ -168,6 +174,14 @@ fn test_ttrpc_interface(
                 UnixStream::connect(&com1_path).unwrap()
             };
 
+            // Get the console connection the same way.
+            let console = if let Some(listener) = console_listener {
+                let (stream, _) = listener.accept().unwrap();
+                stream
+            } else {
+                UnixStream::connect(&console_path).unwrap()
+            };
+
             let _com1_task = driver.spawn(
                 "com1",
                 petri::log_task(
@@ -177,8 +191,6 @@ fn test_ttrpc_interface(
                 ),
             );
 
-            // Verify the virtio console socket was created and is connectable.
-            let console = UnixStream::connect(&console_path).unwrap();
             let _console_task = driver.spawn(
                 "console",
                 petri::log_task(
@@ -238,6 +250,11 @@ fn test_ttrpc_interface(
                 }
                 _ => unreachable!(),
             }
+
+            // Clean up temp files from this iteration.
+            let _ = std::fs::remove_file(&com1_path);
+            let _ = std::fs::remove_file(&console_path);
+            let _ = std::fs::remove_dir_all(&virtiofs_root);
         }
     });
 

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -14,6 +14,7 @@ use petri::ResolvedArtifact;
 use petri_artifacts_vmm_test::artifacts;
 use std::io::Read;
 use std::process::Stdio;
+use unix_socket::UnixListener;
 use unix_socket::UnixStream;
 
 petri::test!(test_ttrpc_interface, |resolver| {
@@ -83,6 +84,19 @@ fn test_ttrpc_interface(
             let mut com1_path = std::env::temp_dir();
             com1_path.push(Guid::new_random().to_string());
 
+            let mut console_path = std::env::temp_dir();
+            console_path.push(Guid::new_random().to_string());
+
+            // On iteration 0, test serial `connect: true` by pre-creating a
+            // listener that the VM will connect to. On other iterations, test
+            // the default `connect: false` (VM creates the socket).
+            let use_serial_connect = i == 0;
+            let com1_listener = if use_serial_connect {
+                Some(UnixListener::bind(&com1_path).unwrap())
+            } else {
+                None
+            };
+
             client
                 .call()
                 .start(
@@ -110,7 +124,25 @@ fn test_ttrpc_interface(
                                 ports: vec![vmservice::serial_config::Config {
                                     port: 0,
                                     socket_path: com1_path.to_string_lossy().into(),
+                                    connect: use_serial_connect,
                                 }],
+                            }),
+                            devices_config: Some(vmservice::DevicesConfig {
+                                nic_config: vec![vmservice::NicConfig {
+                                    nic_id: Guid::new_random().to_string(),
+                                    mac_address: "00-15-5D-12-12-12".to_string(),
+                                    backend: Some(vmservice::nic_config::Backend::Consomme(
+                                        vmservice::ConsommeBackend {
+                                            cidr: String::new(),
+                                        },
+                                    )),
+                                    ..Default::default()
+                                }],
+                                virtio_console: Some(vmservice::VirtioConsoleConfig {
+                                    socket_path: console_path.to_string_lossy().into(),
+                                    connect: false,
+                                }),
+                                ..Default::default()
                             }),
                             ..Default::default()
                         }),
@@ -120,7 +152,14 @@ fn test_ttrpc_interface(
                 .await
                 .unwrap();
 
-            let com1 = UnixStream::connect(&com1_path).unwrap();
+            // Get the serial connection - either by accepting on our listener
+            // (connect: true) or connecting to the VM's socket (connect: false).
+            let com1 = if let Some(listener) = com1_listener {
+                let (stream, _) = listener.accept().unwrap();
+                stream
+            } else {
+                UnixStream::connect(&com1_path).unwrap()
+            };
 
             let _com1_task = driver.spawn(
                 "com1",
@@ -128,6 +167,17 @@ fn test_ttrpc_interface(
                     params.logger.log_file("linux").unwrap(),
                     PolledSocket::new(&driver, com1).unwrap(),
                     "linux com1",
+                ),
+            );
+
+            // Verify the virtio console socket was created and is connectable.
+            let console = UnixStream::connect(&console_path).unwrap();
+            let _console_task = driver.spawn(
+                "console",
+                petri::log_task(
+                    params.logger.log_file("virtio-console").unwrap(),
+                    PolledSocket::new(&driver, console).unwrap(),
+                    "virtio console",
                 ),
             );
 

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -87,6 +87,9 @@ fn test_ttrpc_interface(
             let mut console_path = std::env::temp_dir();
             console_path.push(Guid::new_random().to_string());
 
+            let virtiofs_root = std::env::temp_dir().join(Guid::new_random().to_string());
+            std::fs::create_dir_all(&virtiofs_root).unwrap();
+
             // On iteration 0, test serial `connect: true` by pre-creating a
             // listener that the VM will connect to. On other iterations, test
             // the default `connect: false` (VM creates the socket).
@@ -142,6 +145,10 @@ fn test_ttrpc_interface(
                                     socket_path: console_path.to_string_lossy().into(),
                                     connect: false,
                                 }),
+                                virtiofs_config: vec![vmservice::VirtioFsConfig {
+                                    tag: "testfs".to_string(),
+                                    root_path: virtiofs_root.to_string_lossy().into(),
+                                }],
                                 ..Default::default()
                             }),
                             ..Default::default()


### PR DESCRIPTION
This PR extends the ttrpc VM service interface with three new capabilities:
1. Virtio console device backed by UDS or named pipe
2. Consommé NIC backend
3. Adds a connect option for serial and virtio console devices so that openvmm can connect to a pre-existing socket/pipe as a client

These new capabilities are utilized by a new workstream/proof-of-concept work to use OpenVMM as the VMM backend for WSLC.