### PR TITLE
vmbus_server: avoid reset deadlock on Opening channels

### DIFF
--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -507,6 +507,18 @@ enum ChannelState {
     /// The guest has released the channel but there is still a pending close
     /// request to the device.
     ClosingClientRelease,
+
+    /// The guest has released the channel, but there is still a pending open
+    /// request to the device.
+    ///
+    /// This variant is currently unconstructed: `client_release_channel`
+    /// force-releases `Opening` channels directly to `ClientReleased` to
+    /// avoid deadlocking the vmbus reset on a device task that has been
+    /// stopped (and so will never deliver an open response). The variant is
+    /// retained for now to preserve match-arm coverage in callers that
+    /// continue to handle the state defensively.
+    #[expect(dead_code)]
+    OpeningClientRelease,
 }
 
 impl ChannelState {
@@ -522,7 +534,9 @@ impl ChannelState {
             | ChannelState::Revoked
             | ChannelState::Reoffered => false,
 
-            ChannelState::ClientReleased | ChannelState::ClosingClientRelease => true,
+            ChannelState::ClientReleased
+            | ChannelState::ClosingClientRelease
+            | ChannelState::OpeningClientRelease => true,
         }
     }
 
@@ -537,7 +551,8 @@ impl ChannelState {
             | ChannelState::Open { .. }
             | ChannelState::Closing { .. }
             | ChannelState::ClosingReopen { .. }
-            | ChannelState::ClosingClientRelease => false,
+            | ChannelState::ClosingClientRelease
+            | ChannelState::OpeningClientRelease => false,
         }
     }
 
@@ -565,7 +580,8 @@ impl ChannelState {
             | ChannelState::ClosingReopen { .. }
             | ChannelState::Revoked
             | ChannelState::Reoffered
-            | ChannelState::ClosingClientRelease => false,
+            | ChannelState::ClosingClientRelease
+            | ChannelState::OpeningClientRelease => false,
         }
     }
 }
@@ -582,6 +598,7 @@ impl Display for ChannelState {
             Self::Revoked => "Revoked",
             Self::Reoffered => "Reoffered",
             Self::ClosingClientRelease => "ClosingClientRelease",
+            Self::OpeningClientRelease => "OpeningClientRelease",
         };
         write!(f, "{}", state)
     }
@@ -795,6 +812,7 @@ impl Channel {
             ChannelState::Revoked => "revoked",
             ChannelState::Reoffered => "reoffered",
             ChannelState::ClosingClientRelease => "closing_client_release",
+            ChannelState::OpeningClientRelease => "opening_client_release",
         };
         let restore_state = match self.restore_state {
             RestoreState::New => "new",
@@ -1476,7 +1494,9 @@ impl Server {
             ChannelState::ClientReleased | ChannelState::Reoffered => {
                 return Err(RestoreError::MissingChannel(channel.offer.key()));
             }
-            ChannelState::Revoked | ChannelState::ClosingClientRelease => unreachable!(),
+            ChannelState::Revoked
+            | ChannelState::ClosingClientRelease
+            | ChannelState::OpeningClientRelease => unreachable!(),
         };
 
         Ok(OpenParams::from_request(
@@ -1582,7 +1602,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                 ChannelState::ClientReleased | ChannelState::Reoffered => {
                     return Err(RestoreError::MissingChannel(channel.offer.key()));
                 }
-                ChannelState::Revoked | ChannelState::ClosingClientRelease => unreachable!(),
+                ChannelState::Revoked
+                | ChannelState::ClosingClientRelease
+                | ChannelState::OpeningClientRelease => unreachable!(),
             };
         } else {
             match channel.state {
@@ -1636,7 +1658,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                 ChannelState::ClientReleased => {
                     return Err(RestoreError::MissingChannel(channel.offer.key()));
                 }
-                ChannelState::Revoked | ChannelState::ClosingClientRelease => unreachable!(),
+                ChannelState::Revoked
+                | ChannelState::ClosingClientRelease
+                | ChannelState::OpeningClientRelease => unreachable!(),
             }
         }
 
@@ -1915,6 +1939,22 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                     ChannelState::Closed
                 };
             }
+            ChannelState::OpeningClientRelease => {
+                tracing::info!(
+                    offer_id = offer_id.0,
+                    key = %channel.offer.key(),
+                    result,
+                    "opened channel (client released)"
+                );
+
+                if result >= 0 {
+                    channel.state = ChannelState::ClosingClientRelease;
+                    self.notifier.notify(offer_id, Action::Close);
+                } else {
+                    channel.state = ChannelState::ClientReleased;
+                    self.check_disconnected();
+                }
+            }
 
             ChannelState::ClientReleased
             | ChannelState::Closed
@@ -2049,7 +2089,8 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             | ChannelState::Opening { .. }
             | ChannelState::Open { .. }
             | ChannelState::Revoked
-            | ChannelState::Reoffered => {
+            | ChannelState::Reoffered
+            | ChannelState::OpeningClientRelease => {
                 tracing::error!(?offer_id, key = %channel.offer.key(), state = ?channel.state, "invalid close complete")
             }
         }
@@ -3004,7 +3045,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             | ChannelState::Opening { .. }
             | ChannelState::ClosingReopen { .. } => return Err(ChannelError::ChannelAlreadyOpen),
 
-            ChannelState::ClientReleased | ChannelState::ClosingClientRelease => unreachable!(),
+            ChannelState::ClientReleased
+            | ChannelState::ClosingClientRelease
+            | ChannelState::OpeningClientRelease => unreachable!(),
         }
         Ok(())
     }
@@ -3049,7 +3092,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             | ChannelState::Closing { .. }
             | ChannelState::ClosingReopen { .. } => return Err(ChannelError::ChannelNotOpen),
 
-            ChannelState::ClientReleased | ChannelState::ClosingClientRelease => unreachable!(),
+            ChannelState::ClientReleased
+            | ChannelState::ClosingClientRelease
+            | ChannelState::OpeningClientRelease => unreachable!(),
         }
 
         Ok(())
@@ -3097,7 +3142,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                 return Err(ChannelError::InvalidChannelState);
             }
 
-            ChannelState::ClientReleased | ChannelState::ClosingClientRelease => unreachable!(),
+            ChannelState::ClientReleased
+            | ChannelState::ClosingClientRelease
+            | ChannelState::OpeningClientRelease => unreachable!(),
         }
         Ok(())
     }
@@ -3140,7 +3187,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             | ChannelState::Closing { .. }
             | ChannelState::ClosingReopen { .. } => return Err(ChannelError::ChannelNotOpen),
 
-            ChannelState::ClientReleased | ChannelState::ClosingClientRelease => unreachable!(),
+            ChannelState::ClientReleased
+            | ChannelState::ClosingClientRelease
+            | ChannelState::OpeningClientRelease => unreachable!(),
         }
 
         Ok(())
@@ -3243,7 +3292,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                 false
             }
 
-            ChannelState::ClosingClientRelease | ChannelState::ClientReleased => false,
+            ChannelState::ClosingClientRelease
+            | ChannelState::OpeningClientRelease
+            | ChannelState::ClientReleased => false,
         };
 
         assert!(channel.state.is_released());
@@ -3290,7 +3341,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             | ChannelState::Open { .. }
             | ChannelState::ClosingReopen { .. } => return Err(ChannelError::InvalidChannelState),
 
-            ChannelState::ClientReleased | ChannelState::ClosingClientRelease => unreachable!(),
+            ChannelState::ClientReleased
+            | ChannelState::OpeningClientRelease
+            | ChannelState::ClosingClientRelease => unreachable!(),
         }
         Ok(())
     }
@@ -3764,7 +3817,9 @@ fn revoke<N: Notifier>(
             channel.state = ChannelState::Revoked;
             None
         }
-        ChannelState::ClientReleased | ChannelState::ClosingClientRelease => None,
+        ChannelState::ClientReleased
+        | ChannelState::OpeningClientRelease
+        | ChannelState::ClosingClientRelease => None,
         // If the channel is being dropped, it may already have been revoked explicitly.
         ChannelState::Revoked => return true,
     };

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -507,18 +507,6 @@ enum ChannelState {
     /// The guest has released the channel but there is still a pending close
     /// request to the device.
     ClosingClientRelease,
-
-    /// The guest has released the channel, but there is still a pending open
-    /// request to the device.
-    ///
-    /// This variant is currently unconstructed: `client_release_channel`
-    /// force-releases `Opening` channels directly to `ClientReleased` to
-    /// avoid deadlocking the vmbus reset on a device task that has been
-    /// stopped (and so will never deliver an open response). The variant is
-    /// retained for now to preserve match-arm coverage in callers that
-    /// continue to handle the state defensively.
-    #[expect(dead_code)]
-    OpeningClientRelease,
 }
 
 impl ChannelState {
@@ -534,9 +522,7 @@ impl ChannelState {
             | ChannelState::Revoked
             | ChannelState::Reoffered => false,
 
-            ChannelState::ClientReleased
-            | ChannelState::ClosingClientRelease
-            | ChannelState::OpeningClientRelease => true,
+            ChannelState::ClientReleased | ChannelState::ClosingClientRelease => true,
         }
     }
 
@@ -551,8 +537,7 @@ impl ChannelState {
             | ChannelState::Open { .. }
             | ChannelState::Closing { .. }
             | ChannelState::ClosingReopen { .. }
-            | ChannelState::ClosingClientRelease
-            | ChannelState::OpeningClientRelease => false,
+            | ChannelState::ClosingClientRelease => false,
         }
     }
 
@@ -580,8 +565,7 @@ impl ChannelState {
             | ChannelState::ClosingReopen { .. }
             | ChannelState::Revoked
             | ChannelState::Reoffered
-            | ChannelState::ClosingClientRelease
-            | ChannelState::OpeningClientRelease => false,
+            | ChannelState::ClosingClientRelease => false,
         }
     }
 }
@@ -598,7 +582,6 @@ impl Display for ChannelState {
             Self::Revoked => "Revoked",
             Self::Reoffered => "Reoffered",
             Self::ClosingClientRelease => "ClosingClientRelease",
-            Self::OpeningClientRelease => "OpeningClientRelease",
         };
         write!(f, "{}", state)
     }
@@ -812,7 +795,6 @@ impl Channel {
             ChannelState::Revoked => "revoked",
             ChannelState::Reoffered => "reoffered",
             ChannelState::ClosingClientRelease => "closing_client_release",
-            ChannelState::OpeningClientRelease => "opening_client_release",
         };
         let restore_state = match self.restore_state {
             RestoreState::New => "new",
@@ -1494,9 +1476,7 @@ impl Server {
             ChannelState::ClientReleased | ChannelState::Reoffered => {
                 return Err(RestoreError::MissingChannel(channel.offer.key()));
             }
-            ChannelState::Revoked
-            | ChannelState::ClosingClientRelease
-            | ChannelState::OpeningClientRelease => unreachable!(),
+            ChannelState::Revoked | ChannelState::ClosingClientRelease => unreachable!(),
         };
 
         Ok(OpenParams::from_request(
@@ -1602,9 +1582,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                 ChannelState::ClientReleased | ChannelState::Reoffered => {
                     return Err(RestoreError::MissingChannel(channel.offer.key()));
                 }
-                ChannelState::Revoked
-                | ChannelState::ClosingClientRelease
-                | ChannelState::OpeningClientRelease => unreachable!(),
+                ChannelState::Revoked | ChannelState::ClosingClientRelease => unreachable!(),
             };
         } else {
             match channel.state {
@@ -1658,9 +1636,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                 ChannelState::ClientReleased => {
                     return Err(RestoreError::MissingChannel(channel.offer.key()));
                 }
-                ChannelState::Revoked
-                | ChannelState::ClosingClientRelease
-                | ChannelState::OpeningClientRelease => unreachable!(),
+                ChannelState::Revoked | ChannelState::ClosingClientRelease => unreachable!(),
             }
         }
 
@@ -1939,22 +1915,6 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                     ChannelState::Closed
                 };
             }
-            ChannelState::OpeningClientRelease => {
-                tracing::info!(
-                    offer_id = offer_id.0,
-                    key = %channel.offer.key(),
-                    result,
-                    "opened channel (client released)"
-                );
-
-                if result >= 0 {
-                    channel.state = ChannelState::ClosingClientRelease;
-                    self.notifier.notify(offer_id, Action::Close);
-                } else {
-                    channel.state = ChannelState::ClientReleased;
-                    self.check_disconnected();
-                }
-            }
 
             ChannelState::ClientReleased
             | ChannelState::Closed
@@ -2089,8 +2049,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             | ChannelState::Opening { .. }
             | ChannelState::Open { .. }
             | ChannelState::Revoked
-            | ChannelState::Reoffered
-            | ChannelState::OpeningClientRelease => {
+            | ChannelState::Reoffered => {
                 tracing::error!(?offer_id, key = %channel.offer.key(), state = ?channel.state, "invalid close complete")
             }
         }
@@ -3045,9 +3004,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             | ChannelState::Opening { .. }
             | ChannelState::ClosingReopen { .. } => return Err(ChannelError::ChannelAlreadyOpen),
 
-            ChannelState::ClientReleased
-            | ChannelState::ClosingClientRelease
-            | ChannelState::OpeningClientRelease => unreachable!(),
+            ChannelState::ClientReleased | ChannelState::ClosingClientRelease => unreachable!(),
         }
         Ok(())
     }
@@ -3092,9 +3049,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             | ChannelState::Closing { .. }
             | ChannelState::ClosingReopen { .. } => return Err(ChannelError::ChannelNotOpen),
 
-            ChannelState::ClientReleased
-            | ChannelState::ClosingClientRelease
-            | ChannelState::OpeningClientRelease => unreachable!(),
+            ChannelState::ClientReleased | ChannelState::ClosingClientRelease => unreachable!(),
         }
 
         Ok(())
@@ -3142,9 +3097,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                 return Err(ChannelError::InvalidChannelState);
             }
 
-            ChannelState::ClientReleased
-            | ChannelState::ClosingClientRelease
-            | ChannelState::OpeningClientRelease => unreachable!(),
+            ChannelState::ClientReleased | ChannelState::ClosingClientRelease => unreachable!(),
         }
         Ok(())
     }
@@ -3187,9 +3140,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             | ChannelState::Closing { .. }
             | ChannelState::ClosingReopen { .. } => return Err(ChannelError::ChannelNotOpen),
 
-            ChannelState::ClientReleased
-            | ChannelState::ClosingClientRelease
-            | ChannelState::OpeningClientRelease => unreachable!(),
+            ChannelState::ClientReleased | ChannelState::ClosingClientRelease => unreachable!(),
         }
 
         Ok(())
@@ -3292,9 +3243,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                 false
             }
 
-            ChannelState::ClosingClientRelease
-            | ChannelState::OpeningClientRelease
-            | ChannelState::ClientReleased => false,
+            ChannelState::ClosingClientRelease | ChannelState::ClientReleased => false,
         };
 
         assert!(channel.state.is_released());
@@ -3341,9 +3290,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             | ChannelState::Open { .. }
             | ChannelState::ClosingReopen { .. } => return Err(ChannelError::InvalidChannelState),
 
-            ChannelState::ClientReleased
-            | ChannelState::OpeningClientRelease
-            | ChannelState::ClosingClientRelease => unreachable!(),
+            ChannelState::ClientReleased | ChannelState::ClosingClientRelease => unreachable!(),
         }
         Ok(())
     }
@@ -3817,9 +3764,7 @@ fn revoke<N: Notifier>(
             channel.state = ChannelState::Revoked;
             None
         }
-        ChannelState::ClientReleased
-        | ChannelState::OpeningClientRelease
-        | ChannelState::ClosingClientRelease => None,
+        ChannelState::ClientReleased | ChannelState::ClosingClientRelease => None,
         // If the channel is being dropped, it may already have been revoked explicitly.
         ChannelState::Revoked => return true,
     };

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -510,6 +510,14 @@ enum ChannelState {
 
     /// The guest has released the channel, but there is still a pending open
     /// request to the device.
+    ///
+    /// This variant is currently unconstructed: `client_release_channel`
+    /// force-releases `Opening` channels directly to `ClientReleased` to
+    /// avoid deadlocking the vmbus reset on a device task that has been
+    /// stopped (and so will never deliver an open response). The variant is
+    /// retained for now to preserve match-arm coverage in callers that
+    /// continue to handle the state defensively.
+    #[expect(dead_code)]
     OpeningClientRelease,
 }
 
@@ -3257,7 +3265,21 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                 true
             }
             ChannelState::Opening { .. } => {
-                channel.state = ChannelState::OpeningClientRelease;
+                // The device has not yet opened the channel. There is no
+                // device-side state to tear down, so release immediately
+                // rather than waiting for the in-flight open response. The
+                // pending `Action::Open` RPC may complete later (or be
+                // dropped by the device task when it is reset); any late
+                // response will hit the `invalid open complete` branch of
+                // `open_complete` and be ignored.
+                //
+                // Waiting here would deadlock if the device task has been
+                // stopped (e.g. during `pulse_save_restore`) before it could
+                // process the open: the device pends `ChannelRequest::Open`
+                // until restart, but the state-unit reset blocks behind this
+                // vmbus reset, which in turn blocks behind the never-arriving
+                // open response.
+                channel.state = ChannelState::ClientReleased;
                 false
             }
             ChannelState::Open { .. } => {

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -510,14 +510,6 @@ enum ChannelState {
 
     /// The guest has released the channel, but there is still a pending open
     /// request to the device.
-    ///
-    /// This variant is currently unconstructed: `client_release_channel`
-    /// force-releases `Opening` channels directly to `ClientReleased` to
-    /// avoid deadlocking the vmbus reset on a device task that has been
-    /// stopped (and so will never deliver an open response). The variant is
-    /// retained for now to preserve match-arm coverage in callers that
-    /// continue to handle the state defensively.
-    #[expect(dead_code)]
     OpeningClientRelease,
 }
 
@@ -2067,6 +2059,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                         &mut self.inner.assigned_channels,
                         &mut self.inner.assigned_monitors,
                         None,
+                        false,
                     ) {
                         self.inner.channels.remove(offer_id);
                     }
@@ -2554,6 +2547,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                     &mut self.inner.assigned_channels,
                     &mut self.inner.assigned_monitors,
                     None,
+                    vm_reset,
                 )
         });
 
@@ -3208,6 +3202,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
         assigned_channels: &mut AssignedChannels,
         assigned_monitors: &mut AssignedMonitors,
         info: Option<&ConnectionInfo>,
+        vm_reset: bool,
     ) -> bool {
         tracelimit::info_ratelimited!(?offer_id, key = %channel.offer.key(), "client released channel");
         // Release any GPADLs that remain for this channel.
@@ -3265,21 +3260,28 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                 true
             }
             ChannelState::Opening { .. } => {
-                // The device has not yet opened the channel. There is no
-                // device-side state to tear down, so release immediately
-                // rather than waiting for the in-flight open response. The
-                // pending `Action::Open` RPC may complete later (or be
-                // dropped by the device task when it is reset); any late
-                // response will hit the `invalid open complete` branch of
-                // `open_complete` and be ignored.
+                // Normally we transition to `OpeningClientRelease` and wait
+                // for the device to deliver an `open_complete`, then close
+                // the channel. During a VM reset, however, channel device
+                // tasks may already be stopped (state-unit reset stops them
+                // in reverse-dependency order, before the vmbus unit), in
+                // which case the in-flight `Action::Open` has been pended
+                // in the device task's stopped-state queue and will never
+                // be answered. Waiting would deadlock the vmbus reset,
+                // which in turn blocks the channel-unit reset that would
+                // drain the queue.
                 //
-                // Waiting here would deadlock if the device task has been
-                // stopped (e.g. during `pulse_save_restore`) before it could
-                // process the open: the device pends `ChannelRequest::Open`
-                // until restart, but the state-unit reset blocks behind this
-                // vmbus reset, which in turn blocks behind the never-arriving
-                // open response.
-                channel.state = ChannelState::ClientReleased;
+                // Force-release directly to `ClientReleased` in that case.
+                // The device has not opened the channel yet, so there is
+                // no resource to tear down. Any late `Action::Open`
+                // response that does arrive (for a still-running device
+                // that races us) is caught by the `invalid open complete`
+                // branch of `open_complete` and ignored.
+                if vm_reset {
+                    channel.state = ChannelState::ClientReleased;
+                } else {
+                    channel.state = ChannelState::OpeningClientRelease;
+                }
                 false
             }
             ChannelState::Open { .. } => {
@@ -3330,6 +3332,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                     &mut self.inner.assigned_channels,
                     &mut self.inner.assigned_monitors,
                     self.inner.state.get_connected_info(),
+                    false,
                 ) {
                     self.inner.channels.remove(offer_id);
                 }

--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -1147,9 +1147,9 @@ impl ChannelState {
 
             super::ChannelState::Revoked => ChannelState::Revoked,
             super::ChannelState::Reoffered => ChannelState::Revoked,
-            super::ChannelState::ClientReleased | super::ChannelState::ClosingClientRelease => {
-                return None;
-            }
+            super::ChannelState::ClientReleased
+            | super::ChannelState::ClosingClientRelease
+            | super::ChannelState::OpeningClientRelease => return None,
         })
     }
 

--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -1147,9 +1147,9 @@ impl ChannelState {
 
             super::ChannelState::Revoked => ChannelState::Revoked,
             super::ChannelState::Reoffered => ChannelState::Revoked,
-            super::ChannelState::ClientReleased
-            | super::ChannelState::ClosingClientRelease
-            | super::ChannelState::OpeningClientRelease => return None,
+            super::ChannelState::ClientReleased | super::ChannelState::ClosingClientRelease => {
+                return None;
+            }
         })
     }
 


### PR DESCRIPTION
## Problem

VMM tests periodically hang in cycle 4 of `verify_save_restore`, in the vmbus state-unit reset.

When `vmbus_server::reset` → `request_disconnect` → `client_release_channel` ran on a channel in the `Opening` state, it transitioned to `OpeningClientRelease` and waited for the device to deliver an `open_complete`. During VM state-unit reset, channel device tasks stop **before** the vmbus state-unit stops (reverse-dependency order). If a guest `OpenChannel` message was processed in that race window, vmbus_server set the channel to `Opening` and dispatched `Action::Open` via `channel.send.call()`. The channel task — already in `DeviceState::Stopped` — pended the request in `pending_messages` and never responded, deadlocking the vmbus reset (`are_channels_reset` strictly requires `ChannelState::ClientReleased`).

All channels observed hung in failure logs (`kvp_ic`, `timesync_ic`, hvsock relay channels) return `None` from `supports_save_restore()`, so they are revoked, reoffered, and reopened on every `pulse_save_restore` cycle, repeatedly exposing the race.

## Fix

`client_release_channel` gains a `vm_reset: bool` parameter. When `true`, the `Opening` arm force-releases directly to `ClientReleased` instead of waiting via `OpeningClientRelease`. No device-side state has been established yet, so there is nothing to tear down. Any late `Action::Open` response is caught by the existing `invalid open complete` branch of `open_complete` and harmlessly ignored.

Only `request_disconnect` passes `vm_reset = matches!(new_action, ConnectionAction::Reset)`. The two non-reset call sites — `handle_rel_id_released` (guest-driven release) and the reserved-channel `close_complete` disconnect path — pass `false`, preserving the original `OpeningClientRelease` behavior so a still-running device's open completes cleanly and is not leaked. The unload and reconnect disconnect paths also pass `false` for the same reason.