### PR TITLE
nvme_manager: Relax timing bound on a unit test

### DIFF
--- a/openhcl/underhill_core/src/nvme_manager/manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager/manager.rs
@@ -1038,7 +1038,7 @@ mod tests {
         for (i, duration) in results {
             println!("Device {} took {:?}", i, duration);
             assert!(
-                duration >= Duration::from_millis(190) && duration <= Duration::from_millis(300),
+                duration >= Duration::from_millis(190) && duration <= Duration::from_millis(400),
                 "Device {} timing {:?} outside expected range",
                 i,
                 duration

--- a/openhcl/underhill_core/src/nvme_manager/manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager/manager.rs
@@ -1038,7 +1038,7 @@ mod tests {
         for (i, duration) in results {
             println!("Device {} took {:?}", i, duration);
             assert!(
-                duration >= Duration::from_millis(190) && duration <= Duration::from_millis(400),
+                duration >= Duration::from_millis(190) && duration <= Duration::from_millis(350),
                 "Device {} timing {:?} outside expected range",
                 i,
                 duration


### PR DESCRIPTION
In https://github.com/microsoft/openvmm/actions/runs/25820038059/job/75860545644?pr=3457 this test failed the previous timing by 3 miliseconds. Relax the timing check to account for CI being slow.