### PR TITLE
CI: Switch from powershell to pwsh

### DIFF
--- a/hyperv/tools/hypestv/src/windows/hyperv.rs
+++ b/hyperv/tools/hypestv/src/windows/hyperv.rs
@@ -45,7 +45,7 @@ pub fn hvc_output(
 }
 
 pub fn powershell_script(script: &str, args: &[&str]) -> anyhow::Result<String> {
-    let mut cmd = std::process::Command::new("powershell.exe");
+    let mut cmd = std::process::Command::new("pwsh.exe");
     cmd.arg("-NoProfile")
         .arg("-Command")
         .arg(format!("&{{{script}}}"))

--- a/support/powershell_builder/src/lib.rs
+++ b/support/powershell_builder/src/lib.rs
@@ -21,7 +21,7 @@ pub struct PowerShellBuilder(Command);
 impl PowerShellBuilder {
     /// Create a new PowerShell command
     pub fn new() -> Self {
-        PowerShellCmdletBuilder(Command::new("powershell.exe"))
+        PowerShellCmdletBuilder(Command::new("pwsh.exe"))
             .flag("NoProfile")
             .finish()
     }


### PR DESCRIPTION
We've been seeing a lot of test flakiness lately that seems to be coming from powershell itself crashing during startup, not any of our code. Claude seems to think that switching to the newer pwsh should fix it. Let's see what happens.

Alternative to #3457