### PR TITLE
virtiofs: fix readdir panic on Linux hosts for '.' and '..' entries

### DIFF
--- a/vm/devices/virtio/virtiofs/src/file.rs
+++ b/vm/devices/virtio/virtiofs/src/file.rs
@@ -118,9 +118,11 @@ impl VirtioFsFile {
 
                 Ok(buffer.dir_entry_plus(&entry.name, entry.offset as u64, fuse_entry))
             } else {
-                // Windows doesn't report the inode number for . and .., so just use the current file's
-                // inode number for that.
-                let inode_nr = if entry.inode_nr == 0 {
+                // Use the current file's inode number for . and .. entries.
+                // On Windows inode_nr is 0 for these; on Linux it may be
+                // non-zero, so check by name rather than relying on the
+                // inode number to identify them.
+                let inode_nr = if entry.name == "." || entry.name == ".." {
                     self_inode_nr
                 } else {
                     if get_child_fuse_entry()?.is_none() {


### PR DESCRIPTION
## Bug

`VirtioFsFile::read_dir` panics when serving `FUSE_READDIR` (non-plus) from a Linux host:

```
thread 'basic_device_thread' panicked at vm/devices/virtio/virtiofs/src/inode.rs:283:9:
child name is '.' or '..'
```

## Cause

The non-plus branch identified `.` and `..` entries by checking `entry.inode_nr == 0`. That is a Windows-specific heuristic — on Windows the host enumerator skips `.`/`..` and they are synthesized by lxutil with `inode_nr = 0`. On Linux `getdents` returns `.`/`..` with real inode numbers, so they fell through to `lookup_helper` → `child_path(".")` which asserts.

## Fix

Identify `.`/`..` by name, matching what the readdirplus branch in the same function already does.

## Testing

Reproduced on a Linux host with `--virtio-fs` exposing a directory to an Alpine guest, mounted with `mount -t virtiofs`. To force the non-plus path (Linux's FUSE driver prefers `READDIRPLUS` adaptively), temporarily disabled the `FUSE_DO_READDIRPLUS` negotiation. `find` on the mount panicked before the fix and succeeded after.