### PR TITLE
flowey: split openvmm-deps downloads for v0.3.0 artifact layout

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -904,8 +904,14 @@ jobs:
       run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
+      run: flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
@@ -1131,12 +1137,6 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 12 flowey_lib_common::download_gh_release 0
       shell: bash
@@ -1160,8 +1160,11 @@ jobs:
         flowey e 12 flowey_lib_common::cache 2
         flowey e 12 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 12 flowey_lib_common::install_rust 0
@@ -1198,6 +1201,12 @@ jobs:
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
       run: |-
@@ -1240,6 +1249,9 @@ jobs:
       run: |-
         flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: |-
@@ -2151,12 +2163,6 @@ jobs:
         flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 15 flowey_lib_common::download_gh_release 0
       shell: bash
@@ -2185,6 +2191,12 @@ jobs:
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -3186,12 +3198,6 @@ jobs:
         flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 18 flowey_lib_common::download_gh_release 0
       shell: bash
@@ -3220,6 +3226,12 @@ jobs:
       shell: bash
     - name: extract Aarch64 sysroot.tar.gz
       run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -3656,8 +3668,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 19 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 19 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 19 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -4103,8 +4118,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 20 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 20 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 20 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -4369,8 +4387,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -4639,8 +4660,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -4905,8 +4929,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -5118,8 +5145,11 @@ jobs:
     - name: write to directory variables
       run: flowey e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -5422,8 +5452,11 @@ jobs:
     - name: write to directory variables
       run: flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -5773,8 +5806,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
       run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -845,8 +845,14 @@ jobs:
       run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
+      run: flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
@@ -1008,12 +1014,6 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 12 flowey_lib_common::download_gh_release 0
       shell: bash
@@ -1037,8 +1037,11 @@ jobs:
         flowey e 12 flowey_lib_common::cache 2
         flowey e 12 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 12 flowey_lib_common::install_rust 0
@@ -1075,6 +1078,12 @@ jobs:
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
       run: |-
@@ -1117,6 +1126,9 @@ jobs:
       run: |-
         flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: |-
@@ -1914,12 +1926,6 @@ jobs:
         flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 15 flowey_lib_common::download_gh_release 0
       shell: bash
@@ -1948,6 +1954,12 @@ jobs:
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -2955,12 +2967,6 @@ jobs:
         flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 18 flowey_lib_common::download_gh_release 0
       shell: bash
@@ -2989,6 +2995,12 @@ jobs:
       shell: bash
     - name: extract Aarch64 sysroot.tar.gz
       run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -3426,8 +3438,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 19 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 19 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 19 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -3876,8 +3891,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 20 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 20 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 20 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -4143,8 +4161,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -4414,8 +4435,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -4681,8 +4705,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -4895,8 +4922,11 @@ jobs:
     - name: write to directory variables
       run: flowey e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -5200,8 +5230,11 @@ jobs:
     - name: write to directory variables
       run: flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -5552,8 +5585,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
       run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -701,12 +701,6 @@ jobs:
         flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 11 flowey_lib_common::download_gh_release 0
       shell: bash
@@ -738,6 +732,12 @@ jobs:
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
       run: flowey e 11 flowey_lib_common::resolve_protoc 0
@@ -1040,8 +1040,14 @@ jobs:
       run: flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
+      run: flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
@@ -1229,12 +1235,6 @@ jobs:
         flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 13 flowey_lib_common::download_gh_release 0
       shell: bash
@@ -1266,6 +1266,12 @@ jobs:
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
       run: flowey e 13 flowey_lib_common::resolve_protoc 0
@@ -1399,12 +1405,6 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 14 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 14 flowey_lib_common::download_gh_release 0
       shell: bash
@@ -1428,8 +1428,11 @@ jobs:
         flowey e 14 flowey_lib_common::cache 2
         flowey e 14 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 14 flowey_lib_common::install_rust 0
@@ -1466,6 +1469,12 @@ jobs:
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
       run: |-
@@ -1508,6 +1517,9 @@ jobs:
       run: |-
         flowey e 14 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: |-
@@ -2305,12 +2317,6 @@ jobs:
         flowey e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 17 flowey_lib_common::download_gh_release 0
       shell: bash
@@ -2339,6 +2345,12 @@ jobs:
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
       run: flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -3530,12 +3542,6 @@ jobs:
         flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 20 flowey_lib_common::download_gh_release 0
       shell: bash
@@ -3564,6 +3570,12 @@ jobs:
       shell: bash
     - name: extract Aarch64 sysroot.tar.gz
       run: flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 20 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 20 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 20 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -4001,8 +4013,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -4267,8 +4282,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -4534,8 +4552,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -4805,8 +4826,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -5072,8 +5096,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -5286,8 +5313,11 @@ jobs:
     - name: write to directory variables
       run: flowey e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -5591,8 +5621,11 @@ jobs:
     - name: write to directory variables
       run: flowey e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -5943,8 +5976,11 @@ jobs:
     - name: write to directory variables
       run: flowey.exe e 28 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 28 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey.exe e 28 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey.exe e 28 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
       run: flowey.exe e 28 flowey_lib_hvlite::download_uefi_mu_msvm 0

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -280,10 +280,6 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -311,6 +307,10 @@ jobs:
     displayName: unpack openvmm-deps archive
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
     displayName: extract X86_64 sysroot.tar.gz
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::resolve_protoc 0
@@ -1132,10 +1132,6 @@ jobs:
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | $FLOWEY_BIN v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -1159,8 +1155,10 @@ jobs:
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    displayName: unpack openvmm-test-linux archives
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+    displayName: unpack openvmm-test-initrd archives
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
@@ -1189,6 +1187,10 @@ jobs:
     displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::resolve_protoc 0
@@ -1231,6 +1233,8 @@ jobs:
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
     displayName: extract and resolve kernel package
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
@@ -1546,13 +1550,17 @@ jobs:
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
     displayName: extract and resolve kernel package
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+    displayName: building openhcl initrd
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    displayName: unpack openvmm-test-linux archives
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-    displayName: building openhcl initrd
+    displayName: unpack openvmm-test-initrd archives
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 0
@@ -4040,8 +4048,10 @@ jobs:
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
     displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+    displayName: unpack openvmm-test-initrd archives
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    displayName: unpack openvmm-test-linux archives
   - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
     displayName: unpack mu_msvm package (x64)
   - bash: |-
@@ -4305,8 +4315,10 @@ jobs:
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
     displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+    displayName: unpack openvmm-test-initrd archives
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    displayName: unpack openvmm-test-linux archives
   - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
     displayName: unpack mu_msvm package (x64)
   - bash: |-
@@ -4576,8 +4588,10 @@ jobs:
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
     displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+    displayName: unpack openvmm-test-initrd archives
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    displayName: unpack openvmm-test-linux archives
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_uefi_mu_msvm 0
     displayName: unpack mu_msvm package (x64)
   - bash: |-
@@ -4847,8 +4861,10 @@ jobs:
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
     displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+    displayName: unpack openvmm-test-initrd archives
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    displayName: unpack openvmm-test-linux archives
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_uefi_mu_msvm 0
     displayName: unpack mu_msvm package (x64)
   - bash: |-

--- a/flowey/flowey_lib_common/src/_util/extract.rs
+++ b/flowey/flowey_lib_common/src/_util/extract.rs
@@ -114,6 +114,63 @@ pub fn extract_zip_if_new(
     Ok(extract_dir)
 }
 
+/// Extracts the given `.tar.gz` `file` into `persistent_dir` (or into
+/// [`std::env::current_dir()`], if no persistent dir is available).
+///
+/// Unlike `.tar.bz2`, `.tar.gz` is handled natively by every platform's `tar`,
+/// so this helper has no install-package dependency to track. The caller
+/// resolves the persistent dir itself and passes it (already read) as
+/// `persistent_dir` — no `Deps` struct needed.
+///
+/// To avoid redundant extracts between pipeline runs, callers must provide a
+/// `file_version` string that identifies the current file. If the previous
+/// run already extracted an archive with the given `file_version`, this
+/// function will return nearly instantaneously.
+pub fn extract_tar_gz_if_new(
+    rt: &mut RustRuntimeServices<'_>,
+    persistent_dir: Option<&Path>,
+    file: &Path,
+    file_version: &str,
+) -> anyhow::Result<PathBuf> {
+    let root_dir = match persistent_dir {
+        Some(dir) => dir.to_path_buf(),
+        None => rt.sh.current_dir(),
+    };
+
+    let filename = file.file_name().expect("tar.gz file was not a file");
+    let extract_dir = root_dir.join(FLOWEY_EXTRACT_DIR).join(filename);
+    fs_err::create_dir_all(&extract_dir)?;
+
+    let pkg_info_dir = root_dir.join(FLOWEY_INFO_DIR);
+    fs_err::create_dir_all(&pkg_info_dir)?;
+    let pkg_info_file = pkg_info_dir.join(filename);
+
+    let mut already_extracted = false;
+    if let Ok(info) = fs_err::read_to_string(&pkg_info_file) {
+        if info == file_version {
+            already_extracted = true;
+        }
+    }
+
+    if !already_extracted {
+        // clear out any old version that was present
+        fs_err::remove_dir_all(&extract_dir)?;
+        fs_err::create_dir(&extract_dir)?;
+
+        rt.sh.change_dir(&extract_dir);
+
+        // windows builds past Windows 10 build 17063 come with tar installed,
+        // and `tar -xf` auto-detects gzip compression on all platforms
+        flowey::shell_cmd!(rt, "tar -xf {file}").run()?;
+
+        fs_err::write(pkg_info_file, file_version)?;
+    } else {
+        log::info!("already extracted!");
+    }
+
+    Ok(extract_dir)
+}
+
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct ExtractTarBz2Deps<C = VarNotClaimed> {

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -32,7 +32,7 @@ pub const NODEJS: &str = "24.x";
 //      increases with each release from the respective branch.
 pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.2";
 pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.2";
-pub const OPENVMM_DEPS: &str = "0.2.0-7";
+pub const OPENVMM_DEPS: &str = "0.3.0-29";
 pub const PROTOC: &str = "27.1";
 
 flowey_request! {
@@ -62,6 +62,8 @@ impl FlowNode for Node {
     fn imports(ctx: &mut ImportCtx<'_>) {
         ctx.import::<crate::resolve_openhcl_kernel_package::Node>();
         ctx.import::<crate::resolve_openvmm_deps::Node>();
+        ctx.import::<crate::resolve_openvmm_test_initrd::Node>();
+        ctx.import::<crate::resolve_openvmm_test_linux_kernel::Node>();
         ctx.import::<crate::download_uefi_mu_msvm::Node>();
         ctx.import::<crate::cfg_rustup_version::Node>();
         ctx.import::<flowey_lib_common::download_azcopy::Node>();
@@ -196,6 +198,18 @@ impl FlowNode for Node {
                 ..Default::default()
             });
         }
+        // The test Linux kernel and shared test initrd are always pulled
+        // from the openvmm-deps GitHub release; `LocalOpenvmmDeps` only
+        // overrides the (non-kernel/initrd) openvmm-deps tarball, since the
+        // 0.3.0 split moved the kernel and initrd into their own artifacts.
+        ctx.config(crate::resolve_openvmm_test_linux_kernel::Config {
+            version: Some(OPENVMM_DEPS.into()),
+            ..Default::default()
+        });
+        ctx.config(crate::resolve_openvmm_test_initrd::Config {
+            version: Some(OPENVMM_DEPS.into()),
+            ..Default::default()
+        });
         if !has_local_uefi {
             ctx.config(crate::download_uefi_mu_msvm::Config {
                 version: Some(MU_MSVM.into()),

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
@@ -272,6 +272,8 @@ impl SimpleFlowNode for Node {
         ctx.import::<crate::build_sidecar::Node>();
         ctx.import::<crate::resolve_openhcl_kernel_package::Node>();
         ctx.import::<crate::resolve_openvmm_deps::Node>();
+        ctx.import::<crate::resolve_openvmm_test_initrd::Node>();
+        ctx.import::<crate::resolve_openvmm_test_linux_kernel::Node>();
         ctx.import::<crate::download_uefi_mu_msvm::Node>();
         ctx.import::<crate::git_checkout_openvmm_repo::Node>();
         ctx.import::<crate::run_igvmfilegen::Node>();
@@ -378,9 +380,10 @@ impl SimpleFlowNode for Node {
             } else {
                 match typ {
                     Vtl0KernelType::Example => ctx.reqv(|v| {
-                        crate::resolve_openvmm_deps::Request::Get(
-                            crate::resolve_openvmm_deps::OpenvmmDepFile::LinuxTestKernel,
+                        crate::resolve_openvmm_test_linux_kernel::Request::Get(
+                            crate::resolve_openvmm_test_linux_kernel::OpenvmmTestKernelFile::Kernel,
                             arch,
+                            crate::resolve_openvmm_test_linux_kernel::DEFAULT_LINUX_TEST_KERNEL_VERSION,
                             v,
                         )
                     }),
@@ -389,11 +392,7 @@ impl SimpleFlowNode for Node {
             };
 
             let initrd = ctx.reqv(|v| {
-                crate::resolve_openvmm_deps::Request::Get(
-                    crate::resolve_openvmm_deps::OpenvmmDepFile::LinuxTestInitrd,
-                    arch,
-                    v,
-                )
+                crate::resolve_openvmm_test_initrd::Request::Get(arch, v)
             });
 
             Vtl0KernelResource { kernel, initrd }

--- a/flowey/flowey_lib_hvlite/src/init_openvmm_magicpath_openvmm_deps.rs
+++ b/flowey/flowey_lib_hvlite/src/init_openvmm_magicpath_openvmm_deps.rs
@@ -37,30 +37,20 @@ struct DepFile {
     dest_filename: fn(CommonArch) -> &'static str,
 }
 
-/// The table of dep files to copy. To add a new dep, add an entry here.
+/// The table of dep files to copy from the main openvmm-deps archive. To
+/// add a new dep, add an entry here.
+///
+/// The Linux test kernel and matching shared initrd are *not* in this table —
+/// the kernel comes from per-(arch, kver) archives via
+/// [`crate::resolve_openvmm_test_linux_kernel`], the initrd from the shared
+/// [`crate::resolve_openvmm_test_initrd`] node, and both are placed into the
+/// magicpath separately below.
 fn dep_files() -> Vec<DepFile> {
     use crate::resolve_openvmm_deps::OpenvmmDepFile;
-    vec![
-        DepFile {
-            dep: OpenvmmDepFile::LinuxTestKernel,
-            dest_filename: |arch| match arch {
-                CommonArch::Aarch64 => "Image",
-                CommonArch::X86_64 => "vmlinux",
-            },
-        },
-        DepFile {
-            dep: OpenvmmDepFile::LinuxTestBzImage,
-            dest_filename: |_arch| "bzImage",
-        },
-        DepFile {
-            dep: OpenvmmDepFile::LinuxTestInitrd,
-            dest_filename: |_arch| "initrd",
-        },
-        DepFile {
-            dep: OpenvmmDepFile::PetritoolsErofs,
-            dest_filename: |_arch| "petritools.erofs",
-        },
-    ]
+    vec![DepFile {
+        dep: OpenvmmDepFile::PetritoolsErofs,
+        dest_filename: |_arch| "petritools.erofs",
+    }]
 }
 
 impl FlowNode for Node {
@@ -69,6 +59,8 @@ impl FlowNode for Node {
     fn imports(ctx: &mut ImportCtx<'_>) {
         ctx.import::<crate::cfg_openvmm_magicpath::Node>();
         ctx.import::<crate::resolve_openvmm_deps::Node>();
+        ctx.import::<crate::resolve_openvmm_test_initrd::Node>();
+        ctx.import::<crate::resolve_openvmm_test_linux_kernel::Node>();
     }
 
     fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
@@ -83,9 +75,8 @@ impl FlowNode for Node {
 
         for (arch, out_vars) in by_arch {
             // Resolve all dep files for this arch.
-            let resolved: Vec<(ReadVar<PathBuf>, &'static str)> = dep_files()
+            let mut resolved: Vec<(ReadVar<PathBuf>, &'static str)> = dep_files()
                 .into_iter()
-                .filter(|dep_file| dep_file.dep.is_available_for(arch))
                 .map(|dep_file| {
                     let src = ctx
                         .reqv(|v| crate::resolve_openvmm_deps::Request::Get(dep_file.dep, arch, v));
@@ -93,6 +84,37 @@ impl FlowNode for Node {
                     (src, dst_name)
                 })
                 .collect();
+
+            // Resolve the Linux test kernel for this arch from the per-(arch,
+            // kver) `openvmm-test-linux` archive, and the matching guest-
+            // userland initrd from the version-independent
+            // `openvmm-test-initrd` archive.
+            use crate::resolve_openvmm_test_linux_kernel::DEFAULT_LINUX_TEST_KERNEL_VERSION as KVER;
+            use crate::resolve_openvmm_test_linux_kernel::OpenvmmTestKernelFile;
+            let kernel_src = ctx.reqv(|v| {
+                crate::resolve_openvmm_test_linux_kernel::Request::Get(
+                    OpenvmmTestKernelFile::Kernel,
+                    arch,
+                    KVER,
+                    v,
+                )
+            });
+            let kernel_dst_name = OpenvmmTestKernelFile::Kernel.filename(arch);
+            resolved.push((kernel_src, kernel_dst_name));
+            if OpenvmmTestKernelFile::BzImage.is_available_for(arch) {
+                let bzimage_src = ctx.reqv(|v| {
+                    crate::resolve_openvmm_test_linux_kernel::Request::Get(
+                        OpenvmmTestKernelFile::BzImage,
+                        arch,
+                        KVER,
+                        v,
+                    )
+                });
+                resolved.push((bzimage_src, OpenvmmTestKernelFile::BzImage.filename(arch)));
+            }
+            let initrd_src =
+                ctx.reqv(|v| crate::resolve_openvmm_test_initrd::Request::Get(arch, v));
+            resolved.push((initrd_src, "initrd"));
 
             ctx.emit_rust_step(
                 format!("copy {arch:?} openvmm-deps files to magicpath"),

--- a/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
+++ b/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
@@ -82,6 +82,8 @@ impl SimpleFlowNode for Node {
 
     fn imports(ctx: &mut ImportCtx<'_>) {
         ctx.import::<crate::resolve_openvmm_deps::Node>();
+        ctx.import::<crate::resolve_openvmm_test_initrd::Node>();
+        ctx.import::<crate::resolve_openvmm_test_linux_kernel::Node>();
         ctx.import::<crate::git_checkout_openvmm_repo::Node>();
         ctx.import::<crate::download_uefi_mu_msvm::Node>();
     }
@@ -114,31 +116,29 @@ impl SimpleFlowNode for Node {
 
         let arch = CommonArch::from_architecture(vmm_tests_target.architecture)?;
 
-        let test_linux_initrd = ctx.reqv(|v| {
-            crate::resolve_openvmm_deps::Request::Get(
-                crate::resolve_openvmm_deps::OpenvmmDepFile::LinuxTestInitrd,
-                arch,
-                v,
-            )
-        });
+        let test_linux_initrd =
+            ctx.reqv(|v| crate::resolve_openvmm_test_initrd::Request::Get(arch, v));
         let test_linux_kernel = ctx.reqv(|v| {
-            crate::resolve_openvmm_deps::Request::Get(
-                crate::resolve_openvmm_deps::OpenvmmDepFile::LinuxTestKernel,
+            crate::resolve_openvmm_test_linux_kernel::Request::Get(
+                crate::resolve_openvmm_test_linux_kernel::OpenvmmTestKernelFile::Kernel,
                 arch,
+                crate::resolve_openvmm_test_linux_kernel::DEFAULT_LINUX_TEST_KERNEL_VERSION,
                 v,
             )
         });
-        let test_linux_bzimage = crate::resolve_openvmm_deps::OpenvmmDepFile::LinuxTestBzImage
-            .is_available_for(arch)
-            .then(|| {
-                ctx.reqv(|v| {
-                    crate::resolve_openvmm_deps::Request::Get(
-                        crate::resolve_openvmm_deps::OpenvmmDepFile::LinuxTestBzImage,
-                        arch,
-                        v,
-                    )
-                })
-            });
+        let test_linux_bzimage =
+            crate::resolve_openvmm_test_linux_kernel::OpenvmmTestKernelFile::BzImage
+                .is_available_for(arch)
+                .then(|| {
+                    ctx.reqv(|v| {
+                        crate::resolve_openvmm_test_linux_kernel::Request::Get(
+                            crate::resolve_openvmm_test_linux_kernel::OpenvmmTestKernelFile::BzImage,
+                            arch,
+                            crate::resolve_openvmm_test_linux_kernel::DEFAULT_LINUX_TEST_KERNEL_VERSION,
+                            v,
+                        )
+                    })
+                });
 
         let uefi =
             ctx.reqv(|v| crate::download_uefi_mu_msvm::Request::GetMsvmFd { arch, msvm_fd: v });

--- a/flowey/flowey_lib_hvlite/src/lib.rs
+++ b/flowey/flowey_lib_hvlite/src/lib.rs
@@ -55,6 +55,8 @@ pub mod install_openvmm_rust_build_essential;
 pub mod install_vmm_tests_deps;
 pub mod resolve_openhcl_kernel_package;
 pub mod resolve_openvmm_deps;
+pub mod resolve_openvmm_test_initrd;
+pub mod resolve_openvmm_test_linux_kernel;
 pub mod run_cargo_build;
 pub mod run_cargo_nextest_run;
 pub mod run_igvmfilegen;

--- a/flowey/flowey_lib_hvlite/src/resolve_openvmm_deps.rs
+++ b/flowey/flowey_lib_hvlite/src/resolve_openvmm_deps.rs
@@ -10,9 +10,6 @@ use std::collections::BTreeMap;
 /// Which file to extract from the openvmm-deps archive.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum OpenvmmDepFile {
-    LinuxTestKernel,
-    LinuxTestBzImage,
-    LinuxTestInitrd,
     OpenhclCpioDbgrd,
     OpenhclCpioShell,
     OpenhclSysroot,
@@ -20,26 +17,12 @@ pub enum OpenvmmDepFile {
 }
 
 impl OpenvmmDepFile {
-    pub fn filename(self, arch: CommonArch) -> &'static str {
+    pub fn filename(self) -> &'static str {
         match self {
-            Self::LinuxTestKernel => match arch {
-                CommonArch::X86_64 => "vmlinux",
-                CommonArch::Aarch64 => "Image",
-            },
-            Self::LinuxTestBzImage => "bzImage",
-            Self::LinuxTestInitrd => "initrd",
             Self::OpenhclCpioDbgrd => "dbgrd.cpio.gz",
             Self::OpenhclCpioShell => "shell.cpio.gz",
             Self::OpenhclSysroot => "sysroot.tar.gz",
             Self::PetritoolsErofs => "petritools.erofs",
-        }
-    }
-
-    /// Whether this dep file is available for the given architecture.
-    pub fn is_available_for(self, arch: CommonArch) -> bool {
-        match self {
-            Self::LinuxTestBzImage => matches!(arch, CommonArch::X86_64),
-            _ => true,
         }
     }
 }
@@ -124,7 +107,7 @@ impl FlowNodeWithConfig for Node {
                         let base_dir = resolved_paths.get(&arch).ok_or_else(|| {
                             anyhow::anyhow!("No local path specified for architecture {:?}", arch)
                         })?;
-                        let path = base_dir.join(dep.filename(arch));
+                        let path = base_dir.join(dep.filename());
                         rt.write_all(vars, &path)
                     }
 
@@ -135,8 +118,7 @@ impl FlowNodeWithConfig for Node {
             return Ok(());
         }
 
-        let extract_tar_bz2_deps =
-            flowey_lib_common::_util::extract::extract_tar_bz2_if_new_deps(ctx);
+        let extract_tar_gz_persistent_dir = ctx.persistent_dir();
 
         let download_archive = |arch: CommonArch, ctx: &mut NodeCtx<'_>| {
             let version = version.clone().expect("local requests handled above");
@@ -154,35 +136,36 @@ impl FlowNodeWithConfig for Node {
             })
         };
 
-        let openvmm_deps_tar_bz2_x64 =
+        let openvmm_deps_tar_gz_x64 =
             needs_arch(CommonArch::X86_64).then(|| download_archive(CommonArch::X86_64, ctx));
-        let openvmm_deps_tar_bz2_aarch64 =
+        let openvmm_deps_tar_gz_aarch64 =
             needs_arch(CommonArch::Aarch64).then(|| download_archive(CommonArch::Aarch64, ctx));
 
         ctx.emit_rust_step("unpack openvmm-deps archive", |ctx| {
-            let extract_tar_bz2_deps = extract_tar_bz2_deps.claim(ctx);
-            let openvmm_deps_tar_bz2_x64 = openvmm_deps_tar_bz2_x64.claim(ctx);
-            let openvmm_deps_tar_bz2_aarch64 = openvmm_deps_tar_bz2_aarch64.claim(ctx);
+            let extract_tar_gz_persistent_dir = extract_tar_gz_persistent_dir.claim(ctx);
+            let openvmm_deps_tar_gz_x64 = openvmm_deps_tar_gz_x64.claim(ctx);
+            let openvmm_deps_tar_gz_aarch64 = openvmm_deps_tar_gz_aarch64.claim(ctx);
             let deps = deps.claim(ctx);
             let version = version.clone().expect("local requests handled above");
             move |rt| {
-                let extract_dir_x64 = openvmm_deps_tar_bz2_x64
+                let persistent_dir = extract_tar_gz_persistent_dir.map(|d| rt.read(d));
+                let extract_dir_x64 = openvmm_deps_tar_gz_x64
                     .map(|file| {
                         let file = rt.read(file);
-                        flowey_lib_common::_util::extract::extract_tar_bz2_if_new(
+                        flowey_lib_common::_util::extract::extract_tar_gz_if_new(
                             rt,
-                            extract_tar_bz2_deps.clone(),
+                            persistent_dir.as_deref(),
                             &file,
                             &version,
                         )
                     })
                     .transpose()?;
-                let extract_dir_aarch64 = openvmm_deps_tar_bz2_aarch64
+                let extract_dir_aarch64 = openvmm_deps_tar_gz_aarch64
                     .map(|file| {
                         let file = rt.read(file);
-                        flowey_lib_common::_util::extract::extract_tar_bz2_if_new(
+                        flowey_lib_common::_util::extract::extract_tar_gz_if_new(
                             rt,
-                            extract_tar_bz2_deps.clone(),
+                            persistent_dir.as_deref(),
                             &file,
                             &version,
                         )
@@ -195,7 +178,7 @@ impl FlowNodeWithConfig for Node {
                 };
 
                 for ((dep, arch), vars) in deps {
-                    let path = base_dir(arch).join(dep.filename(arch));
+                    let path = base_dir(arch).join(dep.filename());
                     rt.write_all(vars, &path)
                 }
 

--- a/flowey/flowey_lib_hvlite/src/resolve_openvmm_test_initrd.rs
+++ b/flowey/flowey_lib_hvlite/src/resolve_openvmm_test_initrd.rs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Download the shared test initrd from the `openvmm-deps` GitHub release,
+//! or use a local path if specified.
+//!
+//! The initrd is identical across all kernel versions and ships as its own
+//! versioned artifact (`openvmm-test-initrd.<arch>.<ver>.tar.gz`), separate
+//! from the per-kernel `openvmm-test-linux-<kver>` artifact.
+
+use crate::common::CommonArch;
+use flowey::node::prelude::*;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+flowey_config! {
+    /// Config for the resolve_openvmm_test_initrd node.
+    pub struct Config {
+        /// Specify version of the github release to pull from
+        pub version: Option<String>,
+        /// Use locally downloaded openvmm-test-initrd contents, keyed by
+        /// architecture
+        pub local_paths: BTreeMap<CommonArch, ConfigVar<PathBuf>>,
+    }
+}
+
+flowey_request! {
+    pub enum Request {
+        /// Get the path to the initrd image for a given architecture
+        Get(CommonArch, WriteVar<PathBuf>),
+    }
+}
+
+new_flow_node_with_config!(struct Node);
+
+impl FlowNodeWithConfig for Node {
+    type Request = Request;
+    type Config = Config;
+
+    fn imports(ctx: &mut ImportCtx<'_>) {
+        ctx.import::<flowey_lib_common::install_dist_pkg::Node>();
+        ctx.import::<flowey_lib_common::download_gh_release::Node>();
+    }
+
+    fn emit(
+        config: Config,
+        requests: Vec<Self::Request>,
+        ctx: &mut NodeCtx<'_>,
+    ) -> anyhow::Result<()> {
+        let Config {
+            version,
+            local_paths,
+        } = config;
+        let mut deps: BTreeMap<CommonArch, Vec<WriteVar<PathBuf>>> = BTreeMap::new();
+
+        for req in requests {
+            match req {
+                Request::Get(arch, var) => {
+                    deps.entry(arch).or_default().push(var);
+                }
+            }
+        }
+
+        if version.is_some() && !local_paths.is_empty() {
+            anyhow::bail!("Cannot specify both Version and LocalPath requests");
+        }
+
+        if version.is_none() && local_paths.is_empty() {
+            anyhow::bail!("Must specify a Version or LocalPath request");
+        }
+
+        // -- end of req processing -- //
+
+        if deps.is_empty() {
+            return Ok(());
+        }
+
+        if !local_paths.is_empty() {
+            ctx.emit_rust_step("use local openvmm-test-initrd", |ctx| {
+                let deps = deps.claim(ctx);
+                let local_paths: BTreeMap<_, _> = local_paths
+                    .into_iter()
+                    .map(|(key, var)| (key, var.claim(ctx)))
+                    .collect();
+                move |rt| {
+                    let resolved_paths: BTreeMap<CommonArch, PathBuf> = local_paths
+                        .into_iter()
+                        .map(|(key, var)| (key, rt.read(var)))
+                        .collect();
+
+                    for (arch, vars) in deps {
+                        let base_dir = resolved_paths.get(&arch).ok_or_else(|| {
+                            anyhow::anyhow!("No local path specified for {:?}", arch)
+                        })?;
+                        let path = base_dir.join("initrd");
+                        rt.write_all(vars, &path)
+                    }
+
+                    Ok(())
+                }
+            });
+
+            return Ok(());
+        }
+
+        // The openvmm-test-initrd.<arch>.<ver>.tar.gz archive contains a
+        // single `initrd` file at the archive root. Download one archive per
+        // requested architecture.
+        let needed_archives: BTreeSet<CommonArch> = deps.keys().copied().collect();
+
+        let mut archives = BTreeMap::new();
+        for arch in needed_archives {
+            let version = version.clone().expect("local requests handled above");
+            let arch_str = match arch {
+                CommonArch::X86_64 => "x86_64",
+                CommonArch::Aarch64 => "aarch64",
+            };
+            let archive = ctx.reqv(|v| flowey_lib_common::download_gh_release::Request {
+                repo_owner: "microsoft".into(),
+                repo_name: "openvmm-deps".into(),
+                needs_auth: false,
+                tag: version.clone(),
+                file_name: format!("openvmm-test-initrd.{arch_str}.{version}.tar.gz"),
+                path: v,
+            });
+            archives.insert(arch, archive);
+        }
+
+        let persistent_dir = ctx.persistent_dir();
+
+        ctx.emit_rust_step("unpack openvmm-test-initrd archives", |ctx| {
+            let persistent_dir = persistent_dir.claim(ctx);
+            let archives = archives.claim(ctx);
+            let deps = deps.claim(ctx);
+            let version = version.clone().expect("local requests handled above");
+            move |rt| {
+                let persistent_dir = persistent_dir.map(|d| rt.read(d));
+
+                let mut extract_dirs = BTreeMap::new();
+                for (arch, archive) in archives {
+                    let file = rt.read(archive);
+                    let dir = flowey_lib_common::_util::extract::extract_tar_gz_if_new(
+                        rt,
+                        persistent_dir.as_deref(),
+                        &file,
+                        &version,
+                    )?;
+                    extract_dirs.insert(arch, dir);
+                }
+
+                for (arch, vars) in deps {
+                    let path = extract_dirs[&arch].join("initrd");
+                    rt.write_all(vars, &path)
+                }
+
+                Ok(())
+            }
+        });
+
+        Ok(())
+    }
+}

--- a/flowey/flowey_lib_hvlite/src/resolve_openvmm_test_linux_kernel.rs
+++ b/flowey/flowey_lib_hvlite/src/resolve_openvmm_test_linux_kernel.rs
@@ -1,0 +1,240 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Download files from a Linux test kernel `openvmm-deps` GitHub release
+//! artifact, or use a local path if specified.
+//!
+//! Each [`LinuxTestKernelVersion`] variant corresponds to its own
+//! per-kernel-version GitHub release artifact (e.g.
+//! `openvmm-test-linux-6.1.<arch>.<ver>.tar.gz`), so consumers can target
+//! different kernel versions independently. Each archive contains the
+//! primary kernel image (`vmlinux` on x86_64, `Image` on aarch64) and, on
+//! x86_64, an additional `bzImage`-format kernel — see
+//! [`OpenvmmTestKernelFile`] to select between them. The matching guest-
+//! userland initrd is shared across kernel versions and lives in its own
+//! node (see [`crate::resolve_openvmm_test_initrd`]).
+
+use crate::common::CommonArch;
+use flowey::node::prelude::*;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+/// Which Linux test kernel version to fetch from the openvmm-deps GitHub
+/// release.
+///
+/// The `openvmm-deps` release currently only ships the 6.1 kernel; additional
+/// kernel lines (e.g. 6.6, 6.12) are intended to be added as purely additive
+/// follow-ups, both upstream and as new variants of this enum.
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LinuxTestKernelVersion {
+    Linux6_1,
+}
+
+impl LinuxTestKernelVersion {
+    /// The version string used in the openvmm-deps GitHub release artifact
+    /// filename (e.g. `"6.1"` for `openvmm-test-linux-6.1.<arch>.<ver>.tar.gz`).
+    pub fn artifact_tag(self) -> &'static str {
+        match self {
+            Self::Linux6_1 => "6.1",
+        }
+    }
+}
+
+/// Which file to extract from a per-(arch, kver) `openvmm-test-linux` archive.
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum OpenvmmTestKernelFile {
+    /// Primary kernel image: `vmlinux` on x86_64, `Image` on aarch64.
+    Kernel,
+    /// `bzImage`-format kernel image. Only available on x86_64.
+    BzImage,
+}
+
+impl OpenvmmTestKernelFile {
+    /// Whether this file is shipped in the archive for the given architecture.
+    pub fn is_available_for(self, arch: CommonArch) -> bool {
+        match self {
+            Self::Kernel => true,
+            Self::BzImage => matches!(arch, CommonArch::X86_64),
+        }
+    }
+
+    /// The filename of this file inside the per-(arch, kver) archive.
+    pub fn filename(self, arch: CommonArch) -> &'static str {
+        match self {
+            Self::Kernel => match arch {
+                CommonArch::X86_64 => "vmlinux",
+                CommonArch::Aarch64 => "Image",
+            },
+            Self::BzImage => "bzImage",
+        }
+    }
+}
+
+/// The default Linux test kernel version. Call sites that don't otherwise care
+/// which kernel they're using should pass this.
+pub const DEFAULT_LINUX_TEST_KERNEL_VERSION: LinuxTestKernelVersion =
+    LinuxTestKernelVersion::Linux6_1;
+
+flowey_config! {
+    /// Config for the resolve_openvmm_test_linux_kernel node.
+    pub struct Config {
+        /// Specify version of the github release to pull from
+        pub version: Option<String>,
+        /// Use locally downloaded openvmm-test-linux contents, keyed by
+        /// (architecture, kernel version)
+        pub local_paths: BTreeMap<(CommonArch, LinuxTestKernelVersion), ConfigVar<PathBuf>>,
+    }
+}
+
+flowey_request! {
+    pub enum Request {
+        /// Get the path to a specific file from the per-(arch, kver) archive.
+        Get(
+            OpenvmmTestKernelFile,
+            CommonArch,
+            LinuxTestKernelVersion,
+            WriteVar<PathBuf>,
+        ),
+    }
+}
+
+new_flow_node_with_config!(struct Node);
+
+impl FlowNodeWithConfig for Node {
+    type Request = Request;
+    type Config = Config;
+
+    fn imports(ctx: &mut ImportCtx<'_>) {
+        ctx.import::<flowey_lib_common::install_dist_pkg::Node>();
+        ctx.import::<flowey_lib_common::download_gh_release::Node>();
+    }
+
+    fn emit(
+        config: Config,
+        requests: Vec<Self::Request>,
+        ctx: &mut NodeCtx<'_>,
+    ) -> anyhow::Result<()> {
+        let Config {
+            version,
+            local_paths,
+        } = config;
+        let mut deps: BTreeMap<
+            (OpenvmmTestKernelFile, CommonArch, LinuxTestKernelVersion),
+            Vec<WriteVar<PathBuf>>,
+        > = BTreeMap::new();
+
+        for req in requests {
+            match req {
+                Request::Get(file, arch, kver, var) => {
+                    if !file.is_available_for(arch) {
+                        anyhow::bail!(
+                            "{file:?} is not available in the openvmm-test-linux archive for {arch:?}"
+                        );
+                    }
+                    deps.entry((file, arch, kver)).or_default().push(var);
+                }
+            }
+        }
+
+        if version.is_some() && !local_paths.is_empty() {
+            anyhow::bail!("Cannot specify both Version and LocalPath requests");
+        }
+
+        if version.is_none() && local_paths.is_empty() {
+            anyhow::bail!("Must specify a Version or LocalPath request");
+        }
+
+        // -- end of req processing -- //
+
+        if deps.is_empty() {
+            return Ok(());
+        }
+
+        if !local_paths.is_empty() {
+            ctx.emit_rust_step("use local openvmm-test-linux", |ctx| {
+                let deps = deps.claim(ctx);
+                let local_paths: BTreeMap<_, _> = local_paths
+                    .into_iter()
+                    .map(|(key, var)| (key, var.claim(ctx)))
+                    .collect();
+                move |rt| {
+                    let resolved_paths: BTreeMap<(CommonArch, LinuxTestKernelVersion), PathBuf> =
+                        local_paths
+                            .into_iter()
+                            .map(|(key, var)| (key, rt.read(var)))
+                            .collect();
+
+                    for ((file, arch, kver), vars) in deps {
+                        let base_dir = resolved_paths.get(&(arch, kver)).ok_or_else(|| {
+                            anyhow::anyhow!("No local path specified for ({:?}, {:?})", arch, kver)
+                        })?;
+                        let path = base_dir.join(file.filename(arch));
+                        rt.write_all(vars, &path)
+                    }
+
+                    Ok(())
+                }
+            });
+
+            return Ok(());
+        }
+
+        // The same per-(arch, kver) archive can satisfy multiple file
+        // requests (e.g. `Kernel` and `BzImage` for the same x86_64 6.1
+        // archive), so dedupe download + extract on `(arch, kver)`.
+        let needed_archives: BTreeSet<(CommonArch, LinuxTestKernelVersion)> =
+            deps.keys().map(|(_, arch, kver)| (*arch, *kver)).collect();
+
+        let mut archives = BTreeMap::new();
+        for (arch, kver) in needed_archives {
+            let version = version.clone().expect("local requests handled above");
+            let arch_str = match arch {
+                CommonArch::X86_64 => "x86_64",
+                CommonArch::Aarch64 => "aarch64",
+            };
+            let kver_str = kver.artifact_tag();
+            let archive = ctx.reqv(|v| flowey_lib_common::download_gh_release::Request {
+                repo_owner: "microsoft".into(),
+                repo_name: "openvmm-deps".into(),
+                needs_auth: false,
+                tag: version.clone(),
+                file_name: format!("openvmm-test-linux-{kver_str}.{arch_str}.{version}.tar.gz"),
+                path: v,
+            });
+            archives.insert((arch, kver), archive);
+        }
+
+        let persistent_dir = ctx.persistent_dir();
+
+        ctx.emit_rust_step("unpack openvmm-test-linux archives", |ctx| {
+            let persistent_dir = persistent_dir.claim(ctx);
+            let archives = archives.claim(ctx);
+            let deps = deps.claim(ctx);
+            let version = version.clone().expect("local requests handled above");
+            move |rt| {
+                let persistent_dir = persistent_dir.map(|d| rt.read(d));
+
+                let mut extract_dirs = BTreeMap::new();
+                for (key, archive) in archives {
+                    let file = rt.read(archive);
+                    let dir = flowey_lib_common::_util::extract::extract_tar_gz_if_new(
+                        rt,
+                        persistent_dir.as_deref(),
+                        &file,
+                        &version,
+                    )?;
+                    extract_dirs.insert(key, dir);
+                }
+
+                for ((file, arch, kver), vars) in deps {
+                    let path = extract_dirs[&(arch, kver)].join(file.filename(arch));
+                    rt.write_all(vars, &path)
+                }
+
+                Ok(())
+            }
+        });
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adapts OSS flowey to consume the `microsoft/openvmm-deps` 0.3.0 release layout.

Companion: **microsoft/openvmm-deps#62** (merged, [v0.3.0-29 released](https://github.com/microsoft/openvmm-deps/releases/tag/0.3.0-29)).

## openvmm-deps 0.3.0 artifacts

Each release ships three `.tar.gz` artifacts per arch:

| Artifact | Contents |
| --- | --- |
| `openvmm-deps.<arch>.<ver>.tar.gz` | sdk + dbgrd + shell + petritools |
| `openvmm-test-initrd.<arch>.<ver>.tar.gz` | shared test guest-userland initrd |
| `openvmm-test-linux-6.1.<arch>.<ver>.tar.gz` | 6.1 LTS test kernel: `vmlinux`/`Image`, `bzImage` (x86_64), final `config` |

The Linux kernel + initrd here are a test payload only (Vtl0 `Example` recipe, Linux-direct VMM tests). Production OpenHCL kernels flow through `resolve_openhcl_kernel_package`.

## Nodes

- **`resolve_openvmm_deps`** — fetches `openvmm-deps.<arch>.<ver>.tar.gz` and exposes individual files via `OpenvmmDepFile` (`OpenhclCpioDbgrd` / `OpenhclCpioShell` / `OpenhclSysroot` / `PetritoolsErofs`).
- **`resolve_openvmm_test_initrd`** — fetches `openvmm-test-initrd.<arch>.<ver>.tar.gz` and returns the path to the `initrd` file. Parameterized by arch.
- **`resolve_openvmm_test_linux_kernel`** — fetches `openvmm-test-linux-<kver>.<arch>.<ver>.tar.gz` and returns the path to a selected file via `OpenvmmTestKernelFile`: `Kernel` (the primary `vmlinux` on x86_64 / `Image` on aarch64) or `BzImage` (x86_64 only). Parameterized by `(file, arch, kver)`. Archive download + extraction is deduped on `(arch, kver)` so requesting both `Kernel` and `BzImage` from the same archive only extracts once. The `LinuxTestKernelVersion` enum currently contains just `Linux6_1`; `DEFAULT_LINUX_TEST_KERNEL_VERSION` is exported for callers that don't care which kernel they get. Future kernel lines are added by extending the enum.

All three nodes accept either a `version` (download from the public GH release with `needs_auth: false`) or `local_paths` (use a pre-extracted directory on disk).

## Other changes

- `flowey_lib_common::_util::extract::extract_tar_gz_if_new` — cached `.tar.gz` extract helper (`{root_dir}/.flowey_info/{filename}` tracks `file_version`, skip re-extract on match), mirroring the existing `extract_zip_if_new` / `extract_tar_bz2_if_new`.
- `cfg_versions::OPENVMM_DEPS = "0.3.0-29"` drives the `version` config of all three resolve nodes.
- `init_vmm_tests_env`, `init_openvmm_magicpath_openvmm_deps`, and `build_openhcl_igvm_from_recipe` request the kernel + initrd from the new nodes; the magicpath and vmm_tests_env consumers also request `BzImage` on x86_64.
- Pipeline YAMLs regenerated.
