### PR TITLE
Revert "virtiofs: negotiate FUSE_MAX_PAGES for larger I/O requests"

### DIFF
--- a/vm/devices/support/fs/fuse/src/session.rs
+++ b/vm/devices/support/fs/fuse/src/session.rs
@@ -24,7 +24,6 @@ const DEFAULT_FLAGS: u32 = FUSE_ASYNC_READ
     | FUSE_ASYNC_DIO
     | FUSE_ATOMIC_O_TRUNC
     | FUSE_BIG_WRITES
-    | FUSE_MAX_PAGES
     | FUSE_INIT_EXT;
 
 // Default flags2 to negotiate when FUSE_INIT_EXT is supported.


### PR DESCRIPTION
Reverts c1105b45b5e1ac6ebd6734bfe1ee7b08a68ee47f.

## Problem

`FUSE_MAX_PAGES` increases the max FUSE request size from 128 KiB (32 pages) to ~1008 KiB (252 pages). This is an 8x increase in the number of guest memory accesses per request.

In the wsldevicehost HDV path, the aperture cache is currently disabled (`DISABLE_CACHE = true`) due to a bug where apertures can stop mapping real guest memory after a cold discard. Without the cache, every guest memory access creates and destroys a fresh VID PPM aperture handle.

The combination of 8x more aperture churn per request and the 512-handle VID PPM table limit causes `ERROR_NOT_ENOUGH_QUOTA` under concurrent I/O. The retry path sleeps 100ms per attempt, leading to cascading stalls that surface as EIO and ECONNREFUSED in the guest.

## Plan

Re-land `FUSE_MAX_PAGES` once the HDV memory access path is updated to batch mappings or the aperture cache can be re-enabled.