### PR TITLE
pal_uring: quiesce minircu before blocking in io_uring worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5782,6 +5782,7 @@ dependencies = [
  "io-uring",
  "libc",
  "loan_cell",
+ "minircu",
  "once_cell",
  "pal",
  "pal_async",

--- a/support/pal/pal_uring/Cargo.toml
+++ b/support/pal/pal_uring/Cargo.toml
@@ -13,6 +13,7 @@ ci = []
 [target.'cfg(target_os = "linux")'.dependencies]
 inspect.workspace = true
 loan_cell.workspace = true
+minircu.workspace = true
 pal.workspace = true
 pal_async.workspace = true
 

--- a/support/pal/pal_uring/src/threadpool.rs
+++ b/support/pal/pal_uring/src/threadpool.rs
@@ -279,6 +279,27 @@ impl Worker {
                             }
                         }
 
+                        // About to block in io_uring_enter. Mark this thread
+                        // as quiesced for the global RCU domain so that any
+                        // concurrent `synchronize_blocking()` writer (e.g.
+                        // `guestmem::rcu()` page-protection updates in
+                        // OpenHCL's `underhill_mem`) can complete without
+                        // issuing a process-wide `membarrier()` on our
+                        // behalf. Without this, every worker that has ever
+                        // polled a future containing a `guestmem` critical
+                        // section stays registered as a non-quiesced RCU
+                        // reader for the lifetime of the thread, forcing
+                        // each writer to broadcast `membarrier(PRIVATE_
+                        // EXPEDITED)` to every CPU. On large isolated VMs
+                        // (e.g. 64-VP) that broadcast can stall long
+                        // enough to trigger kernel `rcu_preempt self-
+                        // detected stall` warnings in
+                        // `smp_call_function_many_cond`. Re-entering a
+                        // critical section after this issues a local
+                        // memory barrier via `ThreadData::enter_slow`, so
+                        // correctness is preserved.
+                        minircu::global().quiesce();
+
                         state.worker.io_ring.submit_and_wait();
                     }
                 }


### PR DESCRIPTION
## Summary

Fix recurring `rcu_preempt self-detected stall` failures in OpenHCL on large isolated VMs (most visible on the `x64-windows-amd-snp` CI runner, e.g. the `memory_validation_debug_very_heavy` test) by having io-uring worker threads quiesce the global minircu domain immediately before blocking in `io_uring_enter`.

## Root cause

Every `pal_uring` threadpool worker (the threads named `tp`) registers itself as a non-quiesced reader in the global minircu domain the first time it polls a future that enters an RCU read-side critical section — which happens as soon as a worker touches anything in `guestmem`. After that point the worker stays registered for the lifetime of the thread.

The only production caller of `minircu::global().quiesce()` is the VTL2 VP loop in `openhcl/virt_mshv_vtl/src/processor/mod.rs`. Threadpool workers never quiesced, so every `guestmem::rcu().synchronize_blocking()` writer in `openhcl/underhill_mem/src/lib.rs` (five hot call sites — page visibility / VTL protection updates) was forced to broadcast `membarrier(MEMBARRIER_CMD_PRIVATE_EXPEDITED)` to every CPU.

On a 64-VP SNP CVM with most VPs running VTL0 guest code, the IPI broadcast can stall for tens of seconds waiting for VPs to context-switch, long enough to trigger:

```
rcu: INFO: rcu_preempt self-detected stall on CPU
...
smp_call_function_many_cond+0x113/0x300
__x64_sys_membarrier+0x27c/0x360
```

inside one of the `tp` workers, after which dependent tests eventually hit their nextest timeout. This was observed e.g. on PR #3487 CI in run `25867445619` on `x64-windows-amd-snp`.

This is essentially the same class of symptom as #2334 (TDX AP-start stall) but with a different trigger.

## Fix

`minircu`'s own docs ([support/minircu/src/lib.rs](https://github.com/microsoft/openvmm/blob/main/support/minircu/src/lib.rs#L80-L82)) prescribe the fix:

> *"For best performance, ensure all threads in your process call `quiesce` when a thread is going to sleep or block."*

Call `minircu::global().quiesce()` in the io-uring worker loop just before `submit_and_wait`. Once quiesced, the worker is invisible to membarrier broadcasts until it next enters a critical section, at which point `ThreadData::enter_slow` already emits a `fence(SeqCst)` to publish the transition — so correctness is preserved. This mirrors the existing quiesce call in the VTL2 VP loop.

Cost: a single TLS load + relaxed atomic store per idle cycle on the worker. No-op for threads that have never entered a critical section.