### PR TITLE
openvmm_entry: Implement PidfileGuard for automatic pidfile cleanup on panic

### DIFF
--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -145,14 +145,26 @@ use vmgs_resources::VmgsResource;
 use vmotherboard::ChipsetDeviceHandle;
 use vnc_worker_defs::VncParameters;
 
+/// RAII guard that removes the pidfile when dropped. Ensures the pidfile is
+/// cleaned up even if [`do_main`] panics.
+struct PidfileGuard(Option<PathBuf>);
+
+impl Drop for PidfileGuard {
+    fn drop(&mut self) {
+        if let Some(path) = &self.0 {
+            fs_err::remove_file(path).unwrap();
+        }
+    }
+}
+
 pub fn openvmm_main() {
     // Save the current state of the terminal so we can restore it back to
     // normal before exiting.
     #[cfg(unix)]
     let orig_termios = io::stderr().is_terminal().then(term::get_termios);
 
-    let mut pidfile_path = None;
-    let exit_code = match do_main(&mut pidfile_path) {
+    let mut pidfile_guard = PidfileGuard(None);
+    let exit_code = match do_main(&mut pidfile_guard.0) {
         Ok(_) => 0,
         Err(err) => {
             eprintln!("fatal error: {:?}", err);
@@ -168,9 +180,7 @@ pub fn openvmm_main() {
 
     // Clean up the pidfile before terminating, since pal::process::terminate
     // skips destructors.
-    if let Some(ref path) = pidfile_path {
-        let _ = std::fs::remove_file(path);
-    }
+    drop(pidfile_guard);
 
     // Terminate the process immediately without graceful shutdown of DLLs or
     // C++ destructors or anything like that. This is all unnecessary and saves

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -152,7 +152,7 @@ struct PidfileGuard(Option<PathBuf>);
 impl Drop for PidfileGuard {
     fn drop(&mut self) {
         if let Some(path) = &self.0 {
-            fs_err::remove_file(path).unwrap();
+            let _ = fs_err::remove_file(path);
         }
     }
 }


### PR DESCRIPTION
Introduce a RAII guard to ensure the pidfile is removed even if a panic occurs during execution. Seen when investigating flaky VMM tests.