### PR TITLE
Add ACS support to PCI emulation

### DIFF
--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -144,6 +144,32 @@ attached to a root port to appear as PCIe devices in the guest.
 --pcie-root-complex rc0 --pcie-root-port rc0:rp0
 ```
 
+### Root port and switch options
+
+`--pcie-root-port` accepts optional comma-separated options after the port
+name:
+
+```sh
+--pcie-root-port rc0:rp0,hotplug,acs=0x005f
+```
+
+- `hotplug`: enables hotplug support for that root port.
+- `acs=<mask>`: sets the Access Control Services capability mask for the
+  root port. The value can be decimal or hexadecimal. Default is `0x005f`.
+  Use `acs=0` to disable ACS for a root port.
+
+`--pcie-switch` accepts optional comma-separated options as well:
+
+```sh
+--pcie-switch rp0:switch0,num_downstream_ports=4,acs=0x005f
+```
+
+- `num_downstream_ports=<N>`: number of downstream ports for the switch.
+- `hotplug`: enables hotplug support on all downstream switch ports.
+- `acs=<mask>`: ACS capability mask requested for downstream switch ports.
+  The upstream switch port does not expose ACS. Default is `0x005f`.
+  Use `acs=0` to disable ACS for switch downstream ports.
+
 ### Attaching devices to PCIe
 
 Several device types support the `pcie_port=<name>` option to attach to a

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -77,6 +77,8 @@ use pal_async::local::block_with_io;
 use pal_async::task::Spawn;
 use pal_async::task::Task;
 use pci_core::PciInterruptPin;
+use pci_core::spec::caps::acs::DEFAULT_ACS_CAP_MASK;
+use pcie::PciePortSettings;
 use pcie::root::GenericPcieRootComplex;
 use pcie::root::GenericPcieRootPortDefinition;
 use pcie::switch::GenericPcieSwitch;
@@ -1800,6 +1802,11 @@ impl InitializedVm {
                                 .map(|rp_cfg| GenericPcieRootPortDefinition {
                                     name: rp_cfg.name.into(),
                                     hotplug: rp_cfg.hotplug,
+                                    settings: PciePortSettings {
+                                        acs_capabilities_supported: rp_cfg
+                                            .acs_capabilities_supported
+                                            .unwrap_or(DEFAULT_ACS_CAP_MASK),
+                                    },
                                 })
                                 .collect();
 
@@ -1917,6 +1924,11 @@ impl InitializedVm {
                         downstream_port_count: switch.num_downstream_ports,
                         hotplug: switch.hotplug,
                         msi_target,
+                        dsp_settings: PciePortSettings {
+                            acs_capabilities_supported: switch
+                                .acs_capabilities_supported
+                                .unwrap_or(DEFAULT_ACS_CAP_MASK),
+                        },
                     };
                     GenericPcieSwitch::new(definition)
                 })?;

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -233,6 +233,7 @@ pub struct PcieRootComplexConfig {
 pub struct PcieRootPortConfig {
     pub name: String,
     pub hotplug: bool,
+    pub acs_capabilities_supported: Option<u16>,
 }
 
 #[derive(Debug, MeshPayload)]
@@ -241,6 +242,7 @@ pub struct PcieSwitchConfig {
     pub num_downstream_ports: u8,
     pub parent_port: String,
     pub hotplug: bool,
+    pub acs_capabilities_supported: Option<u16>,
 }
 
 #[derive(Debug, MeshPayload)]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -826,10 +826,11 @@ Examples:
     # Attach root port rc0rp1 to root complex rc0 with hotplug support
     --pcie-root-port rc0:rc0rp1,hotplug
 
-Syntax: <root_complex_name>:<name>[,hotplug]
+Syntax: <root_complex_name>:<name>[,opt,opt=arg,...]
 
 Options:
     `hotplug`                      enable hotplug support for this root port
+    `acs=<mask>`                   ACS capability bitmask (u16, decimal or 0x-prefixed hex)
 "#)]
     #[clap(long, conflicts_with("pcat"))]
     pub pcie_root_port: Vec<PcieRootPortCli>,
@@ -862,6 +863,7 @@ Syntax: <port_name>:<name>[,opt,opt=arg,...]
 Options:
     `hotplug`                       enable hotplug support for all downstream switch ports
     `num_downstream_ports=<value>`  number of downstream ports, default 4
+    `acs=<mask>`                    ACS capability bitmask for downstream switch ports
 "#)]
     #[clap(long, conflicts_with("pcat"))]
     pub pcie_switch: Vec<GenericPcieSwitchCli>,
@@ -1111,6 +1113,17 @@ fn parse_memory(s: &str) -> anyhow::Result<u64> {
             n.checked_mul(multi.unwrap_or(1))
         }()
         .with_context(|| format!("invalid memory size '{0}'", s))
+    }
+}
+
+fn parse_acs_capability_mask(value: &str) -> anyhow::Result<u16> {
+    if let Some(hex) = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+    {
+        u16::from_str_radix(hex, 16).context("invalid ACS capability mask")
+    } else {
+        value.parse::<u16>().context("invalid ACS capability mask")
     }
 }
 
@@ -2216,6 +2229,7 @@ pub struct PcieRootPortCli {
     pub root_complex_name: String,
     pub name: String,
     pub hotplug: bool,
+    pub acs_capabilities_supported: Option<u16>,
 }
 
 impl FromStr for PcieRootPortCli {
@@ -2237,11 +2251,28 @@ impl FromStr for PcieRootPortCli {
         }
 
         let mut hotplug = false;
+        let mut acs_capabilities_supported = None;
 
         // Parse optional flags
         for opt in opts {
-            match opt {
-                "hotplug" => hotplug = true,
+            let mut kv = opt.split('=');
+            let key = kv.next().context("expected option name")?;
+            let value = kv.next();
+
+            match key {
+                "hotplug" => {
+                    if value.is_some() {
+                        anyhow::bail!("hotplug option does not take a value")
+                    }
+                    hotplug = true;
+                }
+                "acs" => {
+                    let value = value.context("acs option requires a value")?;
+                    if kv.next().is_some() {
+                        anyhow::bail!("acs option expects a single value")
+                    }
+                    acs_capabilities_supported = Some(parse_acs_capability_mask(value)?);
+                }
                 _ => anyhow::bail!("unexpected option: '{opt}'"),
             }
         }
@@ -2250,6 +2281,7 @@ impl FromStr for PcieRootPortCli {
             root_complex_name: rc_name.to_string(),
             name: rp_name.to_string(),
             hotplug,
+            acs_capabilities_supported,
         })
     }
 }
@@ -2260,6 +2292,7 @@ pub struct GenericPcieSwitchCli {
     pub name: String,
     pub num_downstream_ports: u8,
     pub hotplug: bool,
+    pub acs_capabilities_supported: Option<u16>,
 }
 
 impl FromStr for GenericPcieSwitchCli {
@@ -2282,6 +2315,7 @@ impl FromStr for GenericPcieSwitchCli {
 
         let mut num_downstream_ports = 4u8; // Default value
         let mut hotplug = false;
+        let mut acs_capabilities_supported = None;
 
         for opt in opts {
             let mut kv = opt.split('=');
@@ -2301,6 +2335,13 @@ impl FromStr for GenericPcieSwitchCli {
                     }
                     hotplug = true;
                 }
+                "acs" => {
+                    let value = kv.next().context("acs option requires a value")?;
+                    if kv.next().is_some() {
+                        anyhow::bail!("acs option expects a single value")
+                    }
+                    acs_capabilities_supported = Some(parse_acs_capability_mask(value)?);
+                }
                 _ => anyhow::bail!("unknown option: '{key}'"),
             }
         }
@@ -2310,6 +2351,7 @@ impl FromStr for GenericPcieSwitchCli {
             name: switch_name.to_string(),
             num_downstream_ports,
             hotplug,
+            acs_capabilities_supported,
         })
     }
 }
@@ -3439,6 +3481,7 @@ mod tests {
                 root_complex_name: "rc0".to_string(),
                 name: "rc0rp0".to_string(),
                 hotplug: false,
+                acs_capabilities_supported: None,
             }
         );
 
@@ -3448,6 +3491,7 @@ mod tests {
                 root_complex_name: "my_rc".to_string(),
                 name: "port2".to_string(),
                 hotplug: false,
+                acs_capabilities_supported: None,
             }
         );
 
@@ -3458,6 +3502,27 @@ mod tests {
                 root_complex_name: "my_rc".to_string(),
                 name: "port2".to_string(),
                 hotplug: true,
+                acs_capabilities_supported: None,
+            }
+        );
+
+        assert_eq!(
+            PcieRootPortCli::from_str("my_rc:port3,acs=0").unwrap(),
+            PcieRootPortCli {
+                root_complex_name: "my_rc".to_string(),
+                name: "port3".to_string(),
+                hotplug: false,
+                acs_capabilities_supported: Some(0),
+            }
+        );
+
+        assert_eq!(
+            PcieRootPortCli::from_str("my_rc:port3,acs=0x5f").unwrap(),
+            PcieRootPortCli {
+                root_complex_name: "my_rc".to_string(),
+                name: "port3".to_string(),
+                hotplug: false,
+                acs_capabilities_supported: Some(0x005f),
             }
         );
 
@@ -3478,6 +3543,7 @@ mod tests {
                 name: "switch0".to_string(),
                 num_downstream_ports: 4,
                 hotplug: false,
+                acs_capabilities_supported: None,
             }
         );
 
@@ -3488,6 +3554,7 @@ mod tests {
                 name: "my_switch".to_string(),
                 num_downstream_ports: 4,
                 hotplug: false,
+                acs_capabilities_supported: None,
             }
         );
 
@@ -3498,6 +3565,7 @@ mod tests {
                 name: "sw".to_string(),
                 num_downstream_ports: 8,
                 hotplug: false,
+                acs_capabilities_supported: None,
             }
         );
 
@@ -3509,6 +3577,7 @@ mod tests {
                 name: "child_switch".to_string(),
                 num_downstream_ports: 4,
                 hotplug: false,
+                acs_capabilities_supported: None,
             }
         );
 
@@ -3520,6 +3589,7 @@ mod tests {
                 name: "switch0".to_string(),
                 num_downstream_ports: 4,
                 hotplug: true,
+                acs_capabilities_supported: None,
             }
         );
 
@@ -3531,6 +3601,29 @@ mod tests {
                 name: "switch0".to_string(),
                 num_downstream_ports: 8,
                 hotplug: true,
+                acs_capabilities_supported: None,
+            }
+        );
+
+        assert_eq!(
+            GenericPcieSwitchCli::from_str("rp0:switch0,acs=0").unwrap(),
+            GenericPcieSwitchCli {
+                port_name: "rp0".to_string(),
+                name: "switch0".to_string(),
+                num_downstream_ports: 4,
+                hotplug: false,
+                acs_capabilities_supported: Some(0),
+            }
+        );
+
+        assert_eq!(
+            GenericPcieSwitchCli::from_str("rp0:switch0,acs=95").unwrap(),
+            GenericPcieSwitchCli {
+                port_name: "rp0".to_string(),
+                name: "switch0".to_string(),
+                num_downstream_ports: 4,
+                hotplug: false,
+                acs_capabilities_supported: Some(95),
             }
         );
 

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -222,6 +222,7 @@ fn build_switch_list(all_switches: &[cli_args::GenericPcieSwitchCli]) -> Vec<Pci
             num_downstream_ports: switch_cli.num_downstream_ports,
             parent_port: switch_cli.port_name.clone(),
             hotplug: switch_cli.hotplug,
+            acs_capabilities_supported: switch_cli.acs_capabilities_supported,
         })
         .collect()
 }
@@ -753,6 +754,7 @@ async fn vm_config_from_command_line(
             .map(|port_cli| PcieRootPortConfig {
                 name: port_cli.name.clone(),
                 hotplug: port_cli.hotplug,
+                acs_capabilities_supported: port_cli.acs_capabilities_supported,
             })
             .collect();
 

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -288,6 +288,7 @@ impl PetriVmConfigOpenVmm {
                     .map(|i| PcieRootPortConfig {
                         name: format!("s{}rc{}rp{}", segment, rc_index_in_segment, i),
                         hotplug: true,
+                        acs_capabilities_supported: Some(0),
                     })
                     .collect();
 
@@ -321,6 +322,7 @@ impl PetriVmConfigOpenVmm {
             num_downstream_ports: port_count,
             parent_port: port_name.to_string(),
             hotplug,
+            acs_capabilities_supported: Some(0),
         });
         self
     }

--- a/vm/devices/chipset_legacy/src/i440bx_host_pci_bridge.rs
+++ b/vm/devices/chipset_legacy/src/i440bx_host_pci_bridge.rs
@@ -94,6 +94,7 @@ impl HostPciBridge {
                 type0_sub_system_id: 0,
             },
             Vec::new(),
+            Vec::new(),
             DeviceBars::new(),
         );
 

--- a/vm/devices/chipset_legacy/src/piix4_pci_isa_bridge/mod.rs
+++ b/vm/devices/chipset_legacy/src/piix4_pci_isa_bridge/mod.rs
@@ -92,6 +92,7 @@ impl PciIsaBridge {
                 type0_sub_system_id: 0,
             },
             Vec::new(),
+            Vec::new(),
             DeviceBars::new(),
         )
         .with_multi_function_bit(true);

--- a/vm/devices/chipset_legacy/src/piix4_pm.rs
+++ b/vm/devices/chipset_legacy/src/piix4_pm.rs
@@ -136,6 +136,7 @@ impl Piix4Pm {
                 type0_sub_system_id: 0,
             },
             Vec::new(),
+            Vec::new(),
             DeviceBars::new(),
         );
 

--- a/vm/devices/missing_dev/src/lib.rs
+++ b/vm/devices/missing_dev/src/lib.rs
@@ -187,6 +187,7 @@ impl PciConfigSpace for MissingDev {
                 type0_sub_system_id: 0,
             },
             vec![],
+            vec![],
             pci_core::cfg_space_emu::DeviceBars::new(),
         )
         .read_u32(offset, value)

--- a/vm/devices/net/gdma/src/lib.rs
+++ b/vm/devices/net/gdma/src/lib.rs
@@ -171,6 +171,7 @@ impl GdmaDevice {
         let config = ConfigSpaceType0Emulator::new(
             hardware_ids,
             capabilities,
+            Vec::new(),
             DeviceBars::new()
                 .bar0(8192, BarMemoryKind::Intercept(bar0_mem))
                 .bar4(msix.bar_len(), BarMemoryKind::Intercept(bar2_mem)),

--- a/vm/devices/pci/pci_core/src/capabilities/extended/acs.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/extended/acs.rs
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! PCIe Access Control Services (ACS) extended capability.
+
+use super::PciExtendedCapability;
+use crate::spec::caps::ExtendedCapabilityId;
+use crate::spec::caps::acs::AcsCapabilities;
+use crate::spec::caps::acs::AcsControl;
+use crate::spec::caps::acs::AcsExtendedCapabilityHeader;
+use crate::spec::caps::acs::DEFAULT_ACS_CAP_MASK;
+use inspect::Inspect;
+
+/// PCIe Access Control Services (ACS) extended capability emulator.
+#[derive(Debug, Inspect)]
+pub struct AcsExtendedCapability {
+    capabilities: AcsCapabilities,
+    control: AcsControl,
+}
+
+impl AcsExtendedCapability {
+    /// Creates an ACS capability with the default set of sub-capabilities enabled (SV, TB, RR, CR, UF, DT).
+    pub fn new() -> Self {
+        Self::with_capabilities(DEFAULT_ACS_CAP_MASK)
+    }
+
+    /// Creates an ACS capability with the sub-capabilities indicated by `capability_bits`.
+    pub fn with_capabilities(capability_bits: u16) -> Self {
+        let capabilities = AcsCapabilities::from_bits(capability_bits);
+
+        Self {
+            capabilities,
+            control: AcsControl::new(),
+        }
+    }
+}
+
+impl PciExtendedCapability for AcsExtendedCapability {
+    fn label(&self) -> &str {
+        "acs"
+    }
+
+    fn extended_capability_id(&self) -> u16 {
+        ExtendedCapabilityId::ACS.0
+    }
+
+    fn capability_version(&self) -> u8 {
+        1
+    }
+
+    fn len(&self) -> usize {
+        12
+    }
+
+    fn read_u32(&self, offset: u16) -> u32 {
+        match AcsExtendedCapabilityHeader(offset) {
+            AcsExtendedCapabilityHeader::HEADER => {
+                u32::from(self.extended_capability_id())
+                    | (u32::from(self.capability_version()) << 16)
+            }
+            AcsExtendedCapabilityHeader::CAPS_CONTROL => {
+                self.capabilities.into_bits() as u32 | ((self.control.into_bits() as u32) << 16)
+            }
+            AcsExtendedCapabilityHeader::EGRESS_CONTROL_VECTOR => 0,
+            _ => !0,
+        }
+    }
+
+    fn write_u32(&mut self, offset: u16, val: u32) {
+        // Note that all ACS control only affect the emulated port, and do not reflect
+        // any underlying hardware capabilities.
+        match AcsExtendedCapabilityHeader(offset) {
+            AcsExtendedCapabilityHeader::HEADER => {
+                tracelimit::warn_ratelimited!(
+                    offset,
+                    value = val,
+                    "write to read-only ACS extended capability register"
+                );
+            }
+            AcsExtendedCapabilityHeader::CAPS_CONTROL => {
+                // Control bits are writable only if the matching capability bit is set.
+                self.control =
+                    AcsControl::from_bits(((val >> 16) as u16) & self.capabilities.into_bits());
+            }
+            AcsExtendedCapabilityHeader::EGRESS_CONTROL_VECTOR => {
+                tracelimit::warn_ratelimited!(
+                    offset,
+                    value = val,
+                    "ACS egress control vector writes are currently not supported; dropping write"
+                );
+            }
+            _ => {
+                tracelimit::warn_ratelimited!(
+                    offset,
+                    value = val,
+                    "unexpected ACS extended capability write"
+                );
+            }
+        }
+    }
+
+    fn reset(&mut self) {
+        self.control = AcsControl::new();
+    }
+}
+
+mod save_restore {
+    use super::*;
+    use vmcore::save_restore::RestoreError;
+    use vmcore::save_restore::SaveError;
+    use vmcore::save_restore::SaveRestore;
+
+    mod state {
+        use mesh::payload::Protobuf;
+        use vmcore::save_restore::SavedStateRoot;
+
+        #[derive(Debug, Protobuf, SavedStateRoot)]
+        #[mesh(package = "pci.capabilities.extended.acs")]
+        pub struct SavedState {
+            #[mesh(1)]
+            pub control: u16,
+        }
+    }
+
+    impl SaveRestore for AcsExtendedCapability {
+        type SavedState = state::SavedState;
+
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            Ok(state::SavedState {
+                control: self.control.into_bits(),
+            })
+        }
+
+        fn restore(&mut self, state: Self::SavedState) -> Result<(), RestoreError> {
+            self.control = AcsControl::from_bits(state.control & self.capabilities.into_bits());
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capabilities::extended::assert_extended_header_contract;
+    use vmcore::save_restore::SaveRestore;
+
+    #[test]
+    fn test_acs_defaults() {
+        let cap = AcsExtendedCapability::new();
+
+        assert_eq!(cap.label(), "acs");
+        assert_eq!(cap.extended_capability_id(), ExtendedCapabilityId::ACS.0);
+        assert_eq!(cap.capability_version(), 1);
+        assert_eq!(cap.len(), 12);
+        assert_extended_header_contract(&cap);
+
+        let caps_ctl = cap.read_u32(AcsExtendedCapabilityHeader::CAPS_CONTROL.0);
+        assert_eq!(caps_ctl as u16, DEFAULT_ACS_CAP_MASK);
+        assert_eq!((caps_ctl >> 16) as u16, 0);
+    }
+
+    #[test]
+    fn test_acs_control_write_masks_unsupported_bits() {
+        let mut cap = AcsExtendedCapability::new();
+
+        cap.write_u32(AcsExtendedCapabilityHeader::CAPS_CONTROL.0, 0xffff_0000);
+        let caps_ctl = cap.read_u32(AcsExtendedCapabilityHeader::CAPS_CONTROL.0);
+
+        assert_eq!((caps_ctl >> 16) as u16, DEFAULT_ACS_CAP_MASK);
+    }
+
+    #[test]
+    fn test_acs_reset_clears_control() {
+        let mut cap = AcsExtendedCapability::new();
+
+        cap.write_u32(AcsExtendedCapabilityHeader::CAPS_CONTROL.0, 0xffff_0000);
+        cap.reset();
+
+        let caps_ctl = cap.read_u32(AcsExtendedCapabilityHeader::CAPS_CONTROL.0);
+        assert_eq!((caps_ctl >> 16) as u16, 0);
+    }
+
+    #[test]
+    fn test_acs_save_restore() {
+        let mut cap = AcsExtendedCapability::new();
+        cap.write_u32(AcsExtendedCapabilityHeader::CAPS_CONTROL.0, 0xffff_0000);
+
+        let saved = cap.save().expect("save should succeed");
+
+        cap.reset();
+        assert_eq!(
+            (cap.read_u32(AcsExtendedCapabilityHeader::CAPS_CONTROL.0) >> 16) as u16,
+            0
+        );
+
+        cap.restore(saved).expect("restore should succeed");
+        assert_eq!(
+            (cap.read_u32(AcsExtendedCapabilityHeader::CAPS_CONTROL.0) >> 16) as u16,
+            DEFAULT_ACS_CAP_MASK
+        );
+    }
+}

--- a/vm/devices/pci/pci_core/src/capabilities/extended/mod.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/extended/mod.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! PCIe extended capabilities.
+
+use inspect::Inspect;
+use vmcore::save_restore::ProtobufSaveRestore;
+
+pub mod acs;
+
+/// A generic PCIe extended capability structure.
+pub trait PciExtendedCapability: Send + Sync + Inspect + ProtobufSaveRestore {
+    /// A descriptive label for use in Save/Restore + Inspect output.
+    fn label(&self) -> &str;
+
+    /// Returns the PCIe extended capability ID for this capability.
+    fn extended_capability_id(&self) -> u16;
+
+    /// Returns this extended capability structure version.
+    fn capability_version(&self) -> u8;
+
+    /// Length of the extended capability structure in bytes.
+    ///
+    /// Implementations must satisfy all of the following invariants:
+    /// - Length must be non-zero.
+    /// - Length must be 32-bit aligned (a multiple of 4).
+    /// - When packed into config space by `cfg_space_emu` starting at 0x100,
+    ///   the cumulative size of all extended capabilities must not exceed
+    ///   0x1000.
+    fn len(&self) -> usize;
+
+    /// Read a u32 at the given capability-relative offset.
+    fn read_u32(&self, offset: u16) -> u32;
+
+    /// Write a u32 at the given capability-relative offset.
+    fn write_u32(&mut self, offset: u16, val: u32);
+
+    /// Reset the capability.
+    fn reset(&mut self);
+}
+
+#[cfg(test)]
+pub(crate) fn assert_extended_header_contract(cap: &dyn PciExtendedCapability) {
+    let value = cap.read_u32(0);
+    let expected =
+        u32::from(cap.extended_capability_id()) | (u32::from(cap.capability_version()) << 16);
+
+    // Capability-local header must contain ID+Version only.
+    // Next-pointer bits are injected by cfg_space_emu list traversal.
+    assert_eq!(value & 0x000f_ffff, expected);
+    assert_eq!(value & 0xfff0_0000, 0);
+}

--- a/vm/devices/pci/pci_core/src/capabilities/mod.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/mod.rs
@@ -3,12 +3,14 @@
 
 //! PCI capabilities.
 
+pub use self::extended::PciExtendedCapability;
 pub use self::read_only::ReadOnlyCapability;
 
 use crate::spec::caps::CapabilityId;
 use inspect::Inspect;
 use vmcore::save_restore::ProtobufSaveRestore;
 
+pub mod extended;
 pub mod msi_cap;
 pub mod msix;
 pub mod pci_express;

--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -9,7 +9,8 @@
 use crate::PciInterruptPin;
 use crate::bar_mapping::BarMappings;
 use crate::capabilities::PciCapability;
-use crate::spec::caps::CapabilityId;
+use crate::capabilities::extended::PciExtendedCapability;
+use crate::spec::caps::{COMMON_HEADER_END, CapabilityId, EXT_CAP_END, EXT_CAP_START};
 use crate::spec::cfg_space;
 use crate::spec::hwid::HardwareIds;
 use chipset_device::io::IoError;
@@ -207,6 +208,8 @@ pub struct ConfigSpaceCommonHeaderEmulator<const N: usize> {
     mapped_memory: [Option<BarMemoryKind>; N],
     #[inspect(with = "|x| inspect::iter_by_key(x.iter().map(|cap| (cap.label(), cap)))")]
     capabilities: Vec<Box<dyn PciCapability>>,
+    #[inspect(with = "|x| inspect::iter_by_key(x.iter().map(|cap| (cap.label(), cap)))")]
+    extended_capabilities: Vec<Box<dyn PciExtendedCapability>>,
     intx_interrupt: Option<Arc<IntxInterrupt>>,
 
     // Runtime book-keeping
@@ -225,10 +228,27 @@ pub type ConfigSpaceCommonHeaderEmulatorType1 =
     ConfigSpaceCommonHeaderEmulator<{ header_type_consts::TYPE1_BAR_COUNT }>;
 
 impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
+    fn validated_extended_cap_len_bytes(cap: &dyn PciExtendedCapability) -> usize {
+        let len = cap.len();
+        assert!(
+            len != 0,
+            "extended capability '{}' len() must be non-zero",
+            cap.label()
+        );
+        assert!(
+            len.is_multiple_of(4),
+            "extended capability '{}' len() must be 4-byte aligned, got {}",
+            cap.label(),
+            len
+        );
+        len
+    }
+
     /// Create a new common header emulator
     pub fn new(
         hardware_ids: HardwareIds,
         capabilities: Vec<Box<dyn PciCapability>>,
+        extended_capabilities: Vec<Box<dyn PciExtendedCapability>>,
         bars: DeviceBars,
     ) -> Self {
         let mut bar_masks = {
@@ -263,8 +283,27 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
             mapped_memory[bar_index] = Some(mapped);
         }
 
+        // Validate extended capability packing invariants so next-pointer
+        // traversal remains correct.
+        let mut cap_base = usize::from(EXT_CAP_START);
+        for cap in &extended_capabilities {
+            let len = Self::validated_extended_cap_len_bytes(cap.as_ref());
+
+            cap_base = cap_base
+                .checked_add(len)
+                .expect("extended capability size overflow");
+            assert!(
+                cap_base <= usize::from(EXT_CAP_END),
+                "extended capabilities exceed config space window {:#x}..{:#x} (exclusive end), cap_base={:#x}",
+                EXT_CAP_START,
+                EXT_CAP_END,
+                cap_base
+            );
+        }
+
         Self {
             hardware_ids,
+            extended_capabilities,
             capabilities,
             bar_masks,
             mapped_memory,
@@ -322,6 +361,14 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
             self.capabilities.len()
         );
         for cap in &mut self.capabilities {
+            cap.reset();
+        }
+
+        tracing::info!(
+            "ConfigSpaceCommonHeaderEmulator: resetting {} extended capabilities",
+            self.extended_capabilities.len()
+        );
+        for cap in &mut self.extended_capabilities {
             cap.reset();
         }
 
@@ -501,15 +548,15 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
                 if self.capabilities.is_empty() {
                     0
                 } else {
-                    0x40
+                    COMMON_HEADER_END as u32
                 }
             }
             // Capabilities space - handled by common emulator
-            _ if (0x40..0x100).contains(&offset) => {
+            _ if (COMMON_HEADER_END..EXT_CAP_START).contains(&offset) => {
                 return self.read_capabilities(offset, value);
             }
             // Extended capabilities space - handled by common emulator
-            _ if (0x100..0x1000).contains(&offset) => {
+            _ if (EXT_CAP_START..EXT_CAP_END).contains(&offset) => {
                 return self.read_extended_capabilities(offset, value);
             }
             // Check if this is a BAR read
@@ -563,11 +610,11 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
                 self.state.command = command;
             }
             // Capabilities space - handled by common emulator
-            _ if (0x40..0x100).contains(&offset) => {
+            _ if (COMMON_HEADER_END..EXT_CAP_START).contains(&offset) => {
                 return self.write_capabilities(offset, val);
             }
             // Extended capabilities space - handled by common emulator
-            _ if (0x100..0x1000).contains(&offset) => {
+            _ if (EXT_CAP_START..EXT_CAP_END).contains(&offset) => {
                 return self.write_extended_capabilities(offset, val);
             }
             // Check if this is a BAR write (Type 0: 0x10-0x27, Type 1: 0x10-0x17)
@@ -624,11 +671,11 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
         CommonHeaderResult::Handled
     }
 
-    /// Read from capabilities space. `offset` must be 32-bit aligned and >= 0x40.
+    /// Read from capabilities space. `offset` must be 32-bit aligned and >= COMMON_HEADER_END.
     fn read_capabilities(&self, offset: u16, value: &mut u32) -> CommonHeaderResult {
-        if (0x40..0x100).contains(&offset) {
+        if (COMMON_HEADER_END..EXT_CAP_START).contains(&offset) {
             if let Some((cap_index, cap_offset)) =
-                self.get_capability_index_and_offset(offset - 0x40)
+                self.get_capability_index_and_offset(offset - COMMON_HEADER_END)
             {
                 *value = self.capabilities[cap_index].read_u32(cap_offset);
                 if cap_offset == 0 {
@@ -650,11 +697,11 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
         }
     }
 
-    /// Write to capabilities space. `offset` must be 32-bit aligned and >= 0x40.
+    /// Write to capabilities space. `offset` must be 32-bit aligned and >= COMMON_HEADER_END.
     fn write_capabilities(&mut self, offset: u16, val: u32) -> CommonHeaderResult {
-        if (0x40..0x100).contains(&offset) {
+        if (COMMON_HEADER_END..EXT_CAP_START).contains(&offset) {
             if let Some((cap_index, cap_offset)) =
-                self.get_capability_index_and_offset(offset - 0x40)
+                self.get_capability_index_and_offset(offset - COMMON_HEADER_END)
             {
                 self.capabilities[cap_index].write_u32(cap_offset, val);
                 CommonHeaderResult::Handled
@@ -667,12 +714,32 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
         }
     }
 
-    /// Read from extended capabilities space (0x100-0x1000). `offset` must be 32-bit aligned.
+    /// Read from extended capabilities space (EXT_CAP_START-EXT_CAP_END). `offset` must be 32-bit aligned.
     fn read_extended_capabilities(&self, offset: u16, value: &mut u32) -> CommonHeaderResult {
-        if (0x100..0x1000).contains(&offset) {
+        if (EXT_CAP_START..EXT_CAP_END).contains(&offset) {
             if self.is_pcie_device() {
-                *value = 0xffffffff;
-                CommonHeaderResult::Handled
+                if let Some((cap_index, cap_offset, cap_base)) =
+                    self.get_extended_capability_index_and_offset(offset)
+                {
+                    let mut result = self.extended_capabilities[cap_index].read_u32(cap_offset);
+                    if cap_offset == 0 {
+                        let next = if cap_index < self.extended_capabilities.len() - 1 {
+                            let cap_size = Self::validated_extended_cap_len_bytes(
+                                self.extended_capabilities[cap_index].as_ref(),
+                            ) as u16;
+                            cap_base + cap_size
+                        } else {
+                            0
+                        };
+                        assert!(result & 0xfff0_0000 == 0);
+                        result |= u32::from(next) << 20;
+                    }
+                    *value = result;
+                    CommonHeaderResult::Handled
+                } else {
+                    *value = 0xffffffff;
+                    CommonHeaderResult::Handled
+                }
             } else {
                 tracelimit::warn_ratelimited!(offset, "unhandled extended config space read");
                 CommonHeaderResult::Failed(IoError::InvalidRegister)
@@ -682,11 +749,15 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
         }
     }
 
-    /// Write to extended capabilities space (0x100-0x1000). `offset` must be 32-bit aligned.
+    /// Write to extended capabilities space (EXT_CAP_START-EXT_CAP_END). `offset` must be 32-bit aligned.
     fn write_extended_capabilities(&mut self, offset: u16, val: u32) -> CommonHeaderResult {
-        if (0x100..0x1000).contains(&offset) {
+        if (EXT_CAP_START..EXT_CAP_END).contains(&offset) {
             if self.is_pcie_device() {
-                // For now, just ignore writes to extended config space
+                if let Some((cap_index, cap_offset, _)) =
+                    self.get_extended_capability_index_and_offset(offset)
+                {
+                    self.extended_capabilities[cap_index].write_u32(cap_offset, val);
+                }
                 CommonHeaderResult::Handled
             } else {
                 tracelimit::warn_ratelimited!(
@@ -718,6 +789,28 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
         self.capabilities
             .iter()
             .any(|cap| cap.capability_id() == CapabilityId::PCI_EXPRESS)
+    }
+
+    /// Get extended capability index and offset for a given config offset.
+    fn get_extended_capability_index_and_offset(&self, offset: u16) -> Option<(usize, u16, u16)> {
+        let mut cap_base = EXT_CAP_START;
+        for i in 0..self.extended_capabilities.len() {
+            let cap_size =
+                Self::validated_extended_cap_len_bytes(self.extended_capabilities[i].as_ref())
+                    as u16;
+            if offset < cap_base + cap_size {
+                return Some((i, offset - cap_base, cap_base));
+            }
+            cap_base += cap_size;
+            assert!(
+                cap_base <= EXT_CAP_END,
+                "extended capabilities exceed config space window {:#x}..{:#x} (exclusive end), cap_base={:#x}",
+                EXT_CAP_START,
+                EXT_CAP_END,
+                cap_base
+            );
+        }
+        None
     }
 
     /// Get capability index and offset for a given offset
@@ -869,9 +962,15 @@ impl ConfigSpaceType0Emulator {
     pub fn new(
         hardware_ids: HardwareIds,
         capabilities: Vec<Box<dyn PciCapability>>,
+        extended_capabilities: Vec<Box<dyn PciExtendedCapability>>,
         bars: DeviceBars,
     ) -> Self {
-        let common = ConfigSpaceCommonHeaderEmulator::new(hardware_ids, capabilities, bars);
+        let common = ConfigSpaceCommonHeaderEmulator::new(
+            hardware_ids,
+            capabilities,
+            extended_capabilities,
+            bars,
+        );
 
         Self {
             common,
@@ -974,7 +1073,7 @@ impl ConfigSpaceType0Emulator {
                 self.state.latency_timer = (val >> 16) as u8;
             }
             // all other base regs are noops
-            _ if offset < 0x40 && offset.is_multiple_of(4) => (),
+            _ if offset < COMMON_HEADER_END && offset.is_multiple_of(4) => (),
             _ => {
                 tracelimit::warn_ratelimited!(offset, value = val, "unexpected config space write");
                 return IoResult::Err(IoError::InvalidRegister);
@@ -1104,9 +1203,17 @@ pub struct ConfigSpaceType1Emulator {
 
 impl ConfigSpaceType1Emulator {
     /// Create a new [`ConfigSpaceType1Emulator`]
-    pub fn new(hardware_ids: HardwareIds, capabilities: Vec<Box<dyn PciCapability>>) -> Self {
-        let common =
-            ConfigSpaceCommonHeaderEmulator::new(hardware_ids, capabilities, DeviceBars::new());
+    pub fn new(
+        hardware_ids: HardwareIds,
+        capabilities: Vec<Box<dyn PciCapability>>,
+        extended_capabilities: Vec<Box<dyn PciExtendedCapability>>,
+    ) -> Self {
+        let common = ConfigSpaceCommonHeaderEmulator::new(
+            hardware_ids,
+            capabilities,
+            extended_capabilities,
+            DeviceBars::new(),
+        );
 
         Self {
             common,
@@ -1294,7 +1401,7 @@ impl ConfigSpaceType1Emulator {
                 self.state.bridge_control = (val >> 16) as u16;
             }
             // all other base regs are noops
-            _ if offset < 0x40 && offset.is_multiple_of(4) => (),
+            _ if offset < COMMON_HEADER_END && offset.is_multiple_of(4) => (),
             _ => {
                 tracelimit::warn_ratelimited!(offset, value = val, "unexpected config space write");
                 return IoResult::Err(IoError::InvalidRegister);
@@ -1377,6 +1484,8 @@ mod save_restore {
             pub latency_timer: u8,
             #[mesh(5)]
             pub capabilities: Vec<(String, SavedStateBlob)>,
+            #[mesh(16)]
+            pub extended_capabilities: Vec<(String, SavedStateBlob)>,
 
             // Type 1 specific fields (bridge devices)
             // These fields default to 0 for backward compatibility with old save state
@@ -1431,6 +1540,15 @@ mod save_restore {
                         Ok((id, cap.save()?))
                     })
                     .collect::<Result<_, _>>()?,
+                extended_capabilities: self
+                    .common
+                    .extended_capabilities
+                    .iter_mut()
+                    .map(|cap| {
+                        let id = cap.label().to_owned();
+                        Ok((id, cap.save()?))
+                    })
+                    .collect::<Result<_, _>>()?,
                 // Type 1 specific fields - not used for Type 0
                 subordinate_bus_number: 0,
                 secondary_bus_number: 0,
@@ -1454,6 +1572,7 @@ mod save_restore {
                 interrupt_line,
                 latency_timer,
                 capabilities,
+                extended_capabilities,
                 // Type 1 specific fields - ignored for Type 0
                 subordinate_bus_number: _,
                 secondary_bus_number: _,
@@ -1489,6 +1608,25 @@ mod save_restore {
                 // handful of caps, so it's totally fine.
                 let mut restored = false;
                 for cap in self.common.capabilities_mut() {
+                    if cap.label() == id {
+                        cap.restore(entry)?;
+                        restored = true;
+                        break;
+                    }
+                }
+
+                if !restored {
+                    return Err(RestoreError::InvalidSavedState(
+                        ConfigSpaceRestoreError::InvalidCap(id).into(),
+                    ));
+                }
+            }
+
+            for (id, entry) in extended_capabilities {
+                tracing::debug!(save_id = id.as_str(), "restoring pci extended capability");
+
+                let mut restored = false;
+                for cap in &mut self.common.extended_capabilities {
                     if cap.label() == id {
                         cap.restore(entry)?;
                         restored = true;
@@ -1544,6 +1682,15 @@ mod save_restore {
                         Ok((id, cap.save()?))
                     })
                     .collect::<Result<_, _>>()?,
+                extended_capabilities: self
+                    .common
+                    .extended_capabilities
+                    .iter_mut()
+                    .map(|cap| {
+                        let id = cap.label().to_owned();
+                        Ok((id, cap.save()?))
+                    })
+                    .collect::<Result<_, _>>()?,
                 // Type 1 specific fields
                 subordinate_bus_number,
                 secondary_bus_number,
@@ -1567,6 +1714,7 @@ mod save_restore {
                 interrupt_line,
                 latency_timer: _, // Not used for Type 1
                 capabilities,
+                extended_capabilities,
                 subordinate_bus_number,
                 secondary_bus_number,
                 primary_bus_number,
@@ -1632,6 +1780,25 @@ mod save_restore {
                 }
             }
 
+            for (id, entry) in extended_capabilities {
+                tracing::debug!(save_id = id.as_str(), "restoring pci extended capability");
+
+                let mut restored = false;
+                for cap in &mut self.common.extended_capabilities {
+                    if cap.label() == id {
+                        cap.restore(entry)?;
+                        restored = true;
+                        break;
+                    }
+                }
+
+                if !restored {
+                    return Err(RestoreError::InvalidSavedState(
+                        ConfigSpaceRestoreError::InvalidCap(id).into(),
+                    ));
+                }
+            }
+
             Ok(())
         }
     }
@@ -1640,6 +1807,7 @@ mod save_restore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::capabilities::extended::acs::AcsExtendedCapability;
     use crate::capabilities::pci_express::PciExpressCapability;
     use crate::capabilities::read_only::ReadOnlyCapability;
     use crate::spec::caps::pci_express::DevicePortType;
@@ -1660,6 +1828,7 @@ mod tests {
                 type0_sub_system_id: 0x4444,
             },
             caps,
+            vec![],
             DeviceBars::new(),
         )
     }
@@ -1677,6 +1846,7 @@ mod tests {
                 type0_sub_system_id: 0,
             },
             caps,
+            vec![],
         )
     }
 
@@ -1923,6 +2093,7 @@ mod tests {
                 type0_sub_system_id: 0,
             },
             vec![Box::new(ReadOnlyCapability::new("foo", 0))],
+            vec![],
             DeviceBars::new(),
         );
         assert!(!emu.is_pcie_device());
@@ -1943,6 +2114,7 @@ mod tests {
                 DevicePortType::Endpoint,
                 None,
             ))],
+            vec![],
             DeviceBars::new(),
         );
         assert!(emu.is_pcie_device());
@@ -1964,6 +2136,7 @@ mod tests {
                 Box::new(PciExpressCapability::new(DevicePortType::Endpoint, None)),
                 Box::new(ReadOnlyCapability::new("bar", 0)),
             ],
+            vec![],
             DeviceBars::new(),
         );
         assert!(emu.is_pcie_device());
@@ -1980,6 +2153,7 @@ mod tests {
                 type0_sub_vendor_id: 0,
                 type0_sub_system_id: 0,
             },
+            vec![],
             vec![],
             DeviceBars::new(),
         );
@@ -2013,7 +2187,7 @@ mod tests {
         let bars = DeviceBars::new().bar0(4096, BarMemoryKind::Dummy);
 
         let common_emu: ConfigSpaceCommonHeaderEmulatorType0 =
-            ConfigSpaceCommonHeaderEmulator::new(hardware_ids, vec![], bars);
+            ConfigSpaceCommonHeaderEmulator::new(hardware_ids, vec![], vec![], bars);
 
         assert_eq!(common_emu.hardware_ids().vendor_id, 0x1111);
         assert_eq!(common_emu.hardware_ids().device_id, 0x2222);
@@ -2045,6 +2219,7 @@ mod tests {
                     DevicePortType::RootPort,
                     None,
                 ))],
+                vec![],
                 bars,
             )
             .with_multi_function_bit(true);
@@ -2079,7 +2254,7 @@ mod tests {
         let bars = DeviceBars::new();
 
         let common_emu: ConfigSpaceCommonHeaderEmulatorType0 =
-            ConfigSpaceCommonHeaderEmulator::new(hardware_ids, vec![], bars);
+            ConfigSpaceCommonHeaderEmulator::new(hardware_ids, vec![], vec![], bars);
 
         assert_eq!(common_emu.hardware_ids().vendor_id, 0x5555);
         assert_eq!(common_emu.hardware_ids().device_id, 0x6666);
@@ -2111,7 +2286,7 @@ mod tests {
             .bar4(16384, BarMemoryKind::Dummy);
 
         let common_emu: ConfigSpaceCommonHeaderEmulatorType1 =
-            ConfigSpaceCommonHeaderEmulator::new(hardware_ids, vec![], bars);
+            ConfigSpaceCommonHeaderEmulator::new(hardware_ids, vec![], vec![], bars);
 
         assert_eq!(common_emu.hardware_ids().vendor_id, 0x7777);
         assert_eq!(common_emu.hardware_ids().device_id, 0x8888);
@@ -2140,6 +2315,7 @@ mod tests {
                 type0_sub_system_id: 0,
             },
             vec![Box::new(ReadOnlyCapability::new("foo", 0))],
+            vec![],
             DeviceBars::new(),
         );
         assert!(!common_emu_no_pcie.is_pcie_device());
@@ -2159,6 +2335,7 @@ mod tests {
                 DevicePortType::Endpoint,
                 None,
             ))],
+            vec![],
             DeviceBars::new(),
         );
         assert!(common_emu_pcie.is_pcie_device());
@@ -2166,27 +2343,27 @@ mod tests {
         // Test reading extended capabilities - non-PCIe device should return error
         let mut value = 0;
         assert!(matches!(
-            common_emu_no_pcie.read_extended_capabilities(0x100, &mut value),
+            common_emu_no_pcie.read_extended_capabilities(EXT_CAP_START, &mut value),
             CommonHeaderResult::Failed(IoError::InvalidRegister)
         ));
 
         // Test reading extended capabilities - PCIe device should return 0xffffffff
         let mut value = 0;
         assert!(matches!(
-            common_emu_pcie.read_extended_capabilities(0x100, &mut value),
+            common_emu_pcie.read_extended_capabilities(EXT_CAP_START, &mut value),
             CommonHeaderResult::Handled
         ));
         assert_eq!(value, 0xffffffff);
 
         // Test writing extended capabilities - non-PCIe device should return error
         assert!(matches!(
-            common_emu_no_pcie.write_extended_capabilities(0x100, 0x1234),
+            common_emu_no_pcie.write_extended_capabilities(EXT_CAP_START, 0x1234),
             CommonHeaderResult::Failed(IoError::InvalidRegister)
         ));
 
         // Test writing extended capabilities - PCIe device should accept writes
         assert!(matches!(
-            common_emu_pcie.write_extended_capabilities(0x100, 0x1234),
+            common_emu_pcie.write_extended_capabilities(EXT_CAP_START, 0x1234),
             CommonHeaderResult::Handled
         ));
 
@@ -2197,9 +2374,55 @@ mod tests {
             CommonHeaderResult::Failed(IoError::InvalidRegister)
         ));
         assert!(matches!(
-            common_emu_pcie.read_extended_capabilities(0x1000, &mut value),
+            common_emu_pcie.read_extended_capabilities(EXT_CAP_END, &mut value),
             CommonHeaderResult::Failed(IoError::InvalidRegister)
         ));
+    }
+
+    #[test]
+    fn test_type1_acs_extended_capability() {
+        let mut common_emu_pcie = ConfigSpaceCommonHeaderEmulatorType1::new(
+            HardwareIds {
+                vendor_id: 0x1111,
+                device_id: 0x2222,
+                revision_id: 1,
+                prog_if: ProgrammingInterface::NONE,
+                sub_class: Subclass::BRIDGE_PCI_TO_PCI,
+                base_class: ClassCode::BRIDGE,
+                type0_sub_vendor_id: 0,
+                type0_sub_system_id: 0,
+            },
+            vec![Box::new(PciExpressCapability::new(
+                DevicePortType::RootPort,
+                None,
+            ))],
+            vec![Box::new(AcsExtendedCapability::new())],
+            DeviceBars::new(),
+        );
+
+        let mut value = 0;
+        assert!(matches!(
+            common_emu_pcie.read_extended_capabilities(EXT_CAP_START, &mut value),
+            CommonHeaderResult::Handled
+        ));
+        assert_eq!(value, 0x0001_000d);
+
+        assert!(matches!(
+            common_emu_pcie.read_extended_capabilities(0x104, &mut value),
+            CommonHeaderResult::Handled
+        ));
+        assert_eq!(value as u16, 0x005f);
+        assert_eq!((value >> 16) as u16, 0x0000);
+
+        assert!(matches!(
+            common_emu_pcie.write_extended_capabilities(0x104, 0xffff_0000),
+            CommonHeaderResult::Handled
+        ));
+        assert!(matches!(
+            common_emu_pcie.read_extended_capabilities(0x104, &mut value),
+            CommonHeaderResult::Handled
+        ));
+        assert_eq!((value >> 16) as u16, 0x005f);
     }
 
     #[test]
@@ -2300,6 +2523,46 @@ mod tests {
     }
 
     #[test]
+    fn test_type1_emulator_save_restore_with_extended_capabilities() {
+        use vmcore::save_restore::SaveRestore;
+
+        let mut emu = ConfigSpaceType1Emulator::new(
+            HardwareIds {
+                vendor_id: 0x1111,
+                device_id: 0x2222,
+                revision_id: 1,
+                prog_if: ProgrammingInterface::NONE,
+                sub_class: Subclass::BRIDGE_PCI_TO_PCI,
+                base_class: ClassCode::BRIDGE,
+                type0_sub_vendor_id: 0,
+                type0_sub_system_id: 0,
+            },
+            vec![Box::new(PciExpressCapability::new(
+                DevicePortType::RootPort,
+                None,
+            ))],
+            vec![Box::new(AcsExtendedCapability::new())],
+        );
+
+        // Enable all supported ACS control bits.
+        emu.write_u32(0x104, 0xffff_0000).unwrap();
+
+        let mut value = 0u32;
+        emu.read_u32(0x104, &mut value).unwrap();
+        assert_eq!((value >> 16) as u16, 0x005f);
+
+        let saved_state = emu.save().expect("save should succeed");
+
+        emu.reset();
+        emu.read_u32(0x104, &mut value).unwrap();
+        assert_eq!((value >> 16) as u16, 0);
+
+        emu.restore(saved_state).expect("restore should succeed");
+        emu.read_u32(0x104, &mut value).unwrap();
+        assert_eq!((value >> 16) as u16, 0x005f);
+    }
+
+    #[test]
     fn test_config_space_type1_set_presence_detect_state() {
         // Test that ConfigSpaceType1Emulator can set presence detect state
         // when it has a PCIe Express capability with hotplug support
@@ -2312,7 +2575,7 @@ mod tests {
 
         // Initially, presence detect state should be 0
         let mut slot_status_val = 0u32;
-        let result = emulator.read_u32(0x58, &mut slot_status_val); // 0x40 (cap start) + 0x18 (slot control/status)
+        let result = emulator.read_u32(COMMON_HEADER_END + 0x18, &mut slot_status_val); // COMMON_HEADER_END (cap start) + 0x18 (slot control/status)
         assert!(matches!(result, IoResult::Ok));
         let initial_presence_detect = (slot_status_val >> 22) & 0x1; // presence_detect_state is bit 6 of slot status
         assert_eq!(
@@ -2370,6 +2633,7 @@ mod tests {
                 type0_sub_system_id: 0,
             },
             vec![],
+            vec![],
             DeviceBars::new(),
         );
 
@@ -2405,6 +2669,7 @@ mod tests {
                 type0_sub_vendor_id: 0,
                 type0_sub_system_id: 0,
             },
+            vec![],
             vec![],
             DeviceBars::new(),
         );

--- a/vm/devices/pci/pci_core/src/spec.rs
+++ b/vm/devices/pci/pci_core/src/spec.rs
@@ -441,6 +441,7 @@ pub mod caps {
     }
 
     open_enum::open_enum! {
+
         /// PCIe Extended Capability IDs (offsets 0x100+ in config space).
         ///
         /// Sources: PCI Express Base Specification
@@ -449,6 +450,7 @@ pub mod caps {
         /// variants on an as-needed basis!
         pub enum ExtendedCapabilityId: u16 {
             #![expect(missing_docs)] // self explanatory variants
+            ACS   = 0x0D,
             ARI   = 0x0E,
             SRIOV = 0x10,
             REBAR = 0x15,
@@ -457,6 +459,10 @@ pub mod caps {
 
     /// Starting offset of the PCIe extended capability region in config space.
     pub const EXT_CAP_START: u16 = 0x100;
+    /// Ending offset (exclusive) of the PCIe extended capability region in config space.
+    pub const EXT_CAP_END: u16 = 0x1000;
+    /// Ending offset (exclusive) of the common config header region.
+    pub const COMMON_HEADER_END: u16 = 0x40;
 
     /// MSI
     #[expect(missing_docs)] // primarily enums/structs with self-explanatory variants
@@ -1100,6 +1106,66 @@ pub mod caps {
         #[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
         pub struct SlotStatus2 {
             #[bits(16)]
+            _reserved: u16,
+        }
+    }
+
+    /// Access Control Services (ACS) extended capability
+    #[expect(missing_docs)] // primarily enums/structs with self-explanatory variants
+    pub mod acs {
+        use bitfield_struct::bitfield;
+        use inspect::Inspect;
+        use zerocopy::FromBytes;
+        use zerocopy::Immutable;
+        use zerocopy::IntoBytes;
+        use zerocopy::KnownLayout;
+
+        /// Default ACS capability mask: SV, TB, RR, CR, UF, DT (no egress control vector).
+        pub const DEFAULT_ACS_CAP_MASK: u16 = 0x005f;
+
+        open_enum::open_enum! {
+            /// Offsets into the ACS Extended Capability structure.
+            ///
+            /// | Offset    | Bits 31-16                | Bits 15-0               |
+            /// |-----------|---------------------------|-------------------------|
+            /// | Ext + 0x0 | Next Cap Ptr + Version    | Extended Capability ID  |
+            /// | Ext + 0x4 | ACS Control Register      | ACS Capability Register |
+            /// | Ext + 0x8 | Egress Control Vector (DWORD 0, if required)        |
+            /// | Ext + 0xC | Egress Control Vector (additional DWORDs, optional) |
+            pub enum AcsExtendedCapabilityHeader: u16 {
+                HEADER = 0x00,
+                CAPS_CONTROL = 0x04,
+                EGRESS_CONTROL_VECTOR = 0x08,
+            }
+        }
+
+        /// Access Control Services Capability register.
+        #[bitfield(u16)]
+        #[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
+        pub struct AcsCapabilities {
+            pub source_validation: bool,
+            pub translation_blocking: bool,
+            pub p2p_request_redirect: bool,
+            pub p2p_completion_redirect: bool,
+            pub upstream_forwarding: bool,
+            pub p2p_egress_control: bool,
+            pub direct_translated_p2p: bool,
+            #[bits(9)]
+            _reserved: u16,
+        }
+
+        /// Access Control Services Control register.
+        #[bitfield(u16)]
+        #[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
+        pub struct AcsControl {
+            pub source_validation_enable: bool,
+            pub translation_blocking_enable: bool,
+            pub p2p_request_redirect_enable: bool,
+            pub p2p_completion_redirect_enable: bool,
+            pub upstream_forwarding_enable: bool,
+            pub p2p_egress_control_enable: bool,
+            pub direct_translated_p2p_enable: bool,
+            #[bits(9)]
             _reserved: u16,
         }
     }

--- a/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
+++ b/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
@@ -13,7 +13,11 @@ use chipset_device::mmio::MmioIntercept;
 use chipset_device::pci::PciConfigSpace;
 use memory_range::MemoryRange;
 use pci_bus::GenericPciBusDevice;
+<<<<<<< HEAD
 use pci_core::msi::MsiTarget;
+=======
+use pcie::PciePortSettings;
+>>>>>>> d2facfb1 (Add ACS capability)
 use pcie::root::GenericPcieRootComplex;
 use pcie::root::GenericPcieRootPortDefinition;
 use pcie::switch::GenericPcieSwitch;
@@ -123,6 +127,7 @@ impl FuzzRootComplex {
             .map(|i| GenericPcieRootPortDefinition {
                 name: format!("rp{}", i).into(),
                 hotplug,
+                settings: PciePortSettings::default(),
             })
             .collect();
         let msi_conn =
@@ -282,7 +287,11 @@ fn do_fuzz(u: &mut Unstructured<'_>) -> arbitrary::Result<()> {
                 name: "sw0".into(),
                 downstream_port_count: 2,
                 hotplug: false,
+<<<<<<< HEAD
                 msi_target: MsiTarget::disconnected(),
+=======
+                dsp_settings: PciePortSettings::default(),
+>>>>>>> d2facfb1 (Add ACS capability)
             });
             rc.add_pcie_device(port0_key, "sw0", Box::new(SwitchAdapter(switch)))
                 .map_err(|_| arbitrary::Error::IncorrectFormat)?;

--- a/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
+++ b/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
@@ -13,11 +13,8 @@ use chipset_device::mmio::MmioIntercept;
 use chipset_device::pci::PciConfigSpace;
 use memory_range::MemoryRange;
 use pci_bus::GenericPciBusDevice;
-<<<<<<< HEAD
 use pci_core::msi::MsiTarget;
-=======
 use pcie::PciePortSettings;
->>>>>>> d2facfb1 (Add ACS capability)
 use pcie::root::GenericPcieRootComplex;
 use pcie::root::GenericPcieRootPortDefinition;
 use pcie::switch::GenericPcieSwitch;
@@ -287,11 +284,8 @@ fn do_fuzz(u: &mut Unstructured<'_>) -> arbitrary::Result<()> {
                 name: "sw0".into(),
                 downstream_port_count: 2,
                 hotplug: false,
-<<<<<<< HEAD
                 msi_target: MsiTarget::disconnected(),
-=======
                 dsp_settings: PciePortSettings::default(),
->>>>>>> d2facfb1 (Add ACS capability)
             });
             rc.add_pcie_device(port0_key, "sw0", Box::new(SwitchAdapter(switch)))
                 .map_err(|_| arbitrary::Error::IncorrectFormat)?;

--- a/vm/devices/pci/pcie/src/lib.rs
+++ b/vm/devices/pci/pcie/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod its;
 pub(crate) mod port;
+pub use port::PciePortSettings;
 pub mod root;
 pub mod switch;
 

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -73,16 +73,16 @@ impl PcieDownstreamPort {
     /// * `port_type` - The PCIe port type (root port, downstream switch port, etc.)
     /// * `multi_function` - Whether this port should have the multi-function flag set
     /// * `hotplug_slot_number` - The slot number for hotplug support. `Some(slot_number)` enables hotplug, `None` disables it
-    /// * `settings` - Express-level port settings (ACS, etc.)
     /// * `msi_target` - MSI target for interrupt delivery
+    /// * `settings` - Express-level port settings (ACS, etc.)
     pub fn new(
         name: impl Into<String>,
         hardware_ids: HardwareIds,
         port_type: DevicePortType,
         multi_function: bool,
         hotplug_slot_number: Option<u32>,
-        settings: PciePortSettings,
         msi_target: &MsiTarget,
+        settings: PciePortSettings,
     ) -> Self {
         let port_name = name.into();
 
@@ -435,8 +435,8 @@ mod tests {
             DevicePortType::RootPort,
             false,
             Some(1), // Enable hotplug with slot number 1
-            PciePortSettings::default(),
             msi_conn.target(),
+            PciePortSettings::default(),
         );
 
         // Initially, presence detect state should be 0
@@ -487,8 +487,8 @@ mod tests {
             DevicePortType::RootPort,
             false,
             None, // No hotplug
-            PciePortSettings::default(),
             msi_conn.target(),
+            PciePortSettings::default(),
         );
 
         // Add a device to the port (should not panic even without hotplug support)
@@ -522,8 +522,8 @@ mod tests {
             DevicePortType::RootPort,
             false,
             None,
-            PciePortSettings::default(),
             &msi_target,
+            PciePortSettings::default(),
         );
 
         port.cfg_space
@@ -578,8 +578,8 @@ mod tests {
             DevicePortType::RootPort,
             false,
             None,
-            PciePortSettings::default(),
             msi_conn.target(),
+            PciePortSettings::default(),
         );
 
         port.cfg_space
@@ -637,8 +637,8 @@ mod tests {
             DevicePortType::RootPort,
             false,
             None,
-            PciePortSettings::default(),
             msi_conn.target(),
+            PciePortSettings::default(),
         );
 
         // Program bridge bus numbers (Type1 register at offset 0x18).
@@ -700,10 +700,10 @@ mod tests {
             DevicePortType::RootPort,
             false,
             None,
+            &msi_target,
             PciePortSettings {
                 acs_capabilities_supported: 0x005f,
             },
-            &msi_target,
         );
         let mut value = 0u32;
         with_acs.cfg_space.read_u32(0x100, &mut value).unwrap();
@@ -715,8 +715,8 @@ mod tests {
             DevicePortType::RootPort,
             false,
             None,
-            PciePortSettings::default(),
             &msi_target,
+            PciePortSettings::default(),
         );
         without_acs.cfg_space.read_u32(0x100, &mut value).unwrap();
         assert_eq!(value, 0xffff_ffff);

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -8,6 +8,7 @@ use chipset_device::io::IoResult;
 use inspect::Inspect;
 use pci_bus::GenericPciBusDevice;
 use pci_core::bus_range::AssignedBusRange;
+use pci_core::capabilities::extended::acs::AcsExtendedCapability;
 use pci_core::capabilities::msi_cap::MsiCapability;
 use pci_core::capabilities::pci_express::PciExpressCapability;
 use pci_core::cfg_space_emu::ConfigSpaceType1Emulator;
@@ -15,6 +16,36 @@ use pci_core::msi::MsiTarget;
 use pci_core::spec::caps::pci_express::DevicePortType;
 use pci_core::spec::hwid::HardwareIds;
 use std::sync::Arc;
+
+const ACS_CAPABILITY_IMPLEMENTED_MASK: u16 = 0x00df;
+const ACS_CAPABILITY_ALLOWED_ROOT_OR_DSP_MASK: u16 = 0x00ff;
+const ACS_CAPABILITY_ALLOWED_USP_MASK: u16 = 0x0000;
+
+/// Express-level settings for a PCIe port.
+///
+/// Collects feature flags that apply uniformly to a port so that adding new
+/// capabilities does not require changing every constructor signature.
+#[derive(Debug, Default, Clone)]
+pub struct PciePortSettings {
+    /// ACS capability bits to advertise on this port. `0` means the ACS
+    /// extended capability is not present.
+    pub acs_capabilities_supported: u16,
+}
+
+pub(crate) fn filter_acs_capabilities_for_bridge(
+    port_type: &DevicePortType,
+    requested: u16,
+) -> u16 {
+    let type_mask = match port_type {
+        DevicePortType::RootPort | DevicePortType::DownstreamSwitchPort => {
+            ACS_CAPABILITY_ALLOWED_ROOT_OR_DSP_MASK
+        }
+        DevicePortType::UpstreamSwitchPort => ACS_CAPABILITY_ALLOWED_USP_MASK,
+        DevicePortType::Endpoint => 0,
+    };
+
+    requested & ACS_CAPABILITY_IMPLEMENTED_MASK & type_mask
+}
 
 /// A common PCIe downstream facing port implementation that handles device connections and configuration forwarding.
 ///
@@ -42,6 +73,7 @@ impl PcieDownstreamPort {
     /// * `port_type` - The PCIe port type (root port, downstream switch port, etc.)
     /// * `multi_function` - Whether this port should have the multi-function flag set
     /// * `hotplug_slot_number` - The slot number for hotplug support. `Some(slot_number)` enables hotplug, `None` disables it
+    /// * `settings` - Express-level port settings (ACS, etc.)
     /// * `msi_target` - MSI target for interrupt delivery
     pub fn new(
         name: impl Into<String>,
@@ -49,6 +81,7 @@ impl PcieDownstreamPort {
         port_type: DevicePortType,
         multi_function: bool,
         hotplug_slot_number: Option<u32>,
+        settings: PciePortSettings,
         msi_target: &MsiTarget,
     ) -> Self {
         let port_name = name.into();
@@ -59,6 +92,8 @@ impl PcieDownstreamPort {
         };
 
         let msi_capability = MsiCapability::new(0, true, false, msi_target);
+        let acs_supported =
+            filter_acs_capabilities_for_bridge(&port_type, settings.acs_capabilities_supported);
 
         let pcie_cap = if hotplug {
             let slot_num = slot_number.unwrap_or(0);
@@ -67,9 +102,16 @@ impl PcieDownstreamPort {
             PciExpressCapability::new(port_type, None)
         };
 
+        let extended_capabilities = if acs_supported != 0 {
+            vec![Box::new(AcsExtendedCapability::with_capabilities(acs_supported)) as _]
+        } else {
+            vec![]
+        };
+
         let cfg_space = ConfigSpaceType1Emulator::new(
             hardware_ids,
             vec![Box::new(pcie_cap), Box::new(msi_capability)],
+            extended_capabilities,
         )
         .with_multi_function_bit(multi_function);
 
@@ -393,6 +435,7 @@ mod tests {
             DevicePortType::RootPort,
             false,
             Some(1), // Enable hotplug with slot number 1
+            PciePortSettings::default(),
             msi_conn.target(),
         );
 
@@ -444,6 +487,7 @@ mod tests {
             DevicePortType::RootPort,
             false,
             None, // No hotplug
+            PciePortSettings::default(),
             msi_conn.target(),
         );
 
@@ -471,14 +515,15 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_target = MsiTarget::disconnected();
         let mut port = PcieDownstreamPort::new(
             "test-port",
             hardware_ids,
             DevicePortType::RootPort,
             false,
             None,
-            msi_conn.target(),
+            PciePortSettings::default(),
+            &msi_target,
         );
 
         port.cfg_space
@@ -533,6 +578,7 @@ mod tests {
             DevicePortType::RootPort,
             false,
             None,
+            PciePortSettings::default(),
             msi_conn.target(),
         );
 
@@ -566,5 +612,113 @@ mod tests {
             stats.forward_writes,
             vec![(1, 0, 0x10, 0xAAAA_0000), (1, 2, 0x14, 0xBBBB_0000)]
         );
+    }
+
+    #[test]
+    fn test_port_cfg_space_save_restore() {
+        use pci_core::spec::hwid::{ClassCode, ProgrammingInterface, Subclass};
+        use vmcore::save_restore::SaveRestore;
+
+        let hardware_ids = HardwareIds {
+            vendor_id: 0x1234,
+            device_id: 0x5678,
+            revision_id: 0,
+            prog_if: ProgrammingInterface::NONE,
+            sub_class: Subclass::BRIDGE_PCI_TO_PCI,
+            base_class: ClassCode::BRIDGE,
+            type0_sub_vendor_id: 0,
+            type0_sub_system_id: 0,
+        };
+
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+        let mut port = PcieDownstreamPort::new(
+            "test-port",
+            hardware_ids,
+            DevicePortType::RootPort,
+            false,
+            None,
+            PciePortSettings::default(),
+            msi_conn.target(),
+        );
+
+        // Program bridge bus numbers (Type1 register at offset 0x18).
+        port.cfg_space.write_u32(0x18, 0x0012_1000).unwrap();
+        assert_eq!(port.cfg_space.assigned_bus_range(), 0x10..=0x12);
+
+        let saved = port.cfg_space.save().expect("save should succeed");
+
+        // Change state away from saved values.
+        port.cfg_space.write_u32(0x18, 0x0000_0000).unwrap();
+        assert_eq!(port.cfg_space.assigned_bus_range(), 0..=0);
+
+        port.cfg_space
+            .restore(saved)
+            .expect("restore should succeed");
+        assert_eq!(port.cfg_space.assigned_bus_range(), 0x10..=0x12);
+    }
+
+    #[test]
+    fn test_filter_acs_capabilities_for_bridge_type() {
+        assert_eq!(
+            filter_acs_capabilities_for_bridge(&DevicePortType::RootPort, 0x00ff),
+            0x00df
+        );
+        assert_eq!(
+            filter_acs_capabilities_for_bridge(&DevicePortType::DownstreamSwitchPort, 0x00ff),
+            0x00df
+        );
+        assert_eq!(
+            filter_acs_capabilities_for_bridge(&DevicePortType::UpstreamSwitchPort, 0x00ff),
+            0
+        );
+        assert_eq!(
+            filter_acs_capabilities_for_bridge(&DevicePortType::Endpoint, 0x00ff),
+            0
+        );
+    }
+
+    #[test]
+    fn test_root_port_adds_acs_only_when_non_zero() {
+        use pci_core::spec::caps::ExtendedCapabilityId;
+        use pci_core::spec::hwid::{ClassCode, ProgrammingInterface, Subclass};
+
+        let hardware_ids = HardwareIds {
+            vendor_id: 0x1234,
+            device_id: 0x5678,
+            revision_id: 0,
+            prog_if: ProgrammingInterface::NONE,
+            sub_class: Subclass::BRIDGE_PCI_TO_PCI,
+            base_class: ClassCode::BRIDGE,
+            type0_sub_vendor_id: 0,
+            type0_sub_system_id: 0,
+        };
+
+        let msi_target = MsiTarget::disconnected();
+        let with_acs = PcieDownstreamPort::new(
+            "with-acs",
+            hardware_ids,
+            DevicePortType::RootPort,
+            false,
+            None,
+            PciePortSettings {
+                acs_capabilities_supported: 0x005f,
+            },
+            &msi_target,
+        );
+        let mut value = 0u32;
+        with_acs.cfg_space.read_u32(0x100, &mut value).unwrap();
+        assert_eq!(value & 0xffff, ExtendedCapabilityId::ACS.0 as u32);
+
+        let without_acs = PcieDownstreamPort::new(
+            "without-acs",
+            hardware_ids,
+            DevicePortType::RootPort,
+            false,
+            None,
+            PciePortSettings::default(),
+            &msi_target,
+        );
+        without_acs.cfg_space.read_u32(0x100, &mut value).unwrap();
+        assert_eq!(value, 0xffff_ffff);
     }
 }

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -13,6 +13,7 @@ use crate::PAGE_SIZE64;
 use crate::ROOT_PORT_DEVICE_ID;
 use crate::VENDOR_ID;
 use crate::port::PcieDownstreamPort;
+use crate::port::PciePortSettings;
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
@@ -66,6 +67,8 @@ pub struct GenericPcieRootPortDefinition {
     pub name: Arc<str>,
     /// Whether hotplug is enabled for this root port.
     pub hotplug: bool,
+    /// Express-level port settings (ACS, etc.).
+    pub settings: PciePortSettings,
 }
 
 /// A flat description of a PCIe switch without hierarchy.
@@ -78,6 +81,8 @@ pub struct GenericSwitchDefinition {
     pub parent_port: Arc<str>,
     /// Whether hotplug is enabled for this switch.
     pub hotplug: bool,
+    /// Express-level settings for downstream switch ports.
+    pub dsp_settings: PciePortSettings,
 }
 
 impl GenericSwitchDefinition {
@@ -87,12 +92,14 @@ impl GenericSwitchDefinition {
         num_downstream_ports: u8,
         parent_port: impl Into<Arc<str>>,
         hotplug: bool,
+        dsp_settings: PciePortSettings,
     ) -> Self {
         Self {
             name: name.into(),
             num_downstream_ports,
             parent_port: parent_port.into(),
             hotplug,
+            dsp_settings,
         }
     }
 }
@@ -142,6 +149,7 @@ impl GenericPcieRootComplex {
                 let root_port = RootPort::new(
                     definition.name.clone(),
                     hotplug_slot_number,
+                    definition.settings,
                     &port_msi_target,
                 );
                 (device_number, (definition.name, root_port))
@@ -429,10 +437,12 @@ impl RootPort {
     /// # Arguments
     /// * `name` - The name for this root port
     /// * `hotplug_slot_number` - The slot number for hotplug support. `Some(slot_number)` enables hotplug, `None` disables it
+    /// * `settings` - Express-level port settings (ACS, etc.)
     /// * `msi_target` - MSI target for interrupt delivery
     pub fn new(
         name: impl Into<Arc<str>>,
         hotplug_slot_number: Option<u32>,
+        settings: PciePortSettings,
         msi_target: &MsiTarget,
     ) -> Self {
         let name_str = name.into();
@@ -453,6 +463,7 @@ impl RootPort {
             DevicePortType::RootPort,
             false,
             hotplug_slot_number,
+            settings,
             msi_target,
         );
 
@@ -651,6 +662,7 @@ mod tests {
             .map(|i| GenericPcieRootPortDefinition {
                 name: format!("test-port-{}", i).into(),
                 hotplug: false,
+                settings: PciePortSettings::default(),
             })
             .collect();
 
@@ -915,7 +927,7 @@ mod tests {
         // Test with hotplug disabled (None)
         let root_port_no_hotplug = {
             let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-            RootPort::new("test-port-no-hotplug", None, c.target())
+            RootPort::new("test-port-no-hotplug", None, PciePortSettings::default(), c.target())
         };
         // We can't easily verify hotplug is disabled without accessing internal state,
         // but we can verify the port was created successfully
@@ -931,7 +943,7 @@ mod tests {
         // Test with hotplug enabled (Some(slot_number))
         let root_port_with_hotplug = {
             let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-            RootPort::new("test-port-hotplug", Some(5), c.target())
+            RootPort::new("test-port-hotplug", Some(5), PciePortSettings::default(), c.target())
         };
         let mut vendor_device_id_hotplug: u32 = 0;
         root_port_with_hotplug
@@ -948,7 +960,7 @@ mod tests {
     fn test_root_port_invalid_bus_range_handling() {
         let mut root_port = {
             let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-            RootPort::new("test-port", None, c.target())
+            RootPort::new("test-port", None, PciePortSettings::default(), c.target())
         };
 
         // Don't configure bus numbers, so the range should be 0..=0 (invalid)

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -149,8 +149,8 @@ impl GenericPcieRootComplex {
                 let root_port = RootPort::new(
                     definition.name.clone(),
                     hotplug_slot_number,
-                    definition.settings,
                     &port_msi_target,
+                    definition.settings,
                 );
                 (device_number, (definition.name, root_port))
             })
@@ -437,13 +437,13 @@ impl RootPort {
     /// # Arguments
     /// * `name` - The name for this root port
     /// * `hotplug_slot_number` - The slot number for hotplug support. `Some(slot_number)` enables hotplug, `None` disables it
-    /// * `settings` - Express-level port settings (ACS, etc.)
     /// * `msi_target` - MSI target for interrupt delivery
+    /// * `settings` - Express-level port settings (ACS, etc.)
     pub fn new(
         name: impl Into<Arc<str>>,
         hotplug_slot_number: Option<u32>,
-        settings: PciePortSettings,
         msi_target: &MsiTarget,
+        settings: PciePortSettings,
     ) -> Self {
         let name_str = name.into();
         let hardware_ids = HardwareIds {
@@ -463,8 +463,8 @@ impl RootPort {
             DevicePortType::RootPort,
             false,
             hotplug_slot_number,
-            settings,
             msi_target,
+            settings,
         );
 
         Self { port }
@@ -927,7 +927,12 @@ mod tests {
         // Test with hotplug disabled (None)
         let root_port_no_hotplug = {
             let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-            RootPort::new("test-port-no-hotplug", None, PciePortSettings::default(), c.target())
+            RootPort::new(
+                "test-port-no-hotplug",
+                None,
+                c.target(),
+                PciePortSettings::default(),
+            )
         };
         // We can't easily verify hotplug is disabled without accessing internal state,
         // but we can verify the port was created successfully
@@ -943,7 +948,12 @@ mod tests {
         // Test with hotplug enabled (Some(slot_number))
         let root_port_with_hotplug = {
             let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-            RootPort::new("test-port-hotplug", Some(5), PciePortSettings::default(), c.target())
+            RootPort::new(
+                "test-port-hotplug",
+                Some(5),
+                c.target(),
+                PciePortSettings::default(),
+            )
         };
         let mut vendor_device_id_hotplug: u32 = 0;
         root_port_with_hotplug
@@ -960,7 +970,7 @@ mod tests {
     fn test_root_port_invalid_bus_range_handling() {
         let mut root_port = {
             let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-            RootPort::new("test-port", None, PciePortSettings::default(), c.target())
+            RootPort::new("test-port", None, c.target(), PciePortSettings::default())
         };
 
         // Don't configure bus numbers, so the range should be 0..=0 (invalid)

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -14,6 +14,7 @@ use crate::DOWNSTREAM_SWITCH_PORT_DEVICE_ID;
 use crate::UPSTREAM_SWITCH_PORT_DEVICE_ID;
 use crate::VENDOR_ID;
 use crate::port::PcieDownstreamPort;
+use crate::port::PciePortSettings;
 use anyhow::{Context, bail};
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoResult;
@@ -60,6 +61,7 @@ impl UpstreamSwitchPort {
                 DevicePortType::UpstreamSwitchPort,
                 None,
             ))],
+            vec![],
         );
         Self { cfg_space }
     }
@@ -94,11 +96,13 @@ impl DownstreamSwitchPort {
     /// * `multi_function` - Whether this port should have the multi-function flag set (default: false)
     /// * `hotplug_slot_number` - The slot number for hotplug support. `Some(slot_number)` enables hotplug, `None` disables it
     /// * `msi_target` - MSI target for interrupt delivery
+    /// * `settings` - Express-level port settings (ACS, etc.)
     pub fn new(
         name: impl Into<Arc<str>>,
         multi_function: Option<bool>,
         hotplug_slot_number: Option<u32>,
         msi_target: &MsiTarget,
+        settings: PciePortSettings,
     ) -> Self {
         let multi_function = multi_function.unwrap_or(false);
         let hardware_ids = HardwareIds {
@@ -118,6 +122,7 @@ impl DownstreamSwitchPort {
             DevicePortType::DownstreamSwitchPort,
             multi_function,
             hotplug_slot_number,
+            settings,
             msi_target,
         );
 
@@ -147,6 +152,8 @@ pub struct GenericPcieSwitchDefinition {
     /// MSI target from the parent connection. The switch re-derives
     /// per-port targets using the upstream port's bus range.
     pub msi_target: MsiTarget,
+    /// Express-level settings for downstream switch ports.
+    pub dsp_settings: PciePortSettings,
 }
 
 /// A PCI Express switch emulator that implements a complete switch with upstream and downstream ports.
@@ -199,6 +206,7 @@ impl GenericPcieSwitch {
                     Some(multi_function),
                     hotplug_slot_number,
                     &port_msi_target,
+                    definition.dsp_settings.clone(),
                 );
                 (i, (port_name.into(), port))
             })
@@ -634,6 +642,7 @@ mod tests {
             None,
             None,
             &MsiTarget::disconnected(),
+            PciePortSettings::default(),
         );
         assert!(port.port.link.is_none());
 
@@ -650,8 +659,13 @@ mod tests {
     #[test]
     fn test_downstream_switch_port_multi_function_options() {
         // Test with default multi_function (false)
-        let port_default =
-            DownstreamSwitchPort::new("test-port-default", None, None, &MsiTarget::disconnected());
+        let port_default = DownstreamSwitchPort::new(
+            "test-port-default",
+            None,
+            None,
+            &MsiTarget::disconnected(),
+            PciePortSettings::default(),
+        );
         let mut header_type_value: u32 = 0;
         port_default
             .cfg_space()
@@ -670,6 +684,7 @@ mod tests {
             Some(false),
             None,
             &MsiTarget::disconnected(),
+            PciePortSettings::default(),
         );
         let mut header_type_value_false: u32 = 0;
         port_false
@@ -689,6 +704,7 @@ mod tests {
             Some(true),
             None,
             &MsiTarget::disconnected(),
+            PciePortSettings::default(),
         );
         let mut header_type_value_true: u32 = 0;
         port_true
@@ -711,6 +727,7 @@ mod tests {
             None,
             None,
             &MsiTarget::disconnected(),
+            PciePortSettings::default(),
         );
         // We can't easily verify hotplug is disabled without accessing internal state,
         // but we can verify the port was created successfully
@@ -728,6 +745,7 @@ mod tests {
             None,
             Some(42),
             &MsiTarget::disconnected(),
+            PciePortSettings::default(),
         );
         let mut vendor_device_id_hotplug: u32 = 0;
         port_with_hotplug
@@ -745,6 +763,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 3,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let switch = GenericPcieSwitch::new(definition);
@@ -777,6 +796,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
@@ -824,6 +844,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
@@ -858,6 +879,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 4,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
@@ -888,6 +910,7 @@ mod tests {
             name: "default-switch".into(),
             downstream_port_count: 4,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let switch = GenericPcieSwitch::new(definition);
@@ -901,6 +924,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 16,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let switch = GenericPcieSwitch::new(definition);
@@ -913,6 +937,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 3,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
@@ -957,6 +982,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
@@ -983,6 +1009,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
@@ -1023,6 +1050,7 @@ mod tests {
             name: "multi-port-switch".into(),
             downstream_port_count: 3,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let multi_port_switch = GenericPcieSwitch::new(multi_port_definition);
@@ -1063,6 +1091,7 @@ mod tests {
             name: "single-port-switch".into(),
             downstream_port_count: 1,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let single_port_switch = GenericPcieSwitch::new(single_port_definition);
@@ -1106,6 +1135,7 @@ mod tests {
             name: "test-switch-no-hotplug".into(),
             downstream_port_count: 1,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let switch_no_hotplug = GenericPcieSwitch::new(definition_no_hotplug);
@@ -1116,6 +1146,7 @@ mod tests {
             name: "test-switch-with-hotplug".into(),
             downstream_port_count: 1,
             hotplug: true,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let switch_with_hotplug = GenericPcieSwitch::new(definition_with_hotplug);
@@ -1134,6 +1165,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 3,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
@@ -1147,6 +1179,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let mut switch2 = GenericPcieSwitch::new(definition2);
@@ -1164,6 +1197,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
@@ -1179,6 +1213,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let mut switch2 = GenericPcieSwitch::new(definition2);
@@ -1195,6 +1230,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 3,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
@@ -1224,6 +1260,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 3,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let mut switch2 = GenericPcieSwitch::new(definition2);
@@ -1251,6 +1288,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
@@ -1286,6 +1324,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         };
         let mut switch2 = GenericPcieSwitch::new(definition2);
@@ -1306,6 +1345,63 @@ mod tests {
             let restored_bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(*restored_bus_range.start(), 10);
             assert_eq!(*restored_bus_range.end(), 20);
+        }
+    }
+
+    #[test]
+    fn test_save_restore_preserves_upstream_and_downstream_cfg_space() {
+        use vmcore::save_restore::SaveRestore;
+
+        let definition = GenericPcieSwitchDefinition {
+            name: "test-switch".into(),
+            downstream_port_count: 2,
+            hotplug: false,
+            dsp_settings: PciePortSettings::default(),
+            msi_target: MsiTarget::disconnected(),
+        };
+        let mut switch = GenericPcieSwitch::new(definition);
+
+        // Upstream primary/secondary/subordinate bus numbers.
+        switch
+            .upstream_port
+            .cfg_space_mut()
+            .write_u32(0x18, 0x0014_1200)
+            .unwrap();
+
+        // Downstream port 1 bus range.
+        if let Some((_, downstream_port)) = switch.downstream_ports.get_mut(&1) {
+            downstream_port
+                .port
+                .cfg_space
+                .write_u32(0x18, 0x0020_1f12)
+                .unwrap();
+        }
+
+        let saved_state = switch.save().expect("save should succeed");
+
+        let definition2 = GenericPcieSwitchDefinition {
+            name: "test-switch".into(),
+            downstream_port_count: 2,
+            hotplug: false,
+            dsp_settings: PciePortSettings::default(),
+            msi_target: MsiTarget::disconnected(),
+        };
+        let mut switch2 = GenericPcieSwitch::new(definition2);
+
+        switch2
+            .restore(saved_state)
+            .expect("restore should succeed");
+
+        let upstream_bus_range = switch2.upstream_port.cfg_space().assigned_bus_range();
+        assert_eq!(*upstream_bus_range.start(), 0x12);
+        assert_eq!(*upstream_bus_range.end(), 0x14);
+
+        if let Some((_, downstream_port)) = switch2.downstream_ports.get(&1) {
+            let downstream_bus_range = downstream_port.cfg_space().assigned_bus_range();
+            assert_eq!(*downstream_bus_range.start(), 0x1f);
+            assert_eq!(*downstream_bus_range.end(), 0x20);
+        } else {
+            panic!("missing downstream port 1");
         }
     }
 
@@ -1380,6 +1476,7 @@ mod tests {
             DevicePortType::RootPort,
             false,
             None,
+            PciePortSettings::default(),
             msi_conn.target(),
         );
 
@@ -1393,6 +1490,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            dsp_settings: PciePortSettings::default(),
             msi_target: MsiTarget::disconnected(),
         });
 
@@ -1420,5 +1518,53 @@ mod tests {
             value2, !0,
             "Non-zero function should return all-1s (no device)"
         );
+    }
+
+    #[test]
+    fn test_switch_acs_only_applies_to_dsp() {
+        use pci_core::spec::caps::ExtendedCapabilityId;
+
+        let switch = GenericPcieSwitch::new(GenericPcieSwitchDefinition {
+            name: "acs-switch".into(),
+            downstream_port_count: 1,
+            hotplug: false,
+            dsp_settings: PciePortSettings {
+                acs_capabilities_supported: 0x0001,
+            },
+            msi_target: MsiTarget::disconnected(),
+        });
+
+        // Upstream switch ports do not expose ACS in this model.
+        let mut upstream_header = 0u32;
+        switch
+            .upstream_port()
+            .cfg_space()
+            .read_u32(0x100, &mut upstream_header)
+            .unwrap();
+        assert_eq!(upstream_header, 0xffff_ffff);
+
+        let mut switch = switch;
+        let (_, (_, downstream_port)) = switch
+            .downstream_ports
+            .iter_mut()
+            .next()
+            .expect("expected downstream port");
+
+        let mut downstream_header = 0u32;
+        downstream_port
+            .cfg_space_mut()
+            .read_u32(0x100, &mut downstream_header)
+            .unwrap();
+        assert_eq!(
+            downstream_header & 0xffff,
+            ExtendedCapabilityId::ACS.0 as u32
+        );
+
+        let mut caps_control = 0u32;
+        downstream_port
+            .cfg_space_mut()
+            .read_u32(0x104, &mut caps_control)
+            .unwrap();
+        assert_eq!(caps_control as u16, 0x0001);
     }
 }

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -122,8 +122,8 @@ impl DownstreamSwitchPort {
             DevicePortType::DownstreamSwitchPort,
             multi_function,
             hotplug_slot_number,
-            settings,
             msi_target,
+            settings,
         );
 
         Self { port }
@@ -1476,8 +1476,8 @@ mod tests {
             DevicePortType::RootPort,
             false,
             None,
-            PciePortSettings::default(),
             msi_conn.target(),
+            PciePortSettings::default(),
         );
 
         // Configure the root port's bus range: secondary=1, subordinate=10

--- a/vm/devices/pci/vpci/src/device.rs
+++ b/vm/devices/pci/vpci/src/device.rs
@@ -1891,7 +1891,12 @@ mod tests {
         };
 
         let pci = Arc::new(CloseableMutex::new(NullDevice {
-            config_space: ConfigSpaceType0Emulator::new(pci_config, Vec::new(), DeviceBars::new()),
+            config_space: ConfigSpaceType0Emulator::new(
+                pci_config,
+                Vec::new(),
+                Vec::new(),
+                DeviceBars::new(),
+            ),
         }));
         let mut guest_driver = connected_device(&driver, pci.clone(), msi_controller);
         let base_address = 0x140000000;
@@ -1912,7 +1917,12 @@ mod tests {
             type0_sub_system_id: 0x1,
         };
         let pci = Arc::new(CloseableMutex::new(NullDevice {
-            config_space: ConfigSpaceType0Emulator::new(pci_config, Vec::new(), DeviceBars::new()),
+            config_space: ConfigSpaceType0Emulator::new(
+                pci_config,
+                Vec::new(),
+                Vec::new(),
+                DeviceBars::new(),
+            ),
         }));
         let mut guest_driver = connected_device(&driver, pci.clone(), msi_controller);
         guest_driver.protocol_version = protocol::ProtocolVersion(0x00020000);
@@ -1943,6 +1953,7 @@ mod tests {
             config_space: ConfigSpaceType0Emulator::new(
                 pci_config,
                 vec![Box::new(msix_capability)],
+                Vec::new(),
                 DeviceBars::new(),
             ),
         }));
@@ -1968,6 +1979,7 @@ mod tests {
         let pci = Arc::new(CloseableMutex::new(NullDevice {
             config_space: ConfigSpaceType0Emulator::new(
                 pci_config,
+                Vec::new(),
                 Vec::new(),
                 DeviceBars::new().bar0(0x1000, BarMemoryKind::Dummy),
             ),
@@ -2039,6 +2051,7 @@ mod tests {
                         type0_sub_vendor_id: 0x456,
                         type0_sub_system_id: 0x1,
                     },
+                    Vec::new(),
                     Vec::new(),
                     DeviceBars::new()
                         .bar0(
@@ -2273,7 +2286,12 @@ mod tests {
         };
 
         let pci = Arc::new(CloseableMutex::new(NullDevice {
-            config_space: ConfigSpaceType0Emulator::new(pci_config, Vec::new(), DeviceBars::new()),
+            config_space: ConfigSpaceType0Emulator::new(
+                pci_config,
+                Vec::new(),
+                Vec::new(),
+                DeviceBars::new(),
+            ),
         }));
         let mut guest_driver = connected_device(&driver, pci.clone(), msi_controller);
         let base_address = 0x1000000;

--- a/vm/devices/storage/nvme/src/pci.rs
+++ b/vm/devices/storage/nvme/src/pci.rs
@@ -144,6 +144,7 @@ impl NvmeController {
                     None,
                 )),
             ],
+            Vec::new(),
             bars,
         );
 

--- a/vm/devices/storage/nvme_test/src/pci.rs
+++ b/vm/devices/storage/nvme_test/src/pci.rs
@@ -160,6 +160,7 @@ impl NvmeFaultController {
                 type0_sub_system_id: 0,
             },
             vec![Box::new(msix_cap)],
+            Vec::new(),
             bars,
         );
 

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -258,7 +258,7 @@ impl VirtioPciDevice {
                 .map_err(io::Error::other)?;
         }
 
-        let mut config_space = ConfigSpaceType0Emulator::new(hardware_ids, caps, bars);
+        let mut config_space = ConfigSpaceType0Emulator::new(hardware_ids, caps, Vec::new(), bars);
         let interrupt_kind = match interrupt_model {
             PciInterruptModel::Msix(_) => InterruptKind::Msix(msix.unwrap()),
             PciInterruptModel::IntX(pin, line) => {


### PR DESCRIPTION
This change adds ACS capability emulation to PCI root ports and switches and also add CLI options to add ACS capability.

```
root@ubuntu:~# lspci -s 0:0.0 -vv
00:00.0 PCI bridge: Microsoft Corporation Device c030 (prog-if 00 [Normal decode])
        Control: I/O+ Mem+ BusMaster+ SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx+
        Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx-
        Latency: 0
        Interrupt: pin ? routed to IRQ 24
        Bus: primary=00, secondary=01, subordinate=08, sec-latency=0
        Memory behind bridge: [disabled] [32-bit]
        Prefetchable memory behind bridge: [disabled] [64-bit]
        Secondary status: 66MHz- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- <SERR- <PERR-
        BridgeCtl: Parity- SERR+ NoISA- VGA- VGA16- MAbort- >Reset- FastB2B-
                PriDiscTmr- SecDiscTmr- DiscTmrStat- DiscTmrSERREn-
[...]
        Capabilities: [100 v1] Access Control Services
                ACSCap: SrcValid+ TransBlk+ ReqRedir+ CmpltRedir+ UpstreamFwd+ EgressCtrl- DirectTrans+
                ACSCtl: SrcValid- TransBlk- ReqRedir- CmpltRedir- UpstreamFwd- EgressCtrl- DirectTrans-
        Kernel driver in use: pcieport
```