### PR TITLE
vmbus_server: don't panic in channel inspect when disconnected

### DIFF
--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -1669,8 +1669,12 @@ impl Notifier for ServerTaskInner {
     fn inspect(&self, version: Option<VersionInfo>, offer_id: OfferId, req: inspect::Request<'_>) {
         let channel = self.channels.get(&offer_id).expect("should exist");
         let mut resp = req.respond();
-        if let ChannelState::Open(state) = &channel.state {
-            let mem = self.get_gm_for_channel(version.expect("must be connected"), channel);
+        // Only inspect ring buffers if we have an active connection; during
+        // disconnect/reset, `version` may be None even if an individual channel
+        // is still in the Open state, and we must not panic during inspect
+        // (e.g., timeout diagnostics rely on inspect succeeding).
+        if let (ChannelState::Open(state), Some(version)) = (&channel.state, version) {
+            let mem = self.get_gm_for_channel(version, channel);
             inspect_rings(
                 &mut resp,
                 mem,


### PR DESCRIPTION
`Channel::inspect` calls `version.expect("must be connected")` to fetch guest memory for inspecting an `Open` channel's ring buffers. During reset/disconnect the connection state has no version even while individual channels may still report `ChannelState::Open`, so this panics. I ran into this while investigating a VMM test timeout.