### PR TITLE
Repo: Use `push_mut`

### DIFF
--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -824,12 +824,11 @@ impl Response<'_> {
                 new_path_start,
                 new_depth,
             } => {
-                children.push(InternalEntry {
+                let entry = children.push_mut(InternalEntry {
                     name: name.to_owned(),
                     node: InternalNode::Unevaluated,
                     sensitivity,
                 });
-                let entry = children.last_mut().unwrap();
                 Some(
                     RequestParams {
                         path_start: new_path_start,
@@ -1013,12 +1012,11 @@ assert_eq!(
     /// no need (or ability--requests must have nodes) to propagate the request.
     fn request(&mut self) -> Option<Request<'_>> {
         let children = &mut **self.children.as_mut()?;
-        children.push(InternalEntry {
+        let entry = children.push_mut(InternalEntry {
             name: String::new(),
             node: InternalNode::Unevaluated,
             sensitivity: SensitivityLevel::Unspecified,
         });
-        let entry = children.last_mut().unwrap();
         Some(self.params.request(&mut entry.node))
     }
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -1539,8 +1539,7 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
 
         // Add the queue pair before aliasing its memory with the device so
         // that it can be torn down correctly on failure.
-        self.io.push(IoQueue { queue, iv, cpu });
-        let io_queue = self.io.last_mut().unwrap();
+        let io_queue = self.io.push_mut(IoQueue { queue, iv, cpu });
 
         let admin = self.admin.as_ref().unwrap().issuer().as_ref();
         let pci_id_str = self.device.id().to_owned();


### PR DESCRIPTION
Replace a few spots with the new push_mut helper added in a very recent Rust release.