### PR TITLE
[wip] publish_test_results: annotate test failures on GitHub Actions

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1259,22 +1259,26 @@ jobs:
         flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 2
         flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 3
         flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 12 flowey_lib_common::publish_test_results 5
         flowey.exe e 12 flowey_lib_common::publish_test_results 6
-        flowey.exe e 12 flowey_lib_common::publish_test_results 4
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 12 flowey_lib_common::publish_test_results 7
+        flowey.exe e 12 flowey_lib_common::publish_test_results 5
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-unit-tests-unit-tests crypto (rust)'
+      run: |-
+        flowey.exe e 12 flowey_lib_common::publish_test_results 9
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
         flowey.exe e 12 flowey_lib_common::run_cargo_build 1
         flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 1
         flowey.exe e 12 flowey_lib_hvlite::build_xtask 1
@@ -1290,19 +1294,22 @@ jobs:
         flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 4
         flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 5
         flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 12 flowey_lib_common::publish_test_results 8
-        flowey.exe e 12 flowey_lib_common::publish_test_results 9
         flowey.exe e 12 flowey_lib_common::publish_test_results 10
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 12 flowey_lib_common::publish_test_results 11
+        flowey.exe e 12 flowey_lib_common::publish_test_results 12
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-unit-tests-unit-tests'
+      run: flowey.exe e 12 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -1314,7 +1321,7 @@ jobs:
         flowey.exe e 12 flowey_lib_common::publish_test_results 0
         flowey.exe e 12 flowey_lib_common::publish_test_results 1
         flowey.exe e 12 flowey_lib_common::publish_test_results 2
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -1324,10 +1331,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: x64-windows-unit-tests-unit-tests crypto (none)'
       run: |-
+        flowey.exe e 12 flowey_lib_common::publish_test_results 4
         flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
       run: flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -1591,19 +1601,22 @@ jobs:
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 13 flowey_lib_common::publish_test_results 5
         flowey e 13 flowey_lib_common::publish_test_results 6
-        flowey e 13 flowey_lib_common::publish_test_results 4
-        flowey v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::publish_test_results 7
+        flowey e 13 flowey_lib_common::publish_test_results 5
+        flowey v 13 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 13 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (none)'
+      run: flowey e 13 flowey_lib_common::publish_test_results 9
+      shell: bash
     - name: generate nextest command
       run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
@@ -1612,19 +1625,22 @@ jobs:
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 13 flowey_lib_common::publish_test_results 8
-        flowey e 13 flowey_lib_common::publish_test_results 9
         flowey e 13 flowey_lib_common::publish_test_results 10
-        flowey v 13 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 13 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::publish_test_results 11
+        flowey e 13 flowey_lib_common::publish_test_results 12
+        flowey v 13 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 13 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (rust)'
+      run: flowey e 13 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
@@ -1633,19 +1649,22 @@ jobs:
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 13 flowey_lib_common::publish_test_results 12
-        flowey e 13 flowey_lib_common::publish_test_results 13
-        flowey e 13 flowey_lib_common::publish_test_results 14
-        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::publish_test_results 15
+        flowey e 13 flowey_lib_common::publish_test_results 16
+        flowey e 13 flowey_lib_common::publish_test_results 17
+        flowey v 13 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 13 'flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__15
+    - id: flowey_lib_common__publish_test_results__18
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (openssl)'
+      run: flowey e 13 flowey_lib_common::publish_test_results 19
+      shell: bash
     - name: generate nextest command
       run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -1654,22 +1673,26 @@ jobs:
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 13 flowey_lib_common::publish_test_results 16
-        flowey e 13 flowey_lib_common::publish_test_results 17
-        flowey e 13 flowey_lib_common::publish_test_results 18
-        flowey v 13 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 13 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::publish_test_results 20
+        flowey e 13 flowey_lib_common::publish_test_results 21
+        flowey e 13 flowey_lib_common::publish_test_results 22
+        flowey v 13 'flowey_lib_common::publish_test_results:36:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 13 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__19
+    - id: flowey_lib_common__publish_test_results__23
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (all)'
+      run: |-
+        flowey e 13 flowey_lib_common::publish_test_results 24
+        flowey e 13 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 13 flowey_lib_hvlite::init_cross_build 2
         flowey e 13 flowey_lib_common::run_cargo_build 0
         flowey e 13 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
@@ -1693,7 +1716,7 @@ jobs:
         flowey e 13 flowey_lib_common::publish_test_results 0
         flowey e 13 flowey_lib_common::publish_test_results 1
         flowey e 13 flowey_lib_common::publish_test_results 2
-        flowey v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -1703,10 +1726,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: x64-linux-unit-tests-unit-tests'
       run: |-
+        flowey e 13 flowey_lib_common::publish_test_results 4
         flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
       run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -1960,19 +1986,22 @@ jobs:
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 14 flowey_lib_common::publish_test_results 5
         flowey e 14 flowey_lib_common::publish_test_results 6
-        flowey e 14 flowey_lib_common::publish_test_results 4
-        flowey v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::publish_test_results 7
+        flowey e 14 flowey_lib_common::publish_test_results 5
+        flowey v 14 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 14 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (none)'
+      run: flowey e 14 flowey_lib_common::publish_test_results 9
+      shell: bash
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
@@ -1981,19 +2010,22 @@ jobs:
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 14 flowey_lib_common::publish_test_results 8
-        flowey e 14 flowey_lib_common::publish_test_results 9
         flowey e 14 flowey_lib_common::publish_test_results 10
-        flowey v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::publish_test_results 11
+        flowey e 14 flowey_lib_common::publish_test_results 12
+        flowey v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (rust)'
+      run: flowey e 14 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
@@ -2002,19 +2034,22 @@ jobs:
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 14 flowey_lib_common::publish_test_results 12
-        flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey e 14 flowey_lib_common::publish_test_results 14
-        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::publish_test_results 15
+        flowey e 14 flowey_lib_common::publish_test_results 16
+        flowey e 14 flowey_lib_common::publish_test_results 17
+        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__15
+    - id: flowey_lib_common__publish_test_results__18
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl)'
+      run: flowey e 14 flowey_lib_common::publish_test_results 19
+      shell: bash
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
@@ -2023,19 +2058,22 @@ jobs:
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 14 flowey_lib_common::publish_test_results 16
-        flowey e 14 flowey_lib_common::publish_test_results 17
-        flowey e 14 flowey_lib_common::publish_test_results 18
-        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::publish_test_results 20
+        flowey e 14 flowey_lib_common::publish_test_results 21
+        flowey e 14 flowey_lib_common::publish_test_results 22
+        flowey v 14 'flowey_lib_common::publish_test_results:36:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__19
+    - id: flowey_lib_common__publish_test_results__23
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
+      run: flowey e 14 flowey_lib_common::publish_test_results 24
+      shell: bash
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -2044,22 +2082,26 @@ jobs:
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 14 flowey_lib_common::publish_test_results 20
-        flowey e 14 flowey_lib_common::publish_test_results 21
-        flowey e 14 flowey_lib_common::publish_test_results 22
-        flowey v 14 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::publish_test_results 25
+        flowey e 14 flowey_lib_common::publish_test_results 26
+        flowey e 14 flowey_lib_common::publish_test_results 27
+        flowey v 14 'flowey_lib_common::publish_test_results:44:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:40:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::publish_test_results:40:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__23
+    - id: flowey_lib_common__publish_test_results__28
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar6 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (all)'
+      run: |-
+        flowey e 14 flowey_lib_common::publish_test_results 29
+        flowey e 14 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_hvlite::init_cross_build 1
         flowey e 14 flowey_lib_common::run_cargo_build 1
         flowey e 14 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -2083,7 +2125,7 @@ jobs:
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
         flowey e 14 flowey_lib_common::publish_test_results 2
-        flowey v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -2093,10 +2135,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests'
       run: |-
+        flowey e 14 flowey_lib_common::publish_test_results 4
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 7
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
       run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -2318,22 +2363,26 @@ jobs:
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 2
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 3
         flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 15 flowey_lib_common::publish_test_results 5
         flowey.exe e 15 flowey_lib_common::publish_test_results 6
-        flowey.exe e 15 flowey_lib_common::publish_test_results 4
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::publish_test_results 7
+        flowey.exe e 15 flowey_lib_common::publish_test_results 5
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-windows-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests crypto (rust)'
+      run: |-
+        flowey.exe e 15 flowey_lib_common::publish_test_results 9
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
         flowey.exe e 15 flowey_lib_common::run_cargo_build 1
         flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
         flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
@@ -2349,19 +2398,22 @@ jobs:
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 4
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 5
         flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 15 flowey_lib_common::publish_test_results 8
-        flowey.exe e 15 flowey_lib_common::publish_test_results 9
         flowey.exe e 15 flowey_lib_common::publish_test_results 10
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::publish_test_results 11
+        flowey.exe e 15 flowey_lib_common::publish_test_results 12
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-windows-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests'
+      run: flowey.exe e 15 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -2373,7 +2425,7 @@ jobs:
         flowey.exe e 15 flowey_lib_common::publish_test_results 0
         flowey.exe e 15 flowey_lib_common::publish_test_results 1
         flowey.exe e 15 flowey_lib_common::publish_test_results 2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -2383,10 +2435,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests crypto (none)'
       run: |-
+        flowey.exe e 15 flowey_lib_common::publish_test_results 4
         flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
       run: flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -2626,19 +2681,22 @@ jobs:
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 16 flowey_lib_common::publish_test_results 5
         flowey e 16 flowey_lib_common::publish_test_results 6
-        flowey e 16 flowey_lib_common::publish_test_results 4
-        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::publish_test_results 7
+        flowey e 16 flowey_lib_common::publish_test_results 5
+        flowey v 16 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 16 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (none)'
+      run: flowey e 16 flowey_lib_common::publish_test_results 9
+      shell: bash
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
@@ -2647,19 +2705,22 @@ jobs:
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 16 flowey_lib_common::publish_test_results 8
-        flowey e 16 flowey_lib_common::publish_test_results 9
         flowey e 16 flowey_lib_common::publish_test_results 10
-        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::publish_test_results 11
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey v 16 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 16 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (rust)'
+      run: flowey e 16 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
@@ -2668,19 +2729,22 @@ jobs:
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::publish_test_results 15
+        flowey e 16 flowey_lib_common::publish_test_results 16
+        flowey e 16 flowey_lib_common::publish_test_results 17
+        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__15
+    - id: flowey_lib_common__publish_test_results__18
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (openssl)'
+      run: flowey e 16 flowey_lib_common::publish_test_results 19
+      shell: bash
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -2689,22 +2753,26 @@ jobs:
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 16 flowey_lib_common::publish_test_results 16
-        flowey e 16 flowey_lib_common::publish_test_results 17
-        flowey e 16 flowey_lib_common::publish_test_results 18
-        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::publish_test_results 20
+        flowey e 16 flowey_lib_common::publish_test_results 21
+        flowey e 16 flowey_lib_common::publish_test_results 22
+        flowey v 16 'flowey_lib_common::publish_test_results:36:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__19
+    - id: flowey_lib_common__publish_test_results__23
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (all)'
+      run: |-
+        flowey e 16 flowey_lib_common::publish_test_results 24
+        flowey e 16 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_cross_build 3
         flowey e 16 flowey_lib_common::run_cargo_build 1
         flowey e 16 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -2728,7 +2796,7 @@ jobs:
         flowey e 16 flowey_lib_common::publish_test_results 0
         flowey e 16 flowey_lib_common::publish_test_results 1
         flowey e 16 flowey_lib_common::publish_test_results 2
-        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -2738,10 +2806,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests'
       run: |-
+        flowey e 16 flowey_lib_common::publish_test_results 4
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
       run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -2995,19 +3066,22 @@ jobs:
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 17 flowey_lib_common::publish_test_results 5
         flowey e 17 flowey_lib_common::publish_test_results 6
-        flowey e 17 flowey_lib_common::publish_test_results 4
-        flowey v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::publish_test_results 7
+        flowey e 17 flowey_lib_common::publish_test_results 5
+        flowey v 17 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 17 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none)'
+      run: flowey e 17 flowey_lib_common::publish_test_results 9
+      shell: bash
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
@@ -3016,19 +3090,22 @@ jobs:
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 17 flowey_lib_common::publish_test_results 8
-        flowey e 17 flowey_lib_common::publish_test_results 9
         flowey e 17 flowey_lib_common::publish_test_results 10
-        flowey v 17 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 17 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::publish_test_results 11
+        flowey e 17 flowey_lib_common::publish_test_results 12
+        flowey v 17 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 17 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)'
+      run: flowey e 17 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
@@ -3037,19 +3114,22 @@ jobs:
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 17 flowey_lib_common::publish_test_results 12
-        flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey e 17 flowey_lib_common::publish_test_results 14
-        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::publish_test_results 15
+        flowey e 17 flowey_lib_common::publish_test_results 16
+        flowey e 17 flowey_lib_common::publish_test_results 17
+        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__15
+    - id: flowey_lib_common__publish_test_results__18
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)'
+      run: flowey e 17 flowey_lib_common::publish_test_results 19
+      shell: bash
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
@@ -3058,19 +3138,22 @@ jobs:
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 17 flowey_lib_common::publish_test_results 16
-        flowey e 17 flowey_lib_common::publish_test_results 17
-        flowey e 17 flowey_lib_common::publish_test_results 18
-        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::publish_test_results 20
+        flowey e 17 flowey_lib_common::publish_test_results 21
+        flowey e 17 flowey_lib_common::publish_test_results 22
+        flowey v 17 'flowey_lib_common::publish_test_results:36:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__19
+    - id: flowey_lib_common__publish_test_results__23
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
+      run: flowey e 17 flowey_lib_common::publish_test_results 24
+      shell: bash
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -3079,22 +3162,26 @@ jobs:
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 17 flowey_lib_common::publish_test_results 20
-        flowey e 17 flowey_lib_common::publish_test_results 21
-        flowey e 17 flowey_lib_common::publish_test_results 22
-        flowey v 17 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::publish_test_results 25
+        flowey e 17 flowey_lib_common::publish_test_results 26
+        flowey e 17 flowey_lib_common::publish_test_results 27
+        flowey v 17 'flowey_lib_common::publish_test_results:44:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:40:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::publish_test_results:40:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__23
+    - id: flowey_lib_common__publish_test_results__28
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar6 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all)'
+      run: |-
+        flowey e 17 flowey_lib_common::publish_test_results 29
+        flowey e 17 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 17 flowey_lib_hvlite::init_cross_build 1
         flowey e 17 flowey_lib_common::run_cargo_build 1
         flowey e 17 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -3118,7 +3205,7 @@ jobs:
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
         flowey e 17 flowey_lib_common::publish_test_results 2
-        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -3128,10 +3215,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests'
       run: |-
+        flowey e 17 flowey_lib_common::publish_test_results 4
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 7
-        flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
       run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -3367,12 +3457,12 @@ jobs:
       run: |-
         flowey.exe e 18 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 18 flowey_lib_common::publish_test_results 4
+        flowey.exe e 18 flowey_lib_common::publish_test_results 6
         flowey.exe e 18 flowey_lib_common::publish_test_results 5
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-intel-vmm-tests-logs
@@ -3385,7 +3475,7 @@ jobs:
         flowey.exe e 18 flowey_lib_common::publish_test_results 0
         flowey.exe e 18 flowey_lib_common::publish_test_results 1
         flowey.exe e 18 flowey_lib_common::publish_test_results 2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -3395,6 +3485,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-intel-vmm-tests'
+      run: flowey.exe e 18 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
@@ -3638,12 +3731,12 @@ jobs:
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 19 flowey_lib_common::publish_test_results 4
+        flowey.exe e 19 flowey_lib_common::publish_test_results 6
         flowey.exe e 19 flowey_lib_common::publish_test_results 5
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-intel-tdx-vmm-tests-logs
@@ -3656,7 +3749,7 @@ jobs:
         flowey.exe e 19 flowey_lib_common::publish_test_results 0
         flowey.exe e 19 flowey_lib_common::publish_test_results 1
         flowey.exe e 19 flowey_lib_common::publish_test_results 2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -3666,6 +3759,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-intel-tdx-vmm-tests'
+      run: flowey.exe e 19 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
@@ -4085,12 +4181,12 @@ jobs:
       run: |-
         flowey.exe e 20 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 20 flowey_lib_common::publish_test_results 4
+        flowey.exe e 20 flowey_lib_common::publish_test_results 6
         flowey.exe e 20 flowey_lib_common::publish_test_results 5
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-amd-vmm-tests-logs
@@ -4103,7 +4199,7 @@ jobs:
         flowey.exe e 20 flowey_lib_common::publish_test_results 0
         flowey.exe e 20 flowey_lib_common::publish_test_results 1
         flowey.exe e 20 flowey_lib_common::publish_test_results 2
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -4113,6 +4209,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-amd-vmm-tests'
+      run: flowey.exe e 20 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
@@ -4356,12 +4455,12 @@ jobs:
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 21 flowey_lib_common::publish_test_results 4
+        flowey.exe e 21 flowey_lib_common::publish_test_results 6
         flowey.exe e 21 flowey_lib_common::publish_test_results 5
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-amd-snp-vmm-tests-logs
@@ -4374,7 +4473,7 @@ jobs:
         flowey.exe e 21 flowey_lib_common::publish_test_results 0
         flowey.exe e 21 flowey_lib_common::publish_test_results 1
         flowey.exe e 21 flowey_lib_common::publish_test_results 2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -4384,6 +4483,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-amd-snp-vmm-tests'
+      run: flowey.exe e 21 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
@@ -4612,12 +4714,12 @@ jobs:
         flowey e 22 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 22 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 22 flowey_lib_common::publish_test_results 4
+        flowey e 22 flowey_lib_common::publish_test_results 6
         flowey e 22 flowey_lib_common::publish_test_results 5
-        flowey v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey v 22 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey v 22 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-amd-kvm-vmm-tests-logs
@@ -4630,7 +4732,7 @@ jobs:
         flowey e 22 flowey_lib_common::publish_test_results 0
         flowey e 22 flowey_lib_common::publish_test_results 1
         flowey e 22 flowey_lib_common::publish_test_results 2
-        flowey v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -4640,6 +4742,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-amd-kvm-vmm-tests'
+      run: flowey e 22 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
@@ -4912,12 +5017,12 @@ jobs:
         flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 23 flowey_lib_common::publish_test_results 4
+        flowey e 23 flowey_lib_common::publish_test_results 6
         flowey e 23 flowey_lib_common::publish_test_results 5
-        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey v 23 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey v 23 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-intel-mshv-vmm-tests-logs
@@ -4930,7 +5035,7 @@ jobs:
         flowey e 23 flowey_lib_common::publish_test_results 0
         flowey e 23 flowey_lib_common::publish_test_results 1
         flowey e 23 flowey_lib_common::publish_test_results 2
-        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -4940,6 +5045,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-intel-mshv-vmm-tests'
+      run: flowey e 23 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
@@ -5219,12 +5327,12 @@ jobs:
       run: |-
         flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 24 flowey_lib_common::publish_test_results 4
+        flowey.exe e 24 flowey_lib_common::publish_test_results 6
         flowey.exe e 24 flowey_lib_common::publish_test_results 5
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-windows-vmm-tests-logs
@@ -5237,7 +5345,7 @@ jobs:
         flowey.exe e 24 flowey_lib_common::publish_test_results 0
         flowey.exe e 24 flowey_lib_common::publish_test_results 1
         flowey.exe e 24 flowey_lib_common::publish_test_results 2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -5247,6 +5355,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-windows-vmm-tests'
+      run: flowey.exe e 24 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
@@ -5918,12 +6029,12 @@ jobs:
       run: |-
         flowey.exe e 27 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 27 flowey_lib_common::publish_test_results 4
+        flowey.exe e 27 flowey_lib_common::publish_test_results 6
         flowey.exe e 27 flowey_lib_common::publish_test_results 5
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-intel-mi-secure-vmm-tests-logs
@@ -5936,7 +6047,7 @@ jobs:
         flowey.exe e 27 flowey_lib_common::publish_test_results 0
         flowey.exe e 27 flowey_lib_common::publish_test_results 1
         flowey.exe e 27 flowey_lib_common::publish_test_results 2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -5946,6 +6057,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-intel-mi-secure-vmm-tests'
+      run: flowey.exe e 27 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1272,7 +1272,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: x64-windows-unit-tests-unit-tests crypto (rust)'
       run: |-
         flowey.exe e 12 flowey_lib_common::publish_test_results 9
         flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
@@ -1307,7 +1307,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-unit-tests-unit-tests'
+    - name: 'report failed tests: x64-windows-unit-tests-unit-tests'
       run: flowey.exe e 12 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -1331,7 +1331,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: x64-windows-unit-tests-unit-tests crypto (none)'
       run: |-
         flowey.exe e 12 flowey_lib_common::publish_test_results 4
         flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
@@ -1614,7 +1614,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: x64-linux-unit-tests-unit-tests crypto (none)'
       run: flowey e 13 flowey_lib_common::publish_test_results 9
       shell: bash
     - name: generate nextest command
@@ -1638,7 +1638,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: x64-linux-unit-tests-unit-tests crypto (rust)'
       run: flowey e 13 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -1662,7 +1662,7 @@ jobs:
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (openssl)'
+    - name: 'report failed tests: x64-linux-unit-tests-unit-tests crypto (openssl)'
       run: flowey e 13 flowey_lib_common::publish_test_results 19
       shell: bash
     - name: generate nextest command
@@ -1686,7 +1686,7 @@ jobs:
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (all)'
+    - name: 'report failed tests: x64-linux-unit-tests-unit-tests crypto (all)'
       run: |-
         flowey e 13 flowey_lib_common::publish_test_results 24
         flowey e 13 flowey_lib_hvlite::init_cross_build 2
@@ -1726,7 +1726,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-unit-tests-unit-tests'
+    - name: 'report failed tests: x64-linux-unit-tests-unit-tests'
       run: |-
         flowey e 13 flowey_lib_common::publish_test_results 4
         flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 6
@@ -1999,7 +1999,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests crypto (none)'
       run: flowey e 14 flowey_lib_common::publish_test_results 9
       shell: bash
     - name: generate nextest command
@@ -2023,7 +2023,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests crypto (rust)'
       run: flowey e 14 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -2047,7 +2047,7 @@ jobs:
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl)'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests crypto (openssl)'
       run: flowey e 14 flowey_lib_common::publish_test_results 19
       shell: bash
     - name: generate nextest command
@@ -2071,7 +2071,7 @@ jobs:
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
       run: flowey e 14 flowey_lib_common::publish_test_results 24
       shell: bash
     - name: generate nextest command
@@ -2095,7 +2095,7 @@ jobs:
         path: ${{ env.floweyvar6 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (all)'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests crypto (all)'
       run: |-
         flowey e 14 flowey_lib_common::publish_test_results 29
         flowey e 14 flowey_lib_hvlite::init_cross_build 1
@@ -2135,7 +2135,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests'
       run: |-
         flowey e 14 flowey_lib_common::publish_test_results 4
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 7
@@ -2376,7 +2376,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: aarch64-windows-unit-tests-unit-tests crypto (rust)'
       run: |-
         flowey.exe e 15 flowey_lib_common::publish_test_results 9
         flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
@@ -2411,7 +2411,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests'
+    - name: 'report failed tests: aarch64-windows-unit-tests-unit-tests'
       run: flowey.exe e 15 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -2435,7 +2435,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: aarch64-windows-unit-tests-unit-tests crypto (none)'
       run: |-
         flowey.exe e 15 flowey_lib_common::publish_test_results 4
         flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
@@ -2694,7 +2694,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: aarch64-linux-unit-tests-unit-tests crypto (none)'
       run: flowey e 16 flowey_lib_common::publish_test_results 9
       shell: bash
     - name: generate nextest command
@@ -2718,7 +2718,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: aarch64-linux-unit-tests-unit-tests crypto (rust)'
       run: flowey e 16 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -2742,7 +2742,7 @@ jobs:
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (openssl)'
+    - name: 'report failed tests: aarch64-linux-unit-tests-unit-tests crypto (openssl)'
       run: flowey e 16 flowey_lib_common::publish_test_results 19
       shell: bash
     - name: generate nextest command
@@ -2766,7 +2766,7 @@ jobs:
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (all)'
+    - name: 'report failed tests: aarch64-linux-unit-tests-unit-tests crypto (all)'
       run: |-
         flowey e 16 flowey_lib_common::publish_test_results 24
         flowey e 16 flowey_lib_hvlite::init_cross_build 3
@@ -2806,7 +2806,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests'
+    - name: 'report failed tests: aarch64-linux-unit-tests-unit-tests'
       run: |-
         flowey e 16 flowey_lib_common::publish_test_results 4
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
@@ -3079,7 +3079,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests crypto (none)'
       run: flowey e 17 flowey_lib_common::publish_test_results 9
       shell: bash
     - name: generate nextest command
@@ -3103,7 +3103,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)'
       run: flowey e 17 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -3127,7 +3127,7 @@ jobs:
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)'
       run: flowey e 17 flowey_lib_common::publish_test_results 19
       shell: bash
     - name: generate nextest command
@@ -3151,7 +3151,7 @@ jobs:
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
       run: flowey e 17 flowey_lib_common::publish_test_results 24
       shell: bash
     - name: generate nextest command
@@ -3175,7 +3175,7 @@ jobs:
         path: ${{ env.floweyvar6 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all)'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests crypto (all)'
       run: |-
         flowey e 17 flowey_lib_common::publish_test_results 29
         flowey e 17 flowey_lib_hvlite::init_cross_build 1
@@ -3215,7 +3215,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests'
       run: |-
         flowey e 17 flowey_lib_common::publish_test_results 4
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 7
@@ -3485,7 +3485,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-intel-vmm-tests'
+    - name: 'report failed tests: x64-windows-intel-vmm-tests'
       run: flowey.exe e 18 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -3759,7 +3759,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-intel-tdx-vmm-tests'
+    - name: 'report failed tests: x64-windows-intel-tdx-vmm-tests'
       run: flowey.exe e 19 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -4209,7 +4209,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-amd-vmm-tests'
+    - name: 'report failed tests: x64-windows-amd-vmm-tests'
       run: flowey.exe e 20 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -4483,7 +4483,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-amd-snp-vmm-tests'
+    - name: 'report failed tests: x64-windows-amd-snp-vmm-tests'
       run: flowey.exe e 21 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -4742,7 +4742,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-amd-kvm-vmm-tests'
+    - name: 'report failed tests: x64-linux-amd-kvm-vmm-tests'
       run: flowey e 22 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -5045,7 +5045,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-intel-mshv-vmm-tests'
+    - name: 'report failed tests: x64-linux-intel-mshv-vmm-tests'
       run: flowey e 23 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -5355,7 +5355,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-windows-vmm-tests'
+    - name: 'report failed tests: aarch64-windows-vmm-tests'
       run: flowey.exe e 24 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -6057,7 +6057,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-intel-mi-secure-vmm-tests'
+    - name: 'report failed tests: x64-windows-intel-mi-secure-vmm-tests'
       run: flowey.exe e 27 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -1193,7 +1193,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: x64-windows-unit-tests-unit-tests crypto (rust)'
       run: |-
         flowey.exe e 12 flowey_lib_common::publish_test_results 9
         flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
@@ -1228,7 +1228,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-unit-tests-unit-tests'
+    - name: 'report failed tests: x64-windows-unit-tests-unit-tests'
       run: flowey.exe e 12 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -1252,7 +1252,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: x64-windows-unit-tests-unit-tests crypto (none)'
       run: |-
         flowey.exe e 12 flowey_lib_common::publish_test_results 4
         flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
@@ -1461,7 +1461,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: x64-linux-unit-tests-unit-tests crypto (none)'
       run: flowey e 13 flowey_lib_common::publish_test_results 9
       shell: bash
     - name: generate nextest command
@@ -1485,7 +1485,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: x64-linux-unit-tests-unit-tests crypto (rust)'
       run: flowey e 13 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -1509,7 +1509,7 @@ jobs:
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (openssl)'
+    - name: 'report failed tests: x64-linux-unit-tests-unit-tests crypto (openssl)'
       run: flowey e 13 flowey_lib_common::publish_test_results 19
       shell: bash
     - name: generate nextest command
@@ -1533,7 +1533,7 @@ jobs:
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (all)'
+    - name: 'report failed tests: x64-linux-unit-tests-unit-tests crypto (all)'
       run: |-
         flowey e 13 flowey_lib_common::publish_test_results 24
         flowey e 13 flowey_lib_hvlite::init_cross_build 2
@@ -1573,7 +1573,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-unit-tests-unit-tests'
+    - name: 'report failed tests: x64-linux-unit-tests-unit-tests'
       run: |-
         flowey e 13 flowey_lib_common::publish_test_results 4
         flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 6
@@ -1804,7 +1804,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests crypto (none)'
       run: flowey e 14 flowey_lib_common::publish_test_results 9
       shell: bash
     - name: generate nextest command
@@ -1828,7 +1828,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests crypto (rust)'
       run: flowey e 14 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -1852,7 +1852,7 @@ jobs:
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl)'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests crypto (openssl)'
       run: flowey e 14 flowey_lib_common::publish_test_results 19
       shell: bash
     - name: generate nextest command
@@ -1876,7 +1876,7 @@ jobs:
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
       run: flowey e 14 flowey_lib_common::publish_test_results 24
       shell: bash
     - name: generate nextest command
@@ -1900,7 +1900,7 @@ jobs:
         path: ${{ env.floweyvar6 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (all)'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests crypto (all)'
       run: |-
         flowey e 14 flowey_lib_common::publish_test_results 29
         flowey e 14 flowey_lib_hvlite::init_cross_build 1
@@ -1940,7 +1940,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests'
       run: |-
         flowey e 14 flowey_lib_common::publish_test_results 4
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 7
@@ -2183,7 +2183,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: aarch64-windows-unit-tests-unit-tests crypto (rust)'
       run: |-
         flowey.exe e 15 flowey_lib_common::publish_test_results 9
         flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
@@ -2218,7 +2218,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests'
+    - name: 'report failed tests: aarch64-windows-unit-tests-unit-tests'
       run: flowey.exe e 15 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -2242,7 +2242,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: aarch64-windows-unit-tests-unit-tests crypto (none)'
       run: |-
         flowey.exe e 15 flowey_lib_common::publish_test_results 4
         flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
@@ -2503,7 +2503,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: aarch64-linux-unit-tests-unit-tests crypto (none)'
       run: flowey e 16 flowey_lib_common::publish_test_results 9
       shell: bash
     - name: generate nextest command
@@ -2527,7 +2527,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: aarch64-linux-unit-tests-unit-tests crypto (rust)'
       run: flowey e 16 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -2551,7 +2551,7 @@ jobs:
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (openssl)'
+    - name: 'report failed tests: aarch64-linux-unit-tests-unit-tests crypto (openssl)'
       run: flowey e 16 flowey_lib_common::publish_test_results 19
       shell: bash
     - name: generate nextest command
@@ -2575,7 +2575,7 @@ jobs:
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (all)'
+    - name: 'report failed tests: aarch64-linux-unit-tests-unit-tests crypto (all)'
       run: |-
         flowey e 16 flowey_lib_common::publish_test_results 24
         flowey e 16 flowey_lib_hvlite::init_cross_build 3
@@ -2615,7 +2615,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests'
+    - name: 'report failed tests: aarch64-linux-unit-tests-unit-tests'
       run: |-
         flowey e 16 flowey_lib_common::publish_test_results 4
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
@@ -2890,7 +2890,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests crypto (none)'
       run: flowey e 17 flowey_lib_common::publish_test_results 9
       shell: bash
     - name: generate nextest command
@@ -2914,7 +2914,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)'
       run: flowey e 17 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -2938,7 +2938,7 @@ jobs:
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)'
       run: flowey e 17 flowey_lib_common::publish_test_results 19
       shell: bash
     - name: generate nextest command
@@ -2962,7 +2962,7 @@ jobs:
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
       run: flowey e 17 flowey_lib_common::publish_test_results 24
       shell: bash
     - name: generate nextest command
@@ -2986,7 +2986,7 @@ jobs:
         path: ${{ env.floweyvar6 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all)'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests crypto (all)'
       run: |-
         flowey e 17 flowey_lib_common::publish_test_results 29
         flowey e 17 flowey_lib_hvlite::init_cross_build 1
@@ -3026,7 +3026,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests'
       run: |-
         flowey e 17 flowey_lib_common::publish_test_results 4
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 7
@@ -3297,7 +3297,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-intel-vmm-tests'
+    - name: 'report failed tests: x64-windows-intel-vmm-tests'
       run: flowey.exe e 18 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -3572,7 +3572,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-intel-tdx-vmm-tests'
+    - name: 'report failed tests: x64-windows-intel-tdx-vmm-tests'
       run: flowey.exe e 19 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -4025,7 +4025,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-amd-vmm-tests'
+    - name: 'report failed tests: x64-windows-amd-vmm-tests'
       run: flowey.exe e 20 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -4300,7 +4300,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-amd-snp-vmm-tests'
+    - name: 'report failed tests: x64-windows-amd-snp-vmm-tests'
       run: flowey.exe e 21 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -4560,7 +4560,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-amd-kvm-vmm-tests'
+    - name: 'report failed tests: x64-linux-amd-kvm-vmm-tests'
       run: flowey e 22 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -4864,7 +4864,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-intel-mshv-vmm-tests'
+    - name: 'report failed tests: x64-linux-intel-mshv-vmm-tests'
       run: flowey e 23 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -5175,7 +5175,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-windows-vmm-tests'
+    - name: 'report failed tests: aarch64-windows-vmm-tests'
       run: flowey.exe e 24 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -5794,7 +5794,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-intel-mi-secure-vmm-tests'
+    - name: 'report failed tests: x64-windows-intel-mi-secure-vmm-tests'
       run: flowey.exe e 27 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -1180,22 +1180,26 @@ jobs:
         flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 2
         flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 3
         flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 12 flowey_lib_common::publish_test_results 5
         flowey.exe e 12 flowey_lib_common::publish_test_results 6
-        flowey.exe e 12 flowey_lib_common::publish_test_results 4
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 12 flowey_lib_common::publish_test_results 7
+        flowey.exe e 12 flowey_lib_common::publish_test_results 5
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-unit-tests-unit-tests crypto (rust)'
+      run: |-
+        flowey.exe e 12 flowey_lib_common::publish_test_results 9
+        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
         flowey.exe e 12 flowey_lib_common::run_cargo_build 1
         flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 1
         flowey.exe e 12 flowey_lib_hvlite::build_xtask 1
@@ -1211,19 +1215,22 @@ jobs:
         flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 4
         flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 5
         flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 12 flowey_lib_common::publish_test_results 8
-        flowey.exe e 12 flowey_lib_common::publish_test_results 9
         flowey.exe e 12 flowey_lib_common::publish_test_results 10
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 12 flowey_lib_common::publish_test_results 11
+        flowey.exe e 12 flowey_lib_common::publish_test_results 12
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-unit-tests-unit-tests'
+      run: flowey.exe e 12 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -1235,7 +1242,7 @@ jobs:
         flowey.exe e 12 flowey_lib_common::publish_test_results 0
         flowey.exe e 12 flowey_lib_common::publish_test_results 1
         flowey.exe e 12 flowey_lib_common::publish_test_results 2
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -1245,10 +1252,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: x64-windows-unit-tests-unit-tests crypto (none)'
       run: |-
+        flowey.exe e 12 flowey_lib_common::publish_test_results 4
         flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
       run: flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -1438,19 +1448,22 @@ jobs:
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 13 flowey_lib_common::publish_test_results 5
         flowey e 13 flowey_lib_common::publish_test_results 6
-        flowey e 13 flowey_lib_common::publish_test_results 4
-        flowey v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::publish_test_results 7
+        flowey e 13 flowey_lib_common::publish_test_results 5
+        flowey v 13 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 13 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (none)'
+      run: flowey e 13 flowey_lib_common::publish_test_results 9
+      shell: bash
     - name: generate nextest command
       run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
@@ -1459,19 +1472,22 @@ jobs:
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 13 flowey_lib_common::publish_test_results 8
-        flowey e 13 flowey_lib_common::publish_test_results 9
         flowey e 13 flowey_lib_common::publish_test_results 10
-        flowey v 13 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 13 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::publish_test_results 11
+        flowey e 13 flowey_lib_common::publish_test_results 12
+        flowey v 13 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 13 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (rust)'
+      run: flowey e 13 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
@@ -1480,19 +1496,22 @@ jobs:
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 13 flowey_lib_common::publish_test_results 12
-        flowey e 13 flowey_lib_common::publish_test_results 13
-        flowey e 13 flowey_lib_common::publish_test_results 14
-        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::publish_test_results 15
+        flowey e 13 flowey_lib_common::publish_test_results 16
+        flowey e 13 flowey_lib_common::publish_test_results 17
+        flowey v 13 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 13 'flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__15
+    - id: flowey_lib_common__publish_test_results__18
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (openssl)'
+      run: flowey e 13 flowey_lib_common::publish_test_results 19
+      shell: bash
     - name: generate nextest command
       run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -1501,22 +1520,26 @@ jobs:
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 13 flowey_lib_common::publish_test_results 16
-        flowey e 13 flowey_lib_common::publish_test_results 17
-        flowey e 13 flowey_lib_common::publish_test_results 18
-        flowey v 13 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 13 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 13 flowey_lib_common::publish_test_results 20
+        flowey e 13 flowey_lib_common::publish_test_results 21
+        flowey e 13 flowey_lib_common::publish_test_results 22
+        flowey v 13 'flowey_lib_common::publish_test_results:36:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 13 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__19
+    - id: flowey_lib_common__publish_test_results__23
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (all)'
+      run: |-
+        flowey e 13 flowey_lib_common::publish_test_results 24
+        flowey e 13 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 13 flowey_lib_hvlite::init_cross_build 2
         flowey e 13 flowey_lib_common::run_cargo_build 1
         flowey e 13 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -1540,7 +1563,7 @@ jobs:
         flowey e 13 flowey_lib_common::publish_test_results 0
         flowey e 13 flowey_lib_common::publish_test_results 1
         flowey e 13 flowey_lib_common::publish_test_results 2
-        flowey v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -1550,10 +1573,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: x64-linux-unit-tests-unit-tests'
       run: |-
+        flowey e 13 flowey_lib_common::publish_test_results 4
         flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
       run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -1765,19 +1791,22 @@ jobs:
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 14 flowey_lib_common::publish_test_results 5
         flowey e 14 flowey_lib_common::publish_test_results 6
-        flowey e 14 flowey_lib_common::publish_test_results 4
-        flowey v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::publish_test_results 7
+        flowey e 14 flowey_lib_common::publish_test_results 5
+        flowey v 14 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 14 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (none)'
+      run: flowey e 14 flowey_lib_common::publish_test_results 9
+      shell: bash
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
@@ -1786,19 +1815,22 @@ jobs:
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 14 flowey_lib_common::publish_test_results 8
-        flowey e 14 flowey_lib_common::publish_test_results 9
         flowey e 14 flowey_lib_common::publish_test_results 10
-        flowey v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::publish_test_results 11
+        flowey e 14 flowey_lib_common::publish_test_results 12
+        flowey v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (rust)'
+      run: flowey e 14 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
@@ -1807,19 +1839,22 @@ jobs:
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 14 flowey_lib_common::publish_test_results 12
-        flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey e 14 flowey_lib_common::publish_test_results 14
-        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::publish_test_results 15
+        flowey e 14 flowey_lib_common::publish_test_results 16
+        flowey e 14 flowey_lib_common::publish_test_results 17
+        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__15
+    - id: flowey_lib_common__publish_test_results__18
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl)'
+      run: flowey e 14 flowey_lib_common::publish_test_results 19
+      shell: bash
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
@@ -1828,19 +1863,22 @@ jobs:
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 14 flowey_lib_common::publish_test_results 16
-        flowey e 14 flowey_lib_common::publish_test_results 17
-        flowey e 14 flowey_lib_common::publish_test_results 18
-        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::publish_test_results 20
+        flowey e 14 flowey_lib_common::publish_test_results 21
+        flowey e 14 flowey_lib_common::publish_test_results 22
+        flowey v 14 'flowey_lib_common::publish_test_results:36:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__19
+    - id: flowey_lib_common__publish_test_results__23
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
+      run: flowey e 14 flowey_lib_common::publish_test_results 24
+      shell: bash
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -1849,22 +1887,26 @@ jobs:
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 14 flowey_lib_common::publish_test_results 20
-        flowey e 14 flowey_lib_common::publish_test_results 21
-        flowey e 14 flowey_lib_common::publish_test_results 22
-        flowey v 14 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 14 flowey_lib_common::publish_test_results 25
+        flowey e 14 flowey_lib_common::publish_test_results 26
+        flowey e 14 flowey_lib_common::publish_test_results 27
+        flowey v 14 'flowey_lib_common::publish_test_results:44:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:40:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::publish_test_results:40:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__23
+    - id: flowey_lib_common__publish_test_results__28
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar6 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (all)'
+      run: |-
+        flowey e 14 flowey_lib_common::publish_test_results 29
+        flowey e 14 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_hvlite::init_cross_build 1
         flowey e 14 flowey_lib_common::run_cargo_build 1
         flowey e 14 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -1888,7 +1930,7 @@ jobs:
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
         flowey e 14 flowey_lib_common::publish_test_results 2
-        flowey v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -1898,10 +1940,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests'
       run: |-
+        flowey e 14 flowey_lib_common::publish_test_results 4
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 7
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
       run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -2125,22 +2170,26 @@ jobs:
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 2
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 3
         flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 15 flowey_lib_common::publish_test_results 5
         flowey.exe e 15 flowey_lib_common::publish_test_results 6
-        flowey.exe e 15 flowey_lib_common::publish_test_results 4
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::publish_test_results 7
+        flowey.exe e 15 flowey_lib_common::publish_test_results 5
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-windows-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests crypto (rust)'
+      run: |-
+        flowey.exe e 15 flowey_lib_common::publish_test_results 9
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
         flowey.exe e 15 flowey_lib_common::run_cargo_build 1
         flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
         flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
@@ -2156,19 +2205,22 @@ jobs:
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 4
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 5
         flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 15 flowey_lib_common::publish_test_results 8
-        flowey.exe e 15 flowey_lib_common::publish_test_results 9
         flowey.exe e 15 flowey_lib_common::publish_test_results 10
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::publish_test_results 11
+        flowey.exe e 15 flowey_lib_common::publish_test_results 12
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-windows-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests'
+      run: flowey.exe e 15 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -2180,7 +2232,7 @@ jobs:
         flowey.exe e 15 flowey_lib_common::publish_test_results 0
         flowey.exe e 15 flowey_lib_common::publish_test_results 1
         flowey.exe e 15 flowey_lib_common::publish_test_results 2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -2190,10 +2242,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests crypto (none)'
       run: |-
+        flowey.exe e 15 flowey_lib_common::publish_test_results 4
         flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
       run: flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -2435,19 +2490,22 @@ jobs:
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 16 flowey_lib_common::publish_test_results 5
         flowey e 16 flowey_lib_common::publish_test_results 6
-        flowey e 16 flowey_lib_common::publish_test_results 4
-        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::publish_test_results 7
+        flowey e 16 flowey_lib_common::publish_test_results 5
+        flowey v 16 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 16 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (none)'
+      run: flowey e 16 flowey_lib_common::publish_test_results 9
+      shell: bash
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
@@ -2456,19 +2514,22 @@ jobs:
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 16 flowey_lib_common::publish_test_results 8
-        flowey e 16 flowey_lib_common::publish_test_results 9
         flowey e 16 flowey_lib_common::publish_test_results 10
-        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::publish_test_results 11
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey v 16 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 16 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (rust)'
+      run: flowey e 16 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
@@ -2477,19 +2538,22 @@ jobs:
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::publish_test_results 15
+        flowey e 16 flowey_lib_common::publish_test_results 16
+        flowey e 16 flowey_lib_common::publish_test_results 17
+        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__15
+    - id: flowey_lib_common__publish_test_results__18
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (openssl)'
+      run: flowey e 16 flowey_lib_common::publish_test_results 19
+      shell: bash
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -2498,22 +2562,26 @@ jobs:
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 16 flowey_lib_common::publish_test_results 16
-        flowey e 16 flowey_lib_common::publish_test_results 17
-        flowey e 16 flowey_lib_common::publish_test_results 18
-        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::publish_test_results 20
+        flowey e 16 flowey_lib_common::publish_test_results 21
+        flowey e 16 flowey_lib_common::publish_test_results 22
+        flowey v 16 'flowey_lib_common::publish_test_results:36:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__19
+    - id: flowey_lib_common__publish_test_results__23
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (all)'
+      run: |-
+        flowey e 16 flowey_lib_common::publish_test_results 24
+        flowey e 16 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_cross_build 3
         flowey e 16 flowey_lib_common::run_cargo_build 1
         flowey e 16 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -2537,7 +2605,7 @@ jobs:
         flowey e 16 flowey_lib_common::publish_test_results 0
         flowey e 16 flowey_lib_common::publish_test_results 1
         flowey e 16 flowey_lib_common::publish_test_results 2
-        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -2547,10 +2615,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests'
       run: |-
+        flowey e 16 flowey_lib_common::publish_test_results 4
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
       run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -2806,19 +2877,22 @@ jobs:
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 17 flowey_lib_common::publish_test_results 5
         flowey e 17 flowey_lib_common::publish_test_results 6
-        flowey e 17 flowey_lib_common::publish_test_results 4
-        flowey v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::publish_test_results 7
+        flowey e 17 flowey_lib_common::publish_test_results 5
+        flowey v 17 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 17 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none)'
+      run: flowey e 17 flowey_lib_common::publish_test_results 9
+      shell: bash
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
@@ -2827,19 +2901,22 @@ jobs:
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 17 flowey_lib_common::publish_test_results 8
-        flowey e 17 flowey_lib_common::publish_test_results 9
         flowey e 17 flowey_lib_common::publish_test_results 10
-        flowey v 17 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 17 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::publish_test_results 11
+        flowey e 17 flowey_lib_common::publish_test_results 12
+        flowey v 17 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 17 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)'
+      run: flowey e 17 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
@@ -2848,19 +2925,22 @@ jobs:
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 17 flowey_lib_common::publish_test_results 12
-        flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey e 17 flowey_lib_common::publish_test_results 14
-        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::publish_test_results 15
+        flowey e 17 flowey_lib_common::publish_test_results 16
+        flowey e 17 flowey_lib_common::publish_test_results 17
+        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__15
+    - id: flowey_lib_common__publish_test_results__18
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)'
+      run: flowey e 17 flowey_lib_common::publish_test_results 19
+      shell: bash
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
@@ -2869,19 +2949,22 @@ jobs:
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 17 flowey_lib_common::publish_test_results 16
-        flowey e 17 flowey_lib_common::publish_test_results 17
-        flowey e 17 flowey_lib_common::publish_test_results 18
-        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::publish_test_results 20
+        flowey e 17 flowey_lib_common::publish_test_results 21
+        flowey e 17 flowey_lib_common::publish_test_results 22
+        flowey v 17 'flowey_lib_common::publish_test_results:36:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__19
+    - id: flowey_lib_common__publish_test_results__23
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
+      run: flowey e 17 flowey_lib_common::publish_test_results 24
+      shell: bash
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -2890,22 +2973,26 @@ jobs:
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 17 flowey_lib_common::publish_test_results 20
-        flowey e 17 flowey_lib_common::publish_test_results 21
-        flowey e 17 flowey_lib_common::publish_test_results 22
-        flowey v 17 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 17 flowey_lib_common::publish_test_results 25
+        flowey e 17 flowey_lib_common::publish_test_results 26
+        flowey e 17 flowey_lib_common::publish_test_results 27
+        flowey v 17 'flowey_lib_common::publish_test_results:44:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:40:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::publish_test_results:40:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__23
+    - id: flowey_lib_common__publish_test_results__28
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar6 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all)'
+      run: |-
+        flowey e 17 flowey_lib_common::publish_test_results 29
+        flowey e 17 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 17 flowey_lib_hvlite::init_cross_build 1
         flowey e 17 flowey_lib_common::run_cargo_build 1
         flowey e 17 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -2929,7 +3016,7 @@ jobs:
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
         flowey e 17 flowey_lib_common::publish_test_results 2
-        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -2939,10 +3026,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests'
       run: |-
+        flowey e 17 flowey_lib_common::publish_test_results 4
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 7
-        flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
       run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -3179,12 +3269,12 @@ jobs:
       run: |-
         flowey.exe e 18 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 18 flowey_lib_common::publish_test_results 4
+        flowey.exe e 18 flowey_lib_common::publish_test_results 6
         flowey.exe e 18 flowey_lib_common::publish_test_results 5
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-intel-vmm-tests-logs
@@ -3197,7 +3287,7 @@ jobs:
         flowey.exe e 18 flowey_lib_common::publish_test_results 0
         flowey.exe e 18 flowey_lib_common::publish_test_results 1
         flowey.exe e 18 flowey_lib_common::publish_test_results 2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -3207,6 +3297,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-intel-vmm-tests'
+      run: flowey.exe e 18 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
@@ -3451,12 +3544,12 @@ jobs:
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 19 flowey_lib_common::publish_test_results 4
+        flowey.exe e 19 flowey_lib_common::publish_test_results 6
         flowey.exe e 19 flowey_lib_common::publish_test_results 5
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-intel-tdx-vmm-tests-logs
@@ -3469,7 +3562,7 @@ jobs:
         flowey.exe e 19 flowey_lib_common::publish_test_results 0
         flowey.exe e 19 flowey_lib_common::publish_test_results 1
         flowey.exe e 19 flowey_lib_common::publish_test_results 2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -3479,6 +3572,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-intel-tdx-vmm-tests'
+      run: flowey.exe e 19 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
@@ -3901,12 +3997,12 @@ jobs:
       run: |-
         flowey.exe e 20 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 20 flowey_lib_common::publish_test_results 4
+        flowey.exe e 20 flowey_lib_common::publish_test_results 6
         flowey.exe e 20 flowey_lib_common::publish_test_results 5
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-amd-vmm-tests-logs
@@ -3919,7 +4015,7 @@ jobs:
         flowey.exe e 20 flowey_lib_common::publish_test_results 0
         flowey.exe e 20 flowey_lib_common::publish_test_results 1
         flowey.exe e 20 flowey_lib_common::publish_test_results 2
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -3929,6 +4025,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-amd-vmm-tests'
+      run: flowey.exe e 20 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
@@ -4173,12 +4272,12 @@ jobs:
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 21 flowey_lib_common::publish_test_results 4
+        flowey.exe e 21 flowey_lib_common::publish_test_results 6
         flowey.exe e 21 flowey_lib_common::publish_test_results 5
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-amd-snp-vmm-tests-logs
@@ -4191,7 +4290,7 @@ jobs:
         flowey.exe e 21 flowey_lib_common::publish_test_results 0
         flowey.exe e 21 flowey_lib_common::publish_test_results 1
         flowey.exe e 21 flowey_lib_common::publish_test_results 2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -4201,6 +4300,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-amd-snp-vmm-tests'
+      run: flowey.exe e 21 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
@@ -4430,12 +4532,12 @@ jobs:
         flowey e 22 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 22 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 22 flowey_lib_common::publish_test_results 4
+        flowey e 22 flowey_lib_common::publish_test_results 6
         flowey e 22 flowey_lib_common::publish_test_results 5
-        flowey v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey v 22 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey v 22 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-amd-kvm-vmm-tests-logs
@@ -4448,7 +4550,7 @@ jobs:
         flowey e 22 flowey_lib_common::publish_test_results 0
         flowey e 22 flowey_lib_common::publish_test_results 1
         flowey e 22 flowey_lib_common::publish_test_results 2
-        flowey v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -4458,6 +4560,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-amd-kvm-vmm-tests'
+      run: flowey e 22 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
@@ -4731,12 +4836,12 @@ jobs:
         flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 23 flowey_lib_common::publish_test_results 4
+        flowey e 23 flowey_lib_common::publish_test_results 6
         flowey e 23 flowey_lib_common::publish_test_results 5
-        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey v 23 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey v 23 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-intel-mshv-vmm-tests-logs
@@ -4749,7 +4854,7 @@ jobs:
         flowey e 23 flowey_lib_common::publish_test_results 0
         flowey e 23 flowey_lib_common::publish_test_results 1
         flowey e 23 flowey_lib_common::publish_test_results 2
-        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -4759,6 +4864,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-intel-mshv-vmm-tests'
+      run: flowey e 23 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
@@ -5039,12 +5147,12 @@ jobs:
       run: |-
         flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 24 flowey_lib_common::publish_test_results 4
+        flowey.exe e 24 flowey_lib_common::publish_test_results 6
         flowey.exe e 24 flowey_lib_common::publish_test_results 5
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-windows-vmm-tests-logs
@@ -5057,7 +5165,7 @@ jobs:
         flowey.exe e 24 flowey_lib_common::publish_test_results 0
         flowey.exe e 24 flowey_lib_common::publish_test_results 1
         flowey.exe e 24 flowey_lib_common::publish_test_results 2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -5067,6 +5175,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-windows-vmm-tests'
+      run: flowey.exe e 24 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
@@ -5655,12 +5766,12 @@ jobs:
       run: |-
         flowey.exe e 27 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 27 flowey_lib_common::publish_test_results 4
+        flowey.exe e 27 flowey_lib_common::publish_test_results 6
         flowey.exe e 27 flowey_lib_common::publish_test_results 5
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-intel-mi-secure-vmm-tests-logs
@@ -5673,7 +5784,7 @@ jobs:
         flowey.exe e 27 flowey_lib_common::publish_test_results 0
         flowey.exe e 27 flowey_lib_common::publish_test_results 1
         flowey.exe e 27 flowey_lib_common::publish_test_results 2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -5683,6 +5794,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-intel-mi-secure-vmm-tests'
+      run: flowey.exe e 27 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1571,22 +1571,26 @@ jobs:
         flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 2
         flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 3
         flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 14 flowey_lib_common::publish_test_results 5
         flowey.exe e 14 flowey_lib_common::publish_test_results 6
-        flowey.exe e 14 flowey_lib_common::publish_test_results 4
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 14 flowey_lib_common::publish_test_results 7
+        flowey.exe e 14 flowey_lib_common::publish_test_results 5
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-unit-tests-unit-tests crypto (rust)'
+      run: |-
+        flowey.exe e 14 flowey_lib_common::publish_test_results 9
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
         flowey.exe e 14 flowey_lib_common::run_cargo_build 1
         flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 1
         flowey.exe e 14 flowey_lib_hvlite::build_xtask 1
@@ -1602,19 +1606,22 @@ jobs:
         flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 4
         flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 5
         flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 14 flowey_lib_common::publish_test_results 8
-        flowey.exe e 14 flowey_lib_common::publish_test_results 9
         flowey.exe e 14 flowey_lib_common::publish_test_results 10
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 14 flowey_lib_common::publish_test_results 11
+        flowey.exe e 14 flowey_lib_common::publish_test_results 12
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-unit-tests-unit-tests'
+      run: flowey.exe e 14 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -1626,7 +1633,7 @@ jobs:
         flowey.exe e 14 flowey_lib_common::publish_test_results 0
         flowey.exe e 14 flowey_lib_common::publish_test_results 1
         flowey.exe e 14 flowey_lib_common::publish_test_results 2
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -1636,10 +1643,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: x64-windows-unit-tests-unit-tests crypto (none)'
       run: |-
+        flowey.exe e 14 flowey_lib_common::publish_test_results 4
         flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
       run: flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -1829,19 +1839,22 @@ jobs:
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 15 flowey_lib_common::publish_test_results 5
         flowey e 15 flowey_lib_common::publish_test_results 6
-        flowey e 15 flowey_lib_common::publish_test_results 4
-        flowey v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::publish_test_results 7
+        flowey e 15 flowey_lib_common::publish_test_results 5
+        flowey v 15 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 15 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (none)'
+      run: flowey e 15 flowey_lib_common::publish_test_results 9
+      shell: bash
     - name: generate nextest command
       run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
@@ -1850,19 +1863,22 @@ jobs:
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 15 flowey_lib_common::publish_test_results 8
-        flowey e 15 flowey_lib_common::publish_test_results 9
         flowey e 15 flowey_lib_common::publish_test_results 10
-        flowey v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::publish_test_results 11
+        flowey e 15 flowey_lib_common::publish_test_results 12
+        flowey v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 15 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (rust)'
+      run: flowey e 15 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
@@ -1871,19 +1887,22 @@ jobs:
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 15 flowey_lib_common::publish_test_results 12
-        flowey e 15 flowey_lib_common::publish_test_results 13
-        flowey e 15 flowey_lib_common::publish_test_results 14
-        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::publish_test_results 15
+        flowey e 15 flowey_lib_common::publish_test_results 16
+        flowey e 15 flowey_lib_common::publish_test_results 17
+        flowey v 15 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 15 'flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__15
+    - id: flowey_lib_common__publish_test_results__18
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (openssl)'
+      run: flowey e 15 flowey_lib_common::publish_test_results 19
+      shell: bash
     - name: generate nextest command
       run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -1892,22 +1911,26 @@ jobs:
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 15 flowey_lib_common::publish_test_results 16
-        flowey e 15 flowey_lib_common::publish_test_results 17
-        flowey e 15 flowey_lib_common::publish_test_results 18
-        flowey v 15 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 15 flowey_lib_common::publish_test_results 20
+        flowey e 15 flowey_lib_common::publish_test_results 21
+        flowey e 15 flowey_lib_common::publish_test_results 22
+        flowey v 15 'flowey_lib_common::publish_test_results:36:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__19
+    - id: flowey_lib_common__publish_test_results__23
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (all)'
+      run: |-
+        flowey e 15 flowey_lib_common::publish_test_results 24
+        flowey e 15 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 15 flowey_lib_hvlite::init_cross_build 2
         flowey e 15 flowey_lib_common::run_cargo_build 1
         flowey e 15 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -1931,7 +1954,7 @@ jobs:
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
         flowey e 15 flowey_lib_common::publish_test_results 2
-        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -1941,10 +1964,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: x64-linux-unit-tests-unit-tests'
       run: |-
+        flowey e 15 flowey_lib_common::publish_test_results 4
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
       run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -2156,19 +2182,22 @@ jobs:
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 16 flowey_lib_common::publish_test_results 5
         flowey e 16 flowey_lib_common::publish_test_results 6
-        flowey e 16 flowey_lib_common::publish_test_results 4
-        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::publish_test_results 7
+        flowey e 16 flowey_lib_common::publish_test_results 5
+        flowey v 16 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 16 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (none)'
+      run: flowey e 16 flowey_lib_common::publish_test_results 9
+      shell: bash
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
@@ -2177,19 +2206,22 @@ jobs:
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 16 flowey_lib_common::publish_test_results 8
-        flowey e 16 flowey_lib_common::publish_test_results 9
         flowey e 16 flowey_lib_common::publish_test_results 10
-        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::publish_test_results 11
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey v 16 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 16 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (rust)'
+      run: flowey e 16 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
@@ -2198,19 +2230,22 @@ jobs:
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::publish_test_results 15
+        flowey e 16 flowey_lib_common::publish_test_results 16
+        flowey e 16 flowey_lib_common::publish_test_results 17
+        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__15
+    - id: flowey_lib_common__publish_test_results__18
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl)'
+      run: flowey e 16 flowey_lib_common::publish_test_results 19
+      shell: bash
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
@@ -2219,19 +2254,22 @@ jobs:
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 16 flowey_lib_common::publish_test_results 16
-        flowey e 16 flowey_lib_common::publish_test_results 17
-        flowey e 16 flowey_lib_common::publish_test_results 18
-        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::publish_test_results 20
+        flowey e 16 flowey_lib_common::publish_test_results 21
+        flowey e 16 flowey_lib_common::publish_test_results 22
+        flowey v 16 'flowey_lib_common::publish_test_results:36:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__19
+    - id: flowey_lib_common__publish_test_results__23
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
+      run: flowey e 16 flowey_lib_common::publish_test_results 24
+      shell: bash
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -2240,22 +2278,26 @@ jobs:
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 16 flowey_lib_common::publish_test_results 20
-        flowey e 16 flowey_lib_common::publish_test_results 21
-        flowey e 16 flowey_lib_common::publish_test_results 22
-        flowey v 16 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 16 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 16 flowey_lib_common::publish_test_results 25
+        flowey e 16 flowey_lib_common::publish_test_results 26
+        flowey e 16 flowey_lib_common::publish_test_results 27
+        flowey v 16 'flowey_lib_common::publish_test_results:44:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:40:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 16 'flowey_lib_common::publish_test_results:40:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__23
+    - id: flowey_lib_common__publish_test_results__28
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar6 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (all)'
+      run: |-
+        flowey e 16 flowey_lib_common::publish_test_results 29
+        flowey e 16 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_cross_build 1
         flowey e 16 flowey_lib_common::run_cargo_build 1
         flowey e 16 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -2279,7 +2321,7 @@ jobs:
         flowey e 16 flowey_lib_common::publish_test_results 0
         flowey e 16 flowey_lib_common::publish_test_results 1
         flowey e 16 flowey_lib_common::publish_test_results 2
-        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -2289,10 +2331,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests'
       run: |-
+        flowey e 16 flowey_lib_common::publish_test_results 4
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 7
-        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
       run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -2516,22 +2561,26 @@ jobs:
         flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 2
         flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 3
         flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 17 flowey_lib_common::publish_test_results 5
         flowey.exe e 17 flowey_lib_common::publish_test_results 6
-        flowey.exe e 17 flowey_lib_common::publish_test_results 4
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 17 flowey_lib_common::publish_test_results 7
+        flowey.exe e 17 flowey_lib_common::publish_test_results 5
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-windows-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests crypto (rust)'
+      run: |-
+        flowey.exe e 17 flowey_lib_common::publish_test_results 9
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 3
         flowey.exe e 17 flowey_lib_common::run_cargo_build 1
         flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 1
         flowey.exe e 17 flowey_lib_hvlite::build_xtask 1
@@ -2547,19 +2596,22 @@ jobs:
         flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 4
         flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 5
         flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 17 flowey_lib_common::publish_test_results 8
-        flowey.exe e 17 flowey_lib_common::publish_test_results 9
         flowey.exe e 17 flowey_lib_common::publish_test_results 10
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 17 flowey_lib_common::publish_test_results 11
+        flowey.exe e 17 flowey_lib_common::publish_test_results 12
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-windows-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests'
+      run: flowey.exe e 17 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -2571,7 +2623,7 @@ jobs:
         flowey.exe e 17 flowey_lib_common::publish_test_results 0
         flowey.exe e 17 flowey_lib_common::publish_test_results 1
         flowey.exe e 17 flowey_lib_common::publish_test_results 2
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -2581,10 +2633,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests crypto (none)'
       run: |-
+        flowey.exe e 17 flowey_lib_common::publish_test_results 4
         flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
       run: flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -2826,19 +2881,22 @@ jobs:
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 18 flowey_lib_common::publish_test_results 5
         flowey e 18 flowey_lib_common::publish_test_results 6
-        flowey e 18 flowey_lib_common::publish_test_results 4
-        flowey v 18 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::publish_test_results 7
+        flowey e 18 flowey_lib_common::publish_test_results 5
+        flowey v 18 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 18 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (none)'
+      run: flowey e 18 flowey_lib_common::publish_test_results 9
+      shell: bash
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
@@ -2847,19 +2905,22 @@ jobs:
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 18 flowey_lib_common::publish_test_results 8
-        flowey e 18 flowey_lib_common::publish_test_results 9
         flowey e 18 flowey_lib_common::publish_test_results 10
-        flowey v 18 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::publish_test_results 11
+        flowey e 18 flowey_lib_common::publish_test_results 12
+        flowey v 18 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 18 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (rust)'
+      run: flowey e 18 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
@@ -2868,19 +2929,22 @@ jobs:
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 18 flowey_lib_common::publish_test_results 12
-        flowey e 18 flowey_lib_common::publish_test_results 13
-        flowey e 18 flowey_lib_common::publish_test_results 14
-        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 18 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::publish_test_results 15
+        flowey e 18 flowey_lib_common::publish_test_results 16
+        flowey e 18 flowey_lib_common::publish_test_results 17
+        flowey v 18 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 18 'flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__15
+    - id: flowey_lib_common__publish_test_results__18
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (openssl)'
+      run: flowey e 18 flowey_lib_common::publish_test_results 19
+      shell: bash
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -2889,22 +2953,26 @@ jobs:
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 18 flowey_lib_common::publish_test_results 16
-        flowey e 18 flowey_lib_common::publish_test_results 17
-        flowey e 18 flowey_lib_common::publish_test_results 18
-        flowey v 18 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 18 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::publish_test_results 20
+        flowey e 18 flowey_lib_common::publish_test_results 21
+        flowey e 18 flowey_lib_common::publish_test_results 22
+        flowey v 18 'flowey_lib_common::publish_test_results:36:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 18 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__19
+    - id: flowey_lib_common__publish_test_results__23
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (all)'
+      run: |-
+        flowey e 18 flowey_lib_common::publish_test_results 24
+        flowey e 18 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 18 flowey_lib_hvlite::init_cross_build 3
         flowey e 18 flowey_lib_common::run_cargo_build 1
         flowey e 18 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -2928,7 +2996,7 @@ jobs:
         flowey e 18 flowey_lib_common::publish_test_results 0
         flowey e 18 flowey_lib_common::publish_test_results 1
         flowey e 18 flowey_lib_common::publish_test_results 2
-        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -2938,10 +3006,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests'
       run: |-
+        flowey e 18 flowey_lib_common::publish_test_results 4
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
       run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -3197,19 +3268,22 @@ jobs:
         flowey e 19 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 19 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 19 flowey_lib_common::publish_test_results 5
         flowey e 19 flowey_lib_common::publish_test_results 6
-        flowey e 19 flowey_lib_common::publish_test_results 4
-        flowey v 19 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::publish_test_results 7
+        flowey e 19 flowey_lib_common::publish_test_results 5
+        flowey v 19 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 19 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__7
+    - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none)'
+      run: flowey e 19 flowey_lib_common::publish_test_results 9
+      shell: bash
     - name: generate nextest command
       run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
@@ -3218,19 +3292,22 @@ jobs:
         flowey e 19 flowey_lib_common::run_cargo_nextest_run 6
         flowey e 19 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 19 flowey_lib_common::publish_test_results 8
-        flowey e 19 flowey_lib_common::publish_test_results 9
         flowey e 19 flowey_lib_common::publish_test_results 10
-        flowey v 19 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 19 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::publish_test_results 11
+        flowey e 19 flowey_lib_common::publish_test_results 12
+        flowey v 19 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 19 'flowey_lib_common::publish_test_results:16:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__11
+    - id: flowey_lib_common__publish_test_results__13
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)'
+      run: flowey e 19 flowey_lib_common::publish_test_results 14
+      shell: bash
     - name: generate nextest command
       run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
@@ -3239,19 +3316,22 @@ jobs:
         flowey e 19 flowey_lib_common::run_cargo_nextest_run 4
         flowey e 19 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 19 flowey_lib_common::publish_test_results 12
-        flowey e 19 flowey_lib_common::publish_test_results 13
-        flowey e 19 flowey_lib_common::publish_test_results 14
-        flowey v 19 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 19 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::publish_test_results 15
+        flowey e 19 flowey_lib_common::publish_test_results 16
+        flowey e 19 flowey_lib_common::publish_test_results 17
+        flowey v 19 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 19 'flowey_lib_common::publish_test_results:24:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__15
+    - id: flowey_lib_common__publish_test_results__18
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)'
+      run: flowey e 19 flowey_lib_common::publish_test_results 19
+      shell: bash
     - name: generate nextest command
       run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
@@ -3260,19 +3340,22 @@ jobs:
         flowey e 19 flowey_lib_common::run_cargo_nextest_run 8
         flowey e 19 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 19 flowey_lib_common::publish_test_results 16
-        flowey e 19 flowey_lib_common::publish_test_results 17
-        flowey e 19 flowey_lib_common::publish_test_results 18
-        flowey v 19 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 19 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::publish_test_results 20
+        flowey e 19 flowey_lib_common::publish_test_results 21
+        flowey e 19 flowey_lib_common::publish_test_results 22
+        flowey v 19 'flowey_lib_common::publish_test_results:36:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 19 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__19
+    - id: flowey_lib_common__publish_test_results__23
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
+      run: flowey e 19 flowey_lib_common::publish_test_results 24
+      shell: bash
     - name: generate nextest command
       run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
@@ -3281,22 +3364,26 @@ jobs:
         flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 19 flowey_lib_common::publish_test_results 20
-        flowey e 19 flowey_lib_common::publish_test_results 21
-        flowey e 19 flowey_lib_common::publish_test_results 22
-        flowey v 19 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 19 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 19 flowey_lib_common::publish_test_results 25
+        flowey e 19 flowey_lib_common::publish_test_results 26
+        flowey e 19 flowey_lib_common::publish_test_results 27
+        flowey v 19 'flowey_lib_common::publish_test_results:44:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:40:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 19 'flowey_lib_common::publish_test_results:40:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__23
+    - id: flowey_lib_common__publish_test_results__28
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar6 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all)'
+      run: |-
+        flowey e 19 flowey_lib_common::publish_test_results 29
+        flowey e 19 flowey_lib_hvlite::init_cross_build 1
+      shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 19 flowey_lib_hvlite::init_cross_build 1
         flowey e 19 flowey_lib_common::run_cargo_build 1
         flowey e 19 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -3320,7 +3407,7 @@ jobs:
         flowey e 19 flowey_lib_common::publish_test_results 0
         flowey e 19 flowey_lib_common::publish_test_results 1
         flowey e 19 flowey_lib_common::publish_test_results 2
-        flowey v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -3330,10 +3417,13 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
+    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests'
       run: |-
+        flowey e 19 flowey_lib_common::publish_test_results 4
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 7
-        flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: report test results to overall pipeline status
+      run: flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
       run: flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -3754,12 +3844,12 @@ jobs:
       run: |-
         flowey.exe e 20 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 20 flowey_lib_common::publish_test_results 4
+        flowey.exe e 20 flowey_lib_common::publish_test_results 6
         flowey.exe e 20 flowey_lib_common::publish_test_results 5
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-intel-vmm-tests-logs
@@ -3772,7 +3862,7 @@ jobs:
         flowey.exe e 20 flowey_lib_common::publish_test_results 0
         flowey.exe e 20 flowey_lib_common::publish_test_results 1
         flowey.exe e 20 flowey_lib_common::publish_test_results 2
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -3782,6 +3872,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-intel-vmm-tests'
+      run: flowey.exe e 20 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
@@ -4026,12 +4119,12 @@ jobs:
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 21 flowey_lib_common::publish_test_results 4
+        flowey.exe e 21 flowey_lib_common::publish_test_results 6
         flowey.exe e 21 flowey_lib_common::publish_test_results 5
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-intel-tdx-vmm-tests-logs
@@ -4044,7 +4137,7 @@ jobs:
         flowey.exe e 21 flowey_lib_common::publish_test_results 0
         flowey.exe e 21 flowey_lib_common::publish_test_results 1
         flowey.exe e 21 flowey_lib_common::publish_test_results 2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -4054,6 +4147,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-intel-tdx-vmm-tests'
+      run: flowey.exe e 21 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
@@ -4292,12 +4388,12 @@ jobs:
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 22 flowey_lib_common::publish_test_results 4
+        flowey.exe e 22 flowey_lib_common::publish_test_results 6
         flowey.exe e 22 flowey_lib_common::publish_test_results 5
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-amd-vmm-tests-logs
@@ -4310,7 +4406,7 @@ jobs:
         flowey.exe e 22 flowey_lib_common::publish_test_results 0
         flowey.exe e 22 flowey_lib_common::publish_test_results 1
         flowey.exe e 22 flowey_lib_common::publish_test_results 2
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -4320,6 +4416,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-amd-vmm-tests'
+      run: flowey.exe e 22 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
@@ -4564,12 +4663,12 @@ jobs:
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 23 flowey_lib_common::publish_test_results 4
+        flowey.exe e 23 flowey_lib_common::publish_test_results 6
         flowey.exe e 23 flowey_lib_common::publish_test_results 5
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-amd-snp-vmm-tests-logs
@@ -4582,7 +4681,7 @@ jobs:
         flowey.exe e 23 flowey_lib_common::publish_test_results 0
         flowey.exe e 23 flowey_lib_common::publish_test_results 1
         flowey.exe e 23 flowey_lib_common::publish_test_results 2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -4592,6 +4691,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-amd-snp-vmm-tests'
+      run: flowey.exe e 23 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
@@ -4821,12 +4923,12 @@ jobs:
         flowey e 24 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 24 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 24 flowey_lib_common::publish_test_results 4
+        flowey e 24 flowey_lib_common::publish_test_results 6
         flowey e 24 flowey_lib_common::publish_test_results 5
-        flowey v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey v 24 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey v 24 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-amd-kvm-vmm-tests-logs
@@ -4839,7 +4941,7 @@ jobs:
         flowey e 24 flowey_lib_common::publish_test_results 0
         flowey e 24 flowey_lib_common::publish_test_results 1
         flowey e 24 flowey_lib_common::publish_test_results 2
-        flowey v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -4849,6 +4951,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-amd-kvm-vmm-tests'
+      run: flowey e 24 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
@@ -5122,12 +5227,12 @@ jobs:
         flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 25 flowey_lib_common::publish_test_results 4
+        flowey e 25 flowey_lib_common::publish_test_results 6
         flowey e 25 flowey_lib_common::publish_test_results 5
-        flowey v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey v 25 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey v 25 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-linux-intel-mshv-vmm-tests-logs
@@ -5140,7 +5245,7 @@ jobs:
         flowey e 25 flowey_lib_common::publish_test_results 0
         flowey e 25 flowey_lib_common::publish_test_results 1
         flowey e 25 flowey_lib_common::publish_test_results 2
-        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -5150,6 +5255,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-linux-intel-mshv-vmm-tests'
+      run: flowey e 25 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
@@ -5430,12 +5538,12 @@ jobs:
       run: |-
         flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 26 flowey_lib_common::publish_test_results 4
+        flowey.exe e 26 flowey_lib_common::publish_test_results 6
         flowey.exe e 26 flowey_lib_common::publish_test_results 5
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: aarch64-windows-vmm-tests-logs
@@ -5448,7 +5556,7 @@ jobs:
         flowey.exe e 26 flowey_lib_common::publish_test_results 0
         flowey.exe e 26 flowey_lib_common::publish_test_results 1
         flowey.exe e 26 flowey_lib_common::publish_test_results 2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -5458,6 +5566,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: aarch64-windows-vmm-tests'
+      run: flowey.exe e 26 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
@@ -6046,12 +6157,12 @@ jobs:
       run: |-
         flowey.exe e 29 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
         flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 29 flowey_lib_common::publish_test_results 4
+        flowey.exe e 29 flowey_lib_common::publish_test_results 6
         flowey.exe e 29 flowey_lib_common::publish_test_results 5
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:180:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57 write-to-env github floweyvar2
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:8:flowey_lib_common/src/publish_test_results.rs:172:57' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
         name: x64-windows-intel-mi-secure-vmm-tests-logs
@@ -6064,7 +6175,7 @@ jobs:
         flowey.exe e 29 flowey_lib_common::publish_test_results 0
         flowey.exe e 29 flowey_lib_common::publish_test_results 1
         flowey.exe e 29 flowey_lib_common::publish_test_results 2
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 29 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:98:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
         flowey.exe v 29 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
@@ -6074,6 +6185,9 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 'annotate test results: x64-windows-intel-mi-secure-vmm-tests'
+      run: flowey.exe e 29 flowey_lib_common::publish_test_results 4
+      shell: bash
     - name: report test results to overall pipeline status
       run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1584,7 +1584,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: x64-windows-unit-tests-unit-tests crypto (rust)'
       run: |-
         flowey.exe e 14 flowey_lib_common::publish_test_results 9
         flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
@@ -1619,7 +1619,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-unit-tests-unit-tests'
+    - name: 'report failed tests: x64-windows-unit-tests-unit-tests'
       run: flowey.exe e 14 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -1643,7 +1643,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: x64-windows-unit-tests-unit-tests crypto (none)'
       run: |-
         flowey.exe e 14 flowey_lib_common::publish_test_results 4
         flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
@@ -1852,7 +1852,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: x64-linux-unit-tests-unit-tests crypto (none)'
       run: flowey e 15 flowey_lib_common::publish_test_results 9
       shell: bash
     - name: generate nextest command
@@ -1876,7 +1876,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: x64-linux-unit-tests-unit-tests crypto (rust)'
       run: flowey e 15 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -1900,7 +1900,7 @@ jobs:
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (openssl)'
+    - name: 'report failed tests: x64-linux-unit-tests-unit-tests crypto (openssl)'
       run: flowey e 15 flowey_lib_common::publish_test_results 19
       shell: bash
     - name: generate nextest command
@@ -1924,7 +1924,7 @@ jobs:
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-unit-tests-unit-tests crypto (all)'
+    - name: 'report failed tests: x64-linux-unit-tests-unit-tests crypto (all)'
       run: |-
         flowey e 15 flowey_lib_common::publish_test_results 24
         flowey e 15 flowey_lib_hvlite::init_cross_build 2
@@ -1964,7 +1964,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-unit-tests-unit-tests'
+    - name: 'report failed tests: x64-linux-unit-tests-unit-tests'
       run: |-
         flowey e 15 flowey_lib_common::publish_test_results 4
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
@@ -2195,7 +2195,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests crypto (none)'
       run: flowey e 16 flowey_lib_common::publish_test_results 9
       shell: bash
     - name: generate nextest command
@@ -2219,7 +2219,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests crypto (rust)'
       run: flowey e 16 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -2243,7 +2243,7 @@ jobs:
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl)'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests crypto (openssl)'
       run: flowey e 16 flowey_lib_common::publish_test_results 19
       shell: bash
     - name: generate nextest command
@@ -2267,7 +2267,7 @@ jobs:
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
       run: flowey e 16 flowey_lib_common::publish_test_results 24
       shell: bash
     - name: generate nextest command
@@ -2291,7 +2291,7 @@ jobs:
         path: ${{ env.floweyvar6 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests crypto (all)'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests crypto (all)'
       run: |-
         flowey e 16 flowey_lib_common::publish_test_results 29
         flowey e 16 flowey_lib_hvlite::init_cross_build 1
@@ -2331,7 +2331,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-musl-unit-tests-unit-tests'
+    - name: 'report failed tests: x64-linux-musl-unit-tests-unit-tests'
       run: |-
         flowey e 16 flowey_lib_common::publish_test_results 4
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 7
@@ -2574,7 +2574,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: aarch64-windows-unit-tests-unit-tests crypto (rust)'
       run: |-
         flowey.exe e 17 flowey_lib_common::publish_test_results 9
         flowey.exe e 17 flowey_lib_hvlite::init_cross_build 3
@@ -2609,7 +2609,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests'
+    - name: 'report failed tests: aarch64-windows-unit-tests-unit-tests'
       run: flowey.exe e 17 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -2633,7 +2633,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-windows-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: aarch64-windows-unit-tests-unit-tests crypto (none)'
       run: |-
         flowey.exe e 17 flowey_lib_common::publish_test_results 4
         flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
@@ -2894,7 +2894,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: aarch64-linux-unit-tests-unit-tests crypto (none)'
       run: flowey e 18 flowey_lib_common::publish_test_results 9
       shell: bash
     - name: generate nextest command
@@ -2918,7 +2918,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: aarch64-linux-unit-tests-unit-tests crypto (rust)'
       run: flowey e 18 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -2942,7 +2942,7 @@ jobs:
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (openssl)'
+    - name: 'report failed tests: aarch64-linux-unit-tests-unit-tests crypto (openssl)'
       run: flowey e 18 flowey_lib_common::publish_test_results 19
       shell: bash
     - name: generate nextest command
@@ -2966,7 +2966,7 @@ jobs:
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests crypto (all)'
+    - name: 'report failed tests: aarch64-linux-unit-tests-unit-tests crypto (all)'
       run: |-
         flowey e 18 flowey_lib_common::publish_test_results 24
         flowey e 18 flowey_lib_hvlite::init_cross_build 3
@@ -3006,7 +3006,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-unit-tests-unit-tests'
+    - name: 'report failed tests: aarch64-linux-unit-tests-unit-tests'
       run: |-
         flowey e 18 flowey_lib_common::publish_test_results 4
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
@@ -3281,7 +3281,7 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none)'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests crypto (none)'
       run: flowey e 19 flowey_lib_common::publish_test_results 9
       shell: bash
     - name: generate nextest command
@@ -3305,7 +3305,7 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)'
       run: flowey e 19 flowey_lib_common::publish_test_results 14
       shell: bash
     - name: generate nextest command
@@ -3329,7 +3329,7 @@ jobs:
         path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)'
       run: flowey e 19 flowey_lib_common::publish_test_results 19
       shell: bash
     - name: generate nextest command
@@ -3353,7 +3353,7 @@ jobs:
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)'
       run: flowey e 19 flowey_lib_common::publish_test_results 24
       shell: bash
     - name: generate nextest command
@@ -3377,7 +3377,7 @@ jobs:
         path: ${{ env.floweyvar6 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all)'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests crypto (all)'
       run: |-
         flowey e 19 flowey_lib_common::publish_test_results 29
         flowey e 19 flowey_lib_hvlite::init_cross_build 1
@@ -3417,7 +3417,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-linux-musl-unit-tests-unit-tests'
+    - name: 'report failed tests: aarch64-linux-musl-unit-tests-unit-tests'
       run: |-
         flowey e 19 flowey_lib_common::publish_test_results 4
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 7
@@ -3872,7 +3872,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-intel-vmm-tests'
+    - name: 'report failed tests: x64-windows-intel-vmm-tests'
       run: flowey.exe e 20 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -4147,7 +4147,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-intel-tdx-vmm-tests'
+    - name: 'report failed tests: x64-windows-intel-tdx-vmm-tests'
       run: flowey.exe e 21 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -4416,7 +4416,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-amd-vmm-tests'
+    - name: 'report failed tests: x64-windows-amd-vmm-tests'
       run: flowey.exe e 22 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -4691,7 +4691,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-amd-snp-vmm-tests'
+    - name: 'report failed tests: x64-windows-amd-snp-vmm-tests'
       run: flowey.exe e 23 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -4951,7 +4951,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-amd-kvm-vmm-tests'
+    - name: 'report failed tests: x64-linux-amd-kvm-vmm-tests'
       run: flowey e 24 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -5255,7 +5255,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-linux-intel-mshv-vmm-tests'
+    - name: 'report failed tests: x64-linux-intel-mshv-vmm-tests'
       run: flowey e 25 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -5566,7 +5566,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: aarch64-windows-vmm-tests'
+    - name: 'report failed tests: aarch64-windows-vmm-tests'
       run: flowey.exe e 26 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status
@@ -6185,7 +6185,7 @@ jobs:
         path: ${{ env.floweyvar1 }}
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 'annotate test results: x64-windows-intel-mi-secure-vmm-tests'
+    - name: 'report failed tests: x64-windows-intel-mi-secure-vmm-tests'
       run: flowey.exe e 29 flowey_lib_common::publish_test_results 4
       shell: bash
     - name: report test results to overall pipeline status

--- a/flowey/flowey_lib_common/src/publish_test_results.rs
+++ b/flowey/flowey_lib_common/src/publish_test_results.rs
@@ -115,7 +115,7 @@ impl FlowNode for Node {
                     // and job summary for test failures.
                     let label_for_annotate = label.clone();
                     use_side_effects.push(ctx.emit_rust_step(
-                        format!("annotate test results: {label}"),
+                        format!("report failed tests: {label}"),
                         |ctx| {
                             let has_junit = has_junit_xml_for_annotate.claim(ctx);
                             let junit_path = junit_xml_for_annotate.claim(ctx);
@@ -300,8 +300,10 @@ fn annotate_junit_failures(junit_path: &Path, label: &str) -> anyhow::Result<()>
             };
 
             // GitHub Actions workflow command — shows as an annotation on
-            // the PR checks tab.
-            eprintln!("::error title=Test failure: {full_name}::{short_msg}");
+            // the PR checks tab. The title must not contain "::" as that
+            // terminates the parameter section in the workflow command syntax.
+            let safe_title = full_name.replace("::", "/");
+            eprintln!("::error title={safe_title}::{short_msg}");
 
             failures.push((full_name, short_msg));
         }

--- a/flowey/flowey_lib_common/src/publish_test_results.rs
+++ b/flowey/flowey_lib_common/src/publish_test_results.rs
@@ -92,6 +92,9 @@ impl FlowNode for Node {
                     }));
                 }
                 FlowBackend::Github => {
+                    let junit_xml_for_annotate = junit_xml.clone();
+                    let has_junit_xml_for_annotate = has_junit_xml.clone();
+
                     let junit_xml = junit_xml.map(ctx, |p| {
                         p.absolute().expect("invalid path").display().to_string()
                     });
@@ -107,6 +110,31 @@ impl FlowNode for Node {
                             .with("path", junit_xml)
                             .finish(ctx),
                     );
+
+                    // Parse JUnit XML and emit GitHub Actions annotations
+                    // and job summary for test failures.
+                    let label_for_annotate = label.clone();
+                    use_side_effects.push(ctx.emit_rust_step(
+                        format!("annotate test results: {label}"),
+                        |ctx| {
+                            let has_junit = has_junit_xml_for_annotate.claim(ctx);
+                            let junit_path = junit_xml_for_annotate.claim(ctx);
+
+                            move |rt| {
+                                if !rt.read(has_junit) {
+                                    return Ok(());
+                                }
+                                let junit_path = rt.read(junit_path);
+                                if !junit_path.exists() {
+                                    return Ok(());
+                                }
+
+                                annotate_junit_failures(&junit_path, &label_for_annotate)?;
+
+                                Ok(())
+                            }
+                        },
+                    ));
                 }
                 FlowBackend::Local => {
                     if let Some(output_dir) = output_dir.clone() {
@@ -234,4 +262,73 @@ impl FlowNode for Node {
 
         Ok(())
     }
+}
+
+/// Parse a JUnit XML file and emit GitHub Actions `::error::` annotations
+/// for each test failure, plus a Markdown summary table to
+/// `$GITHUB_STEP_SUMMARY`.
+fn annotate_junit_failures(junit_path: &Path, label: &str) -> anyhow::Result<()> {
+    let content = fs_err::read_to_string(junit_path)?;
+    let doc = roxmltree::Document::parse(&content)
+        .map_err(|e| anyhow::anyhow!("failed to parse JUnit XML: {e}"))?;
+
+    let mut failures: Vec<(String, String)> = Vec::new();
+
+    for testcase in doc.descendants().filter(|n| n.has_tag_name("testcase")) {
+        let name = testcase.attribute("name").unwrap_or("<unknown>");
+        let classname = testcase.attribute("classname").unwrap_or("");
+
+        let failure_nodes = testcase
+            .children()
+            .filter(|n| n.has_tag_name("failure") || n.has_tag_name("error"));
+
+        for failure in failure_nodes {
+            let message = failure.attribute("message").unwrap_or("test failed");
+            // Take only the first line and cap length for the annotation.
+            let short_msg: String = message
+                .lines()
+                .next()
+                .unwrap_or("test failed")
+                .chars()
+                .take(200)
+                .collect();
+
+            let full_name = if classname.is_empty() {
+                name.to_string()
+            } else {
+                format!("{classname}::{name}")
+            };
+
+            // GitHub Actions workflow command — shows as an annotation on
+            // the PR checks tab.
+            eprintln!("::error title=Test failure: {full_name}::{short_msg}");
+
+            failures.push((full_name, short_msg));
+        }
+    }
+
+    // Write a summary table to the GitHub Actions job summary.
+    if !failures.is_empty() {
+        if let Ok(summary_path) = std::env::var("GITHUB_STEP_SUMMARY") {
+            use std::io::Write;
+
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(&summary_path)?;
+
+            writeln!(f, "## Test Failures: {label}")?;
+            writeln!(f)?;
+            writeln!(f, "| Test | Error |")?;
+            writeln!(f, "|------|-------|")?;
+            for (name, msg) in &failures {
+                let escaped_name = name.replace('|', "\\|");
+                let escaped_msg = msg.replace('|', "\\|");
+                writeln!(f, "| `{escaped_name}` | {escaped_msg} |")?;
+            }
+            writeln!(f)?;
+        }
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
On the GitHub Actions CI backend, JUnit XML results are uploaded as raw artifacts but never parsed — making it hard to find which tests failed without downloading and reading XML. The ADO backend doesn't have this problem because PublishTestResults@2 natively integrates results into the UI.

Add a Rust step on the GitHub backend that parses the JUnit XML with roxmltree (already a dependency) and emits ::error:: workflow commands for each failure. These show as annotations on the PR checks tab. The step also writes a Markdown summary table to $GITHUB_STEP_SUMMARY for a quick visual overview on the job summary page.