### PR TITLE
vmbus_server: respect max_version when restoring

### DIFF
--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -2446,10 +2446,12 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
 
         assert!(version >= Version::Copper || feature_flags == FeatureFlags::new());
         if feature_flags.into_bits() != request.feature_flags {
-            tracelimit::warn_ratelimited!(
+            // This is a common occurrence, especially with the difference between flags that may
+            // be supported by Hyper-V, OpenVMM, and OpenHCL, so this does not need to be a warning.
+            tracelimit::info_ratelimited!(
                 supported = feature_flags.into_bits(),
                 requested = request.feature_flags,
-                "Guest requested unsupported feature flags."
+                "guest requested unsupported feature flags."
             );
         }
 

--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -14,6 +14,7 @@ use mesh::payload::Protobuf;
 use std::fmt::Display;
 use thiserror::Error;
 use vmbus_channel::bus::OfferKey;
+use vmbus_core::MaxVersionInfo;
 use vmbus_core::protocol;
 use vmbus_core::protocol::ChannelId;
 use vmbus_core::protocol::FeatureFlags;
@@ -24,7 +25,7 @@ use vmcore::monitor::MonitorId;
 
 impl super::Server {
     fn restore_one_channel(&mut self, saved_channel: Channel) -> Result<(), RestoreError> {
-        let (info, stub_offer, state) = saved_channel.restore()?;
+        let (info, stub_offer, state) = saved_channel.restore(self.max_version)?;
         if let Some((offer_id, channel)) = self.channels.get_by_key_mut(&saved_channel.key) {
             // There is an existing channel. Restore on top of it.
 
@@ -190,7 +191,7 @@ impl<'a, N: 'a + Notifier> super::ServerWithNotifier<'a, N> {
         let saved = SavedStateData::from(saved);
         match saved.state {
             SavedConnectionState::Connected(saved) => {
-                self.inner.state = saved.connection.restore()?;
+                self.inner.state = saved.connection.restore(self.inner.max_version)?;
 
                 // Restore server state, and resend server notifications if needed. If these notifications
                 // were processed before the save, it's harmless as the values will be the same.
@@ -442,15 +443,40 @@ impl VersionInfo {
         }
     }
 
-    fn restore(self, trusted: bool) -> Result<vmbus_core::VersionInfo, RestoreError> {
+    fn restore(
+        self,
+        trusted: bool,
+        max_version: Option<MaxVersionInfo>,
+    ) -> Result<vmbus_core::VersionInfo, RestoreError> {
         let version = super::SUPPORTED_VERSIONS
             .iter()
             .find(|v| self.version == **v as u32)
             .copied()
             .ok_or(RestoreError::UnsupportedVersion(self.version))?;
 
+        // Enforce the server's compatibility version limit, if any. This may
+        // restrict both the protocol version and the set of feature flags
+        // permitted, similar to negotiation in `check_version_supported`.
+        if let Some(max_version) = max_version {
+            if version as u32 > max_version.version {
+                return Err(RestoreError::UnsupportedVersion(self.version));
+            }
+        }
+
         let feature_flags = FeatureFlags::from(self.feature_flags);
-        let supported_flags = SUPPORTED_FEATURE_FLAGS.with_confidential_channels(trusted);
+        let supported_flags = if version >= Version::Copper {
+            // Limit feature flags to those supported by the server's
+            // compatibility version, if specified.
+            let max_flags = max_version.map_or(FeatureFlags::from_bits(u32::MAX), |max_version| {
+                max_version.feature_flags
+            });
+
+            SUPPORTED_FEATURE_FLAGS.with_confidential_channels(trusted) & max_flags
+        } else {
+            // Earlier protocol versions don't have feature flags.
+            FeatureFlags::new()
+        };
+
         if !supported_flags.contains(feature_flags) {
             return Err(RestoreError::UnsupportedFeatureFlags(feature_flags.into()));
         }
@@ -548,7 +574,10 @@ impl Connection {
         }
     }
 
-    fn restore(self) -> Result<super::ConnectionState, RestoreError> {
+    fn restore(
+        self,
+        max_version: Option<MaxVersionInfo>,
+    ) -> Result<super::ConnectionState, RestoreError> {
         Ok(match self {
             Connection::Connecting {
                 version,
@@ -560,7 +589,7 @@ impl Connection {
                 trusted,
             } => super::ConnectionState::Connecting {
                 info: super::ConnectionInfo {
-                    version: version.restore(trusted)?,
+                    version: version.restore(trusted, max_version)?,
                     trusted,
                     interrupt_page,
                     monitor_page: monitor_page.map(MonitorPageGpas::restore),
@@ -583,7 +612,7 @@ impl Connection {
                 trusted,
                 paused,
             } => super::ConnectionState::Connected(super::ConnectionInfo {
-                version: version.restore(trusted)?,
+                version: version.restore(trusted, max_version)?,
                 trusted,
                 offers_sent,
                 interrupt_page,
@@ -682,6 +711,7 @@ impl Channel {
 
     fn restore(
         &self,
+        max_version: Option<MaxVersionInfo>,
     ) -> Result<(OfferedInfo, OfferParamsInternal, super::ChannelState), RestoreError> {
         let info = OfferedInfo {
             channel_id: ChannelId(self.channel_id),
@@ -696,7 +726,7 @@ impl Channel {
             ..Default::default()
         };
 
-        let state = self.state.restore()?;
+        let state = self.state.restore(max_version)?;
         tracing::info!(key = %self.key, %state, "channel restored");
         Ok((info, stub_offer, state))
     }
@@ -1009,16 +1039,23 @@ impl ReservedState {
         }
     }
 
-    fn restore(&self) -> Result<super::ReservedState, RestoreError> {
+    fn restore(
+        &self,
+        max_version: Option<MaxVersionInfo>,
+    ) -> Result<super::ReservedState, RestoreError> {
         // We don't know if the connection when the channel was reserved was trusted, so assume it
         // was for what feature flags are accepted here; it doesn't affect any actual behavior.
-        let version = self.version.clone().restore(true).map_err(|e| match e {
-            RestoreError::UnsupportedVersion(v) => RestoreError::UnsupportedReserveVersion(v),
-            RestoreError::UnsupportedFeatureFlags(f) => {
-                RestoreError::UnsupportedReserveFeatureFlags(f)
-            }
-            err => err,
-        })?;
+        let version = self
+            .version
+            .clone()
+            .restore(true, max_version)
+            .map_err(|e| match e {
+                RestoreError::UnsupportedVersion(v) => RestoreError::UnsupportedReserveVersion(v),
+                RestoreError::UnsupportedFeatureFlags(f) => {
+                    RestoreError::UnsupportedReserveFeatureFlags(f)
+                }
+                err => err,
+            })?;
 
         if version.version < Version::Win10 {
             return Err(RestoreError::UnsupportedReserveVersion(
@@ -1115,7 +1152,10 @@ impl ChannelState {
         })
     }
 
-    fn restore(&self) -> Result<super::ChannelState, RestoreError> {
+    fn restore(
+        &self,
+        max_version: Option<MaxVersionInfo>,
+    ) -> Result<super::ChannelState, RestoreError> {
         Ok(match self {
             ChannelState::Closed => super::ChannelState::Closed,
             ChannelState::Opening {
@@ -1125,7 +1165,7 @@ impl ChannelState {
                 request: request.restore(),
                 reserved_state: reserved_state
                     .as_ref()
-                    .map(ReservedState::restore)
+                    .map(|r| r.restore(max_version))
                     .transpose()?,
             },
             ChannelState::ClosingReopen { params, request } => super::ChannelState::ClosingReopen {
@@ -1141,7 +1181,7 @@ impl ChannelState {
                 modify_state: modify_state.restore(),
                 reserved_state: reserved_state
                     .as_ref()
-                    .map(ReservedState::restore)
+                    .map(|r| r.restore(max_version))
                     .transpose()?,
             },
             ChannelState::Closing {
@@ -1151,7 +1191,7 @@ impl ChannelState {
                 params: params.restore(),
                 reserved_state: reserved_state
                     .as_ref()
-                    .map(ReservedState::restore)
+                    .map(|r| r.restore(max_version))
                     .transpose()?,
             },
             ChannelState::Revoked => {

--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -465,13 +465,14 @@ impl VersionInfo {
 
         let feature_flags = FeatureFlags::from(self.feature_flags);
         let supported_flags = if version >= Version::Copper {
+            let mut flags = SUPPORTED_FEATURE_FLAGS.with_confidential_channels(trusted);
             // Limit feature flags to those supported by the server's
             // compatibility version, if specified.
-            let max_flags = max_version.map_or(FeatureFlags::from_bits(u32::MAX), |max_version| {
-                max_version.feature_flags
-            });
+            if let Some(max_version) = max_version {
+                flags &= max_version.feature_flags;
+            }
 
-            SUPPORTED_FEATURE_FLAGS.with_confidential_channels(trusted) & max_flags
+            flags
         } else {
             // Earlier protocol versions don't have feature flags.
             FeatureFlags::new()

--- a/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
@@ -743,6 +743,293 @@ fn test_save_restore_with_no_connection() {
 }
 
 #[test]
+fn test_restore_max_version_rejects_higher_version() {
+    // Save a state that was negotiated at the Copper protocol version, then
+    // try to restore it on a server that has been limited to Win10. The
+    // restore should fail because the saved version exceeds the server's
+    // configured max_version.
+    let mut env = TestEnv::new();
+    env.connect(Version::Copper, FeatureFlags::new());
+    let state = env.server.save();
+
+    let mut env2 = TestEnv::new();
+    env2.server
+        .set_compatibility_version(MaxVersionInfo::new(Version::Win10 as u32), false);
+
+    let err = env2.c().restore(state).unwrap_err();
+    assert!(
+        matches!(err, RestoreError::UnsupportedVersion(v) if v == Version::Copper as u32),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[test]
+fn test_restore_max_version_rejects_disallowed_feature_flags() {
+    // Save a state that was negotiated at Copper with a feature flag set,
+    // then restore it on a server whose max_version permits Copper but
+    // masks out that feature flag. The restore should fail because the
+    // saved feature flags exceed what is allowed.
+    let mut env = TestEnv::new();
+    env.connect(Version::Copper, FeatureFlags::new().with_client_id(true));
+    let state = env.server.save();
+
+    let mut env2 = TestEnv::new();
+    env2.server.set_compatibility_version(
+        MaxVersionInfo {
+            version: Version::Copper as u32,
+            feature_flags: FeatureFlags::new().with_guest_specified_signal_parameters(true),
+        },
+        false,
+    );
+
+    let err = env2.c().restore(state).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            RestoreError::UnsupportedFeatureFlags(f)
+                if f == u32::from(FeatureFlags::new().with_client_id(true))
+        ),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[test]
+fn test_restore_max_version_pre_copper() {
+    // Save a state that was negotiated at a pre-Copper protocol version,
+    // then restore it on a server whose max_version permits that version.
+    // The restore should succeed.
+    let mut env = TestEnv::new();
+    let _offer_id = env.offer(1);
+    env.connect(Version::Win10Rs5, FeatureFlags::new());
+    let state = env.server.save();
+
+    let mut env2 = TestEnv::new();
+    let offer_id2 = env2.offer(1);
+    env2.server
+        .set_compatibility_version(MaxVersionInfo::new(Version::Win10Rs5 as u32), false);
+
+    env2.c().restore(state).unwrap();
+    env2.c().restore_channel(offer_id2, false).unwrap();
+}
+
+#[test]
+fn test_restore_max_version_copper_with_feature_flags() {
+    // Save a state that was negotiated at Copper with a feature flag set,
+    // then restore it on a server whose max_version permits Copper with
+    // that same feature flag. The restore should succeed.
+    let feature_flags = FeatureFlags::new().with_client_id(true);
+    let mut env = TestEnv::new();
+    let _offer_id = env.offer(1);
+    env.connect(Version::Copper, feature_flags);
+    let state = env.server.save();
+
+    let mut env2 = TestEnv::new();
+    let offer_id2 = env2.offer(1);
+    env2.server.set_compatibility_version(
+        MaxVersionInfo {
+            version: Version::Copper as u32,
+            feature_flags,
+        },
+        false,
+    );
+
+    env2.c().restore(state).unwrap();
+    env2.c().restore_channel(offer_id2, false).unwrap();
+}
+
+#[test]
+fn test_restore_pre_copper_with_feature_flags_rejected() {
+    // Save a state at a pre-Copper protocol version, then manipulate the
+    // saved state to inject a feature flag (which is impossible to produce
+    // via real negotiation, since feature flags were introduced in Copper).
+    // Restore on a server with no max_version configured should still fail
+    // because feature flags are not supported below Copper.
+    let mut env = TestEnv::new();
+    let _offer_id = env.offer(1);
+    env.connect(Version::Win10Rs5, FeatureFlags::new());
+    let state = env.server.save();
+
+    // Tamper with the saved state to set a feature flag on a pre-Copper
+    // version.
+    let mut data = SavedStateData::from(state);
+    let injected_flags =
+        u32::from(FeatureFlags::new().with_guest_specified_signal_parameters(true));
+    match &mut data.state {
+        saved_state::SavedConnectionState::Connected(connected) => {
+            match &mut connected.connection {
+                saved_state::Connection::Connected { version, .. } => {
+                    assert_eq!(version.version, Version::Win10Rs5 as u32);
+                    assert_eq!(version.feature_flags, 0);
+                    version.feature_flags = injected_flags;
+                }
+                _ => panic!("unexpected connection state"),
+            }
+        }
+        saved_state::SavedConnectionState::Disconnected(_) => panic!("expected connected state"),
+    }
+    let tampered = SavedState::from(data);
+
+    let mut env2 = TestEnv::new();
+    let _offer_id2 = env2.offer(1);
+    let err = env2.c().restore(tampered).unwrap_err();
+    assert!(
+        matches!(err, RestoreError::UnsupportedFeatureFlags(f) if f == injected_flags),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[test]
+fn test_restore_max_version_reserved_channel_success() {
+    // Save a disconnected state that retains a reserved channel reserved
+    // while the connection was at Copper with a feature flag set, then
+    // restore on a server whose max_version permits Copper with that
+    // feature flag. The restore should succeed.
+    let feature_flags = FeatureFlags::new().with_client_id(true);
+    let mut env = TestEnv::new();
+    let offer_id1 = env.offer(1);
+    env.connect(Version::Copper, feature_flags);
+    env.c().handle_request_offers().unwrap();
+    env.open_reserved(1, 0, VMBUS_SINT.into());
+    env.c().open_complete(offer_id1, protocol::STATUS_SUCCESS);
+    env.c().handle_unload();
+    let state = env.server.save();
+
+    let mut env2 = TestEnv::new();
+    let offer_id1 = env2.offer(1);
+    env2.server.set_compatibility_version(
+        MaxVersionInfo {
+            version: Version::Copper as u32,
+            feature_flags,
+        },
+        false,
+    );
+
+    env2.c().restore(state).unwrap();
+    env2.c().restore_channel(offer_id1, true).unwrap();
+}
+
+#[test]
+fn test_restore_max_version_reserved_channel_rejects_higher_version() {
+    // Save a disconnected state that retains a reserved channel reserved
+    // while the connection was at Copper, then restore on a server whose
+    // max_version permits only Win10. The restore should fail because the
+    // reserved channel's saved version exceeds the server's max_version.
+    let mut env = TestEnv::new();
+    let offer_id1 = env.offer(1);
+    env.connect(Version::Copper, FeatureFlags::new());
+    env.c().handle_request_offers().unwrap();
+    env.open_reserved(1, 0, VMBUS_SINT.into());
+    env.c().open_complete(offer_id1, protocol::STATUS_SUCCESS);
+    env.c().handle_unload();
+    let state = env.server.save();
+
+    let mut env2 = TestEnv::new();
+    let _offer_id1 = env2.offer(1);
+    env2.server
+        .set_compatibility_version(MaxVersionInfo::new(Version::Win10 as u32), false);
+
+    let err = env2.c().restore(state).unwrap_err();
+    assert!(
+        matches!(err, RestoreError::UnsupportedReserveVersion(v) if v == Version::Copper as u32),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[test]
+fn test_restore_max_version_reserved_channel_rejects_disallowed_feature_flags() {
+    // Save a disconnected state that retains a reserved channel reserved
+    // while the connection was at Copper with a feature flag set, then
+    // restore on a server whose max_version permits Copper but masks out
+    // that feature flag. The restore should fail because the reserved
+    // channel's saved feature flags exceed what is allowed.
+    let mut env = TestEnv::new();
+    let offer_id1 = env.offer(1);
+    env.connect(Version::Copper, FeatureFlags::new().with_client_id(true));
+    env.c().handle_request_offers().unwrap();
+    env.open_reserved(1, 0, VMBUS_SINT.into());
+    env.c().open_complete(offer_id1, protocol::STATUS_SUCCESS);
+    env.c().handle_unload();
+    let state = env.server.save();
+
+    let mut env2 = TestEnv::new();
+    let _offer_id1 = env2.offer(1);
+    env2.server.set_compatibility_version(
+        MaxVersionInfo {
+            version: Version::Copper as u32,
+            feature_flags: FeatureFlags::new().with_guest_specified_signal_parameters(true),
+        },
+        false,
+    );
+
+    let err = env2.c().restore(state).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            RestoreError::UnsupportedReserveFeatureFlags(f)
+                if f == u32::from(FeatureFlags::new().with_client_id(true))
+        ),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[test]
+fn test_restore_pre_copper_reserved_channel_with_feature_flags_rejected() {
+    // Save a state with a reserved channel that was reserved while the
+    // connection was at a pre-Copper protocol version, then tamper with
+    // the saved state to inject a feature flag on the reserved channel's
+    // version (which is impossible to produce via real negotiation).
+    // Restore on a server with no max_version configured should still fail
+    // because feature flags are not supported below Copper.
+    let mut env = TestEnv::new();
+    let offer_id1 = env.offer(1);
+    env.connect(Version::Win10Rs5, FeatureFlags::new());
+    env.c().handle_request_offers().unwrap();
+    env.open_reserved(1, 0, VMBUS_SINT.into());
+    env.c().open_complete(offer_id1, protocol::STATUS_SUCCESS);
+    let state = env.server.save();
+
+    // Tamper with the saved state to set a feature flag on the reserved
+    // channel's pre-Copper version.
+    let mut data = SavedStateData::from(state);
+    let injected_flags =
+        u32::from(FeatureFlags::new().with_guest_specified_signal_parameters(true));
+    let channels = match &mut data.state {
+        saved_state::SavedConnectionState::Connected(connected) => &mut connected.channels,
+        saved_state::SavedConnectionState::Disconnected(_) => panic!("expected connected state"),
+    };
+    let channel = channels
+        .iter_mut()
+        .find(|c| {
+            matches!(
+                &c.state,
+                saved_state::ChannelState::Open {
+                    reserved_state: Some(_),
+                    ..
+                }
+            )
+        })
+        .expect("reserved channel preserved");
+    let reserved_state = match &mut channel.state {
+        saved_state::ChannelState::Open { reserved_state, .. } => reserved_state
+            .as_mut()
+            .expect("reserved channel has reserved state"),
+        _ => unreachable!(),
+    };
+    assert_eq!(reserved_state.version.version, Version::Win10Rs5 as u32);
+    assert_eq!(reserved_state.version.feature_flags, 0);
+    reserved_state.version.feature_flags = injected_flags;
+    let tampered = SavedState::from(data);
+
+    let mut env2 = TestEnv::new();
+    let _offer_id1 = env2.offer(1);
+    let err = env2.c().restore(tampered).unwrap_err();
+    assert!(
+        matches!(err, RestoreError::UnsupportedReserveFeatureFlags(f) if f == injected_flags),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[test]
 fn test_save_restore_with_connection() {
     let mut env = TestEnv::new();
 


### PR DESCRIPTION
This change updates restore functionality for VMBus to respect the max version configured for the server, rejecting saved states that contain newer versions or unsupported feature flags. This matches the behavior of Hyper-V for save/restore.

The restore process is also updated to reject invalid saved states that may have feature flags set on a pre-Copper version. Many of the feature flag checks in the code don't check the version, instead assuming that feature flags can only be set if the version is Copper.

Additional tests are added for the new save/restore behavior.

Finally, a small change is made to logging; it has become very common for a guest to request feature flags that may not be supported by a particular server, so the log message for this doesn't need to be a warning. It's changed to info instead.