### PR TITLE
pci_core: refactor MSI to use late-bind connect and lazy BDF resolution

### DIFF
--- a/Guide/src/reference/emulated/pcie/overview.md
+++ b/Guide/src/reference/emulated/pcie/overview.md
@@ -83,12 +83,19 @@ On aarch64, PCIe MSI/MSI-X interrupts are routed through either
 a GICv3 ITS or a GICv2m MSI frame, depending on the platform:
 
 - **GICv3 ITS** (default on KVM with GICv3): The VMM creates a
-  KVM in-kernel ITS device. Each PCIe device gets a 32-bit
-  device ID composed as `(segment << 16) | BDF`, injected
-  transparently by per-device wrappers in the interrupt path.
-  ACPI boots emit an IORT with an ITS Group node and per-root-
-  complex ID mappings. The device tree includes an `its` child
-  node under the GIC with `msi-controller`.
+  KVM in-kernel ITS device. Each MSI is delivered with a 32-bit
+  ITS device ID of the form `(segment << 16) | BDF`. The BDF is
+  resolved lazily at interrupt-delivery time by the device's
+  `MsiTarget`, which combines the parent port's `AssignedBusRange`
+  (updated by the guest as it programs secondary/subordinate bus
+  numbers) with the device's `devfn`. Multi-function devices and
+  root/switch ports that need a specific RID pass it explicitly.
+  A single `ItsSignalMsi`/`ItsIrqFd` wrapper per segment then
+  prepends the segment to produce the final ITS device ID — no
+  per-device wrappers and no push-based RID synchronization are
+  needed. ACPI boots emit an IORT with an ITS Group node and
+  per-root-complex ID mappings; the device tree includes an `its`
+  child node under the GIC with `msi-controller`.
 
 - **GICv2m**: MSI writes map to a fixed pool of 64 SPIs via
   a v2m doorbell register. The MADT includes a GICv2m MSI

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1765,13 +1765,31 @@ impl InitializedVm {
 
         // PCI Express topology
 
+        // Determine whether ITS wrappers are needed for PCIe MSI delivery.
+        // Only aarch64 VMs configured with a GICv3 ITS need device ID
+        // injection; all other configurations pass through directly.
+        #[cfg(guest_arch = "aarch64")]
+        let use_its = matches!(
+            processor_topology.gic_msi(),
+            vm_topology::processor::aarch64::GicMsiController::Its(_)
+        );
+        #[cfg(not(guest_arch = "aarch64"))]
+        let use_its = false;
+
         let (pcie_host_bridges, pcie_root_complexes) = {
             let mut pcie_host_bridges = Vec::new();
             let mut pcie_root_complexes = Vec::new();
 
             for rc in cfg.pcie_root_complexes {
                 let device_name = format!("pcie-root:{}", rc.name);
-                let msi_conn = pci_core::msi::MsiConnection::new();
+
+                // Create a static bus range for the root complex so that
+                // root port MSI targets can lazily resolve their BDF as
+                // (start_bus << 8) | devfn.
+                let rc_bus_range = pci_core::bus_range::AssignedBusRange::new();
+                rc_bus_range.set_bus_range(rc.start_bus, rc.end_bus);
+                let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+
                 let root_complex =
                     chipset_builder
                         .arc_mutex_device(device_name)
@@ -1796,7 +1814,17 @@ impl InitializedVm {
                         })?;
 
                 if let Some(signal_msi) = partition.as_signal_msi(Vtl::Vtl0) {
-                    msi_conn.connect(signal_msi);
+                    // When ITS is active, wrap the root complex's
+                    // SignalMsi with a segment prepender so that all
+                    // MSIs (from both root ports and child devices)
+                    // get the ITS device ID composed.
+                    if use_its {
+                        msi_conn.connect(Arc::new(pcie::its::ItsSignalMsi::new(
+                            signal_msi, rc.segment,
+                        )));
+                    } else {
+                        msi_conn.connect(signal_msi);
+                    }
                 }
 
                 pcie_host_bridges.push(PcieHostBridge {
@@ -1825,7 +1853,7 @@ impl InitializedVm {
         // guest programs secondary/subordinate bus numbers.
         struct PortInfo {
             segment: u16,
-            bus_range: pcie::bus_range::AssignedBusRange,
+            bus_range: pci_core::bus_range::AssignedBusRange,
         }
         let mut port_info: std::collections::HashMap<Arc<str>, PortInfo> =
             std::collections::HashMap::new();
@@ -1858,6 +1886,28 @@ impl InitializedVm {
                 })?
                 .segment;
 
+            let msi_conn =
+                pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+
+            if let Some(signal_msi) = partition.as_signal_msi(Vtl::Vtl0) {
+                if use_its {
+                    msi_conn.connect(Arc::new(pcie::its::ItsSignalMsi::new(
+                        signal_msi,
+                        parent_segment,
+                    )));
+                } else {
+                    msi_conn.connect(signal_msi);
+                }
+            }
+            if let Some(fd) = partition.irqfd() {
+                if use_its {
+                    msi_conn.connect_irqfd(Arc::new(pcie::its::ItsIrqFd::new(fd, parent_segment)));
+                } else {
+                    msi_conn.connect_irqfd(fd);
+                }
+            }
+
+            let msi_target = msi_conn.target().clone();
             let switch_device = chipset_builder
                 .arc_mutex_device(device_name)
                 .on_pcie_port(vmotherboard::BusId::new(&switch.parent_port))
@@ -1866,6 +1916,7 @@ impl InitializedVm {
                         name: switch.name.clone().into(),
                         downstream_port_count: switch.num_downstream_ports,
                         hotplug: switch.hotplug,
+                        msi_target,
                     };
                     GenericPcieSwitch::new(definition)
                 })?;
@@ -1906,23 +1957,45 @@ impl InitializedVm {
             Some(handle)
         };
 
-        // Determine whether ITS wrappers are needed for PCIe MSI delivery.
-        // Only aarch64 VMs configured with a GICv3 ITS need device ID
-        // injection; all other configurations pass through directly.
-        #[cfg(guest_arch = "aarch64")]
-        let use_its = matches!(
-            processor_topology.gic_msi(),
-            vm_topology::processor::aarch64::GicMsiController::Its(_)
-        );
-        #[cfg(not(guest_arch = "aarch64"))]
-        let use_its = false;
-
         // Resolve PCIe devices concurrently.
         //
-        // Each port's ConfigSpaceType1Emulator owns an AssignedBusRange
-        // (Arc<AtomicU16>). We clone it into the ITS wrappers so that when
-        // the guest programs bus numbers, the emulator writes the new values
-        // and the ITS wrapper reads them at interrupt delivery time.
+        // When ITS is active, the root complex's ITS-wrapped SignalMsi
+        // and IrqFd are shared across all devices on that complex. Each
+        // device's MsiConnection carries a default BDF derived from the
+        // port's AssignedBusRange, which the MsiTarget resolves lazily
+        // at interrupt delivery time.
+
+        // Build per-segment ITS-wrapped signal_msi and irqfd. Each root
+        // complex connection already has ITS wrapping for port MSIs; we
+        // share the same wrapped instances for child devices.
+        let its_signal_msi: std::collections::HashMap<u16, Arc<dyn pci_core::msi::SignalMsi>> =
+            if use_its {
+                let mut map = std::collections::HashMap::new();
+                if let Some(s) = partition.as_signal_msi(Vtl::Vtl0) {
+                    for hb in &pcie_host_bridges {
+                        map.entry(hb.segment).or_insert_with(|| {
+                            Arc::new(pcie::its::ItsSignalMsi::new(s.clone(), hb.segment)) as _
+                        });
+                    }
+                }
+                map
+            } else {
+                std::collections::HashMap::new()
+            };
+        let its_irqfd: std::collections::HashMap<u16, Arc<dyn vmcore::irqfd::IrqFd>> = if use_its {
+            let mut map = std::collections::HashMap::new();
+            if let Some(fd) = partition.irqfd() {
+                for hb in &pcie_host_bridges {
+                    map.entry(hb.segment).or_insert_with(|| {
+                        Arc::new(pcie::its::ItsIrqFd::new(fd.clone(), hb.segment)) as _
+                    });
+                }
+            }
+            map
+        } else {
+            std::collections::HashMap::new()
+        };
+
         try_join_all(cfg.pcie_devices.into_iter().map(|dev_cfg| {
             let chipset_builder = &chipset_builder;
             let driver_source = &driver_source;
@@ -1931,6 +2004,8 @@ impl InitializedVm {
             let partition = &partition;
             let mapper = &mapper;
             let port_info = &port_info;
+            let its_signal_msi = &its_signal_msi;
+            let its_irqfd = &its_irqfd;
             async move {
                 let port_name: Arc<str> = dev_cfg.port_name.into();
                 let pi = port_info.get(&port_name).ok_or_else(|| {
@@ -1940,31 +2015,7 @@ impl InitializedVm {
                     )
                 })?;
 
-                // When ITS is active, wrap the partition's SignalMsi
-                // and IrqFd to inject the device identity. Otherwise
-                // pass through directly.
-                let signal_msi = partition.as_signal_msi(Vtl::Vtl0).map(|s| {
-                    if use_its {
-                        Arc::new(pcie::its::ItsSignalMsi::new(
-                            s,
-                            pi.bus_range.clone(),
-                            pi.segment,
-                        )) as Arc<dyn pci_core::msi::SignalMsi>
-                    } else {
-                        s
-                    }
-                });
-                let irqfd = partition.irqfd().map(|fd| {
-                    if use_its {
-                        Arc::new(pcie::its::ItsIrqFd::new(
-                            fd,
-                            pi.bus_range.clone(),
-                            pi.segment,
-                        )) as Arc<dyn vmcore::irqfd::IrqFd>
-                    } else {
-                        fd
-                    }
-                });
+                let msi_conn = pci_core::msi::MsiConnection::new(pi.bus_range.clone(), 0);
 
                 vmm_core::device_builder::build_pcie_device(
                     chipset_builder,
@@ -1975,10 +2026,32 @@ impl InitializedVm {
                     dev_cfg.resource,
                     partition.clone().into_doorbell_registration(Vtl::Vtl0),
                     Some(mapper),
-                    signal_msi,
-                    irqfd,
+                    msi_conn.target(),
                 )
-                .await
+                .await?;
+
+                // When ITS is active, use the per-segment wrapped
+                // SignalMsi and IrqFd. The device's MsiConnection
+                // carries a default BDF from the port's bus range.
+                let signal_msi = if use_its {
+                    its_signal_msi.get(&pi.segment).cloned()
+                } else {
+                    partition.as_signal_msi(Vtl::Vtl0)
+                };
+                if let Some(target) = signal_msi {
+                    msi_conn.connect(target);
+                }
+
+                let irqfd = if use_its {
+                    its_irqfd.get(&pi.segment).cloned()
+                } else {
+                    partition.irqfd()
+                };
+                if let Some(fd) = irqfd {
+                    msi_conn.connect_irqfd(fd);
+                }
+
+                anyhow::Ok(())
             }
         }))
         .await?;
@@ -2991,14 +3064,6 @@ impl LoadedVm {
                                 })
                                 .ok_or_else(|| anyhow::anyhow!("port '{}' not found in any root complex", port_name))?;
 
-                            #[cfg(guest_arch = "aarch64")]
-                            let use_its = matches!(
-                                self.inner.processor_topology.gic_msi(),
-                                vm_topology::processor::aarch64::GicMsiController::Its(_)
-                            );
-                            #[cfg(not(guest_arch = "aarch64"))]
-                            let use_its = false;
-
                             // Get the bus_range from the port's config space emulator.
                             let bus_range = rc.lock()
                                 .downstream_ports()
@@ -3007,35 +3072,7 @@ impl LoadedVm {
                                 .expect("port was just found above")
                                 .bus_range;
 
-                            let signal_msi = self.inner.partition.as_signal_msi(Vtl::Vtl0).map(|s| {
-                                if use_its {
-                                    let segment = self.inner.pcie_host_bridges[rc_idx].segment;
-                                    Arc::new(pcie::its::ItsSignalMsi::new(
-                                        s,
-                                        bus_range.clone(),
-                                        segment,
-                                    )) as Arc<dyn pci_core::msi::SignalMsi>
-                                } else {
-                                    s
-                                }
-                            });
-                            let irqfd = self.inner.partition.irqfd().map(|fd| {
-                                if use_its {
-                                    let segment = self.inner.pcie_host_bridges[rc_idx].segment;
-                                    Arc::new(pcie::its::ItsIrqFd::new(
-                                        fd,
-                                        bus_range.clone(),
-                                        segment,
-                                    )) as Arc<dyn vmcore::irqfd::IrqFd>
-                                } else {
-                                    fd
-                                }
-                            });
-
-                            let msi_conn = match irqfd {
-                                Some(fd) => pci_core::msi::MsiConnection::with_irqfd(fd),
-                                None => pci_core::msi::MsiConnection::new(),
-                            };
+                            let msi_conn = pci_core::msi::MsiConnection::new(bus_range, 0);
 
                             let (unit, device) = self.inner.chipset_devices.add_dyn_device(
                                 &self.inner.driver_source,
@@ -3060,8 +3097,29 @@ impl LoadedVm {
                                 },
                             ).await?;
 
-                            if let Some(target) = signal_msi {
-                                msi_conn.connect(target);
+                            // Connect the MSI target and IrqFd, wrapping
+                            // with ITS segment translation when needed.
+                            #[cfg(guest_arch = "aarch64")]
+                            let use_its = matches!(
+                                self.inner.processor_topology.gic_msi(),
+                                vm_topology::processor::aarch64::GicMsiController::Its(_)
+                            );
+                            #[cfg(not(guest_arch = "aarch64"))]
+                            let use_its = false;
+                            let segment = self.inner.pcie_host_bridges[rc_idx].segment;
+                            if let Some(s) = self.inner.partition.as_signal_msi(Vtl::Vtl0) {
+                                if use_its {
+                                    msi_conn.connect(Arc::new(pcie::its::ItsSignalMsi::new(s, segment)));
+                                } else {
+                                    msi_conn.connect(s);
+                                }
+                            }
+                            if let Some(fd) = self.inner.partition.irqfd() {
+                                if use_its {
+                                    msi_conn.connect_irqfd(Arc::new(pcie::its::ItsIrqFd::new(fd, segment)));
+                                } else {
+                                    msi_conn.connect_irqfd(fd);
+                                }
                             }
 
                             // Wrap the device as a GenericPciBusDevice for the port.

--- a/vm/devices/net/mana_driver/src/tests.rs
+++ b/vm/devices/net/mana_driver/src/tests.rs
@@ -16,6 +16,7 @@ use gdma_defs::GdmaQueueType;
 use net_backend::null::NullEndpoint;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
+use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use std::sync::Arc;
 use test_with_tracing::test;
@@ -29,7 +30,7 @@ use vmcore::vm_task::VmTaskDriverSource;
 #[async_test]
 async fn test_gdma(driver: DefaultDriver) {
     let mem = DeviceTestMemory::new(128, false, "test_gdma");
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
@@ -167,7 +168,7 @@ async fn test_gdma(driver: DefaultDriver) {
 #[async_test]
 async fn test_gdma_save_restore(driver: DefaultDriver) {
     let mem = DeviceTestMemory::new(128, false, "test_gdma");
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
@@ -207,7 +208,7 @@ async fn test_gdma_save_restore(driver: DefaultDriver) {
 #[async_test]
 async fn test_adapter_link_speed_default(driver: DefaultDriver) {
     let mem = DeviceTestMemory::new(128, false, "test_adapter_link_speed_default");
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
@@ -255,7 +256,7 @@ async fn test_adapter_link_speed_default(driver: DefaultDriver) {
 /// and `link_speed_bps()` converts it correctly.
 async fn verify_adapter_link_speed_expected(driver: DefaultDriver, link_speed_mbps: u32) {
     let mem = DeviceTestMemory::new(128, false, "test_adapter_link_speed_expected");
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let device = gdma::GdmaDevice::new_with_config(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
@@ -315,7 +316,7 @@ async fn test_adapter_link_speed_expected(driver: DefaultDriver) {
 #[async_test]
 async fn test_gdma_reconfig_vf(driver: DefaultDriver) {
     let mem = DeviceTestMemory::new(128, false, "test_gdma");
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),

--- a/vm/devices/net/net_mana/src/test.rs
+++ b/vm/devices/net/net_mana/src/test.rs
@@ -23,6 +23,7 @@ use net_backend::TxSegment;
 use net_backend::loopback::LoopbackEndpoint;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
+use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use std::future::poll_fn;
 use std::time::Duration;
@@ -546,7 +547,7 @@ async fn test_multi_mixed_packet(driver: DefaultDriver) {
 async fn test_vport_with_query_filter_state(driver: DefaultDriver) {
     let pages = 512; // 2MB
     let mem = DeviceTestMemory::new(pages, false, "test_vport_with_query_filter_state");
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
@@ -610,7 +611,7 @@ async fn test_link_speed_default(driver: DefaultDriver) {
 
     let pages = 512; // 2MB
     let mem = DeviceTestMemory::new(pages, false, "test_link_speed_default");
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
@@ -674,7 +675,7 @@ async fn verify_link_speed_expected(driver: DefaultDriver, link_speed_mbps: u32)
 
     let pages = 512;
     let mem = DeviceTestMemory::new(pages, false, "test_link_speed_expected");
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let device = gdma::GdmaDevice::new_with_config(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
@@ -894,7 +895,7 @@ async fn test_endpoint(
     let data_to_send = pkt_builder.packet_data();
     let tx_segments = pkt_builder.segments();
 
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),

--- a/vm/devices/net/net_mana/src/test.rs
+++ b/vm/devices/net/net_mana/src/test.rs
@@ -1061,7 +1061,7 @@ async fn new_test_queue(
 ) {
     let pages = 256;
     let mem = DeviceTestMemory::new(pages * 2, true, "test queue");
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),

--- a/vm/devices/pci/pci_core/src/bus_range.rs
+++ b/vm/devices/pci/pci_core/src/bus_range.rs
@@ -54,25 +54,4 @@ impl AssignedBusRange {
         let v = self.0.load(Ordering::Relaxed);
         ((v >> 8) as u8, v as u8)
     }
-
-    /// Composes an ITS device ID from the current bus range, segment, and
-    /// an optional per-device BDF override.
-    ///
-    /// Returns `None` if the secondary bus has not been assigned yet (still 0).
-    /// When `devid` is `None`, defaults to `(secondary_bus, dev 0, fn 0)`.
-    /// Logs a rate-limited warning and returns `None` if the BDF's bus
-    /// number falls outside the port's assigned range.
-    pub fn compose_its_devid(&self, segment: u16, devid: Option<u32>) -> Option<u32> {
-        let (secondary, subordinate) = self.bus_range();
-        if secondary == 0 {
-            return None;
-        }
-        let bdf = devid.unwrap_or((secondary as u32) << 8);
-        let bus = (bdf >> 8) as u8;
-        if bus < secondary || bus > subordinate {
-            tracelimit::warn_ratelimited!(bus, secondary, subordinate, "BDF out of port bus range");
-            return None;
-        }
-        Some((segment as u32) << 16 | (bdf & 0xFFFF))
-    }
 }

--- a/vm/devices/pci/pci_core/src/bus_range.rs
+++ b/vm/devices/pci/pci_core/src/bus_range.rs
@@ -54,4 +54,11 @@ impl AssignedBusRange {
         let v = self.0.load(Ordering::Relaxed);
         ((v >> 8) as u8, v as u8)
     }
+
+    /// Returns whether `bus` falls within the current bus range
+    /// (inclusive on both ends).
+    pub fn contains_bus(&self, bus: u8) -> bool {
+        let (secondary, subordinate) = self.bus_range();
+        bus >= secondary && bus <= subordinate
+    }
 }

--- a/vm/devices/pci/pci_core/src/capabilities/msi_cap.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/msi_cap.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use vmcore::interrupt::Interrupt;
 
 /// MSI capability implementation for PCI configuration space.
-#[derive(Debug, Inspect)]
+#[derive(Debug, Clone, Inspect)]
 pub struct MsiCapability {
     #[inspect(with = "|x| inspect::adhoc(|req| x.lock().inspect_mut(req))")]
     state: Arc<Mutex<MsiCapabilityState>>,
@@ -378,12 +378,13 @@ mod save_restore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bus_range::AssignedBusRange;
     use crate::msi::MsiConnection;
     use crate::test_helpers::TestPciInterruptController;
 
     #[test]
     fn msi_check() {
-        let msi_conn = MsiConnection::new();
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
         let mut cap = MsiCapability::new(2, true, false, msi_conn.target()); // 4 messages max, 64-bit, no masking
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
@@ -420,7 +421,7 @@ mod tests {
 
     #[test]
     fn msi_32bit_check() {
-        let msi_conn = MsiConnection::new();
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
         let mut cap = MsiCapability::new(1, false, false, msi_conn.target()); // 2 messages max, 32-bit, no masking
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
@@ -440,7 +441,7 @@ mod tests {
     fn test_msi_save_restore() {
         use vmcore::save_restore::SaveRestore;
 
-        let msi_conn = MsiConnection::new();
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
         let mut cap = MsiCapability::new(2, true, false, msi_conn.target()); // 4 messages max, 64-bit, no masking
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
@@ -481,7 +482,7 @@ mod tests {
     fn test_msi_save_restore_32bit_with_masking() {
         use vmcore::save_restore::SaveRestore;
 
-        let msi_conn = MsiConnection::new();
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
         let mut cap = MsiCapability::new(3, false, true, msi_conn.target()); // 8 messages max, 32-bit, with masking
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
@@ -531,7 +532,7 @@ mod tests {
     fn test_msi_save_restore_mme_clamping() {
         use vmcore::save_restore::SaveRestore;
 
-        let msi_conn = MsiConnection::new();
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
         let mut cap = MsiCapability::new(1, true, false, msi_conn.target()); // Only 2 messages max (MMC=1)
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());

--- a/vm/devices/pci/pci_core/src/capabilities/msix.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/msix.rs
@@ -149,6 +149,16 @@ impl Debug for MsiInterruptInner {
     }
 }
 
+impl MsiInterruptInner {
+    fn signal_msi(&self) {
+        self.target.signal_msi(None, self.address, self.data);
+    }
+
+    fn enable_route(&self, route: &MsiRoute) {
+        route.enable(self.address, self.data, None);
+    }
+}
+
 impl MsiInterrupt {
     pub fn new(target: MsiTarget) -> Self {
         Self(Arc::new(Mutex::new(MsiInterruptInner {
@@ -170,11 +180,11 @@ impl MsiInterrupt {
 
         // Program the kernel route if present.
         if let Some(route) = &state.route {
-            route.enable(address, data);
+            state.enable_route(route);
         }
 
         if state.pending {
-            state.target.signal_msi(address, data);
+            state.signal_msi();
             state.pending = false;
         }
     }
@@ -210,7 +220,7 @@ impl InterruptTarget for MsiInterruptTarget {
     fn deliver(&self) {
         let mut state = self.0.lock();
         if state.enabled {
-            state.target.signal_msi(state.address, state.data);
+            state.signal_msi();
         } else {
             state.pending = true;
         }
@@ -230,7 +240,7 @@ impl InterruptTarget for MsiInterruptTarget {
             None => return None,
         };
         if state.enabled {
-            route.enable(state.address, state.data);
+            state.enable_route(&route);
         } else {
             route.disable();
         }
@@ -595,11 +605,12 @@ mod save_restore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bus_range::AssignedBusRange;
     use crate::{msi::MsiConnection, test_helpers::TestPciInterruptController};
 
     #[test]
     fn msix_check() {
-        let msi_conn = MsiConnection::new();
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
         let (mut msix, mut cap) = MsixEmulator::new(2, 64, msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
@@ -723,7 +734,8 @@ mod tests {
     #[test]
     fn route_set_msi_on_unmask() {
         let (irqfd, calls) = mock_irqfd(2);
-        let msi_conn = MsiConnection::with_irqfd(irqfd);
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        msi_conn.connect_irqfd(irqfd);
         let (mut msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
@@ -764,7 +776,8 @@ mod tests {
     #[test]
     fn route_mask_on_vector_mask() {
         let (irqfd, calls) = mock_irqfd(2);
-        let msi_conn = MsiConnection::with_irqfd(irqfd);
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        msi_conn.connect_irqfd(irqfd);
         let (mut msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
@@ -792,7 +805,8 @@ mod tests {
     #[test]
     fn route_global_disable_masks_all() {
         let (irqfd, calls) = mock_irqfd(2);
-        let msi_conn = MsiConnection::with_irqfd(irqfd);
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        msi_conn.connect_irqfd(irqfd);
         let (mut msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
@@ -823,7 +837,8 @@ mod tests {
     #[test]
     fn route_consume_pending_on_pba_read() {
         let (irqfd, _calls) = mock_irqfd(2);
-        let msi_conn = MsiConnection::with_irqfd(irqfd);
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        msi_conn.connect_irqfd(irqfd);
         let (msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
@@ -849,7 +864,8 @@ mod tests {
     #[test]
     fn route_set_msi_on_addr_data_change_while_unmasked() {
         let (irqfd, calls) = mock_irqfd(1);
-        let msi_conn = MsiConnection::with_irqfd(irqfd);
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        msi_conn.connect_irqfd(irqfd);
         let (mut msix, mut cap) = MsixEmulator::new(2, 1, msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());

--- a/vm/devices/pci/pci_core/src/capabilities/msix.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/msix.rs
@@ -151,11 +151,11 @@ impl Debug for MsiInterruptInner {
 
 impl MsiInterruptInner {
     fn signal_msi(&self) {
-        self.target.signal_msi(None, self.address, self.data);
+        self.target.signal_msi(self.address, self.data);
     }
 
     fn enable_route(&self, route: &MsiRoute) {
-        route.enable(self.address, self.data, None);
+        route.enable(self.address, self.data);
     }
 }
 

--- a/vm/devices/pci/pci_core/src/msi.rs
+++ b/vm/devices/pci/pci_core/src/msi.rs
@@ -303,3 +303,270 @@ impl MsiTarget {
         inner.irqfd.is_some()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bus_range::AssignedBusRange;
+    use pal_event::Event;
+    use parking_lot::Mutex;
+    use std::collections::VecDeque;
+
+    /// A [`SignalMsi`] mock that records `(devid, address, data)`.
+    struct RecordingSignalMsi {
+        calls: Mutex<VecDeque<(Option<u32>, u64, u32)>>,
+    }
+
+    impl RecordingSignalMsi {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                calls: Mutex::new(VecDeque::new()),
+            })
+        }
+
+        fn pop(&self) -> Option<(Option<u32>, u64, u32)> {
+            self.calls.lock().pop_front()
+        }
+    }
+
+    impl SignalMsi for RecordingSignalMsi {
+        fn signal_msi(&self, devid: Option<u32>, address: u64, data: u32) {
+            self.calls.lock().push_back((devid, address, data));
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    enum RouteCall {
+        Enable {
+            address: u64,
+            data: u32,
+            devid: Option<u32>,
+        },
+        Disable,
+    }
+
+    struct MockIrqFdRoute {
+        event: Event,
+        calls: Arc<Mutex<Vec<RouteCall>>>,
+    }
+
+    impl IrqFdRoute for MockIrqFdRoute {
+        fn event(&self) -> &Event {
+            &self.event
+        }
+
+        fn enable(&self, address: u64, data: u32, devid: Option<u32>) {
+            self.calls.lock().push(RouteCall::Enable {
+                address,
+                data,
+                devid,
+            });
+        }
+
+        fn disable(&self) {
+            self.calls.lock().push(RouteCall::Disable);
+        }
+    }
+
+    fn mock_irqfd(count: usize) -> (Arc<dyn IrqFd>, Vec<Arc<Mutex<Vec<RouteCall>>>>) {
+        let mut call_logs = Vec::new();
+        let route_params = Arc::new(Mutex::new(Vec::new()));
+        for _ in 0..count {
+            let calls = Arc::new(Mutex::new(Vec::new()));
+            call_logs.push(calls.clone());
+            route_params.lock().push(calls);
+        }
+
+        struct MockIrqFd {
+            routes: Mutex<Vec<Arc<Mutex<Vec<RouteCall>>>>>,
+        }
+        impl IrqFd for MockIrqFd {
+            fn new_irqfd_route(&self) -> anyhow::Result<Box<dyn IrqFdRoute>> {
+                let calls = self.routes.lock().remove(0);
+                Ok(Box::new(MockIrqFdRoute {
+                    event: Event::new(),
+                    calls,
+                }))
+            }
+        }
+
+        (
+            Arc::new(MockIrqFd {
+                routes: Mutex::new(call_logs.clone()),
+            }),
+            call_logs,
+        )
+    }
+
+    #[test]
+    fn signal_msi_resolves_default_bdf() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new(bus_range, 0x18); // devfn = dev 3, fn 0
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        msi_conn.target().signal_msi(0xFEE0_0000, 42);
+
+        let (devid, addr, data) = recorder.pop().unwrap();
+        assert_eq!(devid, Some((5 << 8) | 0x18));
+        assert_eq!(addr, 0xFEE0_0000);
+        assert_eq!(data, 42);
+    }
+
+    #[test]
+    fn signal_msi_with_rid_accepts_bus_in_range() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new(bus_range, 0);
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        // RID with bus=7, devfn=0x0A → within [5, 10]
+        let rid: u16 = (7 << 8) | 0x0A;
+        msi_conn.target().signal_msi_with_rid(rid, 0xABCD, 99);
+
+        let (devid, addr, data) = recorder.pop().unwrap();
+        assert_eq!(devid, Some(rid as u32));
+        assert_eq!(addr, 0xABCD);
+        assert_eq!(data, 99);
+    }
+
+    #[test]
+    fn signal_msi_with_rid_drops_bus_outside_range() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new(bus_range, 0);
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        // bus=11, above subordinate=10 → dropped
+        let rid_above: u16 = 11 << 8;
+        msi_conn.target().signal_msi_with_rid(rid_above, 0xABCD, 1);
+        assert!(recorder.pop().is_none());
+
+        // bus=4, below secondary=5 → dropped
+        let rid_below: u16 = 4 << 8;
+        msi_conn.target().signal_msi_with_rid(rid_below, 0xABCD, 2);
+        assert!(recorder.pop().is_none());
+    }
+
+    #[test]
+    fn signal_msi_with_rid_accepts_boundary_buses() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new(bus_range, 0);
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        // Exactly at secondary bus (5)
+        msi_conn.target().signal_msi_with_rid(5 << 8, 0x1000, 10);
+        assert!(recorder.pop().is_some());
+
+        // Exactly at subordinate bus (10)
+        msi_conn.target().signal_msi_with_rid(10 << 8, 0x2000, 20);
+        assert!(recorder.pop().is_some());
+    }
+
+    #[test]
+    fn route_enable_resolves_default_bdf() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(3, 8);
+        let (irqfd, calls) = mock_irqfd(1);
+        let msi_conn = MsiConnection::new(bus_range, 0x10); // devfn = dev 2, fn 0
+        msi_conn.connect_irqfd(irqfd);
+
+        let route = msi_conn.target().new_route().unwrap().unwrap();
+        route.enable(0xFEE0_0000, 55);
+
+        let log = calls[0].lock();
+        assert_eq!(log.len(), 1);
+        assert_eq!(
+            log[0],
+            RouteCall::Enable {
+                address: 0xFEE0_0000,
+                data: 55,
+                devid: Some((3 << 8) | 0x10),
+            }
+        );
+    }
+
+    #[test]
+    fn route_enable_with_rid_accepts_bus_in_range() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let (irqfd, calls) = mock_irqfd(1);
+        let msi_conn = MsiConnection::new(bus_range, 0);
+        msi_conn.connect_irqfd(irqfd);
+
+        let route = msi_conn.target().new_route().unwrap().unwrap();
+        let rid: u16 = (7 << 8) | 0x0A;
+        route.enable_with_rid(rid, 0xBEEF, 77);
+
+        let log = calls[0].lock();
+        assert_eq!(log.len(), 1);
+        assert_eq!(
+            log[0],
+            RouteCall::Enable {
+                address: 0xBEEF,
+                data: 77,
+                devid: Some(rid as u32),
+            }
+        );
+    }
+
+    #[test]
+    fn route_enable_with_rid_disables_when_bus_outside_range() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let (irqfd, calls) = mock_irqfd(1);
+        let msi_conn = MsiConnection::new(bus_range, 0);
+        msi_conn.connect_irqfd(irqfd);
+
+        let route = msi_conn.target().new_route().unwrap().unwrap();
+        // bus=11, above subordinate → should disable
+        let rid: u16 = 11 << 8;
+        route.enable_with_rid(rid, 0xBEEF, 77);
+
+        let log = calls[0].lock();
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0], RouteCall::Disable);
+    }
+
+    #[test]
+    fn with_devfn_derives_target_with_new_devfn() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(2, 5);
+        let msi_conn = MsiConnection::new(bus_range, 0);
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        let derived = msi_conn.target().with_devfn(0x18); // dev 3, fn 0
+        derived.signal_msi(0x1000, 1);
+
+        let (devid, _, _) = recorder.pop().unwrap();
+        assert_eq!(devid, Some((2 << 8) | 0x18));
+    }
+
+    #[test]
+    fn with_bus_range_derives_target_with_new_range() {
+        let parent_range = AssignedBusRange::new();
+        parent_range.set_bus_range(1, 20);
+        let msi_conn = MsiConnection::new(parent_range, 0);
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        let child_range = AssignedBusRange::new();
+        child_range.set_bus_range(10, 15);
+        let derived = msi_conn.target().with_bus_range(child_range, 0x08);
+        derived.signal_msi(0x2000, 2);
+
+        let (devid, _, _) = recorder.pop().unwrap();
+        // secondary=10, devfn=0x08 → BDF = (10 << 8) | 0x08
+        assert_eq!(devid, Some((10 << 8) | 0x08));
+
+        // Validation uses the child range, not the parent
+        derived.signal_msi_with_rid(16 << 8, 0x3000, 3);
+        assert!(recorder.pop().is_none()); // bus 16 > subordinate 15
+    }
+}

--- a/vm/devices/pci/pci_core/src/msi.rs
+++ b/vm/devices/pci/pci_core/src/msi.rs
@@ -40,13 +40,22 @@ impl MsiRoute {
         self.inner.event()
     }
 
-    /// Configures the MSI address and data for this route.
-    ///
-    /// `devid` is an optional segment-local BDF override. When `None`,
-    /// the default BDF (from the port's bus range) is used.
-    pub fn enable(&self, address: u64, data: u32, devid: Option<u32>) {
-        let resolved = devid.unwrap_or_else(|| resolve_default_bdf(&self.default_bdf));
+    /// Configures the MSI address and data for this route, using
+    /// the route's default BDF as the requester ID.
+    pub fn enable(&self, address: u64, data: u32) {
+        let resolved = resolve_default_bdf(&self.default_bdf);
         self.inner.enable(address, data, Some(resolved))
+    }
+
+    /// Configures the MSI address and data for this route, using
+    /// an explicit segment-local BDF (`rid`) as the requester ID.
+    ///
+    /// Use this for multi-function devices whose functions span
+    /// multiple buses: the caller composes the full `(bus << 8) | devfn`
+    /// itself from whatever bus range it owns. The route's own
+    /// default BDF is bypassed entirely.
+    pub fn enable_with_rid(&self, rid: u16, address: u64, data: u32) {
+        self.inner.enable(address, data, Some(rid.into()))
     }
 
     /// Disables the MSI route. Interrupts that arrive while disabled
@@ -74,8 +83,8 @@ impl SignalMsi for DisconnectedMsiTarget {
 
 /// Default BDF source for MSI device identification.
 ///
-/// [`MsiTarget::signal_msi`] resolves `devid = None` to
-/// the port's secondary bus combined with the configured `devfn`.
+/// [`MsiTarget::signal_msi`] uses this to compose the requester ID
+/// from the port's secondary bus combined with the configured `devfn`.
 #[derive(Clone, Debug)]
 struct DefaultBdf {
     bus_range: AssignedBusRange,
@@ -148,9 +157,9 @@ impl MsiConnection {
     /// Creates a new disconnected MSI target connection.
     ///
     /// `bus_range` and `devfn` configure the default BDF identity
-    /// for this connection. When a device signals an MSI with
-    /// `devid = None`, the BDF is resolved from the bus range's
-    /// secondary bus and the given `devfn`.
+    /// for this connection. When a device signals an MSI via
+    /// [`MsiTarget::signal_msi`], the BDF is resolved from the bus
+    /// range's secondary bus and the given `devfn`.
     pub fn new(bus_range: AssignedBusRange, devfn: u8) -> Self {
         Self {
             target: MsiTarget {
@@ -213,23 +222,32 @@ impl MsiTarget {
         }
     }
 
-    /// Signals an MSI interrupt to this target.
-    ///
-    /// `devid` is an optional segment-local BDF override for
-    /// multi-function devices. When `None`, the default BDF (from the
-    /// port's bus range) is used.
-    pub fn signal_msi(&self, devid: Option<u32>, address: u64, data: u32) {
-        let resolved = devid.unwrap_or_else(|| resolve_default_bdf(&self.default_bdf));
+    /// Signals an MSI interrupt to this target, using this target's
+    /// default BDF as the requester ID.
+    pub fn signal_msi(&self, address: u64, data: u32) {
+        let resolved = resolve_default_bdf(&self.default_bdf);
         let inner = self.inner.read();
         inner.signal_msi.signal_msi(Some(resolved), address, data);
+    }
+
+    /// Signals an MSI interrupt to this target, using an explicit
+    /// segment-local BDF (`rid`) as the requester ID.
+    ///
+    /// Use this for multi-function devices whose functions span
+    /// multiple buses: the caller composes the full `(bus << 8) | devfn`
+    /// itself from whatever bus range it owns. This target's own
+    /// default BDF is bypassed entirely.
+    pub fn signal_msi_with_rid(&self, rid: u16, address: u64, data: u32) {
+        let inner = self.inner.read();
+        inner.signal_msi.signal_msi(Some(rid.into()), address, data);
     }
 
     /// Creates a new kernel-mediated MSI route for direct interrupt
     /// delivery.
     ///
     /// The route inherits this target's default BDF source so that
-    /// [`MsiRoute::enable`] with `devid = None` resolves the BDF
-    /// the same way [`signal_msi`](Self::signal_msi) does.
+    /// [`MsiRoute::enable`] resolves the BDF the same way
+    /// [`signal_msi`](Self::signal_msi) does.
     ///
     /// Returns `None` if no [`IrqFd`] has been connected.
     pub fn new_route(&self) -> Option<anyhow::Result<MsiRoute>> {
@@ -242,7 +260,8 @@ impl MsiTarget {
         })
     }
 
-    /// Returns the default BDF that will be used when `devid` is `None`.
+    /// Returns the default BDF that will be used by
+    /// [`signal_msi`](Self::signal_msi) and [`MsiRoute::enable`].
     pub fn default_bdf(&self) -> u32 {
         resolve_default_bdf(&self.default_bdf)
     }

--- a/vm/devices/pci/pci_core/src/msi.rs
+++ b/vm/devices/pci/pci_core/src/msi.rs
@@ -53,8 +53,24 @@ impl MsiRoute {
     /// Use this for multi-function devices whose functions span
     /// multiple buses: the caller composes the full `(bus << 8) | devfn`
     /// itself from whatever bus range it owns. The route's own
-    /// default BDF is bypassed entirely.
+    /// default `devfn` is bypassed.
+    ///
+    /// The bus portion of `rid` is validated against the route's
+    /// assigned bus range; if it falls outside the range the route
+    /// is left disabled and a ratelimited warning is emitted.
     pub fn enable_with_rid(&self, rid: u16, address: u64, data: u32) {
+        let bus = (rid >> 8) as u8;
+        if !self.default_bdf.bus_range.contains_bus(bus) {
+            let (secondary, subordinate) = self.default_bdf.bus_range.bus_range();
+            tracelimit::warn_ratelimited!(
+                rid,
+                secondary,
+                subordinate,
+                "refusing to enable MSI route: rid bus outside assigned bus range"
+            );
+            self.inner.disable();
+            return;
+        }
         self.inner.enable(address, data, Some(rid.into()))
     }
 
@@ -236,8 +252,23 @@ impl MsiTarget {
     /// Use this for multi-function devices whose functions span
     /// multiple buses: the caller composes the full `(bus << 8) | devfn`
     /// itself from whatever bus range it owns. This target's own
-    /// default BDF is bypassed entirely.
+    /// default `devfn` is bypassed.
+    ///
+    /// The bus portion of `rid` is validated against this target's
+    /// assigned bus range; if it falls outside the range the MSI is
+    /// dropped and a ratelimited warning is emitted.
     pub fn signal_msi_with_rid(&self, rid: u16, address: u64, data: u32) {
+        let bus = (rid >> 8) as u8;
+        if !self.default_bdf.bus_range.contains_bus(bus) {
+            let (secondary, subordinate) = self.default_bdf.bus_range.bus_range();
+            tracelimit::warn_ratelimited!(
+                rid,
+                secondary,
+                subordinate,
+                "dropping MSI: rid bus outside assigned bus range"
+            );
+            return;
+        }
         let inner = self.inner.read();
         inner.signal_msi.signal_msi(Some(rid.into()), address, data);
     }

--- a/vm/devices/pci/pci_core/src/msi.rs
+++ b/vm/devices/pci/pci_core/src/msi.rs
@@ -3,6 +3,7 @@
 
 //! Traits for working with MSI interrupts.
 
+use crate::bus_range::AssignedBusRange;
 use pal_event::Event;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -26,36 +27,26 @@ pub trait SignalMsi: Send + Sync {
 /// hypervisor to inject the configured MSI into the guest without a
 /// userspace transition. This is used for device passthrough (VFIO)
 /// where the physical device signals the event on interrupt.
-pub struct MsiRoute(Box<dyn IrqFdRoute>);
+pub struct MsiRoute {
+    inner: Box<dyn IrqFdRoute>,
+    default_bdf: DefaultBdf,
+}
 
 impl MsiRoute {
-    /// Wraps a boxed [`IrqFdRoute`] into a concrete route.
-    pub fn new(backing: Box<dyn IrqFdRoute>) -> Self {
-        Self(backing)
-    }
-
     /// Returns the event that triggers interrupt injection when signaled.
     ///
     /// Pass this to VFIO `map_msix` or any other interrupt source.
     pub fn event(&self) -> &Event {
-        self.0.event()
+        self.inner.event()
     }
 
     /// Configures the MSI address and data for this route.
     ///
-    /// `address` and `data` are the MSI address and data values that
-    /// the hypervisor will use when injecting the interrupt.
-    pub fn enable(&self, address: u64, data: u32) {
-        self.0.enable(address, data, None)
-    }
-
-    /// Configures the MSI address and data for this route.
-    ///
-    /// `rid` is the PCIe requester ID (RID) of the device that will signal the
-    /// interrupt. `address` and `data` are the MSI address and data values that
-    /// the hypervisor will use when injecting the interrupt.
-    pub fn enable_with_rid(&self, address: u64, data: u32, rid: u16) {
-        self.0.enable(address, data, Some(rid.into()))
+    /// `devid` is an optional segment-local BDF override. When `None`,
+    /// the default BDF (from the port's bus range) is used.
+    pub fn enable(&self, address: u64, data: u32, devid: Option<u32>) {
+        let resolved = devid.unwrap_or_else(|| resolve_default_bdf(&self.default_bdf));
+        self.inner.enable(address, data, Some(resolved))
     }
 
     /// Disables the MSI route. Interrupts that arrive while disabled
@@ -63,7 +54,7 @@ impl MsiRoute {
     /// [`enable`](Self::enable) is called, or can be drained via
     /// [`consume_pending`](Self::consume_pending).
     pub fn disable(&self) {
-        self.0.disable()
+        self.inner.disable()
     }
 
     /// Drains pending interrupt state and returns whether an interrupt
@@ -81,6 +72,22 @@ impl SignalMsi for DisconnectedMsiTarget {
     }
 }
 
+/// Default BDF source for MSI device identification.
+///
+/// [`MsiTarget::signal_msi`] resolves `devid = None` to
+/// the port's secondary bus combined with the configured `devfn`.
+#[derive(Clone, Debug)]
+struct DefaultBdf {
+    bus_range: AssignedBusRange,
+    devfn: u8,
+}
+
+/// Resolves a BDF from a [`DefaultBdf`] source.
+fn resolve_default_bdf(default: &DefaultBdf) -> u32 {
+    let (secondary, _) = default.bus_range.bus_range();
+    (secondary as u32) << 8 | default.devfn as u32
+}
+
 /// A connection between a device and an MSI target.
 #[derive(Debug)]
 pub struct MsiConnection {
@@ -91,53 +98,67 @@ pub struct MsiConnection {
 #[derive(Clone)]
 pub struct MsiTarget {
     inner: Arc<RwLock<MsiTargetInner>>,
-    irqfd: Option<Arc<dyn IrqFd>>,
+    default_bdf: DefaultBdf,
+}
+
+impl MsiTarget {
+    /// Returns a disconnected MSI target with a dummy BDF.
+    ///
+    /// Useful in tests and contexts where MSI delivery is not needed.
+    pub fn disconnected() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(MsiTargetInner {
+                signal_msi: Arc::new(DisconnectedMsiTarget),
+                irqfd: None,
+            })),
+            default_bdf: DefaultBdf {
+                bus_range: AssignedBusRange::new(),
+                devfn: 0,
+            },
+        }
+    }
 }
 
 impl std::fmt::Debug for MsiTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MsiTarget")
-            .field("has_irqfd", &self.irqfd.is_some())
+            .field("default_bdf", &self.default_bdf)
             .finish()
     }
 }
 
 struct MsiTargetInner {
     signal_msi: Arc<dyn SignalMsi>,
+    irqfd: Option<Arc<dyn IrqFd>>,
 }
 
 impl std::fmt::Debug for MsiTargetInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self { signal_msi: _ } = self;
-        f.debug_struct("MsiTargetInner").finish()
+        let Self {
+            signal_msi: _,
+            irqfd,
+        } = self;
+        f.debug_struct("MsiTargetInner")
+            .field("has_irqfd", &irqfd.is_some())
+            .finish()
     }
 }
 
 impl MsiConnection {
     /// Creates a new disconnected MSI target connection.
-    pub fn new() -> Self {
-        Self {
-            target: MsiTarget {
-                inner: Arc::new(RwLock::new(MsiTargetInner {
-                    signal_msi: Arc::new(DisconnectedMsiTarget),
-                })),
-                irqfd: None,
-            },
-        }
-    }
-
-    /// Creates a new disconnected MSI target connection with an
-    /// [`IrqFd`] for kernel-mediated MSI route allocation.
     ///
-    /// When present, [`MsiTarget::new_route`] can create [`MsiRoute`]
-    /// instances for direct interrupt delivery.
-    pub fn with_irqfd(irqfd: Arc<dyn IrqFd>) -> Self {
+    /// `bus_range` and `devfn` configure the default BDF identity
+    /// for this connection. When a device signals an MSI with
+    /// `devid = None`, the BDF is resolved from the bus range's
+    /// secondary bus and the given `devfn`.
+    pub fn new(bus_range: AssignedBusRange, devfn: u8) -> Self {
         Self {
             target: MsiTarget {
                 inner: Arc::new(RwLock::new(MsiTargetInner {
                     signal_msi: Arc::new(DisconnectedMsiTarget),
+                    irqfd: None,
                 })),
-                irqfd: Some(irqfd),
+                default_bdf: DefaultBdf { bus_range, devfn },
             },
         }
     }
@@ -148,6 +169,15 @@ impl MsiConnection {
         inner.signal_msi = signal_msi;
     }
 
+    /// Sets the [`IrqFd`] for kernel-mediated MSI route allocation.
+    ///
+    /// When present, [`MsiTarget::new_route`] can create [`MsiRoute`]
+    /// instances for direct interrupt delivery.
+    pub fn connect_irqfd(&self, irqfd: Arc<dyn IrqFd>) {
+        let mut inner = self.target.inner.write();
+        inner.irqfd = Some(irqfd);
+    }
+
     /// Returns the MSI target for this connection.
     pub fn target(&self) -> &MsiTarget {
         &self.target
@@ -155,31 +185,71 @@ impl MsiConnection {
 }
 
 impl MsiTarget {
-    /// Signals an MSI interrupt to this target.
-    pub fn signal_msi(&self, address: u64, data: u32) {
-        let inner = self.inner.read();
-        inner.signal_msi.signal_msi(None, address, data);
+    /// Returns a new `MsiTarget` sharing the same connection and bus
+    /// range but with the given `devfn` in the default BDF.
+    ///
+    /// Use this to derive per-port targets: create one target per
+    /// bus range, then call `with_devfn(port_number)` to get a
+    /// target that resolves to `(bus << 8) | devfn`.
+    pub fn with_devfn(&self, devfn: u8) -> MsiTarget {
+        MsiTarget {
+            inner: self.inner.clone(),
+            default_bdf: DefaultBdf {
+                bus_range: self.default_bdf.bus_range.clone(),
+                devfn,
+            },
+        }
     }
 
-    /// Signals an MSI interrupt to this target from a specific RID.
-    pub fn signal_msi_with_rid(&self, rid: u16, address: u64, data: u32) {
+    /// Returns a new `MsiTarget` sharing the same connection but with
+    /// a different bus range and devfn.
+    ///
+    /// Use this when a component (e.g. a PCIe switch) needs to derive
+    /// targets using a bus range it owns rather than the parent's.
+    pub fn with_bus_range(&self, bus_range: AssignedBusRange, devfn: u8) -> MsiTarget {
+        MsiTarget {
+            inner: self.inner.clone(),
+            default_bdf: DefaultBdf { bus_range, devfn },
+        }
+    }
+
+    /// Signals an MSI interrupt to this target.
+    ///
+    /// `devid` is an optional segment-local BDF override for
+    /// multi-function devices. When `None`, the default BDF (from the
+    /// port's bus range) is used.
+    pub fn signal_msi(&self, devid: Option<u32>, address: u64, data: u32) {
+        let resolved = devid.unwrap_or_else(|| resolve_default_bdf(&self.default_bdf));
         let inner = self.inner.read();
-        inner.signal_msi.signal_msi(Some(rid.into()), address, data);
+        inner.signal_msi.signal_msi(Some(resolved), address, data);
     }
 
     /// Creates a new kernel-mediated MSI route for direct interrupt
     /// delivery.
     ///
-    /// Returns `None` if this target was not configured with an
-    /// [`IrqFd`].
+    /// The route inherits this target's default BDF source so that
+    /// [`MsiRoute::enable`] with `devid = None` resolves the BDF
+    /// the same way [`signal_msi`](Self::signal_msi) does.
+    ///
+    /// Returns `None` if no [`IrqFd`] has been connected.
     pub fn new_route(&self) -> Option<anyhow::Result<MsiRoute>> {
-        self.irqfd
-            .as_ref()
-            .map(|fd| Ok(MsiRoute::new(fd.new_irqfd_route()?)))
+        let inner = self.inner.read();
+        inner.irqfd.as_ref().map(|fd| {
+            Ok(MsiRoute {
+                inner: fd.new_irqfd_route()?,
+                default_bdf: self.default_bdf.clone(),
+            })
+        })
+    }
+
+    /// Returns the default BDF that will be used when `devid` is `None`.
+    pub fn default_bdf(&self) -> u32 {
+        resolve_default_bdf(&self.default_bdf)
     }
 
     /// Returns whether this target supports direct MSI routes.
     pub fn supports_direct_msi(&self) -> bool {
-        self.irqfd.is_some()
+        let inner = self.inner.read();
+        inner.irqfd.is_some()
     }
 }

--- a/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
+++ b/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
@@ -13,6 +13,7 @@ use chipset_device::mmio::MmioIntercept;
 use chipset_device::pci::PciConfigSpace;
 use memory_range::MemoryRange;
 use pci_bus::GenericPciBusDevice;
+use pci_core::msi::MsiTarget;
 use pcie::root::GenericPcieRootComplex;
 use pcie::root::GenericPcieRootPortDefinition;
 use pcie::switch::GenericPcieSwitch;
@@ -124,7 +125,8 @@ impl FuzzRootComplex {
                 hotplug,
             })
             .collect();
-        let msi_conn = pci_core::msi::MsiConnection::new();
+        let msi_conn =
+            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
         let rc = GenericPcieRootComplex::new(
             &mut register_mmio,
             START_BUS,
@@ -280,6 +282,7 @@ fn do_fuzz(u: &mut Unstructured<'_>) -> arbitrary::Result<()> {
                 name: "sw0".into(),
                 downstream_port_count: 2,
                 hotplug: false,
+                msi_target: MsiTarget::disconnected(),
             });
             rc.add_pcie_device(port0_key, "sw0", Box::new(SwitchAdapter(switch)))
                 .map_err(|_| arbitrary::Error::IncorrectFormat)?;

--- a/vm/devices/pci/pcie/src/bus_range.rs
+++ b/vm/devices/pci/pcie/src/bus_range.rs
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-//! Re-export of [`pci_core::bus_range`].
-
-pub use pci_core::bus_range::AssignedBusRange;

--- a/vm/devices/pci/pcie/src/its.rs
+++ b/vm/devices/pci/pcie/src/its.rs
@@ -1,78 +1,61 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! GICv3 ITS interrupt wrappers for PCIe devices.
+//! GICv3 ITS interrupt wrappers for PCIe.
 //!
-//! The ITS routes MSIs using a 32-bit device ID. For PCIe, this is `(segment <<
-//! 16) | bdf`, where `bdf = (bus << 8) | (dev << 3) | fn`.
+//! The ITS routes MSIs using a 32-bit device ID. For PCIe, this is
+//! `(segment << 16) | bdf`. The BDF is resolved by `MsiTarget` from
+//! the port's bus range (for single-function devices) or passed
+//! explicitly by multi-function devices and root ports.
 //!
-//! [`ItsSignalMsi`] and [`ItsIrqFd`] wrap a partition's generic MSI and irqfd
-//! implementations to inject the ITS device ID. The bus range comes from a
-//! shared [`AssignedBusRange`] (updated by the PCIe port when the guest assigns
-//! bus numbers); the segment is fixed at construction time.
-//!
-//! For single-function devices (`devid == None`), the wrapper defaults to
-//! device 0, function 0 on the port's secondary bus. Multi-function devices
-//! pass `Some(bdf)` where `bdf = (bus << 8) | (dev << 3) | fn`.
+//! The wrappers here handle only the segment-to-ITS-devid mapping:
+//! prepending the PCI segment number to the BDF. One instance per
+//! root complex or switch connection.
 
-use crate::bus_range::AssignedBusRange;
 use pal_event::Event;
 use pci_core::msi::SignalMsi;
 use std::sync::Arc;
 use vmcore::irqfd::IrqFd;
 use vmcore::irqfd::IrqFdRoute;
 
-/// A [`SignalMsi`] wrapper that composes the ITS device ID before
-/// forwarding to the inner implementation.
+/// A [`SignalMsi`] wrapper that prepends the PCI segment to the BDF,
+/// producing the ITS device ID.
+///
+/// When `devid` is `Some(bdf)`, the ITS device ID is
+/// `(segment << 16) | (bdf & 0xFFFF)`. When `devid` is `None` (bus
+/// not yet assigned), the MSI is silently dropped.
 pub struct ItsSignalMsi {
     inner: Arc<dyn SignalMsi>,
-    bus_range: AssignedBusRange,
     segment: u16,
 }
 
 impl ItsSignalMsi {
-    /// Creates a new wrapper.
-    ///
-    /// `segment` is the PCI segment number of the root complex that
-    /// owns this device.
-    pub fn new(inner: Arc<dyn SignalMsi>, bus_range: AssignedBusRange, segment: u16) -> Self {
-        Self {
-            inner,
-            bus_range,
-            segment,
-        }
+    /// Creates a new wrapper for the given segment.
+    pub fn new(inner: Arc<dyn SignalMsi>, segment: u16) -> Self {
+        Self { inner, segment }
     }
 }
 
 impl SignalMsi for ItsSignalMsi {
     fn signal_msi(&self, devid: Option<u32>, address: u64, data: u32) {
-        let Some(its_devid) = self.bus_range.compose_its_devid(self.segment, devid) else {
+        let Some(bdf) = devid else {
             return;
         };
+        let its_devid = (self.segment as u32) << 16 | (bdf & 0xFFFF);
         self.inner.signal_msi(Some(its_devid), address, data);
     }
 }
 
-/// An [`IrqFd`] wrapper that produces ITS irqfd routes, each
-/// of which injects the ITS device ID into the `devid` parameter on
-/// `enable`.
+/// An [`IrqFd`] wrapper that produces ITS-aware irqfd routes.
 pub struct ItsIrqFd {
     inner: Arc<dyn IrqFd>,
-    bus_range: AssignedBusRange,
     segment: u16,
 }
 
 impl ItsIrqFd {
-    /// Creates a new wrapper.
-    ///
-    /// `segment` is the PCI segment number of the root complex that
-    /// owns this device.
-    pub fn new(inner: Arc<dyn IrqFd>, bus_range: AssignedBusRange, segment: u16) -> Self {
-        Self {
-            inner,
-            bus_range,
-            segment,
-        }
+    /// Creates a new wrapper for the given segment.
+    pub fn new(inner: Arc<dyn IrqFd>, segment: u16) -> Self {
+        Self { inner, segment }
     }
 }
 
@@ -81,17 +64,15 @@ impl IrqFd for ItsIrqFd {
         let inner_route = self.inner.new_irqfd_route()?;
         Ok(Box::new(ItsIrqFdRoute {
             inner: inner_route,
-            bus_range: self.bus_range.clone(),
             segment: self.segment,
         }))
     }
 }
 
-/// An [`IrqFdRoute`] wrapper that composes the ITS device ID on
-/// `enable`.
+/// An [`IrqFdRoute`] wrapper that prepends the PCI segment to the BDF
+/// on `enable`.
 struct ItsIrqFdRoute {
     inner: Box<dyn IrqFdRoute>,
-    bus_range: AssignedBusRange,
     segment: u16,
 }
 
@@ -101,9 +82,10 @@ impl IrqFdRoute for ItsIrqFdRoute {
     }
 
     fn enable(&self, address: u64, data: u32, devid: Option<u32>) {
-        let Some(its_devid) = self.bus_range.compose_its_devid(self.segment, devid) else {
+        let Some(bdf) = devid else {
             return;
         };
+        let its_devid = (self.segment as u32) << 16 | (bdf & 0xFFFF);
         self.inner.enable(address, data, Some(its_devid));
     }
 

--- a/vm/devices/pci/pcie/src/its.rs
+++ b/vm/devices/pci/pcie/src/its.rs
@@ -22,8 +22,14 @@ use vmcore::irqfd::IrqFdRoute;
 /// producing the ITS device ID.
 ///
 /// When `devid` is `Some(bdf)`, the ITS device ID is
-/// `(segment << 16) | (bdf & 0xFFFF)`. When `devid` is `None` (bus
-/// not yet assigned), the MSI is silently dropped.
+/// `(segment << 16) | (bdf & 0xFFFF)`.
+///
+/// In the normal flow this wrapper is invoked via
+/// [`MsiTarget::signal_msi`](pci_core::msi::MsiTarget::signal_msi),
+/// which always resolves a `Some(bdf)` from the device's default BDF
+/// before reaching this layer, so the `None` arm is unreachable.
+/// It is retained as a defensive guard for direct trait callers that
+/// have no BDF to provide.
 pub struct ItsSignalMsi {
     inner: Arc<dyn SignalMsi>,
     segment: u16,

--- a/vm/devices/pci/pcie/src/its.rs
+++ b/vm/devices/pci/pcie/src/its.rs
@@ -25,11 +25,11 @@ use vmcore::irqfd::IrqFdRoute;
 /// `(segment << 16) | (bdf & 0xFFFF)`.
 ///
 /// In the normal flow this wrapper is invoked via
-/// [`MsiTarget::signal_msi`](pci_core::msi::MsiTarget::signal_msi),
-/// which always resolves a `Some(bdf)` from the device's default BDF
-/// before reaching this layer, so the `None` arm is unreachable.
-/// It is retained as a defensive guard for direct trait callers that
-/// have no BDF to provide.
+/// [`MsiTarget::signal_msi`](pci_core::msi::MsiTarget::signal_msi) or
+/// [`MsiTarget::signal_msi_with_rid`](pci_core::msi::MsiTarget::signal_msi_with_rid),
+/// both of which always pass `Some(bdf)`, so the `None` arm is
+/// unreachable. It is retained as a defensive guard for direct trait
+/// callers that have no BDF to provide.
 pub struct ItsSignalMsi {
     inner: Arc<dyn SignalMsi>,
     segment: u16,

--- a/vm/devices/pci/pcie/src/lib.rs
+++ b/vm/devices/pci/pcie/src/lib.rs
@@ -5,7 +5,6 @@
 
 #![forbid(unsafe_code)]
 
-pub mod bus_range;
 pub mod its;
 pub(crate) mod port;
 pub mod root;

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -386,7 +386,7 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = pci_core::msi::MsiConnection::new();
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let mut port = PcieDownstreamPort::new(
             "test-port",
             hardware_ids,
@@ -437,7 +437,7 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = pci_core::msi::MsiConnection::new();
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let mut port = PcieDownstreamPort::new(
             "test-port",
             hardware_ids,
@@ -471,7 +471,7 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = pci_core::msi::MsiConnection::new();
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let mut port = PcieDownstreamPort::new(
             "test-port",
             hardware_ids,
@@ -526,7 +526,7 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = pci_core::msi::MsiConnection::new();
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let mut port = PcieDownstreamPort::new(
             "test-port",
             hardware_ids,

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -12,7 +12,6 @@ use crate::PAGE_SHIFT;
 use crate::PAGE_SIZE64;
 use crate::ROOT_PORT_DEVICE_ID;
 use crate::VENDOR_ID;
-use crate::bus_range::AssignedBusRange;
 use crate::port::PcieDownstreamPort;
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoError;
@@ -24,6 +23,7 @@ use inspect::Inspect;
 use inspect::InspectMut;
 use memory_range::MemoryRange;
 use pci_bus::GenericPciBusDevice;
+use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiTarget;
 use pci_core::spec::caps::pci_express::DevicePortType;
 use pci_core::spec::hwid::ClassCode;
@@ -137,8 +137,13 @@ impl GenericPcieRootComplex {
                 } else {
                     None
                 };
-                let root_port =
-                    RootPort::new(definition.name.clone(), hotplug_slot_number, msi_target);
+                // Derive a per-port MSI target with this port's devfn.
+                let port_msi_target = msi_target.with_devfn(device_number);
+                let root_port = RootPort::new(
+                    definition.name.clone(),
+                    hotplug_slot_number,
+                    &port_msi_target,
+                );
                 (device_number, (definition.name, root_port))
             })
             .collect();
@@ -651,7 +656,9 @@ mod tests {
 
         let mut register_mmio = TestPcieMmioRegistration {};
         let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(start_bus, end_bus));
-        let msi_conn = pci_core::msi::MsiConnection::new();
+        let rc_bus_range = AssignedBusRange::new();
+        rc_bus_range.set_bus_range(start_bus, end_bus);
+        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
         GenericPcieRootComplex::new(
             &mut register_mmio,
             start_bus,
@@ -907,7 +914,7 @@ mod tests {
     fn test_root_port_hotplug_options() {
         // Test with hotplug disabled (None)
         let root_port_no_hotplug = {
-            let c = pci_core::msi::MsiConnection::new();
+            let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
             RootPort::new("test-port-no-hotplug", None, c.target())
         };
         // We can't easily verify hotplug is disabled without accessing internal state,
@@ -923,7 +930,7 @@ mod tests {
 
         // Test with hotplug enabled (Some(slot_number))
         let root_port_with_hotplug = {
-            let c = pci_core::msi::MsiConnection::new();
+            let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
             RootPort::new("test-port-hotplug", Some(5), c.target())
         };
         let mut vendor_device_id_hotplug: u32 = 0;
@@ -940,7 +947,7 @@ mod tests {
     #[test]
     fn test_root_port_invalid_bus_range_handling() {
         let mut root_port = {
-            let c = pci_core::msi::MsiConnection::new();
+            let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
             RootPort::new("test-port", None, c.target())
         };
 
@@ -1122,24 +1129,6 @@ mod tests {
 
         // The shared AssignedBusRange should reflect the new values.
         assert_eq!(bus_range.bus_range(), (5, 10));
-
-        // compose_its_devid should produce (segment << 16 | secondary << 8)
-        // for a single-function device (devid=None).
-        let segment = 2u16;
-        let devid = bus_range.compose_its_devid(segment, None);
-        assert_eq!(devid, Some((2 << 16) | (5 << 8)));
-
-        // With a specific BDF within range: bus=7, dev=1, fn=2
-        let bdf: u32 = (7 << 8) | (1 << 3) | 2;
-        let devid = bus_range.compose_its_devid(segment, Some(bdf));
-        assert_eq!(devid, Some((2 << 16) | bdf));
-
-        // BDF outside range should return None.
-        let out_of_range_bdf: u32 = 11 << 8; // bus=11, beyond subordinate=10
-        assert_eq!(
-            bus_range.compose_its_devid(segment, Some(out_of_range_bdf)),
-            None
-        );
 
         // Reprogram bus numbers and verify tracking follows.
         rc.mmio_write(SECONDARY_BUS_NUM_REG, &[20]).unwrap();

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -23,6 +23,7 @@ use inspect::InspectMut;
 use pci_bus::GenericPciBusDevice;
 use pci_core::capabilities::pci_express::PciExpressCapability;
 use pci_core::cfg_space_emu::ConfigSpaceType1Emulator;
+use pci_core::msi::MsiTarget;
 use pci_core::spec::caps::pci_express::DevicePortType;
 use pci_core::spec::hwid::ClassCode;
 use pci_core::spec::hwid::HardwareIds;
@@ -92,10 +93,12 @@ impl DownstreamSwitchPort {
     /// * `name` - The name for this downstream switch port
     /// * `multi_function` - Whether this port should have the multi-function flag set (default: false)
     /// * `hotplug_slot_number` - The slot number for hotplug support. `Some(slot_number)` enables hotplug, `None` disables it
+    /// * `msi_target` - MSI target for interrupt delivery
     pub fn new(
         name: impl Into<Arc<str>>,
         multi_function: Option<bool>,
         hotplug_slot_number: Option<u32>,
+        msi_target: &MsiTarget,
     ) -> Self {
         let multi_function = multi_function.unwrap_or(false);
         let hardware_ids = HardwareIds {
@@ -109,15 +112,13 @@ impl DownstreamSwitchPort {
             type0_sub_system_id: 0,
         };
 
-        // TODO: Wire MSI for switch downstream ports to enable hotplug.
-        let disconnected = pci_core::msi::MsiConnection::new();
         let port = PcieDownstreamPort::new(
             name.into().to_string(),
             hardware_ids,
             DevicePortType::DownstreamSwitchPort,
             multi_function,
             hotplug_slot_number,
-            disconnected.target(),
+            msi_target,
         );
 
         Self { port }
@@ -143,6 +144,9 @@ pub struct GenericPcieSwitchDefinition {
     pub downstream_port_count: u8,
     /// Whether hotplug is enabled for this switch's downstream ports.
     pub hotplug: bool,
+    /// MSI target from the parent connection. The switch re-derives
+    /// per-port targets using the upstream port's bus range.
+    pub msi_target: MsiTarget,
 }
 
 /// A PCI Express switch emulator that implements a complete switch with upstream and downstream ports.
@@ -172,6 +176,14 @@ impl GenericPcieSwitch {
         // If there are multiple downstream ports, they need the multi-function flag set
         let multi_function = definition.downstream_port_count > 1;
 
+        // Derive per-port MSI targets from the parent's target, using
+        // the upstream port's bus range. When the guest programs the
+        // upstream port's secondary bus, all downstream port MSI RIDs
+        // automatically update.
+        let switch_msi_target = definition
+            .msi_target
+            .with_bus_range(upstream_port.cfg_space().bus_range(), 0);
+
         let downstream_ports = (0..definition.downstream_port_count)
             .map(|i| {
                 let port_name = format!("{}-downstream-{}", definition.name, i);
@@ -181,10 +193,12 @@ impl GenericPcieSwitch {
                 } else {
                     None
                 };
+                let port_msi_target = switch_msi_target.with_devfn(i);
                 let port = DownstreamSwitchPort::new(
                     port_name.clone(),
                     Some(multi_function),
                     hotplug_slot_number,
+                    &port_msi_target,
                 );
                 (i, (port_name.into(), port))
             })
@@ -599,6 +613,8 @@ mod save_restore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pci_core::bus_range::AssignedBusRange;
+    use pci_core::msi::MsiConnection;
 
     #[test]
     fn test_upstream_switch_port_creation() {
@@ -613,7 +629,12 @@ mod tests {
 
     #[test]
     fn test_downstream_switch_port_creation() {
-        let port = DownstreamSwitchPort::new("test-downstream-port", None, None);
+        let port = DownstreamSwitchPort::new(
+            "test-downstream-port",
+            None,
+            None,
+            &MsiTarget::disconnected(),
+        );
         assert!(port.port.link.is_none());
 
         // Verify that we can read the vendor/device ID from config space
@@ -629,7 +650,8 @@ mod tests {
     #[test]
     fn test_downstream_switch_port_multi_function_options() {
         // Test with default multi_function (false)
-        let port_default = DownstreamSwitchPort::new("test-port-default", None, None);
+        let port_default =
+            DownstreamSwitchPort::new("test-port-default", None, None, &MsiTarget::disconnected());
         let mut header_type_value: u32 = 0;
         port_default
             .cfg_space()
@@ -643,7 +665,12 @@ mod tests {
         );
 
         // Test with explicit multi_function false
-        let port_false = DownstreamSwitchPort::new("test-port-false", Some(false), None);
+        let port_false = DownstreamSwitchPort::new(
+            "test-port-false",
+            Some(false),
+            None,
+            &MsiTarget::disconnected(),
+        );
         let mut header_type_value_false: u32 = 0;
         port_false
             .cfg_space()
@@ -657,7 +684,12 @@ mod tests {
         );
 
         // Test with explicit multi_function true
-        let port_true = DownstreamSwitchPort::new("test-port-true", Some(true), None);
+        let port_true = DownstreamSwitchPort::new(
+            "test-port-true",
+            Some(true),
+            None,
+            &MsiTarget::disconnected(),
+        );
         let mut header_type_value_true: u32 = 0;
         port_true
             .cfg_space()
@@ -674,7 +706,12 @@ mod tests {
     #[test]
     fn test_downstream_switch_port_hotplug_options() {
         // Test with hotplug disabled (None)
-        let port_no_hotplug = DownstreamSwitchPort::new("test-port-no-hotplug", None, None);
+        let port_no_hotplug = DownstreamSwitchPort::new(
+            "test-port-no-hotplug",
+            None,
+            None,
+            &MsiTarget::disconnected(),
+        );
         // We can't easily verify hotplug is disabled without accessing internal state,
         // but we can verify the port was created successfully
         let mut vendor_device_id: u32 = 0;
@@ -686,7 +723,12 @@ mod tests {
         assert_eq!(vendor_device_id, expected);
 
         // Test with hotplug enabled (Some(slot_number))
-        let port_with_hotplug = DownstreamSwitchPort::new("test-port-hotplug", None, Some(42));
+        let port_with_hotplug = DownstreamSwitchPort::new(
+            "test-port-hotplug",
+            None,
+            Some(42),
+            &MsiTarget::disconnected(),
+        );
         let mut vendor_device_id_hotplug: u32 = 0;
         port_with_hotplug
             .cfg_space()
@@ -703,6 +745,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 3,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let switch = GenericPcieSwitch::new(definition);
 
@@ -734,6 +777,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
 
@@ -780,6 +824,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
 
@@ -813,6 +858,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 4,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
 
@@ -842,6 +888,7 @@ mod tests {
             name: "default-switch".into(),
             downstream_port_count: 4,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let switch = GenericPcieSwitch::new(definition);
         assert_eq!(switch.name().as_ref(), "default-switch");
@@ -854,6 +901,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 16,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let switch = GenericPcieSwitch::new(definition);
         assert_eq!(switch.downstream_ports().len(), 16);
@@ -865,6 +913,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 3,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
 
@@ -908,6 +957,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
 
@@ -933,6 +983,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
 
@@ -972,6 +1023,7 @@ mod tests {
             name: "multi-port-switch".into(),
             downstream_port_count: 3,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let multi_port_switch = GenericPcieSwitch::new(multi_port_definition);
 
@@ -1011,6 +1063,7 @@ mod tests {
             name: "single-port-switch".into(),
             downstream_port_count: 1,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let single_port_switch = GenericPcieSwitch::new(single_port_definition);
 
@@ -1053,6 +1106,7 @@ mod tests {
             name: "test-switch-no-hotplug".into(),
             downstream_port_count: 1,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let switch_no_hotplug = GenericPcieSwitch::new(definition_no_hotplug);
         assert_eq!(switch_no_hotplug.name().as_ref(), "test-switch-no-hotplug");
@@ -1062,6 +1116,7 @@ mod tests {
             name: "test-switch-with-hotplug".into(),
             downstream_port_count: 1,
             hotplug: true,
+            msi_target: MsiTarget::disconnected(),
         };
         let switch_with_hotplug = GenericPcieSwitch::new(definition_with_hotplug);
         assert_eq!(
@@ -1079,6 +1134,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 3,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
 
@@ -1091,6 +1147,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let mut switch2 = GenericPcieSwitch::new(definition2);
 
@@ -1107,6 +1164,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
 
@@ -1121,6 +1179,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let mut switch2 = GenericPcieSwitch::new(definition2);
         switch2
@@ -1136,6 +1195,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 3,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
 
@@ -1164,6 +1224,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 3,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let mut switch2 = GenericPcieSwitch::new(definition2);
 
@@ -1190,6 +1251,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let mut switch = GenericPcieSwitch::new(definition);
 
@@ -1224,6 +1286,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         };
         let mut switch2 = GenericPcieSwitch::new(definition2);
 
@@ -1310,7 +1373,7 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = pci_core::msi::MsiConnection::new();
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
         let mut port = PcieDownstreamPort::new(
             "root-port",
             hardware_ids,
@@ -1330,6 +1393,7 @@ mod tests {
             name: "test-switch".into(),
             downstream_port_count: 2,
             hotplug: false,
+            msi_target: MsiTarget::disconnected(),
         });
 
         port.link = Some(("switch".into(), Box::new(SwitchAdapter(switch))));

--- a/vm/devices/pci/vpci/src/device.rs
+++ b/vm/devices/pci/vpci/src/device.rs
@@ -1453,6 +1453,7 @@ mod tests {
     use pal_async::DefaultDriver;
     use pal_async::async_test;
     use pal_async::driver::SpawnDriver;
+    use pci_core::bus_range::AssignedBusRange;
     use pci_core::cfg_space_emu::BarMemoryKind;
     use pci_core::cfg_space_emu::ConfigSpaceType0Emulator;
     use pci_core::cfg_space_emu::DeviceBars;
@@ -1921,7 +1922,7 @@ mod tests {
 
     #[async_test]
     async fn verify_simple_capability(driver: DefaultDriver) {
-        let msi_conn = MsiConnection::new();
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
         let pci_config = HardwareIds {
             vendor_id: 0x123,
             device_id: 0x789,

--- a/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
@@ -16,6 +16,7 @@ use nvme_driver::NvmeDriver;
 use nvme_spec::nvm::DsmRange;
 use page_pool_alloc::PagePoolAllocator;
 use pal_async::DefaultDriver;
+use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use scsi_buffers::OwnedRequestBuffers;
 use std::convert::TryFrom;
@@ -43,7 +44,7 @@ impl FuzzNvmeDriver {
 
         // Nvme device and driver setup
         let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-        let msi_conn = MsiConnection::new();
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
 
         let guid = arbitrary_guid()?;
         let nvme = NvmeController::new(

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -34,6 +34,7 @@ use nvme_test::command_match::CommandMatchBuilder;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
 use parking_lot::Mutex;
+use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use scsi_buffers::OwnedRequestBuffers;
 use std::sync::Arc;
@@ -221,7 +222,7 @@ async fn test_nvme_ioqueue_max_mqes(driver: DefaultDriver) {
 
     // Controller Driver Setup
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let nvme = nvme::NvmeController::new(
         &driver_source,
         guest_mem,
@@ -258,7 +259,7 @@ async fn test_nvme_ioqueue_invalid_mqes(driver: DefaultDriver) {
     let dma_client = device_test_memory.dma_client();
 
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let nvme = nvme::NvmeController::new(
         &driver_source,
         guest_mem,
@@ -314,7 +315,7 @@ async fn test_nvme_driver(driver: DefaultDriver, config: NvmeTestConfig) {
 
     // Arrange: Create the NVMe controller and driver.
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let nvme = nvme::NvmeController::new(
         &driver_source,
         guest_mem.clone(),
@@ -458,7 +459,7 @@ async fn test_nvme_fault_injection(driver: DefaultDriver, fault_configuration: F
 
     // Arrange: Create the NVMe controller and driver.
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let nvme = nvme_test::NvmeFaultController::new(
         &driver_source,
         guest_mem.clone(),

--- a/vm/devices/storage/nvme/src/tests/controller_tests.rs
+++ b/vm/devices/storage/nvme/src/tests/controller_tests.rs
@@ -17,6 +17,7 @@ use guestmem::GuestMemory;
 use guid::Guid;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
+use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use pci_core::test_helpers::TestPciInterruptController;
 use user_driver::backoff::Backoff;
@@ -32,7 +33,7 @@ fn instantiate_controller(
 ) -> NvmeController {
     let mut mmio_reg = TestNvmeMmioRegistration {};
     let vm_task_driver = &VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let controller = NvmeController::new(
         vm_task_driver,
         gm.clone(),

--- a/vm/devices/storage/nvme_test/src/tests/controller_tests.rs
+++ b/vm/devices/storage/nvme_test/src/tests/controller_tests.rs
@@ -24,6 +24,7 @@ use nvme_spec::Command;
 use nvme_spec::Completion;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
+use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use pci_core::test_helpers::TestPciInterruptController;
 use user_driver::backoff::Backoff;
@@ -40,7 +41,7 @@ fn instantiate_controller(
 ) -> NvmeFaultController {
     let mut mmio_reg = TestNvmeMmioRegistration {};
     let vm_task_driver = &VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let controller = NvmeFaultController::new(
         vm_task_driver,
         gm.clone(),

--- a/vm/devices/storage/storage_tests/tests/scsidvd_nvme.rs
+++ b/vm/devices/storage/storage_tests/tests/scsidvd_nvme.rs
@@ -16,6 +16,7 @@ use nvme_driver::NvmeDriver;
 use page_pool_alloc::PagePoolAllocator;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
+use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use scsi_buffers::OwnedRequestBuffers;
 use scsi_buffers::RequestBuffers;
@@ -55,7 +56,7 @@ impl ScsiDvdNvmeTest {
         let dma_client = mem.dma_client();
         let payload_mem = mem.payload_mem();
 
-        let msi_conn = MsiConnection::new();
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
         let nvme = NvmeController::new(
             &driver_source,
             guest_mem.clone(),

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -36,6 +36,7 @@ use pal_async::timer::PolledTimer;
 use pal_async::wait::PolledWait;
 use pal_event::Event;
 use parking_lot::Mutex;
+use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use pci_core::spec::caps::CapabilityId;
 use pci_core::spec::cfg_space;
@@ -1391,7 +1392,7 @@ impl VirtioPciTestDevice {
     ) -> Self {
         let doorbell_registration: Arc<dyn DoorbellRegistration> = test_mem.clone();
         let mem = GuestMemory::new("test", test_mem.clone());
-        let msi_conn = MsiConnection::new();
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
         let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone()));
 
         let dev = VirtioPciDevice::new(
@@ -2875,7 +2876,7 @@ async fn verify_enable_failure_mmio_does_not_set_driver_ok(_driver: DefaultDrive
 async fn verify_enable_failure_pci_does_not_set_driver_ok(_driver: DefaultDriver) {
     let test_mem = VirtioTestMemoryAccess::new();
     let doorbell_registration: Arc<dyn DoorbellRegistration> = test_mem.clone();
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
 
     let mut dev = VirtioPciDevice::new(
         Box::new(FailingTestDevice {
@@ -3713,7 +3714,7 @@ impl PciTestTransport {
     fn new(device: Box<dyn DynVirtioDevice>, driver: &DefaultDriver, num_queues: u16) -> Self {
         let test_mem = VirtioTestMemoryAccess::new();
         let doorbell_registration: Arc<dyn DoorbellRegistration> = test_mem;
-        let msi_conn = MsiConnection::new();
+        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
 
         let mut dev = VirtioPciDevice::new(
             device,
@@ -4227,7 +4228,7 @@ async fn pci_save_restore_incompatible_features(driver: DefaultDriver) {
     assert_ne!(saved.common.driver_feature_banks[0] & 2, 0);
 
     // Create a new device that does NOT support that device-specific feature.
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
     let mut dev2 = VirtioPciDevice::new(
         Box::new(TestDevice::new(
             &driver_source,
@@ -4261,7 +4262,7 @@ async fn pci_save_restore_incompatible_features(driver: DefaultDriver) {
 async fn pci_save_not_supported_device(_driver: DefaultDriver) {
     use vmcore::save_restore::SaveRestore;
 
-    let msi_conn = MsiConnection::new();
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
 
     // FailingTestDevice does not override supports_save_restore (default false).
     let mut dev = VirtioPciDevice::new(

--- a/vmm_core/src/device_builder.rs
+++ b/vmm_core/src/device_builder.rs
@@ -16,7 +16,6 @@ use vm_resource::ResourceResolver;
 use vm_resource::kind::PciDeviceHandleKind;
 use vmbus_server::Guid;
 use vmbus_server::VmbusServerControl;
-use vmcore::irqfd::IrqFd;
 use vmcore::vm_task::VmTaskDriverSource;
 use vmcore::vpci_msi::VpciInterruptMapper;
 use vmotherboard::ArcMutexChipsetDeviceBuilder;
@@ -43,7 +42,9 @@ pub async fn build_vpci_device(
         .arc_mutex_device(device_name)
         .with_external_pci();
 
-    let (device, msi_conn) = resolve_and_add_pci_device(
+    let msi_conn = MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+
+    let device = resolve_and_add_pci_device(
         device_builder,
         driver_source,
         resolver,
@@ -51,7 +52,7 @@ pub async fn build_vpci_device(
         resource,
         doorbell_registration,
         mapper,
-        None,
+        msi_conn.target(),
     )
     .await?;
 
@@ -100,15 +101,14 @@ pub async fn build_pcie_device(
     resource: Resource<PciDeviceHandleKind>,
     doorbell_registration: Option<Arc<dyn DoorbellRegistration>>,
     mapper: Option<&dyn guestmem::MemoryMapper>,
-    interrupt_target: Option<Arc<dyn SignalMsi>>,
-    irqfd: Option<Arc<dyn IrqFd>>,
+    msi_target: &pci_core::msi::MsiTarget,
 ) -> anyhow::Result<()> {
     let dev_name = format!("pcie:{}-{}", port_name, resource.id());
     let device_builder = chipset_builder
         .arc_mutex_device(dev_name)
         .on_pcie_port(vmotherboard::BusId::new(&port_name));
 
-    let (_, msi_conn) = resolve_and_add_pci_device(
+    resolve_and_add_pci_device(
         device_builder,
         driver_source,
         resolver,
@@ -116,13 +116,9 @@ pub async fn build_pcie_device(
         resource,
         doorbell_registration,
         mapper,
-        irqfd,
+        msi_target,
     )
     .await?;
-
-    if let Some(target) = interrupt_target {
-        msi_conn.connect(target);
-    }
 
     Ok(())
 }
@@ -136,13 +132,8 @@ pub async fn resolve_and_add_pci_device(
     resource: Resource<PciDeviceHandleKind>,
     doorbell_registration: Option<Arc<dyn DoorbellRegistration>>,
     mapper: Option<&dyn guestmem::MemoryMapper>,
-    irqfd: Option<Arc<dyn IrqFd>>,
-) -> anyhow::Result<(Arc<CloseableMutex<ErasedChipsetDevice>>, MsiConnection)> {
-    let msi_conn = match irqfd {
-        Some(fd) => MsiConnection::with_irqfd(fd),
-        None => MsiConnection::new(),
-    };
-
+    msi_target: &pci_core::msi::MsiTarget,
+) -> anyhow::Result<Arc<CloseableMutex<ErasedChipsetDevice>>> {
     let device = {
         device_builder
             .try_add_async(async |services| {
@@ -150,7 +141,7 @@ pub async fn resolve_and_add_pci_device(
                     .resolve(
                         resource,
                         pci_resources::ResolvePciDeviceHandleParams {
-                            msi_target: msi_conn.target(),
+                            msi_target,
                             register_mmio: &mut services.register_mmio(),
                             driver_source,
                             guest_memory,
@@ -164,5 +155,5 @@ pub async fn resolve_and_add_pci_device(
             .await?
     };
 
-    Ok((device, msi_conn))
+    Ok(device)
 }


### PR DESCRIPTION
The previous MSI architecture required each ITS wrapper to carry its own AssignedBusRange and perform BDF resolution internally, and the MsiConnection had to be constructed with an IrqFd upfront. This made it impossible to wire MSI for PCIe switch downstream ports (they did not have access to the right bus range or signal target at construction time), breaking hotplug on switches and creating a tangle of push-based state synchronization (set_rid, write_cfg, sync_msi_rid) in the port layer.

This change restructures the MSI model around two principles:

1. Lazy BDF resolution: MsiConnection::new(bus_range, devfn) takes a bus range at construction. When a device signals an MSI with devid = None, the MsiTarget resolves the BDF from the bus range current secondary bus and the configured devfn. This means the guest can reprogram bus numbers and MSI delivery automatically picks up the new values -- no push-based synchronization needed.

2. Late-bind connect: Both SignalMsi and IrqFd are connected after construction via connect() and connect_irqfd(), not passed at creation time. This separates device resolution (which needs the target) from interrupt wiring (which needs platform knowledge like whether ITS is active), and allows the same pattern for all device types.

The ITS wrappers (ItsSignalMsi, ItsIrqFd) are simplified to pure segment prependers -- they just compose (segment << 16) | bdf from the already-resolved BDF. They no longer carry bus ranges or perform range validation.

For the switch, GenericPcieSwitchDefinition now takes an MsiTarget instead of an MsiConnection. The switch uses MsiTarget::with_bus_range to re-derive targets using the upstream port bus range, then with_devfn for each downstream port. This means switch downstream ports get properly wired MSI targets that share the parent connection SignalMsi and IrqFd -- fixing hotplug on switches.

The resolve_and_add_pci_device helper is simplified to take &MsiTarget directly, with callers owning the MsiConnection and handling connect calls themselves.