### PR TITLE
Bump openssl to 0.10.79 to address Dependabot alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5145,15 +5145,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.9.3",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -5186,9 +5185,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
Updates the `openssl` crate from 0.10.78 to 0.10.79 to resolve two Dependabot alerts:

- [Alert #33](https://github.com/microsoft/openvmm/security/dependabot/33) (high): rust-openssl has undefined behavior in `X509Ref::ocsp_responders` for certificates with non-UTF-8 OCSP URLs
- [Alert #34](https://github.com/microsoft/openvmm/security/dependabot/34) (medium): rust-openssl vulnerable to heap buffer overflow when encrypting with AES key-wrap-with-padding

Cargo.lock-only change. `cargo check --workspace` and `cargo xtask fmt --fix` pass locally.