### PR TITLE
flowey: integrate mi_secure jobs with the rest of the pipeline

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1049,302 +1049,12 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
         include-hidden-files: true
   job12:
-    name: clippy [x64-windows], unit tests [x64-windows]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
-
-        echo '"debug"' | flowey.exe v 12 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 12 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 12 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey.exe e 12 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey.exe e 12 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey.exe e 12 flowey_lib_common::install_rust 2
-        flowey.exe e 12 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 12 flowey_lib_common::git_checkout 0
-        flowey.exe v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
-        flowey.exe v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar8 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 12 flowey_lib_common::git_checkout 3
-        flowey.exe e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 12 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 12 flowey_lib_common::cache 4
-        flowey.exe v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 12 flowey_lib_common::cache 6
-        flowey.exe e 12 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey.exe e 12 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey.exe e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 12 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 12 flowey_lib_common::cache 0
-        flowey.exe v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 12 flowey_lib_common::cache 2
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey.exe e 12 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey.exe e 12 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
-      run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 12 flowey_lib_common::publish_test_results 5
-        flowey.exe e 12 flowey_lib_common::publish_test_results 6
-        flowey.exe e 12 flowey_lib_common::publish_test_results 4
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-unit-tests-unit-tests crypto (rust)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: cargo build xtask
-      run: |-
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
-        flowey.exe e 12 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 12 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests' nextest tests
-      run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 4
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 5
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 12 flowey_lib_common::publish_test_results 8
-        flowey.exe e 12 flowey_lib_common::publish_test_results 9
-        flowey.exe e 12 flowey_lib_common::publish_test_results 10
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 12 flowey_lib_common::publish_test_results 0
-        flowey.exe e 12 flowey_lib_common::publish_test_results 1
-        flowey.exe e 12 flowey_lib_common::publish_test_results 2
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: |-
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: run doctests for x86_64-pc-windows-msvc
-      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 12 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 12 flowey_lib_common::cache 7
-      shell: bash
-  job13:
-    name: clippy [x64-linux, macos], unit tests [x64-linux]
+    name: build openhcl (mi-secure) [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1410,315 +1120,547 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 13 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 13 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 12 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 13 'verbose' update
+        cat <<'EOF' | flowey v 12 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 12 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 12 flowey_lib_common::cache 0
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 12 flowey_lib_common::cache 2
+        flowey e 12 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 13 flowey_lib_common::install_rust 0
+      run: flowey e 12 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 13 flowey_lib_common::install_rust 1
+      run: flowey e 12 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 13 flowey_lib_common::install_rust 2
-        flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 0
+        flowey e 12 flowey_lib_common::install_rust 2
+        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 13 flowey_lib_common::git_checkout 0
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 12 flowey_lib_common::git_checkout 0
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 13 flowey_lib_common::git_checkout 3
-        flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 12 flowey_lib_common::git_checkout 3
+        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 12 flowey_lib_common::resolve_protoc 0
+        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 0
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build sidecar
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 12 flowey_lib_hvlite::build_sidecar 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 1
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 1
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 12 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 0
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 12 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
+        include-hidden-files: true
+  job13:
+    name: clippy [x64-windows], unit tests [x64-windows]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey.exe pipeline github --runtime $ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+
+        echo '"debug"' | flowey.exe v 13 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 13 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 13 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey.exe e 13 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 13 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey.exe e 13 flowey_lib_common::install_rust 2
+        flowey.exe e 13 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 13 flowey_lib_common::git_checkout 0
+        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
+        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar8 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 13 flowey_lib_common::git_checkout 3
+        flowey.exe e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey.exe e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 13 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 13 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 13 flowey_lib_common::cache 4
-        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 13 flowey_lib_common::cache 4
+        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 13 flowey_lib_common::cache 6
-        flowey e 13 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
+        flowey.exe e 13 flowey_lib_common::cache 6
+        flowey.exe e 13 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey e 13 flowey_lib_common::resolve_protoc 0
-        flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 13 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 13 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 13 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 13 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 1
+      run: flowey.exe e 13 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 13 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 2
+      run: flowey.exe e 13 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_clippy 1
-        flowey e 13 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_build 2
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 13 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 5
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 6
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 7
+      run: flowey.exe e 13 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 13 flowey_lib_common::download_cargo_nextest 0
-        flowey e 13 flowey_lib_common::download_cargo_nextest 1
-        flowey e 13 flowey_lib_common::download_cargo_nextest 2
-        flowey e 13 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 13 flowey_lib_common::cache 0
+        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 13 flowey_lib_common::cache 2
-        flowey e 13 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 13 flowey_lib_common::cache 2
+        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 13 flowey_lib_common::install_rust 3
+      run: flowey.exe e 13 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey e 13 flowey_lib_common::install_cargo_nextest 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 13 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 13 flowey_lib_common::publish_test_results 5
-        flowey e 13 flowey_lib_common::publish_test_results 6
-        flowey e 13 flowey_lib_common::publish_test_results 4
-        flowey v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 13 flowey_lib_common::publish_test_results 5
+        flowey.exe e 13 flowey_lib_common::publish_test_results 6
+        flowey.exe e 13 flowey_lib_common::publish_test_results 4
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-windows-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
+    - name: cargo build xtask
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 13 flowey_lib_common::publish_test_results 8
-        flowey e 13 flowey_lib_common::publish_test_results 9
-        flowey e 13 flowey_lib_common::publish_test_results 10
-        flowey v 13 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 13 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 13 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 13 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 13 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 4
+        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 5
+        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 13 flowey_lib_common::publish_test_results 8
+        flowey.exe e 13 flowey_lib_common::publish_test_results 9
+        flowey.exe e 13 flowey_lib_common::publish_test_results 10
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
+        name: x64-windows-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 13 flowey_lib_common::publish_test_results 12
-        flowey e 13 flowey_lib_common::publish_test_results 13
-        flowey e 13 flowey_lib_common::publish_test_results 14
-        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 13 flowey_lib_common::publish_test_results 16
-        flowey e 13 flowey_lib_common::publish_test_results 17
-        flowey e 13 flowey_lib_common::publish_test_results 18
-        flowey v 13 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 13 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: cargo build xtask
-      run: |-
-        flowey e 13 flowey_lib_hvlite::init_cross_build 2
-        flowey e 13 flowey_lib_common::run_cargo_build 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 13 flowey_lib_hvlite::build_xtask 2
-      shell: bash
-    - name: determine unit test exclusions
-      run: flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 4
-      shell: bash
-    - name: run 'unit-tests' nextest tests
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 13 flowey_lib_common::publish_test_results 0
-        flowey e 13 flowey_lib_common::publish_test_results 1
-        flowey e 13 flowey_lib_common::publish_test_results 2
-        flowey v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 13 flowey_lib_common::publish_test_results 0
+        flowey.exe e 13 flowey_lib_common::publish_test_results 1
+        flowey.exe e 13 flowey_lib_common::publish_test_results 2
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
+        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
-    - name: run doctests for x86_64-unknown-linux-gnu
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+    - name: run doctests for x86_64-pc-windows-msvc
+      run: flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 13 flowey_lib_common::cache 3
+      run: flowey.exe e 13 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 13 flowey_lib_common::cache 7
+      run: flowey.exe e 13 flowey_lib_common::cache 7
       shell: bash
   job14:
-    name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
+    name: clippy [x64-linux, macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -1806,11 +1748,12 @@ jobs:
       run: |-
         flowey e 14 flowey_lib_common::install_rust 2
         flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1818,7 +1761,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1828,13 +1771,9 @@ jobs:
         EOF
         flowey e 14 flowey_lib_common::git_checkout 3
         flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 14 flowey_lib_common::download_gh_release 0
@@ -1842,14 +1781,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1859,53 +1798,35 @@ jobs:
         flowey e 14 flowey_lib_common::cache 6
         flowey e 14 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: checking if packages need to be installed
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    - name: installing packages
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
-      run: flowey e 14 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 14 flowey_lib_common::resolve_protoc 0
+        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 5
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 7
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_clippy 6
-        flowey e 14 flowey_lib_hvlite::init_cross_build 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_build 0
+        flowey e 14 flowey_lib_common::run_cargo_build 1
         flowey e 14 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 14 flowey_lib_hvlite::run_cargo_build 1
         flowey e 14 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey e 14 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey e 14 flowey_lib_hvlite::_jobs::check_clippy 1
       shell: bash
     - name: cargo clippy
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 0
@@ -1915,6 +1836,37 @@ jobs:
       shell: bash
     - name: cargo clippy
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_clippy 1
+        flowey e 14 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_build 2
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 14 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 14 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 5
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 6
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -1926,14 +1878,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1949,7 +1901,7 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 14 flowey_lib_common::install_cargo_nextest 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 3
+        flowey e 14 flowey_lib_hvlite::init_cross_build 1
         flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
@@ -1969,9 +1921,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -1990,9 +1942,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
@@ -2011,17 +1963,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 14 flowey_lib_common::publish_test_results 16
         flowey e 14 flowey_lib_common::publish_test_results 17
@@ -2032,53 +1984,32 @@ jobs:
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar5 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 14 flowey_lib_common::publish_test_results 20
-        flowey e 14 flowey_lib_common::publish_test_results 21
-        flowey e 14 flowey_lib_common::publish_test_results 22
-        flowey v 14 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__23
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar6 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_hvlite::init_cross_build 1
-        flowey e 14 flowey_lib_common::run_cargo_build 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 14 flowey_lib_hvlite::init_cross_build 2
+        flowey e 14 flowey_lib_common::run_cargo_build 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 14 flowey_lib_hvlite::build_xtask 1
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 14 flowey_lib_hvlite::build_xtask 2
       shell: bash
     - name: determine unit test exclusions
       run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 10
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
@@ -2089,16 +2020,16 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests-junit-xml
+        name: x64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
-    - name: run doctests for x86_64-unknown-linux-musl
+    - name: run doctests for x86_64-unknown-linux-gnu
       run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
@@ -2108,12 +2039,402 @@ jobs:
       run: flowey e 14 flowey_lib_common::cache 7
       shell: bash
   job15:
+    name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
+        echo '"debug"' | flowey v 15 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 15 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 15 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 15 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 15 flowey_lib_common::install_rust 2
+        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 15 flowey_lib_common::git_checkout 0
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar11 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 15 flowey_lib_common::git_checkout 3
+        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 15 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 15 flowey_lib_common::cache 4
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 15 flowey_lib_common::cache 6
+        flowey e 15 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 15 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: flowey e 15 flowey_lib_common::resolve_protoc 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 5
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 7
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_clippy 6
+        flowey e 15 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_build 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 15 flowey_lib_common::download_cargo_nextest 0
+        flowey e 15 flowey_lib_common::download_cargo_nextest 1
+        flowey e 15 flowey_lib_common::download_cargo_nextest 2
+        flowey e 15 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 15 flowey_lib_common::cache 0
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 15 flowey_lib_common::cache 2
+        flowey e 15 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 15 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 15 flowey_lib_common::install_cargo_nextest 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 3
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 15 flowey_lib_common::publish_test_results 5
+        flowey e 15 flowey_lib_common::publish_test_results 6
+        flowey e 15 flowey_lib_common::publish_test_results 4
+        flowey v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__7
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'unit-tests crypto (rust)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 15 flowey_lib_common::publish_test_results 8
+        flowey e 15 flowey_lib_common::publish_test_results 9
+        flowey e 15 flowey_lib_common::publish_test_results 10
+        flowey v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 15 flowey_lib_common::publish_test_results 12
+        flowey e 15 flowey_lib_common::publish_test_results 13
+        flowey e 15 flowey_lib_common::publish_test_results 14
+        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      shell: bash
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 15 flowey_lib_common::publish_test_results 16
+        flowey e 15 flowey_lib_common::publish_test_results 17
+        flowey e 15 flowey_lib_common::publish_test_results 18
+        flowey v 15 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 15 flowey_lib_common::publish_test_results 20
+        flowey e 15 flowey_lib_common::publish_test_results 21
+        flowey e 15 flowey_lib_common::publish_test_results 22
+        flowey v 15 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey e 15 flowey_lib_hvlite::init_cross_build 1
+        flowey e 15 flowey_lib_common::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 15 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 15 flowey_lib_common::publish_test_results 0
+        flowey e 15 flowey_lib_common::publish_test_results 1
+        flowey e 15 flowey_lib_common::publish_test_results 2
+        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: |-
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for x86_64-unknown-linux-musl
+      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 15 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 15 flowey_lib_common::cache 7
+      shell: bash
+  job16:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=win-arm64
-    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2179,29 +2500,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 16 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 16 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 15 'verbose' update
+        cat <<'EOF' | flowey.exe v 16 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 15 flowey_lib_common::install_rust 0
+      run: flowey.exe e 16 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 15 flowey_lib_common::install_rust 1
+      run: flowey.exe e 16 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 15 flowey_lib_common::install_rust 2
-        flowey.exe e 15 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 16 flowey_lib_common::install_rust 2
+        flowey.exe e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 15 flowey_lib_common::git_checkout 0
-        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
-        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 16 flowey_lib_common::git_checkout 0
+        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
+        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2213,23 +2534,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 15 flowey_lib_common::git_checkout 3
-        flowey.exe e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 16 flowey_lib_common::git_checkout 3
+        flowey.exe e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 15 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 16 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 15 flowey_lib_common::cache 4
-        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 16 flowey_lib_common::cache 4
+        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2239,53 +2560,53 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 15 flowey_lib_common::cache 6
-        flowey.exe e 15 flowey_lib_common::download_gh_release 1
+        flowey.exe e 16 flowey_lib_common::cache 6
+        flowey.exe e 16 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 15 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 16 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 15 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 16 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 16 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 16 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 16 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 2
+      run: flowey.exe e 16 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 15 flowey_lib_common::cache 0
-        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 16 flowey_lib_common::cache 0
+        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2295,34 +2616,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 15 flowey_lib_common::cache 2
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 16 flowey_lib_common::cache 2
+        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 15 flowey_lib_common::install_rust 3
+      run: flowey.exe e 16 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 15 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 16 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 15 flowey_lib_common::publish_test_results 5
-        flowey.exe e 15 flowey_lib_common::publish_test_results 6
-        flowey.exe e 15 flowey_lib_common::publish_test_results 4
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 16 flowey_lib_common::publish_test_results 5
+        flowey.exe e 16 flowey_lib_common::publish_test_results 6
+        flowey.exe e 16 flowey_lib_common::publish_test_results 4
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2333,27 +2654,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
-        flowey.exe e 15 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 16 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 16 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 16 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 4
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 5
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 15 flowey_lib_common::publish_test_results 8
-        flowey.exe e 15 flowey_lib_common::publish_test_results 9
-        flowey.exe e 15 flowey_lib_common::publish_test_results 10
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 16 flowey_lib_common::publish_test_results 8
+        flowey.exe e 16 flowey_lib_common::publish_test_results 9
+        flowey.exe e 16 flowey_lib_common::publish_test_results 10
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2363,18 +2684,18 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 15 flowey_lib_common::publish_test_results 0
-        flowey.exe e 15 flowey_lib_common::publish_test_results 1
-        flowey.exe e 15 flowey_lib_common::publish_test_results 2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 16 flowey_lib_common::publish_test_results 0
+        flowey.exe e 16 flowey_lib_common::publish_test_results 1
+        flowey.exe e 16 flowey_lib_common::publish_test_results 2
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2385,375 +2706,20 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey.exe e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
-      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 15 flowey_lib_common::cache 3
+      run: flowey.exe e 16 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 15 flowey_lib_common::cache 7
-      shell: bash
-  job16:
-    name: clippy [aarch64-linux], unit tests [aarch64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/aarch64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 16 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 16 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 16 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 16 flowey_lib_common::install_rust 2
-        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 16 flowey_lib_common::git_checkout 3
-        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 16 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 16 flowey_lib_common::cache 6
-        flowey e 16 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 16 flowey_lib_common::resolve_protoc 0
-        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_clippy 1
-        flowey e 16 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_build 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 16 flowey_lib_common::download_cargo_nextest 0
-        flowey e 16 flowey_lib_common::download_cargo_nextest 1
-        flowey e 16 flowey_lib_common::download_cargo_nextest 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 16 flowey_lib_common::cache 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 16 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 16 flowey_lib_common::install_cargo_nextest 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 16 flowey_lib_common::publish_test_results 5
-        flowey e 16 flowey_lib_common::publish_test_results 6
-        flowey e 16 flowey_lib_common::publish_test_results 4
-        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 16 flowey_lib_common::publish_test_results 8
-        flowey e 16 flowey_lib_common::publish_test_results 9
-        flowey e 16 flowey_lib_common::publish_test_results 10
-        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 16 flowey_lib_common::publish_test_results 16
-        flowey e 16 flowey_lib_common::publish_test_results 17
-        flowey e 16 flowey_lib_common::publish_test_results 18
-        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: cargo build xtask
-      run: |-
-        flowey e 16 flowey_lib_hvlite::init_cross_build 3
-        flowey e 16 flowey_lib_common::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 16 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
-      shell: bash
-    - name: run 'unit-tests' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 16 flowey_lib_common::publish_test_results 0
-        flowey e 16 flowey_lib_common::publish_test_results 1
-        flowey e 16 flowey_lib_common::publish_test_results 2
-        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: |-
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 16 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 16 flowey_lib_common::cache 7
+      run: flowey.exe e 16 flowey_lib_common::cache 7
       shell: bash
   job17:
-    name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
+    name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
@@ -2842,10 +2808,16 @@ jobs:
         flowey e 17 flowey_lib_common::install_rust 2
         flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2853,7 +2825,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2863,13 +2835,9 @@ jobs:
         EOF
         flowey e 17 flowey_lib_common::git_checkout 3
         flowey e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 17 flowey_lib_common::download_gh_release 0
@@ -2877,14 +2845,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2894,39 +2862,20 @@ jobs:
         flowey e 17 flowey_lib_common::cache 6
         flowey e 17 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
     - name: unpack protoc
-      run: flowey e 17 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 17 flowey_lib_common::resolve_protoc 0
+        flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 17 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 5
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 7
+        flowey e 17 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_clippy 6
-        flowey e 17 flowey_lib_hvlite::init_cross_build 0
+        flowey e 17 flowey_lib_common::run_cargo_clippy 1
+        flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
@@ -2951,6 +2900,9 @@ jobs:
     - name: cargo clippy
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
       shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey e 17 flowey_lib_common::download_cargo_nextest 0
@@ -2961,14 +2913,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2984,7 +2936,7 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 17 flowey_lib_common::install_cargo_nextest 0
-        flowey e 17 flowey_lib_hvlite::init_cross_build 3
+        flowey e 17 flowey_lib_hvlite::init_cross_build 1
         flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
@@ -3004,9 +2956,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -3025,9 +2977,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
@@ -3046,17 +2998,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 17 flowey_lib_common::publish_test_results 16
         flowey e 17 flowey_lib_common::publish_test_results 17
@@ -3067,34 +3019,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar5 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 17 flowey_lib_common::publish_test_results 20
-        flowey e 17 flowey_lib_common::publish_test_results 21
-        flowey e 17 flowey_lib_common::publish_test_results 22
-        flowey v 17 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__23
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar6 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 17 flowey_lib_hvlite::init_cross_build 1
+        flowey e 17 flowey_lib_hvlite::init_cross_build 3
         flowey e 17 flowey_lib_common::run_cargo_build 1
         flowey e 17 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -3108,12 +3039,12 @@ jobs:
       run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 10
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
@@ -3124,16 +3055,16 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
-    - name: run doctests for aarch64-unknown-linux-musl
+    - name: run doctests for aarch64-unknown-linux-gnu
       run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
@@ -3143,278 +3074,402 @@ jobs:
       run: flowey e 17 flowey_lib_common::cache 7
       shell: bash
   job18:
-    name: run vmm-tests [x64-windows-intel]
+    name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
-    needs:
-    - job11
-    - job2
-    - job3
-    - job7
     if: github.event.pull_request.draft == false
     steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/aarch64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey.exe v 18 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 18 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 18 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 18 'verbose' update
+        cat <<'EOF' | flowey v 18 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 18 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 18 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 18 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 18 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 18 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 18 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 18 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 18 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 18 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 18 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 18 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 3
+    - name: add default cargo home to path
+      run: flowey e 18 flowey_lib_common::install_rust 0
       shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 18 flowey_lib_common::cache 0
-        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+    - name: install Rust
+      run: flowey e 18 flowey_lib_common::install_rust 1
       shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
+    - name: detect active toolchain
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::cache 2
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 4
+        flowey e 18 flowey_lib_common::install_rust 2
+        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 18 flowey_lib_common::git_checkout 0
-        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::git_checkout 0
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar11 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 18 flowey_lib_common::git_checkout 3
-        flowey.exe e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 8
+        flowey e 18 flowey_lib_common::git_checkout 3
+        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+    - name: checking if packages need to be installed
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
       shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+    - name: installing packages
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 18 flowey_lib_common::download_gh_release 0
+      run: flowey e 18 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 18 flowey_lib_common::cache 8
-        flowey.exe v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::cache 10
-        flowey.exe e 18 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 18 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 18 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 18 flowey_lib_common::cache 4
-        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 18 flowey_lib_common::cache 4
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 18 flowey_lib_common::cache 6
-        flowey.exe e 18 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 18 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 18 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 18 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 18 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 18 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+        flowey e 18 flowey_lib_common::cache 6
+        flowey e 18 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    - name: extract Aarch64 sysroot.tar.gz
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
-    - name: setting up vmm_tests env
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: flowey e 18 flowey_lib_common::resolve_protoc 0
+      shell: bash
+    - name: symlink protoc
       run: |-
-        flowey.exe e 18 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 5
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 7
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_clippy 6
+        flowey e 18 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_build 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 18 flowey_lib_common::download_cargo_nextest 0
+        flowey e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey e 18 flowey_lib_common::download_cargo_nextest 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 18 flowey_lib_common::cache 0
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 18 flowey_lib_common::cache 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 18 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 18 flowey_lib_common::install_cargo_nextest 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 3
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 18 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
+    - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 18 flowey_lib_common::publish_test_results 5
+        flowey e 18 flowey_lib_common::publish_test_results 6
+        flowey e 18 flowey_lib_common::publish_test_results 4
+        flowey v 18 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 18 flowey_lib_common::publish_test_results 4
-        flowey.exe e 18 flowey_lib_common::publish_test_results 5
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-vmm-tests-logs
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 18 flowey_lib_common::publish_test_results 0
-        flowey.exe e 18 flowey_lib_common::publish_test_results 1
-        flowey.exe e 18 flowey_lib_common::publish_test_results 2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 18 flowey_lib_common::publish_test_results 8
+        flowey e 18 flowey_lib_common::publish_test_results 9
+        flowey e 18 flowey_lib_common::publish_test_results 10
+        flowey v 18 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 18 flowey_lib_common::publish_test_results 12
+        flowey e 18 flowey_lib_common::publish_test_results 13
+        flowey e 18 flowey_lib_common::publish_test_results 14
+        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 18 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      shell: bash
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 18 flowey_lib_common::publish_test_results 16
+        flowey e 18 flowey_lib_common::publish_test_results 17
+        flowey e 18 flowey_lib_common::publish_test_results 18
+        flowey v 18 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 18 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 18 flowey_lib_common::publish_test_results 20
+        flowey e 18 flowey_lib_common::publish_test_results 21
+        flowey e 18 flowey_lib_common::publish_test_results 22
+        flowey v 18 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 18 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey e 18 flowey_lib_hvlite::init_cross_build 1
+        flowey e 18 flowey_lib_common::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 18 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 18 flowey_lib_common::publish_test_results 0
+        flowey e 18 flowey_lib_common::publish_test_results 1
+        flowey e 18 flowey_lib_common::publish_test_results 2
+        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-vmm-tests-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: |-
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for aarch64-unknown-linux-musl
+      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 18 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 18 flowey_lib_common::cache 7
+      run: flowey e 18 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 18 flowey_lib_common::cache 11
+      run: flowey e 18 flowey_lib_common::cache 7
       shell: bash
   job19:
-    name: run vmm-tests [x64-windows-intel-tdx]
+    name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - Windows
-    - X64
-    - TDX
-    - Baremetal
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3621,12 +3676,7 @@ jobs:
       run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
+      run: flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -3646,9 +3696,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-logs
+        name: x64-windows-intel-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3662,9 +3712,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-junit-xml
+        name: x64-windows-intel-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -3861,17 +3911,17 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-windows-amd]
+    name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
-    - job11
+    - job12
     - job2
     - job3
     - job7
@@ -3880,7 +3930,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
       shell: bash
@@ -3903,7 +3953,7 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 20 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 20 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4093,9 +4143,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-logs
+        name: x64-windows-intel-mi-secure-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4109,9 +4159,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-junit-xml
+        name: x64-windows-intel-mi-secure-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4126,12 +4176,12 @@ jobs:
       run: flowey.exe e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [x64-windows-amd-snp]
+    name: run vmm-tests [x64-windows-intel-tdx]
     runs-on:
     - self-hosted
     - Windows
     - X64
-    - SNP
+    - TDX
     - Baremetal
     permissions:
       contents: read
@@ -4229,10 +4279,6 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
@@ -4240,6 +4286,10 @@ jobs:
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4364,9 +4414,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-snp-vmm-tests-logs
+        name: x64-windows-intel-tdx-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4380,9 +4430,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-snp-vmm-tests-junit-xml
+        name: x64-windows-intel-tdx-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4397,12 +4447,548 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
+    name: run vmm-tests [x64-windows-amd]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job11
+    - job2
+    - job3
+    - job7
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
+
+        echo '"debug"' | flowey.exe v 22 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 22 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 22 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 22 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 22 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 22 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 22 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 0
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 22 flowey_lib_common::git_checkout 0
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::git_checkout 3
+        flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 8
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 10
+        flowey.exe e 22 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 22 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 22 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 4
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 6
+        flowey.exe e 22 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 22 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 22 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 22 flowey_lib_common::publish_test_results 4
+        flowey.exe e 22 flowey_lib_common::publish_test_results 5
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 22 flowey_lib_common::publish_test_results 0
+        flowey.exe e 22 flowey_lib_common::publish_test_results 1
+        flowey.exe e 22 flowey_lib_common::publish_test_results 2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 22 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 22 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 22 flowey_lib_common::cache 11
+      shell: bash
+  job23:
+    name: run vmm-tests [x64-windows-amd-snp]
+    runs-on:
+    - self-hosted
+    - Windows
+    - X64
+    - SNP
+    - Baremetal
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job11
+    - job2
+    - job3
+    - job7
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
+
+        echo '"debug"' | flowey.exe v 23 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 23 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 23 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 23 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 23 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 23 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 23 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 23 flowey_lib_common::cache 0
+        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::cache 2
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 23 flowey_lib_common::git_checkout 0
+        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::git_checkout 3
+        flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 23 flowey_lib_common::cache 8
+        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::cache 10
+        flowey.exe e 23 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 23 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 23 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 23 flowey_lib_common::cache 4
+        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::cache 6
+        flowey.exe e 23 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 23 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 23 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 23 flowey_lib_common::publish_test_results 4
+        flowey.exe e 23 flowey_lib_common::publish_test_results 5
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-snp-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 23 flowey_lib_common::publish_test_results 0
+        flowey.exe e 23 flowey_lib_common::publish_test_results 1
+        flowey.exe e 23 flowey_lib_common::publish_test_results 2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-snp-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 23 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 23 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 23 flowey_lib_common::cache 11
+      shell: bash
+  job24:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4428,46 +5014,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11/flowey
 
-        echo '"debug"' | flowey v 22 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 22 'verbose' update
+        cat <<'EOF' | flowey v 24 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 22 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 22 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 22 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 22 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 24 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 22 flowey_core::pipeline::artifact::resolve 3
-        flowey e 22 flowey_core::pipeline::artifact::resolve 4
-        flowey e 22 flowey_core::pipeline::artifact::resolve 7
-        flowey e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey e 22 flowey_core::pipeline::artifact::resolve 0
-        flowey e 22 flowey_core::pipeline::artifact::resolve 2
-        flowey e 22 flowey_core::pipeline::artifact::resolve 6
-        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 3
+        flowey e 24 flowey_core::pipeline::artifact::resolve 4
+        flowey e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey e 24 flowey_core::pipeline::artifact::resolve 1
+        flowey e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey e 24 flowey_core::pipeline::artifact::resolve 6
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 22 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 22 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 22 flowey_lib_common::download_gh_release 0
+      run: flowey e 24 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 22 flowey_lib_common::cache 8
-        flowey v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 24 flowey_lib_common::cache 8
+        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4477,31 +5063,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 22 flowey_lib_common::cache 10
-        flowey e 22 flowey_lib_common::download_gh_release 1
+        flowey e 24 flowey_lib_common::cache 10
+        flowey e 24 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 22 flowey_lib_common::download_azcopy 0
+      run: flowey e 24 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 22 flowey_lib_common::download_gh_cli 0
+      run: flowey e 24 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 22 flowey_lib_common::cache 4
-        flowey v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 24 flowey_lib_common::cache 4
+        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4511,54 +5097,54 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 22 flowey_lib_common::cache 6
-        flowey e 22 flowey_lib_common::download_gh_cli 1
-        flowey v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 24 flowey_lib_common::cache 6
+        flowey e 24 flowey_lib_common::download_gh_cli 1
+        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 22 flowey_lib_common::use_gh_cli 0
+      run: flowey e 24 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 22 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 24 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 22 flowey_lib_common::download_cargo_nextest 0
-        flowey e 22 flowey_lib_common::download_cargo_nextest 1
-        flowey e 22 flowey_lib_common::download_cargo_nextest 2
-        flowey e 22 flowey_lib_common::download_cargo_nextest 3
+        flowey e 24 flowey_lib_common::download_cargo_nextest 0
+        flowey e 24 flowey_lib_common::download_cargo_nextest 1
+        flowey e 24 flowey_lib_common::download_cargo_nextest 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 22 flowey_lib_common::cache 0
-        flowey v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 24 flowey_lib_common::cache 0
+        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4568,17 +5154,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 22 flowey_lib_common::cache 2
-        flowey e 22 flowey_lib_common::download_cargo_nextest 4
+        flowey e 24 flowey_lib_common::cache 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 22 flowey_lib_common::git_checkout 0
-        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_common::git_checkout 0
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4590,32 +5176,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 22 flowey_lib_common::git_checkout 3
-        flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 22 flowey_core::pipeline::artifact::resolve 5
-        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey e 24 flowey_lib_common::git_checkout 3
+        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
     - name: generate nextest command
-      run: flowey e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 22 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 22 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 22 flowey_lib_common::publish_test_results 4
-        flowey e 22 flowey_lib_common::publish_test_results 5
-        flowey v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 24 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 24 flowey_lib_common::publish_test_results 4
+        flowey e 24 flowey_lib_common::publish_test_results 5
+        flowey v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4626,12 +5212,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 22 flowey_lib_common::publish_test_results 0
-        flowey e 22 flowey_lib_common::publish_test_results 1
-        flowey e 22 flowey_lib_common::publish_test_results 2
-        flowey v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 24 flowey_lib_common::publish_test_results 0
+        flowey e 24 flowey_lib_common::publish_test_results 1
+        flowey e 24 flowey_lib_common::publish_test_results 2
+        flowey v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4641,24 +5227,24 @@ jobs:
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 22 flowey_lib_common::cache 3
+      run: flowey e 24 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 22 flowey_lib_common::cache 7
+      run: flowey e 24 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 22 flowey_lib_common::cache 11
+      run: flowey e 24 flowey_lib_common::cache 11
       shell: bash
-  job23:
+  job25:
     name: run vmm-tests [x64-linux-intel-mshv]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4732,46 +5318,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 23 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 23 'verbose' update
+        cat <<'EOF' | flowey v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 23 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey e 23 flowey_core::pipeline::artifact::resolve 7
-        flowey e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey e 23 flowey_core::pipeline::artifact::resolve 4
-        flowey e 23 flowey_core::pipeline::artifact::resolve 6
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey e 25 flowey_core::pipeline::artifact::resolve 7
+        flowey e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 4
+        flowey e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 23 flowey_lib_common::download_gh_release 0
+      run: flowey e 25 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 23 flowey_lib_common::cache 8
-        flowey v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 25 flowey_lib_common::cache 8
+        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4781,31 +5367,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 23 flowey_lib_common::cache 10
-        flowey e 23 flowey_lib_common::download_gh_release 1
+        flowey e 25 flowey_lib_common::cache 10
+        flowey e 25 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 23 flowey_lib_common::download_azcopy 0
+      run: flowey e 25 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 23 flowey_lib_common::download_gh_cli 0
+      run: flowey e 25 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 23 flowey_lib_common::cache 4
-        flowey v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 25 flowey_lib_common::cache 4
+        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4815,51 +5401,51 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 23 flowey_lib_common::cache 6
-        flowey e 23 flowey_lib_common::download_gh_cli 1
-        flowey v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 25 flowey_lib_common::cache 6
+        flowey e 25 flowey_lib_common::download_gh_cli 1
+        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 23 flowey_lib_common::use_gh_cli 0
+      run: flowey e 25 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 23 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 25 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 23 flowey_lib_common::download_cargo_nextest 0
-        flowey e 23 flowey_lib_common::download_cargo_nextest 1
-        flowey e 23 flowey_lib_common::download_cargo_nextest 2
-        flowey e 23 flowey_lib_common::download_cargo_nextest 3
+        flowey e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 23 flowey_lib_common::cache 0
-        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 25 flowey_lib_common::cache 0
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4869,17 +5455,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 23 flowey_lib_common::cache 2
-        flowey e 23 flowey_lib_common::download_cargo_nextest 4
+        flowey e 25 flowey_lib_common::cache 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 23 flowey_lib_common::git_checkout 0
-        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4891,31 +5477,31 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 23 flowey_lib_common::git_checkout 3
-        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 23 flowey_core::pipeline::artifact::resolve 5
-        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 25 flowey_lib_common::git_checkout 3
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 25 flowey_core::pipeline::artifact::resolve 5
+        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: generate nextest command
-      run: flowey e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 23 flowey_lib_common::publish_test_results 4
-        flowey e 23 flowey_lib_common::publish_test_results 5
-        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 25 flowey_lib_common::publish_test_results 4
+        flowey e 25 flowey_lib_common::publish_test_results 5
+        flowey v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4926,12 +5512,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 23 flowey_lib_common::publish_test_results 0
-        flowey e 23 flowey_lib_common::publish_test_results 1
-        flowey e 23 flowey_lib_common::publish_test_results 2
-        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 25 flowey_lib_common::publish_test_results 0
+        flowey e 25 flowey_lib_common::publish_test_results 1
+        flowey e 25 flowey_lib_common::publish_test_results 2
+        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4941,18 +5527,18 @@ jobs:
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 23 flowey_lib_common::cache 3
+      run: flowey e 25 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 23 flowey_lib_common::cache 7
+      run: flowey e 25 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 23 flowey_lib_common::cache 11
+      run: flowey e 25 flowey_lib_common::cache 11
       shell: bash
-  job24:
+  job26:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -5034,35 +5620,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 24 'verbose' update
+        cat <<'EOF' | flowey.exe v 26 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 24 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 26 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 0
-        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 26 flowey_lib_common::cache 0
+        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5072,17 +5658,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 26 flowey_lib_common::cache 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 24 flowey_lib_common::git_checkout 0
-        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_common::git_checkout 0
+        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5094,35 +5680,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 24 flowey_lib_common::git_checkout 3
-        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 26 flowey_lib_common::git_checkout 3
+        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 8
-        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 26 flowey_lib_common::cache 8
+        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5132,31 +5718,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 10
-        flowey.exe e 24 flowey_lib_common::download_gh_release 1
+        flowey.exe e 26 flowey_lib_common::cache 10
+        flowey.exe e 26 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 26 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 4
-        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 26 flowey_lib_common::cache 4
+        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5166,63 +5752,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 6
-        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 26 flowey_lib_common::cache 6
+        flowey.exe e 26 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 26 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 24 flowey_lib_common::publish_test_results 4
-        flowey.exe e 24 flowey_lib_common::publish_test_results 5
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 26 flowey_lib_common::publish_test_results 4
+        flowey.exe e 26 flowey_lib_common::publish_test_results 5
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5233,12 +5819,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 24 flowey_lib_common::publish_test_results 0
-        flowey.exe e 24 flowey_lib_common::publish_test_results 1
-        flowey.exe e 24 flowey_lib_common::publish_test_results 2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 26 flowey_lib_common::publish_test_results 0
+        flowey.exe e 26 flowey_lib_common::publish_test_results 1
+        flowey.exe e 26 flowey_lib_common::publish_test_results 2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5248,18 +5834,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 24 flowey_lib_common::cache 3
+      run: flowey.exe e 26 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 24 flowey_lib_common::cache 7
+      run: flowey.exe e 26 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 24 flowey_lib_common::cache 11
+      run: flowey.exe e 26 flowey_lib_common::cache 11
       shell: bash
-  job25:
+  job27:
     name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
@@ -5327,18 +5913,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 25 'verbose' update
+        cat <<'EOF' | flowey v 27 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 27 flowey_lib_common::git_checkout 0
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5350,613 +5936,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 27 flowey_lib_common::git_checkout 3
+        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 25 flowey_lib_common::install_rust 0
+      run: flowey e 27 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 25 flowey_lib_common::install_rust 1
+      run: flowey e 27 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 25 flowey_lib_common::install_rust 2
-        flowey v 25 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 27 flowey_lib_common::install_rust 2
+        flowey v 27 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 25 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
-      shell: bash
-  job26:
-    name: build openhcl (mi-secure) [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 26 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 26 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 26 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 26 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 26 flowey_lib_common::cache 0
-        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 26 flowey_lib_common::cache 2
-        flowey e 26 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 26 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 26 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 26 flowey_lib_common::install_rust 2
-        flowey e 26 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 26 flowey_lib_common::git_checkout 0
-        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 26 flowey_lib_common::git_checkout 3
-        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 26 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 26 flowey_lib_common::resolve_protoc 0
-        flowey e 26 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 0
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: cargo build sidecar
-      run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 3
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 26 flowey_lib_hvlite::build_sidecar 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 1
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 1
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 2
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 26 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 26 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 0
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 26 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 26 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 26 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 26 flowey_lib_common::cache 3
-      shell: bash
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
-        include-hidden-files: true
-  job27:
-    name: run vmm-tests [x64-windows-intel-mi-secure]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job2
-    - job26
-    - job3
-    - job7
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
-
-        echo '"debug"' | flowey.exe v 27 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 27 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 27 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 27 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 27 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 27 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 27 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 27 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 27 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 27 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 27 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 27 flowey_lib_common::cache 0
-        flowey.exe v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 27 flowey_lib_common::cache 2
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 27 flowey_lib_common::git_checkout 0
-        flowey.exe v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 27 flowey_lib_common::git_checkout 3
-        flowey.exe e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 27 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 27 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 27 flowey_lib_common::cache 8
-        flowey.exe v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 27 flowey_lib_common::cache 10
-        flowey.exe e 27 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 27 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 27 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 27 flowey_lib_common::cache 4
-        flowey.exe v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 27 flowey_lib_common::cache 6
-        flowey.exe e 27 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 27 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 27 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 27 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 27 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 27 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 27 flowey_lib_common::publish_test_results 4
-        flowey.exe e 27 flowey_lib_common::publish_test_results 5
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-mi-secure-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 27 flowey_lib_common::publish_test_results 0
-        flowey.exe e 27 flowey_lib_common::publish_test_results 1
-        flowey.exe e 27 flowey_lib_common::publish_test_results 2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-mi-secure-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 27 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 27 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 27 flowey_lib_common::cache 11
+      run: flowey e 27 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
   job28:
     name: publish vmgstool

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -968,12 +968,291 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
         include-hidden-files: true
   job12:
+    name: build openhcl (mi-secure) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 12 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 12 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 12 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 12 flowey_lib_common::cache 0
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 12 flowey_lib_common::cache 2
+        flowey e 12 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 12 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 12 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 12 flowey_lib_common::install_rust 2
+        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 12 flowey_lib_common::git_checkout 0
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 12 flowey_lib_common::git_checkout 3
+        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 12 flowey_lib_common::resolve_protoc 0
+        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 0
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build sidecar
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 12 flowey_lib_hvlite::build_sidecar 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 1
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 1
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 12 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 0
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 12 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
+        include-hidden-files: true
+  job13:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1041,29 +1320,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 12 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 12 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 13 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 13 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 12 'verbose' update
+        cat <<'EOF' | flowey.exe v 13 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 12 flowey_lib_common::install_rust 0
+      run: flowey.exe e 13 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 12 flowey_lib_common::install_rust 1
+      run: flowey.exe e 13 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 12 flowey_lib_common::install_rust 2
-        flowey.exe e 12 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 13 flowey_lib_common::install_rust 2
+        flowey.exe e 13 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 12 flowey_lib_common::git_checkout 0
-        flowey.exe v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
-        flowey.exe v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 13 flowey_lib_common::git_checkout 0
+        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
+        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1075,23 +1354,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 12 flowey_lib_common::git_checkout 3
-        flowey.exe e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 13 flowey_lib_common::git_checkout 3
+        flowey.exe e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 12 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 13 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 12 flowey_lib_common::cache 4
-        flowey.exe v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 13 flowey_lib_common::cache 4
+        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1101,53 +1380,53 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 12 flowey_lib_common::cache 6
-        flowey.exe e 12 flowey_lib_common::download_gh_release 1
+        flowey.exe e 13 flowey_lib_common::cache 6
+        flowey.exe e 13 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 12 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 13 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 12 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 13 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 13 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 13 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 13 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 13 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 13 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 12 flowey_lib_common::run_cargo_clippy 2
+      run: flowey.exe e 13 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 12 flowey_lib_common::cache 0
-        flowey.exe v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 13 flowey_lib_common::cache 0
+        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1157,34 +1436,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 12 flowey_lib_common::cache 2
-        flowey.exe e 12 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 13 flowey_lib_common::cache 2
+        flowey.exe e 13 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 12 flowey_lib_common::install_rust 3
+      run: flowey.exe e 13 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 12 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 13 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 12 flowey_lib_common::publish_test_results 5
-        flowey.exe e 12 flowey_lib_common::publish_test_results 6
-        flowey.exe e 12 flowey_lib_common::publish_test_results 4
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 13 flowey_lib_common::publish_test_results 5
+        flowey.exe e 13 flowey_lib_common::publish_test_results 6
+        flowey.exe e 13 flowey_lib_common::publish_test_results 4
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1195,27 +1474,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::init_cross_build 3
-        flowey.exe e 12 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 12 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 12 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 13 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 13 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 13 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 13 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 4
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 5
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 12 flowey_lib_common::publish_test_results 8
-        flowey.exe e 12 flowey_lib_common::publish_test_results 9
-        flowey.exe e 12 flowey_lib_common::publish_test_results 10
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 4
+        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 5
+        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 13 flowey_lib_common::publish_test_results 8
+        flowey.exe e 13 flowey_lib_common::publish_test_results 9
+        flowey.exe e 13 flowey_lib_common::publish_test_results 10
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -1225,18 +1504,18 @@ jobs:
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 12 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 12 flowey_lib_common::publish_test_results 0
-        flowey.exe e 12 flowey_lib_common::publish_test_results 1
-        flowey.exe e 12 flowey_lib_common::publish_test_results 2
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 13 flowey_lib_common::publish_test_results 0
+        flowey.exe e 13 flowey_lib_common::publish_test_results 1
+        flowey.exe e 13 flowey_lib_common::publish_test_results 2
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1247,325 +1526,20 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
-      run: flowey.exe e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 12 flowey_lib_common::cache 3
+      run: flowey.exe e 13 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 12 flowey_lib_common::cache 7
-      shell: bash
-  job13:
-    name: clippy [macos], unit tests [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 13 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 13 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 13 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 13 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 13 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 13 flowey_lib_common::install_rust 2
-        flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 13 flowey_lib_common::git_checkout 0
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 13 flowey_lib_common::git_checkout 3
-        flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 13 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 13 flowey_lib_common::cache 4
-        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 13 flowey_lib_common::cache 6
-        flowey e 13 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 13 flowey_lib_common::resolve_protoc 0
-        flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_build 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 13 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 13 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 13 flowey_lib_common::download_cargo_nextest 0
-        flowey e 13 flowey_lib_common::download_cargo_nextest 1
-        flowey e 13 flowey_lib_common::download_cargo_nextest 2
-        flowey e 13 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 13 flowey_lib_common::cache 2
-        flowey e 13 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 13 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 13 flowey_lib_common::install_cargo_nextest 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 13 flowey_lib_common::publish_test_results 5
-        flowey e 13 flowey_lib_common::publish_test_results 6
-        flowey e 13 flowey_lib_common::publish_test_results 4
-        flowey v 13 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 13 flowey_lib_common::publish_test_results 8
-        flowey e 13 flowey_lib_common::publish_test_results 9
-        flowey e 13 flowey_lib_common::publish_test_results 10
-        flowey v 13 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 13 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 13 flowey_lib_common::publish_test_results 12
-        flowey e 13 flowey_lib_common::publish_test_results 13
-        flowey e 13 flowey_lib_common::publish_test_results 14
-        flowey v 13 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 13 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 13 flowey_lib_common::publish_test_results 16
-        flowey e 13 flowey_lib_common::publish_test_results 17
-        flowey e 13 flowey_lib_common::publish_test_results 18
-        flowey v 13 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 13 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: cargo build xtask
-      run: |-
-        flowey e 13 flowey_lib_hvlite::init_cross_build 2
-        flowey e 13 flowey_lib_common::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 13 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 4
-      shell: bash
-    - name: run 'unit-tests' nextest tests
-      run: |-
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 13 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 13 flowey_lib_common::publish_test_results 0
-        flowey e 13 flowey_lib_common::publish_test_results 1
-        flowey e 13 flowey_lib_common::publish_test_results 2
-        flowey v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: |-
-        flowey e 13 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: run doctests for x86_64-unknown-linux-gnu
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 13 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 13 flowey_lib_common::cache 7
+      run: flowey.exe e 13 flowey_lib_common::cache 7
       shell: bash
   job14:
-    name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
+    name: clippy [macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -1612,10 +1586,16 @@ jobs:
         flowey e 14 flowey_lib_common::install_rust 2
         flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1623,7 +1603,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1633,13 +1613,9 @@ jobs:
         EOF
         flowey e 14 flowey_lib_common::git_checkout 3
         flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 14 flowey_lib_common::download_gh_release 0
@@ -1647,14 +1623,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1664,39 +1640,15 @@ jobs:
         flowey e 14 flowey_lib_common::cache 6
         flowey e 14 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
     - name: unpack protoc
-      run: flowey e 14 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 14 flowey_lib_common::resolve_protoc 0
+        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 5
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 7
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_clippy 6
-        flowey e 14 flowey_lib_hvlite::init_cross_build 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
       run: |-
@@ -1716,10 +1668,10 @@ jobs:
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -1731,14 +1683,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1754,7 +1706,7 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 14 flowey_lib_common::install_cargo_nextest 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 3
+        flowey e 14 flowey_lib_hvlite::init_cross_build 0
         flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
@@ -1774,9 +1726,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -1795,9 +1747,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
@@ -1816,17 +1768,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 14 flowey_lib_common::publish_test_results 16
         flowey e 14 flowey_lib_common::publish_test_results 17
@@ -1837,34 +1789,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar5 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 14 flowey_lib_common::publish_test_results 20
-        flowey e 14 flowey_lib_common::publish_test_results 21
-        flowey e 14 flowey_lib_common::publish_test_results 22
-        flowey v 14 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__23
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar6 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 14 flowey_lib_hvlite::init_cross_build 1
+        flowey e 14 flowey_lib_hvlite::init_cross_build 2
         flowey e 14 flowey_lib_common::run_cargo_build 1
         flowey e 14 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -1878,12 +1809,12 @@ jobs:
       run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 10
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
@@ -1894,16 +1825,16 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests-junit-xml
+        name: x64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
-    - name: run doctests for x86_64-unknown-linux-musl
+    - name: run doctests for x86_64-unknown-linux-gnu
       run: flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
@@ -1913,12 +1844,360 @@ jobs:
       run: flowey e 14 flowey_lib_common::cache 7
       shell: bash
   job15:
+    name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 15 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 15 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 15 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 15 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 15 flowey_lib_common::install_rust 2
+        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 15 flowey_lib_common::git_checkout 0
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar11 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 15 flowey_lib_common::git_checkout 3
+        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 15 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 15 flowey_lib_common::cache 4
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 15 flowey_lib_common::cache 6
+        flowey e 15 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 15 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: flowey e 15 flowey_lib_common::resolve_protoc 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 5
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 7
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_clippy 6
+        flowey e 15 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_build 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 15 flowey_lib_common::download_cargo_nextest 0
+        flowey e 15 flowey_lib_common::download_cargo_nextest 1
+        flowey e 15 flowey_lib_common::download_cargo_nextest 2
+        flowey e 15 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 15 flowey_lib_common::cache 0
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 15 flowey_lib_common::cache 2
+        flowey e 15 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 15 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 15 flowey_lib_common::install_cargo_nextest 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 3
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 15 flowey_lib_common::publish_test_results 5
+        flowey e 15 flowey_lib_common::publish_test_results 6
+        flowey e 15 flowey_lib_common::publish_test_results 4
+        flowey v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__7
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'unit-tests crypto (rust)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 15 flowey_lib_common::publish_test_results 8
+        flowey e 15 flowey_lib_common::publish_test_results 9
+        flowey e 15 flowey_lib_common::publish_test_results 10
+        flowey v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 15 flowey_lib_common::publish_test_results 12
+        flowey e 15 flowey_lib_common::publish_test_results 13
+        flowey e 15 flowey_lib_common::publish_test_results 14
+        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      shell: bash
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 15 flowey_lib_common::publish_test_results 16
+        flowey e 15 flowey_lib_common::publish_test_results 17
+        flowey e 15 flowey_lib_common::publish_test_results 18
+        flowey v 15 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 15 flowey_lib_common::publish_test_results 20
+        flowey e 15 flowey_lib_common::publish_test_results 21
+        flowey e 15 flowey_lib_common::publish_test_results 22
+        flowey v 15 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey e 15 flowey_lib_hvlite::init_cross_build 1
+        flowey e 15 flowey_lib_common::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 15 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 15 flowey_lib_common::publish_test_results 0
+        flowey e 15 flowey_lib_common::publish_test_results 1
+        flowey e 15 flowey_lib_common::publish_test_results 2
+        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: |-
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for x86_64-unknown-linux-musl
+      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 15 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 15 flowey_lib_common::cache 7
+      shell: bash
+  job16:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=win-arm64
-    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1986,29 +2265,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 16 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 16 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 15 'verbose' update
+        cat <<'EOF' | flowey.exe v 16 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 15 flowey_lib_common::install_rust 0
+      run: flowey.exe e 16 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 15 flowey_lib_common::install_rust 1
+      run: flowey.exe e 16 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 15 flowey_lib_common::install_rust 2
-        flowey.exe e 15 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 16 flowey_lib_common::install_rust 2
+        flowey.exe e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 15 flowey_lib_common::git_checkout 0
-        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
-        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 16 flowey_lib_common::git_checkout 0
+        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
+        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2020,23 +2299,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 15 flowey_lib_common::git_checkout 3
-        flowey.exe e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 16 flowey_lib_common::git_checkout 3
+        flowey.exe e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 15 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 16 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 15 flowey_lib_common::cache 4
-        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 16 flowey_lib_common::cache 4
+        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2046,53 +2325,53 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 15 flowey_lib_common::cache 6
-        flowey.exe e 15 flowey_lib_common::download_gh_release 1
+        flowey.exe e 16 flowey_lib_common::cache 6
+        flowey.exe e 16 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 15 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 16 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 15 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 16 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 16 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 16 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 16 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 2
+      run: flowey.exe e 16 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 15 flowey_lib_common::cache 0
-        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 16 flowey_lib_common::cache 0
+        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2102,34 +2381,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 15 flowey_lib_common::cache 2
-        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 16 flowey_lib_common::cache 2
+        flowey.exe e 16 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 15 flowey_lib_common::install_rust 3
+      run: flowey.exe e 16 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 15 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 16 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 15 flowey_lib_common::publish_test_results 5
-        flowey.exe e 15 flowey_lib_common::publish_test_results 6
-        flowey.exe e 15 flowey_lib_common::publish_test_results 4
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 16 flowey_lib_common::publish_test_results 5
+        flowey.exe e 16 flowey_lib_common::publish_test_results 6
+        flowey.exe e 16 flowey_lib_common::publish_test_results 4
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2140,27 +2419,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
-        flowey.exe e 15 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 16 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 16 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 16 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 16 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 4
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 5
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 15 flowey_lib_common::publish_test_results 8
-        flowey.exe e 15 flowey_lib_common::publish_test_results 9
-        flowey.exe e 15 flowey_lib_common::publish_test_results 10
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 16 flowey_lib_common::publish_test_results 8
+        flowey.exe e 16 flowey_lib_common::publish_test_results 9
+        flowey.exe e 16 flowey_lib_common::publish_test_results 10
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2170,18 +2449,18 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 15 flowey_lib_common::publish_test_results 0
-        flowey.exe e 15 flowey_lib_common::publish_test_results 1
-        flowey.exe e 15 flowey_lib_common::publish_test_results 2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 16 flowey_lib_common::publish_test_results 0
+        flowey.exe e 16 flowey_lib_common::publish_test_results 1
+        flowey.exe e 16 flowey_lib_common::publish_test_results 2
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2192,377 +2471,20 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey.exe e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
-      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 15 flowey_lib_common::cache 3
+      run: flowey.exe e 16 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 15 flowey_lib_common::cache 7
-      shell: bash
-  job16:
-    name: clippy [aarch64-linux], unit tests [aarch64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr-release.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/aarch64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr-release.yaml ci checkin-gates --config=pr-release
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 16 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 16 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 16 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 16 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 16 flowey_lib_common::install_rust 2
-        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 16 flowey_lib_common::git_checkout 3
-        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 16 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 16 flowey_lib_common::cache 6
-        flowey e 16 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 16 flowey_lib_common::resolve_protoc 0
-        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_clippy 1
-        flowey e 16 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_build 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 16 flowey_lib_common::download_cargo_nextest 0
-        flowey e 16 flowey_lib_common::download_cargo_nextest 1
-        flowey e 16 flowey_lib_common::download_cargo_nextest 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 16 flowey_lib_common::cache 2
-        flowey e 16 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 16 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 16 flowey_lib_common::install_cargo_nextest 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 16 flowey_lib_common::publish_test_results 5
-        flowey e 16 flowey_lib_common::publish_test_results 6
-        flowey e 16 flowey_lib_common::publish_test_results 4
-        flowey v 16 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 16 flowey_lib_common::publish_test_results 8
-        flowey e 16 flowey_lib_common::publish_test_results 9
-        flowey e 16 flowey_lib_common::publish_test_results 10
-        flowey v 16 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 16 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 16 flowey_lib_common::publish_test_results 16
-        flowey e 16 flowey_lib_common::publish_test_results 17
-        flowey e 16 flowey_lib_common::publish_test_results 18
-        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: cargo build xtask
-      run: |-
-        flowey e 16 flowey_lib_hvlite::init_cross_build 3
-        flowey e 16 flowey_lib_common::run_cargo_build 1
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 16 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
-      shell: bash
-    - name: run 'unit-tests' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 16 flowey_lib_common::publish_test_results 0
-        flowey e 16 flowey_lib_common::publish_test_results 1
-        flowey e 16 flowey_lib_common::publish_test_results 2
-        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: |-
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 16 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 16 flowey_lib_common::cache 7
+      run: flowey.exe e 16 flowey_lib_common::cache 7
       shell: bash
   job17:
-    name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
+    name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
@@ -2653,10 +2575,16 @@ jobs:
         flowey e 17 flowey_lib_common::install_rust 2
         flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2664,7 +2592,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2674,13 +2602,9 @@ jobs:
         EOF
         flowey e 17 flowey_lib_common::git_checkout 3
         flowey e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 17 flowey_lib_common::download_gh_release 0
@@ -2688,14 +2612,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2705,39 +2629,20 @@ jobs:
         flowey e 17 flowey_lib_common::cache 6
         flowey e 17 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
     - name: unpack protoc
-      run: flowey e 17 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 17 flowey_lib_common::resolve_protoc 0
+        flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 17 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 5
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 7
+        flowey e 17 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_clippy 6
-        flowey e 17 flowey_lib_hvlite::init_cross_build 0
+        flowey e 17 flowey_lib_common::run_cargo_clippy 1
+        flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
@@ -2762,6 +2667,9 @@ jobs:
     - name: cargo clippy
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
       shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey e 17 flowey_lib_common::download_cargo_nextest 0
@@ -2772,14 +2680,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2795,7 +2703,7 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 17 flowey_lib_common::install_cargo_nextest 0
-        flowey e 17 flowey_lib_hvlite::init_cross_build 3
+        flowey e 17 flowey_lib_hvlite::init_cross_build 1
         flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
@@ -2815,9 +2723,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2836,9 +2744,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
@@ -2857,17 +2765,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 17 flowey_lib_common::publish_test_results 16
         flowey e 17 flowey_lib_common::publish_test_results 17
@@ -2878,34 +2786,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar5 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 17 flowey_lib_common::publish_test_results 20
-        flowey e 17 flowey_lib_common::publish_test_results 21
-        flowey e 17 flowey_lib_common::publish_test_results 22
-        flowey v 17 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__23
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar6 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 17 flowey_lib_hvlite::init_cross_build 1
+        flowey e 17 flowey_lib_hvlite::init_cross_build 3
         flowey e 17 flowey_lib_common::run_cargo_build 1
         flowey e 17 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -2919,12 +2806,12 @@ jobs:
       run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 10
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
@@ -2935,16 +2822,16 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
-    - name: run doctests for aarch64-unknown-linux-musl
+    - name: run doctests for aarch64-unknown-linux-gnu
       run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
@@ -2954,279 +2841,404 @@ jobs:
       run: flowey e 17 flowey_lib_common::cache 7
       shell: bash
   job18:
-    name: run vmm-tests [x64-windows-intel]
+    name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job11
-    - job2
-    - job3
-    - job7
     if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr-release.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/aarch64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr-release.yaml ci checkin-gates --config=pr-release
+      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey.exe v 18 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 18 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 18 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 18 'verbose' update
+        cat <<'EOF' | flowey v 18 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 18 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 18 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 18 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 18 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 18 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 18 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 18 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 18 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 18 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 18 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 18 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 3
+    - name: add default cargo home to path
+      run: flowey e 18 flowey_lib_common::install_rust 0
       shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 18 flowey_lib_common::cache 0
-        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+    - name: install Rust
+      run: flowey e 18 flowey_lib_common::install_rust 1
       shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
+    - name: detect active toolchain
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::cache 2
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 4
+        flowey e 18 flowey_lib_common::install_rust 2
+        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 18 flowey_lib_common::git_checkout 0
-        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::git_checkout 0
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar11 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 18 flowey_lib_common::git_checkout 3
-        flowey.exe e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 8
+        flowey e 18 flowey_lib_common::git_checkout 3
+        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+    - name: checking if packages need to be installed
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
       shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+    - name: installing packages
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 18 flowey_lib_common::download_gh_release 0
+      run: flowey e 18 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 18 flowey_lib_common::cache 8
-        flowey.exe v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 18 flowey_lib_common::cache 10
-        flowey.exe e 18 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 18 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 18 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 18 flowey_lib_common::cache 4
-        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 18 flowey_lib_common::cache 4
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 18 flowey_lib_common::cache 6
-        flowey.exe e 18 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 18 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 18 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 18 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 18 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 18 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+        flowey e 18 flowey_lib_common::cache 6
+        flowey e 18 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    - name: extract Aarch64 sysroot.tar.gz
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
-    - name: setting up vmm_tests env
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: flowey e 18 flowey_lib_common::resolve_protoc 0
+      shell: bash
+    - name: symlink protoc
       run: |-
-        flowey.exe e 18 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 5
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 7
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_clippy 6
+        flowey e 18 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_build 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 18 flowey_lib_common::download_cargo_nextest 0
+        flowey e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey e 18 flowey_lib_common::download_cargo_nextest 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 18 flowey_lib_common::cache 0
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 18 flowey_lib_common::cache 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 18 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 18 flowey_lib_common::install_cargo_nextest 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 3
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 18 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
+    - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 18 flowey_lib_common::publish_test_results 5
+        flowey e 18 flowey_lib_common::publish_test_results 6
+        flowey e 18 flowey_lib_common::publish_test_results 4
+        flowey v 18 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 18 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 18 flowey_lib_common::publish_test_results 4
-        flowey.exe e 18 flowey_lib_common::publish_test_results 5
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-vmm-tests-logs
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 18 flowey_lib_common::publish_test_results 0
-        flowey.exe e 18 flowey_lib_common::publish_test_results 1
-        flowey.exe e 18 flowey_lib_common::publish_test_results 2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 18 flowey_lib_common::publish_test_results 8
+        flowey e 18 flowey_lib_common::publish_test_results 9
+        flowey e 18 flowey_lib_common::publish_test_results 10
+        flowey v 18 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 18 flowey_lib_common::publish_test_results 12
+        flowey e 18 flowey_lib_common::publish_test_results 13
+        flowey e 18 flowey_lib_common::publish_test_results 14
+        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 18 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      shell: bash
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 18 flowey_lib_common::publish_test_results 16
+        flowey e 18 flowey_lib_common::publish_test_results 17
+        flowey e 18 flowey_lib_common::publish_test_results 18
+        flowey v 18 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 18 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 18 flowey_lib_common::publish_test_results 20
+        flowey e 18 flowey_lib_common::publish_test_results 21
+        flowey e 18 flowey_lib_common::publish_test_results 22
+        flowey v 18 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 18 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey e 18 flowey_lib_hvlite::init_cross_build 1
+        flowey e 18 flowey_lib_common::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 18 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 18 flowey_lib_common::publish_test_results 0
+        flowey e 18 flowey_lib_common::publish_test_results 1
+        flowey e 18 flowey_lib_common::publish_test_results 2
+        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-vmm-tests-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: |-
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for aarch64-unknown-linux-musl
+      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 18 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 18 flowey_lib_common::cache 7
+      run: flowey e 18 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 18 flowey_lib_common::cache 11
+      run: flowey e 18 flowey_lib_common::cache 7
       shell: bash
   job19:
-    name: run vmm-tests [x64-windows-intel-tdx]
+    name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - Windows
-    - X64
-    - TDX
-    - Baremetal
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3434,12 +3446,7 @@ jobs:
       run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
+      run: flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -3459,9 +3466,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-logs
+        name: x64-windows-intel-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3475,9 +3482,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-junit-xml
+        name: x64-windows-intel-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -3676,10 +3683,10 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-windows-amd]
+    name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3687,7 +3694,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    - job11
+    - job12
     - job2
     - job3
     - job7
@@ -3696,7 +3703,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -3719,7 +3726,7 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 20 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 20 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -3909,9 +3916,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-logs
+        name: x64-windows-intel-mi-secure-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3925,9 +3932,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-junit-xml
+        name: x64-windows-intel-mi-secure-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -3942,12 +3949,12 @@ jobs:
       run: flowey.exe e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [x64-windows-amd-snp]
+    name: run vmm-tests [x64-windows-intel-tdx]
     runs-on:
     - self-hosted
     - Windows
     - X64
-    - SNP
+    - TDX
     - Baremetal
     permissions:
       contents: read
@@ -4046,10 +4053,6 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
@@ -4057,6 +4060,10 @@ jobs:
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4181,9 +4188,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-snp-vmm-tests-logs
+        name: x64-windows-intel-tdx-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4197,9 +4204,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-snp-vmm-tests-junit-xml
+        name: x64-windows-intel-tdx-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4214,12 +4221,550 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
+    name: run vmm-tests [x64-windows-amd]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job11
+    - job2
+    - job3
+    - job7
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 22 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 22 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 22 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 22 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 22 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 22 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 22 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 0
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 22 flowey_lib_common::git_checkout 0
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::git_checkout 3
+        flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 8
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 10
+        flowey.exe e 22 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 22 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 22 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 4
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 6
+        flowey.exe e 22 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 22 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 22 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 22 flowey_lib_common::publish_test_results 4
+        flowey.exe e 22 flowey_lib_common::publish_test_results 5
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 22 flowey_lib_common::publish_test_results 0
+        flowey.exe e 22 flowey_lib_common::publish_test_results 1
+        flowey.exe e 22 flowey_lib_common::publish_test_results 2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 22 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 22 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 22 flowey_lib_common::cache 11
+      shell: bash
+  job23:
+    name: run vmm-tests [x64-windows-amd-snp]
+    runs-on:
+    - self-hosted
+    - Windows
+    - X64
+    - SNP
+    - Baremetal
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job11
+    - job2
+    - job3
+    - job7
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 23 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 23 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 23 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 23 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 23 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 23 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 23 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 23 flowey_lib_common::cache 0
+        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::cache 2
+        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 23 flowey_lib_common::git_checkout 0
+        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::git_checkout 3
+        flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 23 flowey_lib_common::cache 8
+        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::cache 10
+        flowey.exe e 23 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 23 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 23 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 23 flowey_lib_common::cache 4
+        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 23 flowey_lib_common::cache 6
+        flowey.exe e 23 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 23 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 23 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 23 flowey_lib_common::publish_test_results 4
+        flowey.exe e 23 flowey_lib_common::publish_test_results 5
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-snp-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 23 flowey_lib_common::publish_test_results 0
+        flowey.exe e 23 flowey_lib_common::publish_test_results 1
+        flowey.exe e 23 flowey_lib_common::publish_test_results 2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-snp-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 23 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 23 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 23 flowey_lib_common::cache 11
+      shell: bash
+  job24:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4246,46 +4791,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 22 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 22 'verbose' update
+        cat <<'EOF' | flowey v 24 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 22 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 22 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 22 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 22 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 22 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 24 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 22 flowey_core::pipeline::artifact::resolve 3
-        flowey e 22 flowey_core::pipeline::artifact::resolve 4
-        flowey e 22 flowey_core::pipeline::artifact::resolve 7
-        flowey e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey e 22 flowey_core::pipeline::artifact::resolve 0
-        flowey e 22 flowey_core::pipeline::artifact::resolve 2
-        flowey e 22 flowey_core::pipeline::artifact::resolve 6
-        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 3
+        flowey e 24 flowey_core::pipeline::artifact::resolve 4
+        flowey e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey e 24 flowey_core::pipeline::artifact::resolve 1
+        flowey e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey e 24 flowey_core::pipeline::artifact::resolve 6
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 22 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 22 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 22 flowey_lib_common::download_gh_release 0
+      run: flowey e 24 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 22 flowey_lib_common::cache 8
-        flowey v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 24 flowey_lib_common::cache 8
+        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4295,31 +4840,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 22 flowey_lib_common::cache 10
-        flowey e 22 flowey_lib_common::download_gh_release 1
+        flowey e 24 flowey_lib_common::cache 10
+        flowey e 24 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 22 flowey_lib_common::download_azcopy 0
+      run: flowey e 24 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 22 flowey_lib_common::download_gh_cli 0
+      run: flowey e 24 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 22 flowey_lib_common::cache 4
-        flowey v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 24 flowey_lib_common::cache 4
+        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4329,54 +4874,54 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 22 flowey_lib_common::cache 6
-        flowey e 22 flowey_lib_common::download_gh_cli 1
-        flowey v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 24 flowey_lib_common::cache 6
+        flowey e 24 flowey_lib_common::download_gh_cli 1
+        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 22 flowey_lib_common::use_gh_cli 0
+      run: flowey e 24 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 22 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 22 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 24 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 22 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 22 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 22 flowey_lib_common::download_cargo_nextest 0
-        flowey e 22 flowey_lib_common::download_cargo_nextest 1
-        flowey e 22 flowey_lib_common::download_cargo_nextest 2
-        flowey e 22 flowey_lib_common::download_cargo_nextest 3
+        flowey e 24 flowey_lib_common::download_cargo_nextest 0
+        flowey e 24 flowey_lib_common::download_cargo_nextest 1
+        flowey e 24 flowey_lib_common::download_cargo_nextest 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 22 flowey_lib_common::cache 0
-        flowey v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 24 flowey_lib_common::cache 0
+        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4386,17 +4931,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 22 flowey_lib_common::cache 2
-        flowey e 22 flowey_lib_common::download_cargo_nextest 4
+        flowey e 24 flowey_lib_common::cache 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 22 flowey_lib_common::git_checkout 0
-        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_common::git_checkout 0
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4408,32 +4953,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 22 flowey_lib_common::git_checkout 3
-        flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-        flowey e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 22 flowey_core::pipeline::artifact::resolve 5
-        flowey e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey e 24 flowey_lib_common::git_checkout 3
+        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
     - name: generate nextest command
-      run: flowey e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 22 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 22 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 22 flowey_lib_common::publish_test_results 4
-        flowey e 22 flowey_lib_common::publish_test_results 5
-        flowey v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 24 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 24 flowey_lib_common::publish_test_results 4
+        flowey e 24 flowey_lib_common::publish_test_results 5
+        flowey v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4444,12 +4989,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 22 flowey_lib_common::publish_test_results 0
-        flowey e 22 flowey_lib_common::publish_test_results 1
-        flowey e 22 flowey_lib_common::publish_test_results 2
-        flowey v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 24 flowey_lib_common::publish_test_results 0
+        flowey e 24 flowey_lib_common::publish_test_results 1
+        flowey e 24 flowey_lib_common::publish_test_results 2
+        flowey v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4459,24 +5004,24 @@ jobs:
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 22 flowey_lib_common::cache 3
+      run: flowey e 24 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 22 flowey_lib_common::cache 7
+      run: flowey e 24 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 22 flowey_lib_common::cache 11
+      run: flowey e 24 flowey_lib_common::cache 11
       shell: bash
-  job23:
+  job25:
     name: run vmm-tests [x64-linux-intel-mshv]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4551,46 +5096,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 23 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 23 'verbose' update
+        cat <<'EOF' | flowey v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 23 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey e 23 flowey_core::pipeline::artifact::resolve 7
-        flowey e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey e 23 flowey_core::pipeline::artifact::resolve 4
-        flowey e 23 flowey_core::pipeline::artifact::resolve 6
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey e 25 flowey_core::pipeline::artifact::resolve 7
+        flowey e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 4
+        flowey e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 23 flowey_lib_common::download_gh_release 0
+      run: flowey e 25 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 23 flowey_lib_common::cache 8
-        flowey v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 25 flowey_lib_common::cache 8
+        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4600,31 +5145,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 23 flowey_lib_common::cache 10
-        flowey e 23 flowey_lib_common::download_gh_release 1
+        flowey e 25 flowey_lib_common::cache 10
+        flowey e 25 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 23 flowey_lib_common::download_azcopy 0
+      run: flowey e 25 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 23 flowey_lib_common::download_gh_cli 0
+      run: flowey e 25 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 23 flowey_lib_common::cache 4
-        flowey v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 25 flowey_lib_common::cache 4
+        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4634,51 +5179,51 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 23 flowey_lib_common::cache 6
-        flowey e 23 flowey_lib_common::download_gh_cli 1
-        flowey v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 25 flowey_lib_common::cache 6
+        flowey e 25 flowey_lib_common::download_gh_cli 1
+        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 23 flowey_lib_common::use_gh_cli 0
+      run: flowey e 25 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 23 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 25 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 23 flowey_lib_common::download_cargo_nextest 0
-        flowey e 23 flowey_lib_common::download_cargo_nextest 1
-        flowey e 23 flowey_lib_common::download_cargo_nextest 2
-        flowey e 23 flowey_lib_common::download_cargo_nextest 3
+        flowey e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 23 flowey_lib_common::cache 0
-        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 25 flowey_lib_common::cache 0
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4688,17 +5233,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 23 flowey_lib_common::cache 2
-        flowey e 23 flowey_lib_common::download_cargo_nextest 4
+        flowey e 25 flowey_lib_common::cache 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 23 flowey_lib_common::git_checkout 0
-        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4710,31 +5255,31 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 23 flowey_lib_common::git_checkout 3
-        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 23 flowey_core::pipeline::artifact::resolve 5
-        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 25 flowey_lib_common::git_checkout 3
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 25 flowey_core::pipeline::artifact::resolve 5
+        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: generate nextest command
-      run: flowey e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 23 flowey_lib_common::publish_test_results 4
-        flowey e 23 flowey_lib_common::publish_test_results 5
-        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 25 flowey_lib_common::publish_test_results 4
+        flowey e 25 flowey_lib_common::publish_test_results 5
+        flowey v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4745,12 +5290,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 23 flowey_lib_common::publish_test_results 0
-        flowey e 23 flowey_lib_common::publish_test_results 1
-        flowey e 23 flowey_lib_common::publish_test_results 2
-        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 25 flowey_lib_common::publish_test_results 0
+        flowey e 25 flowey_lib_common::publish_test_results 1
+        flowey e 25 flowey_lib_common::publish_test_results 2
+        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4760,18 +5305,18 @@ jobs:
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 23 flowey_lib_common::cache 3
+      run: flowey e 25 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 23 flowey_lib_common::cache 7
+      run: flowey e 25 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 23 flowey_lib_common::cache 11
+      run: flowey e 25 flowey_lib_common::cache 11
       shell: bash
-  job24:
+  job26:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -4854,35 +5399,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 24 'verbose' update
+        cat <<'EOF' | flowey.exe v 26 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 24 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 24 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 26 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 0
-        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 26 flowey_lib_common::cache 0
+        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4892,17 +5437,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 2
-        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 26 flowey_lib_common::cache 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 24 flowey_lib_common::git_checkout 0
-        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_common::git_checkout 0
+        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4914,35 +5459,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 24 flowey_lib_common::git_checkout 3
-        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 26 flowey_lib_common::git_checkout 3
+        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 8
-        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 26 flowey_lib_common::cache 8
+        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4952,31 +5497,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 10
-        flowey.exe e 24 flowey_lib_common::download_gh_release 1
+        flowey.exe e 26 flowey_lib_common::cache 10
+        flowey.exe e 26 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 26 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 24 flowey_lib_common::cache 4
-        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 26 flowey_lib_common::cache 4
+        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4986,63 +5531,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 24 flowey_lib_common::cache 6
-        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 26 flowey_lib_common::cache 6
+        flowey.exe e 26 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 26 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 26 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 24 flowey_lib_common::publish_test_results 4
-        flowey.exe e 24 flowey_lib_common::publish_test_results 5
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 26 flowey_lib_common::publish_test_results 4
+        flowey.exe e 26 flowey_lib_common::publish_test_results 5
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5053,12 +5598,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 24 flowey_lib_common::publish_test_results 0
-        flowey.exe e 24 flowey_lib_common::publish_test_results 1
-        flowey.exe e 24 flowey_lib_common::publish_test_results 2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 26 flowey_lib_common::publish_test_results 0
+        flowey.exe e 26 flowey_lib_common::publish_test_results 1
+        flowey.exe e 26 flowey_lib_common::publish_test_results 2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5068,18 +5613,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 24 flowey_lib_common::cache 3
+      run: flowey.exe e 26 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 24 flowey_lib_common::cache 7
+      run: flowey.exe e 26 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 24 flowey_lib_common::cache 11
+      run: flowey.exe e 26 flowey_lib_common::cache 11
       shell: bash
-  job25:
+  job27:
     name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
@@ -5105,18 +5650,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 25 'verbose' update
+        cat <<'EOF' | flowey v 27 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 27 flowey_lib_common::git_checkout 0
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5128,572 +5673,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 27 flowey_lib_common::git_checkout 3
+        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 25 flowey_lib_common::install_rust 0
+      run: flowey e 27 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 25 flowey_lib_common::install_rust 1
+      run: flowey e 27 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 25 flowey_lib_common::install_rust 2
-        flowey v 25 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 27 flowey_lib_common::install_rust 2
+        flowey v 27 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 25 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
-      shell: bash
-  job26:
-    name: build openhcl (mi-secure) [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 26 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 26 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 26 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 26 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 26 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 26 flowey_lib_common::cache 0
-        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 26 flowey_lib_common::cache 2
-        flowey e 26 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 26 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 26 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 26 flowey_lib_common::install_rust 2
-        flowey e 26 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 26 flowey_lib_common::git_checkout 0
-        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 26 flowey_lib_common::git_checkout 3
-        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 26 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 26 flowey_lib_common::resolve_protoc 0
-        flowey e 26 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 0
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: cargo build sidecar
-      run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 3
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 26 flowey_lib_hvlite::build_sidecar 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 1
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 1
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 26 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 26 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 2
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 26 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 26 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 26 flowey_lib_common::run_cargo_build 0
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 26 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 26 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 26 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 26 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 26 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 26 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 26 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 26 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 26 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 26 flowey_lib_common::cache 3
-      shell: bash
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
-        include-hidden-files: true
-  job27:
-    name: run vmm-tests [x64-windows-intel-mi-secure]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job2
-    - job26
-    - job3
-    - job7
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 27 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 27 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 27 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 27 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 27 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 27 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 27 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 27 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 27 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 27 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 27 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 27 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 27 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 27 flowey_lib_common::cache 0
-        flowey.exe v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 27 flowey_lib_common::cache 2
-        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 27 flowey_lib_common::git_checkout 0
-        flowey.exe v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 27 flowey_lib_common::git_checkout 3
-        flowey.exe e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 27 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 27 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 27 flowey_lib_common::cache 8
-        flowey.exe v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 27 flowey_lib_common::cache 10
-        flowey.exe e 27 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 27 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 27 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 27 flowey_lib_common::cache 4
-        flowey.exe v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 27 flowey_lib_common::cache 6
-        flowey.exe e 27 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 27 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 27 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 27 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 27 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 27 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 27 flowey_lib_common::publish_test_results 4
-        flowey.exe e 27 flowey_lib_common::publish_test_results 5
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-mi-secure-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 27 flowey_lib_common::publish_test_results 0
-        flowey.exe e 27 flowey_lib_common::publish_test_results 1
-        flowey.exe e 27 flowey_lib_common::publish_test_results 2
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-mi-secure-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 27 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 27 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 27 flowey_lib_common::cache 11
+      run: flowey e 27 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
   job3:
     name: build artifacts (shared VMM tests) [linux]

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1359,12 +1359,291 @@ jobs:
       run: flowey e 13 flowey_lib_common::cache 7
       shell: bash
   job14:
+    name: build openhcl (mi-secure) [x64-linux]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 14 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 14 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 14 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 14 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 14 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 14 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 14 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 14 flowey_lib_common::cache 0
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 14 flowey_lib_common::cache 2
+        flowey e 14 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 14 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 14 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 14 flowey_lib_common::install_rust 2
+        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 14 flowey_lib_common::git_checkout 0
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 14 flowey_lib_common::git_checkout 3
+        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 14 flowey_lib_common::resolve_protoc 0
+        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build sidecar
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_build 3
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 14 flowey_lib_hvlite::build_sidecar 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 1
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_build 1
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 14 flowey_lib_hvlite::build_openhcl_boot 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 14 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_build 2
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 14 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 14 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_build 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 14 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 14 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 14 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 14 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 14 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 14 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 14 flowey_lib_common::copy_to_artifact_dir 0
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 14 flowey_lib_common::cache 3
+      shell: bash
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
+        include-hidden-files: true
+  job15:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
-    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1432,29 +1711,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 14 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 14 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 14 'verbose' update
+        cat <<'EOF' | flowey.exe v 15 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 14 flowey_lib_common::install_rust 0
+      run: flowey.exe e 15 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 14 flowey_lib_common::install_rust 1
+      run: flowey.exe e 15 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 14 flowey_lib_common::install_rust 2
-        flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 15 flowey_lib_common::install_rust 2
+        flowey.exe e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 14 flowey_lib_common::git_checkout 0
-        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
-        flowey.exe v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::git_checkout 0
+        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
+        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1466,23 +1745,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 14 flowey_lib_common::git_checkout 3
-        flowey.exe e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 15 flowey_lib_common::git_checkout 3
+        flowey.exe e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 14 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 15 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 14 flowey_lib_common::cache 4
-        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 15 flowey_lib_common::cache 4
+        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1492,53 +1771,53 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 14 flowey_lib_common::cache 6
-        flowey.exe e 14 flowey_lib_common::download_gh_release 1
+        flowey.exe e 15 flowey_lib_common::cache 6
+        flowey.exe e 15 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 14 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 15 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 14 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 15 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 15 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 2
+      run: flowey.exe e 15 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 14 flowey_lib_common::cache 0
-        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 15 flowey_lib_common::cache 0
+        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1548,34 +1827,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 14 flowey_lib_common::cache 2
-        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 15 flowey_lib_common::cache 2
+        flowey.exe e 15 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 14 flowey_lib_common::install_rust 3
+      run: flowey.exe e 15 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 14 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 15 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 14 flowey_lib_common::publish_test_results 5
-        flowey.exe e 14 flowey_lib_common::publish_test_results 6
-        flowey.exe e 14 flowey_lib_common::publish_test_results 4
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 15 flowey_lib_common::publish_test_results 5
+        flowey.exe e 15 flowey_lib_common::publish_test_results 6
+        flowey.exe e 15 flowey_lib_common::publish_test_results 4
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -1586,27 +1865,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
-        flowey.exe e 14 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 14 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 15 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 15 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 15 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 4
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 5
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 14 flowey_lib_common::publish_test_results 8
-        flowey.exe e 14 flowey_lib_common::publish_test_results 9
-        flowey.exe e 14 flowey_lib_common::publish_test_results 10
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 4
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 5
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 15 flowey_lib_common::publish_test_results 8
+        flowey.exe e 15 flowey_lib_common::publish_test_results 9
+        flowey.exe e 15 flowey_lib_common::publish_test_results 10
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -1616,18 +1895,18 @@ jobs:
       name: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 14 flowey_lib_common::publish_test_results 0
-        flowey.exe e 14 flowey_lib_common::publish_test_results 1
-        flowey.exe e 14 flowey_lib_common::publish_test_results 2
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 15 flowey_lib_common::publish_test_results 0
+        flowey.exe e 15 flowey_lib_common::publish_test_results 1
+        flowey.exe e 15 flowey_lib_common::publish_test_results 2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -1638,325 +1917,20 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-pc-windows-msvc
-      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 14 flowey_lib_common::cache 3
+      run: flowey.exe e 15 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 14 flowey_lib_common::cache 7
-      shell: bash
-  job15:
-    name: clippy [macos], unit tests [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 15 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 15 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 15 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 15 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 15 flowey_lib_common::install_rust 2
-        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 15 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 15 flowey_lib_common::git_checkout 3
-        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 15 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 15 flowey_lib_common::cache 6
-        flowey e 15 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 15 flowey_lib_common::resolve_protoc 0
-        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_build 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 15 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 15 flowey_lib_common::download_cargo_nextest 0
-        flowey e 15 flowey_lib_common::download_cargo_nextest 1
-        flowey e 15 flowey_lib_common::download_cargo_nextest 2
-        flowey e 15 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 15 flowey_lib_common::cache 2
-        flowey e 15 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 15 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 15 flowey_lib_common::install_cargo_nextest 0
-        flowey e 15 flowey_lib_hvlite::init_cross_build 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 15 flowey_lib_common::publish_test_results 5
-        flowey e 15 flowey_lib_common::publish_test_results 6
-        flowey e 15 flowey_lib_common::publish_test_results 4
-        flowey v 15 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 15 flowey_lib_common::publish_test_results 8
-        flowey e 15 flowey_lib_common::publish_test_results 9
-        flowey e 15 flowey_lib_common::publish_test_results 10
-        flowey v 15 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 15 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 15 flowey_lib_common::publish_test_results 12
-        flowey e 15 flowey_lib_common::publish_test_results 13
-        flowey e 15 flowey_lib_common::publish_test_results 14
-        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 15 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 15 flowey_lib_common::publish_test_results 16
-        flowey e 15 flowey_lib_common::publish_test_results 17
-        flowey e 15 flowey_lib_common::publish_test_results 18
-        flowey v 15 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: cargo build xtask
-      run: |-
-        flowey e 15 flowey_lib_hvlite::init_cross_build 2
-        flowey e 15 flowey_lib_common::run_cargo_build 1
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 15 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
-      shell: bash
-    - name: run 'unit-tests' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 15 flowey_lib_common::publish_test_results 0
-        flowey e 15 flowey_lib_common::publish_test_results 1
-        flowey e 15 flowey_lib_common::publish_test_results 2
-        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: run doctests for x86_64-unknown-linux-gnu
-      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 15 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 15 flowey_lib_common::cache 7
+      run: flowey.exe e 15 flowey_lib_common::cache 7
       shell: bash
   job16:
-    name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
+    name: clippy [macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
@@ -2003,10 +1977,16 @@ jobs:
         flowey e 16 flowey_lib_common::install_rust 2
         flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2014,7 +1994,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2024,13 +2004,9 @@ jobs:
         EOF
         flowey e 16 flowey_lib_common::git_checkout 3
         flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 16 flowey_lib_common::install_dist_pkg 1
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 16 flowey_lib_common::download_gh_release 0
@@ -2038,14 +2014,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2055,39 +2031,15 @@ jobs:
         flowey e 16 flowey_lib_common::cache 6
         flowey e 16 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 16 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
     - name: unpack protoc
-      run: flowey e 16 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 16 flowey_lib_common::resolve_protoc 0
+        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 5
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 7
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_clippy 6
-        flowey e 16 flowey_lib_hvlite::init_cross_build 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
       run: |-
@@ -2107,10 +2059,10 @@ jobs:
       run: flowey e 16 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 16 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2122,14 +2074,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2145,7 +2097,7 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 16 flowey_lib_common::install_cargo_nextest 0
-        flowey e 16 flowey_lib_hvlite::init_cross_build 3
+        flowey e 16 flowey_lib_hvlite::init_cross_build 0
         flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
@@ -2165,9 +2117,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2186,9 +2138,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
@@ -2207,17 +2159,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 16 flowey_lib_common::publish_test_results 16
         flowey e 16 flowey_lib_common::publish_test_results 17
@@ -2228,34 +2180,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar5 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 16 flowey_lib_common::publish_test_results 20
-        flowey e 16 flowey_lib_common::publish_test_results 21
-        flowey e 16 flowey_lib_common::publish_test_results 22
-        flowey v 16 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 16 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__23
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar6 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 16 flowey_lib_hvlite::init_cross_build 1
+        flowey e 16 flowey_lib_hvlite::init_cross_build 2
         flowey e 16 flowey_lib_common::run_cargo_build 1
         flowey e 16 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -2269,12 +2200,12 @@ jobs:
       run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 10
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 16 flowey_lib_common::publish_test_results 0
         flowey e 16 flowey_lib_common::publish_test_results 1
@@ -2285,16 +2216,16 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests-junit-xml
+        name: x64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
-    - name: run doctests for x86_64-unknown-linux-musl
+    - name: run doctests for x86_64-unknown-linux-gnu
       run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
@@ -2304,12 +2235,360 @@ jobs:
       run: flowey e 16 flowey_lib_common::cache 7
       shell: bash
   job17:
+    name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=ubuntu2404-amd64
+    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 17 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 17 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 17 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 17 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 17 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 17 flowey_lib_common::install_rust 2
+        flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 17 flowey_lib_common::git_checkout 0
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar11 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 17 flowey_lib_common::git_checkout 3
+        flowey e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 17 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 17 flowey_lib_common::cache 4
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 17 flowey_lib_common::cache 6
+        flowey e 17 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 17 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: flowey e 17 flowey_lib_common::resolve_protoc 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 17 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 5
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 7
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_clippy 6
+        flowey e 17 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_build 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 17 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 17 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 17 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 17 flowey_lib_common::download_cargo_nextest 0
+        flowey e 17 flowey_lib_common::download_cargo_nextest 1
+        flowey e 17 flowey_lib_common::download_cargo_nextest 2
+        flowey e 17 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 17 flowey_lib_common::cache 0
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 17 flowey_lib_common::cache 2
+        flowey e 17 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 17 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 17 flowey_lib_common::install_cargo_nextest 0
+        flowey e 17 flowey_lib_hvlite::init_cross_build 3
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'unit-tests crypto (none)' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 17 flowey_lib_common::publish_test_results 5
+        flowey e 17 flowey_lib_common::publish_test_results 6
+        flowey e 17 flowey_lib_common::publish_test_results 4
+        flowey v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__7
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'unit-tests crypto (rust)' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 17 flowey_lib_common::publish_test_results 8
+        flowey e 17 flowey_lib_common::publish_test_results 9
+        flowey e 17 flowey_lib_common::publish_test_results 10
+        flowey v 17 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 17 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 17 flowey_lib_common::publish_test_results 12
+        flowey e 17 flowey_lib_common::publish_test_results 13
+        flowey e 17 flowey_lib_common::publish_test_results 14
+        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      shell: bash
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 17 flowey_lib_common::publish_test_results 16
+        flowey e 17 flowey_lib_common::publish_test_results 17
+        flowey e 17 flowey_lib_common::publish_test_results 18
+        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 17 flowey_lib_common::publish_test_results 20
+        flowey e 17 flowey_lib_common::publish_test_results 21
+        flowey e 17 flowey_lib_common::publish_test_results 22
+        flowey v 17 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey e 17 flowey_lib_hvlite::init_cross_build 1
+        flowey e 17 flowey_lib_common::run_cargo_build 1
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 17 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 17 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 17 flowey_lib_common::publish_test_results 0
+        flowey e 17 flowey_lib_common::publish_test_results 1
+        flowey e 17 flowey_lib_common::publish_test_results 2
+        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: |-
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for x86_64-unknown-linux-musl
+      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 17 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 17 flowey_lib_common::cache 7
+      shell: bash
+  job18:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=win-arm64
-    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2377,29 +2656,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 18 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 18 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 17 'verbose' update
+        cat <<'EOF' | flowey.exe v 18 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: add default cargo home to path
-      run: flowey.exe e 17 flowey_lib_common::install_rust 0
+      run: flowey.exe e 18 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 17 flowey_lib_common::install_rust 1
+      run: flowey.exe e 18 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 17 flowey_lib_common::install_rust 2
-        flowey.exe e 17 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 18 flowey_lib_common::install_rust 2
+        flowey.exe e 18 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 17 flowey_lib_common::git_checkout 0
-        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
-        flowey.exe v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 18 flowey_lib_common::git_checkout 0
+        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
+        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2411,23 +2690,23 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 17 flowey_lib_common::git_checkout 3
-        flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 18 flowey_lib_common::git_checkout 3
+        flowey.exe e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey.exe e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      run: flowey.exe e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 17 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 18 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 17 flowey_lib_common::cache 4
-        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 18 flowey_lib_common::cache 4
+        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2437,53 +2716,53 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 17 flowey_lib_common::cache 6
-        flowey.exe e 17 flowey_lib_common::download_gh_release 1
+        flowey.exe e 18 flowey_lib_common::cache 6
+        flowey.exe e 18 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
       run: |-
-        flowey.exe e 17 flowey_lib_common::resolve_protoc 0
-        flowey.exe e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 18 flowey_lib_common::resolve_protoc 0
+        flowey.exe e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
-        flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 18 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 18 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_build 0
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 0
-        flowey.exe e 17 flowey_lib_hvlite::build_xtask 0
+        flowey.exe e 18 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 18 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 18 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::check_clippy 0
+      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 0
+      run: flowey.exe e 18 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 1
+      run: flowey.exe e 18 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 17 flowey_lib_common::run_cargo_clippy 2
+      run: flowey.exe e 18 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 17 flowey_lib_common::cache 0
-        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 18 flowey_lib_common::cache 0
+        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2493,34 +2772,34 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 17 flowey_lib_common::cache 2
-        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 18 flowey_lib_common::cache 2
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 17 flowey_lib_common::install_rust 3
+      run: flowey.exe e 18 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
-        flowey.exe e 17 flowey_lib_common::install_cargo_nextest 0
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 1
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 18 flowey_lib_common::install_cargo_nextest 0
+        flowey.exe e 18 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 2
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 3
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey.exe e 17 flowey_lib_common::publish_test_results 5
-        flowey.exe e 17 flowey_lib_common::publish_test_results 6
-        flowey.exe e 17 flowey_lib_common::publish_test_results 4
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 2
+        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 3
+        flowey.exe e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey.exe e 18 flowey_lib_common::publish_test_results 5
+        flowey.exe e 18 flowey_lib_common::publish_test_results 6
+        flowey.exe e 18 flowey_lib_common::publish_test_results 4
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
@@ -2531,27 +2810,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 3
-        flowey.exe e 17 flowey_lib_common::run_cargo_build 1
-        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 1
-        flowey.exe e 17 flowey_lib_hvlite::build_xtask 1
+        flowey.exe e 18 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 18 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 18 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 18 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: flowey.exe e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 4
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 5
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey.exe e 17 flowey_lib_common::publish_test_results 8
-        flowey.exe e 17 flowey_lib_common::publish_test_results 9
-        flowey.exe e 17 flowey_lib_common::publish_test_results 10
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 4
+        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 5
+        flowey.exe e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey.exe e 18 flowey_lib_common::publish_test_results 8
+        flowey.exe e 18 flowey_lib_common::publish_test_results 9
+        flowey.exe e 18 flowey_lib_common::publish_test_results 10
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2561,18 +2840,18 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey.exe e 17 flowey_lib_common::publish_test_results 0
-        flowey.exe e 17 flowey_lib_common::publish_test_results 1
-        flowey.exe e 17 flowey_lib_common::publish_test_results 2
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey.exe e 18 flowey_lib_common::publish_test_results 0
+        flowey.exe e 18 flowey_lib_common::publish_test_results 1
+        flowey.exe e 18 flowey_lib_common::publish_test_results 2
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -2583,377 +2862,20 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey.exe e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-pc-windows-msvc
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 17 flowey_lib_common::cache 3
+      run: flowey.exe e 18 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 17 flowey_lib_common::cache 7
-      shell: bash
-  job18:
-    name: clippy [aarch64-linux], unit tests [aarch64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=ubuntu2404-arm64
-    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
-        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/aarch64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 18 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 18 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 18 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 18 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 18 flowey_lib_common::install_rust 2
-        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 18 flowey_lib_common::git_checkout 3
-        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 18 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 18 flowey_lib_common::cache 6
-        flowey e 18 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 18 flowey_lib_common::resolve_protoc 0
-        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_clippy 1
-        flowey e 18 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_build 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 18 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 18 flowey_lib_common::download_cargo_nextest 0
-        flowey e 18 flowey_lib_common::download_cargo_nextest 1
-        flowey e 18 flowey_lib_common::download_cargo_nextest 2
-        flowey e 18 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 18 flowey_lib_common::cache 2
-        flowey e 18 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 18 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: |-
-        flowey e 18 flowey_lib_common::install_cargo_nextest 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 18 flowey_lib_common::publish_test_results 5
-        flowey e 18 flowey_lib_common::publish_test_results 6
-        flowey e 18 flowey_lib_common::publish_test_results 4
-        flowey v 18 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
-        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__7
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 18 flowey_lib_common::publish_test_results 8
-        flowey e 18 flowey_lib_common::publish_test_results 9
-        flowey e 18 flowey_lib_common::publish_test_results 10
-        flowey v 18 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
-        flowey v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 18 flowey_lib_common::publish_test_results 12
-        flowey e 18 flowey_lib_common::publish_test_results 13
-        flowey e 18 flowey_lib_common::publish_test_results 14
-        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 18 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 18 flowey_lib_common::publish_test_results 16
-        flowey e 18 flowey_lib_common::publish_test_results 17
-        flowey e 18 flowey_lib_common::publish_test_results 18
-        flowey v 18 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 18 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: cargo build xtask
-      run: |-
-        flowey e 18 flowey_lib_hvlite::init_cross_build 3
-        flowey e 18 flowey_lib_common::run_cargo_build 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 18 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 18 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
-      shell: bash
-    - name: run 'unit-tests' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 18 flowey_lib_common::publish_test_results 0
-        flowey e 18 flowey_lib_common::publish_test_results 1
-        flowey e 18 flowey_lib_common::publish_test_results 2
-        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: |-
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 18 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 18 flowey_lib_common::cache 7
+      run: flowey.exe e 18 flowey_lib_common::cache 7
       shell: bash
   job19:
-    name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
+    name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
@@ -3044,10 +2966,16 @@ jobs:
         flowey e 19 flowey_lib_common::install_rust 2
         flowey e 19 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 19 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 19 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 19 flowey_lib_common::git_checkout 0
-        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -3055,7 +2983,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -3065,13 +2993,9 @@ jobs:
         EOF
         flowey e 19 flowey_lib_common::git_checkout 3
         flowey e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 1
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 19 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 19 flowey_lib_common::download_gh_release 0
@@ -3079,14 +3003,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 19 flowey_lib_common::cache 4
-        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -3096,39 +3020,20 @@ jobs:
         flowey e 19 flowey_lib_common::cache 6
         flowey e 19 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 19 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
     - name: unpack protoc
-      run: flowey e 19 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 19 flowey_lib_common::resolve_protoc 0
+        flowey e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 19 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 5
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 7
+        flowey e 19 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_clippy 6
-        flowey e 19 flowey_lib_hvlite::init_cross_build 0
+        flowey e 19 flowey_lib_common::run_cargo_clippy 1
+        flowey e 19 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
       run: |-
@@ -3153,6 +3058,9 @@ jobs:
     - name: cargo clippy
       run: flowey e 19 flowey_lib_common::run_cargo_clippy 4
       shell: bash
+    - name: cargo clippy
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey e 19 flowey_lib_common::download_cargo_nextest 0
@@ -3163,14 +3071,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 19 flowey_lib_common::cache 0
-        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -3186,7 +3094,7 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 19 flowey_lib_common::install_cargo_nextest 0
-        flowey e 19 flowey_lib_hvlite::init_cross_build 3
+        flowey e 19 flowey_lib_hvlite::init_cross_build 1
         flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
@@ -3206,9 +3114,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -3227,9 +3135,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
@@ -3248,17 +3156,17 @@ jobs:
     - id: flowey_lib_common__publish_test_results__15
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
         path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+    - name: run 'unit-tests crypto (all)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 19 flowey_lib_common::publish_test_results 16
         flowey e 19 flowey_lib_common::publish_test_results 17
@@ -3269,34 +3177,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__19
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
         path: ${{ env.floweyvar5 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 19 flowey_lib_common::publish_test_results 20
-        flowey e 19 flowey_lib_common::publish_test_results 21
-        flowey e 19 flowey_lib_common::publish_test_results 22
-        flowey v 19 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 19 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__23
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar6 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
-        flowey e 19 flowey_lib_hvlite::init_cross_build 1
+        flowey e 19 flowey_lib_hvlite::init_cross_build 3
         flowey e 19 flowey_lib_common::run_cargo_build 1
         flowey e 19 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
@@ -3310,12 +3197,12 @@ jobs:
       run: flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 10
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 19 flowey_lib_common::publish_test_results 0
         flowey e 19 flowey_lib_common::publish_test_results 1
@@ -3326,16 +3213,16 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
-    - name: run doctests for aarch64-unknown-linux-musl
+    - name: run doctests for aarch64-unknown-linux-gnu
       run: flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
@@ -3529,279 +3416,404 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
         include-hidden-files: true
   job20:
-    name: run vmm-tests [x64-windows-intel]
+    name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
     needs:
     - job0
-    - job12
-    - job2
-    - job3
-    - job7
     if: github.event.pull_request.draft == false
     steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
+    - run: |
+        set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target aarch64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/aarch64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
+      shell: bash
     - name: 🌼🛫 Initialize job
       run: |
         AgentTempDirNormal="${{ runner.temp }}"
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey.exe v 20 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 20 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 20 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 20 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 20 'verbose' update
+        cat <<'EOF' | flowey v 20 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 20 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 20 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 20 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 20 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 20 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 20 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 20 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 3
+    - name: add default cargo home to path
+      run: flowey e 20 flowey_lib_common::install_rust 0
       shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 20 flowey_lib_common::cache 0
-        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+    - name: install Rust
+      run: flowey e 20 flowey_lib_common::install_rust 1
       shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
+    - name: detect active toolchain
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 20 flowey_lib_common::cache 2
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 4
+        flowey e 20 flowey_lib_common::install_rust 2
+        flowey e 20 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 20 flowey_lib_common::git_checkout 0
-        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 20 flowey_lib_common::git_checkout 0
+        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
+        persist-credentials: ${{ env.floweyvar11 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 20 flowey_lib_common::git_checkout 3
-        flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
+        flowey e 20 flowey_lib_common::git_checkout 3
+        flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+    - name: checking if packages need to be installed
+      run: flowey e 20 flowey_lib_common::install_dist_pkg 0
       shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 20 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+    - name: installing packages
+      run: flowey e 20 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 20 flowey_lib_common::download_gh_release 0
+      run: flowey e 20 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 20 flowey_lib_common::cache 8
-        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 20 flowey_lib_common::cache 10
-        flowey.exe e 20 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 20 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 20 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 20 flowey_lib_common::cache 4
-        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 20 flowey_lib_common::cache 4
+        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 20 flowey_lib_common::cache 6
-        flowey.exe e 20 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 20 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 20 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 20 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 20 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 20 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+        flowey e 20 flowey_lib_common::cache 6
+        flowey e 20 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    - name: extract Aarch64 sysroot.tar.gz
+      run: flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
-    - name: setting up vmm_tests env
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 20 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: flowey e 20 flowey_lib_common::resolve_protoc 0
+      shell: bash
+    - name: symlink protoc
       run: |-
-        flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 20 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 5
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 7
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_clippy 6
+        flowey e 20 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_build 0
+        flowey e 20 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 20 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 20 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 20 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 20 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 20 flowey_lib_common::download_cargo_nextest 0
+        flowey e 20 flowey_lib_common::download_cargo_nextest 1
+        flowey e 20 flowey_lib_common::download_cargo_nextest 2
+        flowey e 20 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 20 flowey_lib_common::cache 0
+        flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 20 flowey_lib_common::cache 2
+        flowey e 20 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 20 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 20 flowey_lib_common::install_cargo_nextest 0
+        flowey e 20 flowey_lib_hvlite::init_cross_build 3
+        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 20 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 20 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
+    - name: run 'unit-tests crypto (none)' nextest tests
       run: |-
-        flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 20 flowey_lib_common::publish_test_results 5
+        flowey e 20 flowey_lib_common::publish_test_results 6
+        flowey e 20 flowey_lib_common::publish_test_results 4
+        flowey v 20 'flowey_lib_common::publish_test_results:11:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar2
+        flowey v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 20 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 20 flowey_lib_common::publish_test_results 4
-        flowey.exe e 20 flowey_lib_common::publish_test_results 5
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
+    - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-vmm-tests-logs
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
+    - name: generate nextest command
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 20 flowey_lib_common::publish_test_results 0
-        flowey.exe e 20 flowey_lib_common::publish_test_results 1
-        flowey.exe e 20 flowey_lib_common::publish_test_results 2
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 20 flowey_lib_common::publish_test_results 8
+        flowey e 20 flowey_lib_common::publish_test_results 9
+        flowey e 20 flowey_lib_common::publish_test_results 10
+        flowey v 20 'flowey_lib_common::publish_test_results:18:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar3
+        flowey v 20 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (rust)-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 20 flowey_lib_common::publish_test_results 12
+        flowey e 20 flowey_lib_common::publish_test_results 13
+        flowey e 20 flowey_lib_common::publish_test_results 14
+        flowey v 20 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 20 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      shell: bash
+    - name: run 'unit-tests crypto (symcrypt)' nextest tests
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 20 flowey_lib_common::publish_test_results 16
+        flowey e 20 flowey_lib_common::publish_test_results 17
+        flowey e 20 flowey_lib_common::publish_test_results 18
+        flowey v 20 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 20 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 20 flowey_lib_common::publish_test_results 20
+        flowey e 20 flowey_lib_common::publish_test_results 21
+        flowey e 20 flowey_lib_common::publish_test_results 22
+        flowey v 20 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 20 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey e 20 flowey_lib_hvlite::init_cross_build 1
+        flowey e 20 flowey_lib_common::run_cargo_build 1
+        flowey e 20 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 20 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 20 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 20 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      shell: bash
+    - name: run 'unit-tests' nextest tests
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 20 flowey_lib_common::publish_test_results 0
+        flowey e 20 flowey_lib_common::publish_test_results 1
+        flowey e 20 flowey_lib_common::publish_test_results 2
+        flowey v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-vmm-tests-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: |-
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 20 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for aarch64-unknown-linux-musl
+      run: flowey e 20 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 20 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 20 flowey_lib_common::cache 7
+      run: flowey e 20 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 20 flowey_lib_common::cache 11
+      run: flowey e 20 flowey_lib_common::cache 7
       shell: bash
   job21:
-    name: run vmm-tests [x64-windows-intel-tdx]
+    name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - Windows
-    - X64
-    - TDX
-    - Baremetal
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4009,12 +4021,7 @@ jobs:
       run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
+      run: flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4034,9 +4041,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-logs
+        name: x64-windows-intel-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4050,9 +4057,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-junit-xml
+        name: x64-windows-intel-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4067,10 +4074,10 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
-    name: run vmm-tests [x64-windows-amd]
+    name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -4078,7 +4085,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    - job12
+    - job14
     - job2
     - job3
     - job7
@@ -4087,7 +4094,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -4110,7 +4117,7 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 22 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4300,9 +4307,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-logs
+        name: x64-windows-intel-mi-secure-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4316,9 +4323,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-junit-xml
+        name: x64-windows-intel-mi-secure-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4333,12 +4340,12 @@ jobs:
       run: flowey.exe e 22 flowey_lib_common::cache 11
       shell: bash
   job23:
-    name: run vmm-tests [x64-windows-amd-snp]
+    name: run vmm-tests [x64-windows-intel-tdx]
     runs-on:
     - self-hosted
     - Windows
     - X64
-    - SNP
+    - TDX
     - Baremetal
     permissions:
       contents: read
@@ -4437,10 +4444,6 @@ jobs:
         flowey.exe e 23 flowey_lib_common::git_checkout 3
         flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
@@ -4448,6 +4451,10 @@ jobs:
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4572,9 +4579,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-snp-vmm-tests-logs
+        name: x64-windows-intel-tdx-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4588,9 +4595,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-snp-vmm-tests-junit-xml
+        name: x64-windows-intel-tdx-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4605,12 +4612,550 @@ jobs:
       run: flowey.exe e 23 flowey_lib_common::cache 11
       shell: bash
   job24:
+    name: run vmm-tests [x64-windows-amd]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job12
+    - job2
+    - job3
+    - job7
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 24 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 24 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 24 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 24 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 24 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 24 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 24 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 24 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 24 flowey_lib_common::cache 0
+        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 24 flowey_lib_common::cache 2
+        flowey.exe e 24 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 24 flowey_lib_common::git_checkout 0
+        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 24 flowey_lib_common::git_checkout 3
+        flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 24 flowey_lib_common::cache 8
+        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 24 flowey_lib_common::cache 10
+        flowey.exe e 24 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 24 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 24 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 24 flowey_lib_common::cache 4
+        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 24 flowey_lib_common::cache 6
+        flowey.exe e 24 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 24 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 24 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 24 flowey_lib_common::publish_test_results 4
+        flowey.exe e 24 flowey_lib_common::publish_test_results 5
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 24 flowey_lib_common::publish_test_results 0
+        flowey.exe e 24 flowey_lib_common::publish_test_results 1
+        flowey.exe e 24 flowey_lib_common::publish_test_results 2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 24 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 24 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 24 flowey_lib_common::cache 11
+      shell: bash
+  job25:
+    name: run vmm-tests [x64-windows-amd-snp]
+    runs-on:
+    - self-hosted
+    - Windows
+    - X64
+    - SNP
+    - Baremetal
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job12
+    - job2
+    - job3
+    - job7
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
+
+        echo '"debug"' | flowey.exe v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 25 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey.exe v 25 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 25 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 25 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 25 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 25 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 25 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 25 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 25 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 25 flowey_lib_common::cache 0
+        flowey.exe v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 25 flowey_lib_common::cache 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 25 flowey_lib_common::git_checkout 0
+        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 25 flowey_lib_common::git_checkout 3
+        flowey.exe e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 25 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 25 flowey_lib_common::cache 8
+        flowey.exe v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 25 flowey_lib_common::cache 10
+        flowey.exe e 25 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey.exe e 25 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey.exe e 25 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 25 flowey_lib_common::cache 4
+        flowey.exe v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey.exe v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 25 flowey_lib_common::cache 6
+        flowey.exe e 25 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey.exe e 25 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: flowey.exe e 25 flowey_lib_common::download_gh_artifact 0
+      shell: bash
+    - name: write to directory variables
+      run: flowey.exe e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 25 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey.exe e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 25 flowey_lib_hvlite::run_prep_steps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: stopping test_igvm_agent_rpc_server
+      run: |-
+        flowey.exe e 25 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 25 flowey_lib_common::publish_test_results 4
+        flowey.exe e 25 flowey_lib_common::publish_test_results 5
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-snp-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 25 flowey_lib_common::publish_test_results 0
+        flowey.exe e 25 flowey_lib_common::publish_test_results 1
+        flowey.exe e 25 flowey_lib_common::publish_test_results 2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-windows-amd-snp-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 25 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey.exe e 25 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 25 flowey_lib_common::cache 11
+      shell: bash
+  job26:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4637,46 +5182,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 24 'verbose' update
+        cat <<'EOF' | flowey v 26 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 24 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 26 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 26 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 26 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 26 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 26 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 26 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 26 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 26 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey e 24 flowey_core::pipeline::artifact::resolve 7
-        flowey e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 26 flowey_core::pipeline::artifact::resolve 3
+        flowey e 26 flowey_core::pipeline::artifact::resolve 4
+        flowey e 26 flowey_core::pipeline::artifact::resolve 7
+        flowey e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey e 26 flowey_core::pipeline::artifact::resolve 0
+        flowey e 26 flowey_core::pipeline::artifact::resolve 2
+        flowey e 26 flowey_core::pipeline::artifact::resolve 6
+        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 26 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 24 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 26 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 24 flowey_lib_common::download_gh_release 0
+      run: flowey e 26 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 24 flowey_lib_common::cache 8
-        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 26 flowey_lib_common::cache 8
+        flowey v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4686,31 +5231,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 24 flowey_lib_common::cache 10
-        flowey e 24 flowey_lib_common::download_gh_release 1
+        flowey e 26 flowey_lib_common::cache 10
+        flowey e 26 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 24 flowey_lib_common::download_azcopy 0
+      run: flowey e 26 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 24 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 24 flowey_lib_common::download_gh_cli 0
+      run: flowey e 26 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 24 flowey_lib_common::cache 4
-        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 26 flowey_lib_common::cache 4
+        flowey v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4720,54 +5265,54 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 24 flowey_lib_common::cache 6
-        flowey e 24 flowey_lib_common::download_gh_cli 1
-        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 26 flowey_lib_common::cache 6
+        flowey e 26 flowey_lib_common::download_gh_cli 1
+        flowey v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 24 flowey_lib_common::use_gh_cli 0
+      run: flowey e 26 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 24 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 24 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 26 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 24 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 24 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 26 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      run: flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      run: flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey e 24 flowey_lib_common::download_cargo_nextest 3
+        flowey e 26 flowey_lib_common::download_cargo_nextest 0
+        flowey e 26 flowey_lib_common::download_cargo_nextest 1
+        flowey e 26 flowey_lib_common::download_cargo_nextest 2
+        flowey e 26 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 24 flowey_lib_common::cache 0
-        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 26 flowey_lib_common::cache 0
+        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4777,17 +5322,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 24 flowey_lib_common::cache 2
-        flowey e 24 flowey_lib_common::download_cargo_nextest 4
+        flowey e 26 flowey_lib_common::cache 2
+        flowey e 26 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 24 flowey_lib_common::git_checkout 0
-        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 26 flowey_lib_common::git_checkout 0
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4799,32 +5344,32 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 24 flowey_lib_common::git_checkout 3
-        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 24 flowey_core::pipeline::artifact::resolve 5
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey e 26 flowey_lib_common::git_checkout 3
+        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 26 flowey_core::pipeline::artifact::resolve 5
+        flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
     - name: generate nextest command
-      run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 24 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 24 flowey_lib_common::publish_test_results 4
-        flowey e 24 flowey_lib_common::publish_test_results 5
-        flowey v 24 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 26 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 26 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 26 flowey_lib_common::publish_test_results 4
+        flowey e 26 flowey_lib_common::publish_test_results 5
+        flowey v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -4835,12 +5380,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 24 flowey_lib_common::publish_test_results 0
-        flowey e 24 flowey_lib_common::publish_test_results 1
-        flowey e 24 flowey_lib_common::publish_test_results 2
-        flowey v 24 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 26 flowey_lib_common::publish_test_results 0
+        flowey e 26 flowey_lib_common::publish_test_results 1
+        flowey e 26 flowey_lib_common::publish_test_results 2
+        flowey v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -4850,24 +5395,24 @@ jobs:
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 24 flowey_lib_common::cache 3
+      run: flowey e 26 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 24 flowey_lib_common::cache 7
+      run: flowey e 26 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 24 flowey_lib_common::cache 11
+      run: flowey e 26 flowey_lib_common::cache 11
       shell: bash
-  job25:
+  job27:
     name: run vmm-tests [x64-linux-intel-mshv]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4942,46 +5487,46 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 25 'verbose' update
+        cat <<'EOF' | flowey v 27 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 27 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 27 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 27 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 27 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 27 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 25 flowey_core::pipeline::artifact::resolve 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 2
-        flowey e 25 flowey_core::pipeline::artifact::resolve 7
-        flowey e 25 flowey_core::pipeline::artifact::resolve 3
-        flowey e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 4
-        flowey e 25 flowey_core::pipeline::artifact::resolve 6
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+        flowey e 27 flowey_core::pipeline::artifact::resolve 1
+        flowey e 27 flowey_core::pipeline::artifact::resolve 2
+        flowey e 27 flowey_core::pipeline::artifact::resolve 7
+        flowey e 27 flowey_core::pipeline::artifact::resolve 3
+        flowey e 27 flowey_core::pipeline::artifact::resolve 0
+        flowey e 27 flowey_core::pipeline::artifact::resolve 4
+        flowey e 27 flowey_core::pipeline::artifact::resolve 6
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 27 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 27 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_release 0
+      run: flowey e 27 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 8
-        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey e 27 flowey_lib_common::cache 8
+        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4991,31 +5536,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 10
-        flowey e 25 flowey_lib_common::download_gh_release 1
+        flowey e 27 flowey_lib_common::cache 10
+        flowey e 27 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey e 25 flowey_lib_common::download_azcopy 0
+      run: flowey e 27 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_cli 0
+      run: flowey e 27 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 4
-        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey e 27 flowey_lib_common::cache 4
+        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5025,51 +5570,51 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 6
-        flowey e 25 flowey_lib_common::download_gh_cli 1
-        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 27 flowey_lib_common::cache 6
+        flowey e 27 flowey_lib_common::download_gh_cli 1
+        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey e 25 flowey_lib_common::use_gh_cli 0
+      run: flowey e 27 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey e 25 flowey_lib_common::download_gh_artifact 0
+      run: flowey e 27 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
+      run: flowey e 27 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey e 25 flowey_lib_common::download_cargo_nextest 0
-        flowey e 25 flowey_lib_common::download_cargo_nextest 1
-        flowey e 25 flowey_lib_common::download_cargo_nextest 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 3
+        flowey e 27 flowey_lib_common::download_cargo_nextest 0
+        flowey e 27 flowey_lib_common::download_cargo_nextest 1
+        flowey e 27 flowey_lib_common::download_cargo_nextest 2
+        flowey e 27 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey e 27 flowey_lib_common::cache 0
+        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5079,17 +5624,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 25 flowey_lib_common::cache 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 4
+        flowey e 27 flowey_lib_common::cache 2
+        flowey e 27 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 27 flowey_lib_common::git_checkout 0
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5101,31 +5646,31 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 5
-        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 27 flowey_lib_common::git_checkout 3
+        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 27 flowey_core::pipeline::artifact::resolve 5
+        flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: generate nextest command
-      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 25 flowey_lib_common::publish_test_results 4
-        flowey e 25 flowey_lib_common::publish_test_results 5
-        flowey v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey e 27 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 27 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 27 flowey_lib_common::publish_test_results 4
+        flowey e 27 flowey_lib_common::publish_test_results 5
+        flowey v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5136,12 +5681,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 25 flowey_lib_common::publish_test_results 0
-        flowey e 25 flowey_lib_common::publish_test_results 1
-        flowey e 25 flowey_lib_common::publish_test_results 2
-        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 27 flowey_lib_common::publish_test_results 0
+        flowey e 27 flowey_lib_common::publish_test_results 1
+        flowey e 27 flowey_lib_common::publish_test_results 2
+        flowey v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5151,18 +5696,18 @@ jobs:
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 25 flowey_lib_common::cache 3
+      run: flowey e 27 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 25 flowey_lib_common::cache 7
+      run: flowey e 27 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 25 flowey_lib_common::cache 11
+      run: flowey e 27 flowey_lib_common::cache 11
       shell: bash
-  job26:
+  job28:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -5245,35 +5790,35 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 28 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 28 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 26 'verbose' update
+        cat <<'EOF' | flowey.exe v 28 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 26 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 28 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 28 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 28 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 28 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 28 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 28 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 28 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 28 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 28 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 28 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 0
-        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 28 flowey_lib_common::cache 0
+        flowey.exe v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5283,17 +5828,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 28 flowey_lib_common::cache 2
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 28 flowey_lib_common::git_checkout 0
+        flowey.exe v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5305,35 +5850,35 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 26 flowey_lib_common::git_checkout 3
-        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 28 flowey_lib_common::git_checkout 3
+        flowey.exe e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 28 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 8
-        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 28 flowey_lib_common::cache 8
+        flowey.exe v 28 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 28 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5343,31 +5888,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 28 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 10
-        flowey.exe e 26 flowey_lib_common::download_gh_release 1
+        flowey.exe e 28 flowey_lib_common::cache 10
+        flowey.exe e 28 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 26 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 28 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 28 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 28 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 28 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 28 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 4
-        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 28 flowey_lib_common::cache 4
+        flowey.exe v 28 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 28 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5377,63 +5922,63 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 28 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 6
-        flowey.exe e 26 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 28 flowey_lib_common::cache 6
+        flowey.exe e 28 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 28 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 26 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 28 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 28 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
-      run: flowey.exe e 26 flowey_lib_common::download_gh_artifact 0
+      run: flowey.exe e 28 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: write to directory variables
-      run: flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      run: flowey.exe e 28 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_deps 0
+      run: flowey.exe e 28 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 28 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 28 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 28 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 28 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 28 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 28 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 28 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 28 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 26 flowey_lib_common::publish_test_results 4
-        flowey.exe e 26 flowey_lib_common::publish_test_results 5
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 28 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 28 flowey_lib_common::publish_test_results 4
+        flowey.exe e 28 flowey_lib_common::publish_test_results 5
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5444,12 +5989,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 26 flowey_lib_common::publish_test_results 0
-        flowey.exe e 26 flowey_lib_common::publish_test_results 1
-        flowey.exe e 26 flowey_lib_common::publish_test_results 2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 28 flowey_lib_common::publish_test_results 0
+        flowey.exe e 28 flowey_lib_common::publish_test_results 1
+        flowey.exe e 28 flowey_lib_common::publish_test_results 2
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5459,18 +6004,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 26 flowey_lib_common::cache 3
+      run: flowey.exe e 28 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 26 flowey_lib_common::cache 7
+      run: flowey.exe e 28 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 26 flowey_lib_common::cache 11
+      run: flowey.exe e 28 flowey_lib_common::cache 11
       shell: bash
-  job27:
+  job29:
     name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
@@ -5496,18 +6041,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 29 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 29 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 27 'verbose' update
+        cat <<'EOF' | flowey v 29 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 29 flowey_lib_common::git_checkout 0
+        flowey v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5519,572 +6064,27 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 27 flowey_lib_common::git_checkout 3
-        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 29 flowey_lib_common::git_checkout 3
+        flowey e 29 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 27 flowey_lib_common::install_rust 0
+      run: flowey e 29 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 27 flowey_lib_common::install_rust 1
+      run: flowey e 29 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 27 flowey_lib_common::install_rust 2
-        flowey v 27 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 29 flowey_lib_common::install_rust 2
+        flowey v 29 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 27 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
-      shell: bash
-  job28:
-    name: build openhcl (mi-secure) [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job28-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 28 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 28 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 28 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 28 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 28 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 28 flowey_lib_common::cache 0
-        flowey v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 28 flowey_lib_common::cache 2
-        flowey e 28 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 28 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 28 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 28 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 28 flowey_lib_common::install_rust 2
-        flowey e 28 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 28 flowey_lib_common::git_checkout 0
-        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 28 flowey_lib_common::git_checkout 3
-        flowey e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 28 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 28 flowey_lib_common::resolve_protoc 0
-        flowey e 28 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 28 flowey_lib_hvlite::init_cross_build 0
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: cargo build sidecar
-      run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 3
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 28 flowey_lib_hvlite::build_sidecar 0
-        flowey e 28 flowey_lib_hvlite::init_cross_build 1
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 1
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 28 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 28 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 28 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 2
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 28 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 28 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 28 flowey_lib_common::run_cargo_build 0
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 28 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 28 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 28 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 28 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 28 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 28 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 28 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 28 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 28 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 28 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 28 flowey_lib_common::cache 3
-      shell: bash
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
-        include-hidden-files: true
-  job29:
-    name: run vmm-tests [x64-windows-intel-mi-secure]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job29-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job2
-    - job28
-    - job3
-    - job7
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 29 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 29 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 29 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 29 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 29 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 29 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 29 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 29 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 29 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 29 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 29 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 29 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 29 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 29 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 29 flowey_lib_common::cache 0
-        flowey.exe v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 29 flowey_lib_common::cache 2
-        flowey.exe e 29 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 29 flowey_lib_common::git_checkout 0
-        flowey.exe v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 29 flowey_lib_common::git_checkout 3
-        flowey.exe e 29 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 8
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 29 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 29 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 29 flowey_lib_common::cache 8
-        flowey.exe v 29 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 29 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 29 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 29 flowey_lib_common::cache 10
-        flowey.exe e 29 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 29 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 29 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 29 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 29 flowey_lib_common::cache 4
-        flowey.exe v 29 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 29 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 29 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 29 flowey_lib_common::cache 6
-        flowey.exe e 29 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 29 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 29 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: flowey.exe e 29 flowey_lib_common::download_gh_artifact 0
-      shell: bash
-    - name: write to directory variables
-      run: flowey.exe e 29 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey.exe e 29 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 29 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 29 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 29 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 29 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 29 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 29 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 29 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 29 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 29 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 29 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 29 flowey_lib_common::publish_test_results 4
-        flowey.exe e 29 flowey_lib_common::publish_test_results 5
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-mi-secure-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 29 flowey_lib_common::publish_test_results 0
-        flowey.exe e 29 flowey_lib_common::publish_test_results 1
-        flowey.exe e 29 flowey_lib_common::publish_test_results 2
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 29 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-intel-mi-secure-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 29 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 29 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 29 flowey_lib_common::cache 11
+      run: flowey e 29 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
   job3:
     name: build artifacts (shared VMM tests) [linux]

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -216,8 +216,8 @@ jobs:
   - publish: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
     displayName: 🌼🥾 Publish bootstrapped flowey
     artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
-- job: job18
-  displayName: build openhcl (mi-secure) [x64-linux]
+- job: job15
+  displayName: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -246,237 +246,295 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 18 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 18 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 15 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 15 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 18 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 15 'verbose' update
       ${{ parameters.verbose }}
       EOF
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 18 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | $FLOWEY_BIN v 18 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar2)
-      path: $(floweyvar1)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::install_rust 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 18 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar11
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar3)
+    persistCredentials: $(floweyvar11)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar9
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar10
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar10)
+      path: $(floweyvar9)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 6
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+    displayName: extract X86_64 sysroot.tar.gz
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::resolve_protoc 0
     displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 2
     displayName: symlink protoc
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 3
+    displayName: cargo clippy
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 5
+    displayName: cargo clippy
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 1
+    displayName: cargo clippy
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 7
+    displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 9
-    displayName: cargo build sidecar
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 6
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 0
+    displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 10
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_sidecar 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 2
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_build 0
+    displayName: cargo build xtask
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_xtask 0
     displayName: split debug symbols
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::check_clippy 0
+    displayName: determine clippy exclusions
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 0
+    displayName: cargo clippy
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 2
+    displayName: cargo clippy
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 4
+    displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 4
-    displayName: cargo build openhcl_boot
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 3
+    displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 3
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 5
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_boot 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar8)
+      path: $(floweyvar7)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: cargo-nextest'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 4
+    displayName: downloading cargo-nextest
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::install_rust 2
+    displayName: report $CARGO_HOME
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+    displayName: installing cargo-nextest
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+    displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 6
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 7
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 8
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 4
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (rust)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar5)
+      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (rust)
+    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+    displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 4
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 7
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 6
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 6
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (openssl)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar4)
+      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (openssl)
+    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+    displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 8
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 9
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 9
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 10
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 8
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:10:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar6
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (symcrypt)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar6)
+      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)
+    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+    displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 11
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 10
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (all)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar2)
+      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (all)
+    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_build 2
+    displayName: cargo build xtask
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_build 3
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_xtask 1
     displayName: split debug symbols
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+    displayName: determine unit test exclusions
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+    displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-    displayName: extract and resolve kernel package
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 10
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 11
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar1)
+      testRunTitle: x64-linux-musl-unit-tests-unit-tests
+    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+    displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 3
-    displayName: extract X86_64 sysroot.tar.gz
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 3
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 4
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 2
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (none)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar3)
+      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (none)
+    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-    displayName: cargo build openvmm_hcl
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_initrd 2
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_cross_build 2
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 0
-    displayName: cargo build igvmfilegen
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 5
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_igvmfilegen 2
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-    displayName: building igvm file
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (x64)
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_initrd 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::copy_to_artifact_dir 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-    displayName: copying OpenHCL igvm files to artifact dir
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::copy_to_artifact_dir 0
-    displayName: copying OpenHCL igvm extras to artifact dir
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::cache 3
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 7
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+    displayName: report test results to overall pipeline status
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+    displayName: run doctests for x86_64-unknown-linux-musl
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: cargo-nextest'
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm
-    displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm
-    artifact: x64-mi-secure-openhcl-igvm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras
-    displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
-    artifact: x64-mi-secure-openhcl-igvm-extras
 - job: job14
-  displayName: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
+  displayName: clippy [macos], unit tests [x64-linux]
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
@@ -519,17 +577,21 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_common::install_rust 1
       $(FLOWEY_BIN) e 14 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar11
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
       $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar11)
+    persistCredentials: $(floweyvar10)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
@@ -537,24 +599,21 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 2
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar9
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar10
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar10)
-      path: $(floweyvar9)
+      key: $(floweyvar9)
+      path: $(floweyvar8)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
@@ -566,32 +625,16 @@ jobs:
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-    displayName: extract X86_64 sysroot.tar.gz
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-    displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::resolve_protoc 0
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 14 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: unpack protoc
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 1
     displayName: symlink protoc
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 3
-    displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 5
-    displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 1
-    displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 7
-    displayName: cargo clippy
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 6
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 0
-    displayName: cargo clippy
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_build 0
@@ -607,9 +650,9 @@ jobs:
     displayName: determine clippy exclusions
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 0
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 2
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 4
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_clippy 2
     displayName: cargo clippy
   - bash: |-
       set -e
@@ -621,13 +664,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar8)
-      path: $(floweyvar7)
+      key: $(floweyvar7)
+      path: $(floweyvar6)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
@@ -644,7 +687,7 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 0
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -664,8 +707,8 @@ jobs:
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar5)
-      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (rust)
-    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      testRunTitle: x64-linux-unit-tests-unit-tests crypto (rust)
+    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
     displayName: generate nextest command
@@ -684,28 +727,8 @@ jobs:
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar4)
-      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (openssl)
-    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
-    displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 8
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 9
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 9
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 10
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 8
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:10:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar6
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (symcrypt)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar6)
-      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)
-    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      testRunTitle: x64-linux-unit-tests-unit-tests crypto (openssl)
+    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
@@ -713,23 +736,23 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 11
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 9
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 10
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 8
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (all)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar2)
-      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (all)
-    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
+      testRunTitle: x64-linux-unit-tests-unit-tests crypto (all)
+    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 2
       $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_build 1
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 2
     displayName: cargo build xtask
@@ -741,12 +764,12 @@ jobs:
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 10
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 11
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 8
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 9
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 0
@@ -758,8 +781,8 @@ jobs:
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar1)
-      testRunTitle: x64-linux-musl-unit-tests-unit-tests
-    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
+      testRunTitle: x64-linux-unit-tests-unit-tests
+    displayName: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
@@ -778,303 +801,21 @@ jobs:
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar3)
-      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (none)
-    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 7
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-    displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-    displayName: run doctests for x86_64-unknown-linux-musl
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 7
-    displayName: 'validate cache entry: gh-release-download'
-- job: job13
-  displayName: clippy [macos], unit tests [x64-linux]
-  pool:
-    demands:
-    - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
-  dependsOn:
-  - job0
-  condition: and(succeeded(), not(canceled()))
-  variables:
-  - name: FLOWEY_TEMP_DIR
-    value: $(Build.StagingDirectory)/.flowey-internal
-  steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼🥾 Download bootstrapped flowey
-    inputs:
-      artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
-      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
-  - bash: |
-      set -e
-      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
-      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
-
-      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey"
-      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
-    displayName: Set flowey path
-  - bash: |
-      set -e
-      echo '"debug"' | $FLOWEY_BIN v 13 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 13 '_internal_WORKING_DIR' --is-raw-string update
-
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 13 'verbose' update
-      ${{ parameters.verbose }}
-      EOF
-    displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar10)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-    displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar9)
-      path: $(floweyvar8)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 6
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-    displayName: unpack protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 1
-    displayName: symlink protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 0
-    displayName: cargo build xtask
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_xtask 0
-    displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::check_clippy 0
-    displayName: determine clippy exclusions
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_clippy 0
-    displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_clippy 1
-    displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_clippy 2
-    displayName: cargo clippy
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 3
-    displayName: create cargo-nextest cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar7)
-      path: $(floweyvar6)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: cargo-nextest'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 4
-    displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 2
-    displayName: report $CARGO_HOME
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
-    displayName: installing cargo-nextest
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-    displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 6
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 7
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 5
-      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 8
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (rust)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar5)
-      testRunTitle: x64-linux-unit-tests-unit-tests crypto (rust)
-    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-    displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 4
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 5
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 7
-      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 6
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (openssl)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar4)
-      testRunTitle: x64-linux-unit-tests-unit-tests crypto (openssl)
-    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-    displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 5
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 9
-      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 8
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (all)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar2)
-      testRunTitle: x64-linux-unit-tests-unit-tests crypto (all)
-    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 2
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 2
-    displayName: cargo build xtask
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 3
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_xtask 1
-    displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
-    displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 4
-    displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 8
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 9
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar1)
-      testRunTitle: x64-linux-unit-tests-unit-tests
-    displayName: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-    displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 2
-      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 3
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 4
-      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (none)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar3)
       testRunTitle: x64-linux-unit-tests-unit-tests crypto (none)
     displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 6
-      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
     displayName: run doctests for x86_64-unknown-linux-gnu
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
-- job: job12
+- job: job13
   displayName: clippy [x64-windows], unit tests [x64-windows]
   pool:
     demands:
@@ -1149,25 +890,25 @@ jobs:
     displayName: 🌼🔎 Self-check YAML
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 12 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 12 '_internal_WORKING_DIR' --is-raw-string update
+      echo '"debug"' | $FLOWEY_BIN v 13 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 13 '_internal_WORKING_DIR' --is-raw-string update
 
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 12 'verbose' update
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 13 'verbose' update
       ${{ parameters.verbose }}
       EOF
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 0
     displayName: install Rust
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cfg_cargo_common_flags 0
     displayName: detect active toolchain
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar8
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar8
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -1179,18 +920,18 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
     displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1200,50 +941,50 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 6
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 6
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 1
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: unpack protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 2
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 2
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_xtask 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_xtask 0
     displayName: cargo build xtask
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::check_clippy 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::check_clippy 0
     displayName: determine clippy exclusions
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_clippy 0
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 1
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_clippy 2
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_clippy 2
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 3
+      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 3
     displayName: create cargo-nextest cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1253,44 +994,44 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::cache 2
     displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_cargo_nextest 4
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::download_cargo_nextest 4
     displayName: downloading cargo-nextest
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 2
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::install_rust 2
     displayName: report $CARGO_HOME
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::install_cargo_nextest 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 13 flowey_lib_common::install_cargo_nextest 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 3
     displayName: installing cargo-nextest
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_xtask 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_xtask 1
     displayName: cargo build xtask
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 2
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 4
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 5
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 5
-      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 4
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 4
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1299,18 +1040,18 @@ jobs:
       testRunTitle: x64-windows-unit-tests-unit-tests
     displayName: 'publish test results: x64-windows-unit-tests-unit-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 2
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (none)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1319,18 +1060,18 @@ jobs:
       testRunTitle: x64-windows-unit-tests-unit-tests crypto (none)
     displayName: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 2
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_nextest_run 3
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 12 flowey_lib_common::ado_task_publish_test_results 4
-      $(FLOWEY_BIN) e 12 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 12 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 12 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::run_cargo_nextest_run 3
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 4
+      $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 2
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (rust)' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1341,15 +1082,274 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_nextest_unit_tests 4
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
     displayName: run doctests for x86_64-pc-windows-msvc
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::cache 3
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::cache 7
+  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
+- job: job12
+  displayName: build openhcl (mi-secure) [x64-linux]
+  pool:
+    demands:
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
+  dependsOn:
+  - job0
+  condition: and(succeeded(), not(canceled()))
+  variables:
+  - name: FLOWEY_TEMP_DIR
+    value: $(Build.StagingDirectory)/.flowey-internal
+  steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼🥾 Download bootstrapped flowey
+    inputs:
+      artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
+      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - bash: |
+      set -e
+      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
+      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
+
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey"
+      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
+    displayName: Set flowey path
+  - bash: |
+      set -e
+      echo '"debug"' | $FLOWEY_BIN v 12 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 12 '_internal_WORKING_DIR' --is-raw-string update
+
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 12 'verbose' update
+      ${{ parameters.verbose }}
+      EOF
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | $FLOWEY_BIN v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+    displayName: 🌼🛫 Initialize job
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar2)
+      path: $(floweyvar1)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar3)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+    displayName: set '-Dwarnings' in .cargo/config.toml
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    displayName: unpack protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 7
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 8
+    displayName: symlink protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 9
+    displayName: cargo build sidecar
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_sidecar 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 3
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 4
+    displayName: cargo build openhcl_boot
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 5
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_boot 0
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+    displayName: extract and resolve kernel package
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 3
+    displayName: extract X86_64 sysroot.tar.gz
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+    displayName: cargo build openvmm_hcl
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 2
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 0
+    displayName: cargo build igvmfilegen
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_igvmfilegen 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+    displayName: building igvm file
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (x64)
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+    displayName: extract and resolve kernel package
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::copy_to_artifact_dir 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+    displayName: copying OpenHCL igvm files to artifact dir
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::copy_to_artifact_dir 0
+    displayName: copying OpenHCL igvm extras to artifact dir
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: gh-release-download'
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm
+    displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm
+    artifact: x64-mi-secure-openhcl-igvm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras
+    displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
+    artifact: x64-mi-secure-openhcl-igvm-extras
 - job: job11
   displayName: build openhcl [x64-linux]
   pool:
@@ -3856,6 +3856,507 @@ jobs:
     displayName: 🌼📦 Publish x64-windows-pipette
     artifact: x64-windows-pipette
 - job: job19
+  displayName: run vmm-tests [x64-linux-amd-kvm]
+  pool:
+    demands:
+    - ImageOverride -equals ubuntu2404-amd64
+    name: openvmm-ado-amd-westus2
+  dependsOn:
+  - job0
+  - job2
+  - job3
+  - job9
+  condition: and(succeeded(), not(canceled()))
+  variables:
+  - name: FLOWEY_TEMP_DIR
+    value: $(Build.StagingDirectory)/.flowey-internal
+  steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼🥾 Download bootstrapped flowey
+    inputs:
+      artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
+      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-guest_test_uefi
+    inputs:
+      artifact: x64-guest_test_uefi
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-musl-pipette
+    inputs:
+      artifact: x64-linux-musl-pipette
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-musl-tmk_vmm
+    inputs:
+      artifact: x64-linux-musl-tmk_vmm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-openvmm
+    inputs:
+      artifact: x64-linux-openvmm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-openvmm_vhost
+    inputs:
+      artifact: x64-linux-openvmm_vhost
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm_vhost
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-vmm-tests-archive
+    inputs:
+      artifact: x64-linux-vmm-tests-archive
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-vmm-tests-archive
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-tmks
+    inputs:
+      artifact: x64-tmks
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-pipette
+    inputs:
+      artifact: x64-windows-pipette
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette
+  - bash: |
+      set -e
+      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
+      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
+
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey"
+      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
+    displayName: Set flowey path
+  - bash: |
+      set -e
+      echo '"debug"' | $FLOWEY_BIN v 19 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 19 '_internal_WORKING_DIR' --is-raw-string update
+
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 19 'verbose' update
+      ${{ parameters.verbose }}
+      EOF
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 19 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-vmm-tests-archive" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 19 'artifact_use_from_x64-tmks' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+    displayName: 🌼🛫 Initialize job
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+    displayName: ensure hypervisor device is accessible
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+    displayName: ensure 2 MiB hugetlb pages are available
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 3
+    displayName: create cargo-nextest cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar4)
+      path: $(floweyvar3)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: cargo-nextest'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 4
+    displayName: downloading cargo-nextest
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar2)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 7
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 6
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+    displayName: creating new test content dir
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar6)
+      path: $(floweyvar5)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 6
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_azcopy 0
+    displayName: extract azcopy from archive
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+    displayName: calculating required VMM tests disk images
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+    displayName: downloading VMM test disk images
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (x64)
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::init_vmm_tests_env 0
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+    displayName: setting up vmm_tests env
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+    displayName: generate nextest command
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+    displayName: install vmm tests deps (linux)
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 19 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 19 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'vmm_tests' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar1)
+      testRunTitle: x64-linux-amd-kvm-vmm-tests
+    displayName: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 2
+      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+    displayName: report test results to overall pipeline status
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: cargo-nextest'
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::cache 7
+    displayName: 'validate cache entry: gh-release-download'
+- job: job18
+  displayName: run vmm-tests [x64-windows-amd]
+  pool:
+    demands:
+    - ImageOverride -equals win-amd64
+    name: openvmm-ado-amd-westus2
+  dependsOn:
+  - job0
+  - job11
+  - job2
+  - job3
+  - job7
+  condition: and(succeeded(), not(canceled()))
+  variables:
+  - name: FLOWEY_TEMP_DIR
+    value: $(Build.StagingDirectory)/.flowey-internal
+  steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼🥾 Download bootstrapped flowey
+    inputs:
+      artifact: _internal-flowey-bootstrap-x86_64-windows-uid-3
+      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-guest_test_uefi
+    inputs:
+      artifact: x64-guest_test_uefi
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-musl-pipette
+    inputs:
+      artifact: x64-linux-musl-pipette
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-musl-tmk_vmm
+    inputs:
+      artifact: x64-linux-musl-tmk_vmm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-tpm_guest_tests
+    inputs:
+      artifact: x64-linux-tpm_guest_tests
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-openhcl-igvm
+    inputs:
+      artifact: x64-openhcl-igvm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-tmks
+    inputs:
+      artifact: x64-tmks
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-openvmm
+    inputs:
+      artifact: x64-windows-openvmm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-pipette
+    inputs:
+      artifact: x64-windows-pipette
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-prep_steps
+    inputs:
+      artifact: x64-windows-prep_steps
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-test_igvm_agent_rpc_server
+    inputs:
+      artifact: x64-windows-test_igvm_agent_rpc_server
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-tmk_vmm
+    inputs:
+      artifact: x64-windows-tmk_vmm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-tpm_guest_tests
+    inputs:
+      artifact: x64-windows-tpm_guest_tests
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-vmgstool
+    inputs:
+      artifact: x64-windows-vmgstool
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-windows-vmm-tests-archive
+    inputs:
+      artifact: x64-windows-vmm-tests-archive
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive
+  - bash: |
+      set -e
+      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
+      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
+
+      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey.exe"
+      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
+    displayName: Set flowey path
+  - bash: |
+      set -e
+      echo '"debug"' | $FLOWEY_BIN v 18 'FLOWEY_LOG' update
+      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 18 '_internal_WORKING_DIR' --is-raw-string update
+
+      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 18 'verbose' update
+      ${{ parameters.verbose }}
+      EOF
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 18 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 18 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 18 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 18 'artifact_use_from_x64-tmks' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
+    displayName: 🌼🛫 Initialize job
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 1
+      $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 2
+      $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 3
+    displayName: create cargo-nextest cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 0
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar4)
+      path: $(floweyvar3)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: cargo-nextest'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 2
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 4
+    displayName: downloading cargo-nextest
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar2)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 8
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+    displayName: creating new test content dir
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+    displayName: resolve OpenHCL igvm artifact
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar6)
+      path: $(floweyvar5)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 6
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_azcopy 0
+    displayName: extract azcopy from archive
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+    displayName: calculating required VMM tests disk images
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+    displayName: downloading VMM test disk images
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (x64)
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_vmm_tests_env 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+    displayName: setting up vmm_tests env
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+    displayName: generate nextest command
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::install_vmm_tests_deps 0
+    displayName: install vmm tests deps (windows)
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+    displayName: starting test_igvm_agent_rpc_server
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+    displayName: run 'vmm_tests' nextest tests
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 18 flowey_lib_common::ado_task_publish_test_results 0
+      $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 18 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: stopping test_igvm_agent_rpc_server
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar1)
+      testRunTitle: x64-windows-amd-vmm-tests
+    displayName: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 2
+      $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+    displayName: report test results to overall pipeline status
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::cache 3
+    displayName: 'validate cache entry: cargo-nextest'
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::cache 7
+    displayName: 'validate cache entry: gh-release-download'
+- job: job17
   displayName: run vmm-tests [x64-windows-intel-mi-secure]
   pool:
     demands:
@@ -3863,7 +4364,7 @@ jobs:
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
-  - job18
+  - job12
   - job2
   - job3
   - job7
@@ -3959,246 +4460,6 @@ jobs:
     displayName: Set flowey path
   - bash: |
       set -e
-      echo '"debug"' | $FLOWEY_BIN v 19 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 19 '_internal_WORKING_DIR' --is-raw-string update
-
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 19 'verbose' update
-      ${{ parameters.verbose }}
-      EOF
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 19 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 19 'artifact_use_from_x64-tmks' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-    displayName: 🌼🛫 Initialize job
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 3
-    displayName: create cargo-nextest cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar4)
-      path: $(floweyvar3)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: cargo-nextest'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 4
-    displayName: downloading cargo-nextest
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar2)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 6
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 9
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 10
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 8
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-    displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-    displayName: resolve OpenHCL igvm artifact
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar6)
-      path: $(floweyvar5)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 6
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_azcopy 0
-    displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-    displayName: calculating required VMM tests disk images
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-    displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (x64)
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::init_vmm_tests_env 0
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-    displayName: setting up vmm_tests env
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-    displayName: generate nextest command
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
-    displayName: install vmm tests deps (windows)
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-    displayName: starting test_igvm_agent_rpc_server
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-    displayName: run 'vmm_tests' nextest tests
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 19 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 19 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: stopping test_igvm_agent_rpc_server
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar1)
-      testRunTitle: x64-windows-intel-mi-secure-vmm-tests
-    displayName: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 2
-      $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-    displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::cache 7
-    displayName: 'validate cache entry: gh-release-download'
-- job: job17
-  displayName: run vmm-tests [x64-linux-amd-kvm]
-  pool:
-    demands:
-    - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
-  dependsOn:
-  - job0
-  - job2
-  - job3
-  - job9
-  condition: and(succeeded(), not(canceled()))
-  variables:
-  - name: FLOWEY_TEMP_DIR
-    value: $(Build.StagingDirectory)/.flowey-internal
-  steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼🥾 Download bootstrapped flowey
-    inputs:
-      artifact: _internal-flowey-bootstrap-x86_64-linux-uid-1
-      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-guest_test_uefi
-    inputs:
-      artifact: x64-guest_test_uefi
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-musl-pipette
-    inputs:
-      artifact: x64-linux-musl-pipette
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-musl-tmk_vmm
-    inputs:
-      artifact: x64-linux-musl-tmk_vmm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-openvmm
-    inputs:
-      artifact: x64-linux-openvmm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-openvmm_vhost
-    inputs:
-      artifact: x64-linux-openvmm_vhost
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm_vhost
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-vmm-tests-archive
-    inputs:
-      artifact: x64-linux-vmm-tests-archive
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-vmm-tests-archive
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-tmks
-    inputs:
-      artifact: x64-tmks
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-pipette
-    inputs:
-      artifact: x64-windows-pipette
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette
-  - bash: |
-      set -e
-      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
-      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
-
-      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey"
-      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
-    displayName: Set flowey path
-  - bash: |
-      set -e
       echo '"debug"' | $FLOWEY_BIN v 17 'FLOWEY_LOG' update
       echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 17 '_internal_WORKING_DIR' --is-raw-string update
 
@@ -4208,16 +4469,18 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 17 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-vmm-tests-archive" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 17 'artifact_use_from_x64-tmks' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-    displayName: ensure hypervisor device is accessible
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
-    displayName: ensure 2 MiB hugetlb pages are available
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 0
@@ -4265,20 +4528,22 @@ jobs:
       $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 2
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 7
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 6
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 1
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 9
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 8
     displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+    displayName: resolve OpenHCL igvm artifact
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -4318,50 +4583,56 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::init_vmm_tests_env 0
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
     displayName: setting up vmm_tests env
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::install_vmm_tests_deps 0
-    displayName: install vmm tests deps (linux)
+    displayName: install vmm tests deps (windows)
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+    displayName: starting test_igvm_agent_rpc_server
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+    displayName: run 'vmm_tests' nextest tests
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 17 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 0
       $FLOWEY_BIN v 17 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
       $FLOWEY_BIN v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'vmm_tests' nextest tests
+    displayName: stopping test_igvm_agent_rpc_server
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar1)
-      testRunTitle: x64-linux-amd-kvm-vmm-tests
-    displayName: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      testRunTitle: x64-windows-intel-mi-secure-vmm-tests
+    displayName: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 2
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
 - job: job16
-  displayName: run vmm-tests [x64-windows-amd]
+  displayName: run vmm-tests [x64-windows-intel]
   pool:
     demands:
     - ImageOverride -equals win-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
   - job11
@@ -4613,8 +4884,8 @@ jobs:
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar1)
-      testRunTitle: x64-windows-amd-vmm-tests
-    displayName: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      testRunTitle: x64-windows-intel-vmm-tests
+    displayName: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
@@ -4626,277 +4897,6 @@ jobs:
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::cache 7
-    displayName: 'validate cache entry: gh-release-download'
-- job: job15
-  displayName: run vmm-tests [x64-windows-intel]
-  pool:
-    demands:
-    - ImageOverride -equals win-amd64
-    name: openvmm-ado-intel-centralus
-  dependsOn:
-  - job0
-  - job11
-  - job2
-  - job3
-  - job7
-  condition: and(succeeded(), not(canceled()))
-  variables:
-  - name: FLOWEY_TEMP_DIR
-    value: $(Build.StagingDirectory)/.flowey-internal
-  steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼🥾 Download bootstrapped flowey
-    inputs:
-      artifact: _internal-flowey-bootstrap-x86_64-windows-uid-3
-      path: $(FLOWEY_TEMP_DIR)/bootstrapped-flowey
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-guest_test_uefi
-    inputs:
-      artifact: x64-guest_test_uefi
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-musl-pipette
-    inputs:
-      artifact: x64-linux-musl-pipette
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-musl-tmk_vmm
-    inputs:
-      artifact: x64-linux-musl-tmk_vmm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-linux-tpm_guest_tests
-    inputs:
-      artifact: x64-linux-tpm_guest_tests
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-openhcl-igvm
-    inputs:
-      artifact: x64-openhcl-igvm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-tmks
-    inputs:
-      artifact: x64-tmks
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-openvmm
-    inputs:
-      artifact: x64-windows-openvmm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-pipette
-    inputs:
-      artifact: x64-windows-pipette
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-prep_steps
-    inputs:
-      artifact: x64-windows-prep_steps
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-test_igvm_agent_rpc_server
-    inputs:
-      artifact: x64-windows-test_igvm_agent_rpc_server
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-tmk_vmm
-    inputs:
-      artifact: x64-windows-tmk_vmm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-tpm_guest_tests
-    inputs:
-      artifact: x64-windows-tpm_guest_tests
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-vmgstool
-    inputs:
-      artifact: x64-windows-vmgstool
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-windows-vmm-tests-archive
-    inputs:
-      artifact: x64-windows-vmm-tests-archive
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive
-  - bash: |
-      set -e
-      AgentTempDirNormal="$(FLOWEY_TEMP_DIR)"
-      AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-      echo "##vso[task.setvariable variable=AgentTempDirNormal;]$AgentTempDirNormal"
-
-      chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
-      FLOWEY_BIN="$AgentTempDirNormal/bootstrapped-flowey/flowey.exe"
-      echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
-    displayName: Set flowey path
-  - bash: |
-      set -e
-      echo '"debug"' | $FLOWEY_BIN v 15 'FLOWEY_LOG' update
-      echo "$(FLOWEY_TEMP_DIR)/work" | $FLOWEY_BIN v 15 '_internal_WORKING_DIR' --is-raw-string update
-
-      cat <<'EOF' | tr '[:upper:]' '[:lower:]' | $FLOWEY_BIN v 15 'verbose' update
-      ${{ parameters.verbose }}
-      EOF
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-guest_test_uefi" | $FLOWEY_BIN v 15 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-pipette" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 15 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 15 'artifact_use_from_x64-tmks' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-prep_steps" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-test_igvm_agent_rpc_server" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tmk_vmm" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-tpm_guest_tests" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmgstool" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-vmm-tests-archive" | $FLOWEY_BIN v 15 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-    displayName: 🌼🛫 Initialize job
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 0
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 1
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 3
-    displayName: create cargo-nextest cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar4)
-      path: $(floweyvar3)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: cargo-nextest'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 2
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_cargo_nextest 4
-    displayName: downloading cargo-nextest
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar2)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 6
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 9
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 10
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 8
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-    displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-    displayName: resolve OpenHCL igvm artifact
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar6)
-      path: $(floweyvar5)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 15 flowey_lib_common::cache 6
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::download_azcopy 0
-    displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-    displayName: calculating required VMM tests disk images
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-    displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (x64)
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_vmm_tests_env 0
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 15 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-    displayName: setting up vmm_tests env
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-    displayName: generate nextest command
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::install_vmm_tests_deps 0
-    displayName: install vmm tests deps (windows)
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-    displayName: starting test_igvm_agent_rpc_server
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-    displayName: run 'vmm_tests' nextest tests
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: stopping test_igvm_agent_rpc_server
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar1)
-      testRunTitle: x64-windows-intel-vmm-tests
-    displayName: 'publish test results: x64-windows-intel-vmm-tests (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-    displayName: report test results to overall pipeline status
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 3
-    displayName: 'validate cache entry: cargo-nextest'
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::cache 7
     displayName: 'validate cache entry: gh-release-download'
 - job: job1
   displayName: xtask fmt (windows)

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -923,11 +923,23 @@ impl IntoPipeline for CheckinGatesCli {
             all_jobs.push(job.finish());
         }
 
+        let mut use_openhcl_igvm_files_mi_secure_x86 = None;
+
         // emit openhcl build job
-        for arch in [CommonArch::Aarch64, CommonArch::X86_64] {
+        for (arch, mi_secure) in [
+            (CommonArch::Aarch64, false),
+            (CommonArch::X86_64, false),
+            (CommonArch::X86_64, true),
+        ] {
             let arch_tag = match arch {
                 CommonArch::X86_64 => "x64",
                 CommonArch::Aarch64 => "aarch64",
+            };
+
+            let tag = if mi_secure {
+                format!("{arch_tag}-mi-secure")
+            } else {
+                arch_tag.to_string()
             };
 
             let openvmm_hcl_profile = if release {
@@ -937,51 +949,65 @@ impl IntoPipeline for CheckinGatesCli {
             };
 
             let (pub_openhcl_igvm, use_openhcl_igvm) =
-                pipeline.new_artifact(format!("{arch_tag}-openhcl-igvm"));
+                pipeline.new_artifact(format!("{tag}-openhcl-igvm"));
             let (pub_openhcl_igvm_extras, _use_openhcl_igvm_extras) =
-                pipeline.new_artifact(format!("{arch_tag}-openhcl-igvm-extras"));
+                pipeline.new_artifact(format!("{tag}-openhcl-igvm-extras"));
 
             let (pub_openhcl_baseline, _use_openhcl_baseline) =
-                if matches!(config, PipelineConfig::Ci) {
-                    let (p, u) = pipeline.new_artifact(format!("{arch_tag}-openhcl-baseline"));
+                if matches!(config, PipelineConfig::Ci) && !mi_secure {
+                    let (p, u) = pipeline.new_artifact(format!("{tag}-openhcl-baseline"));
                     (Some(p), Some(u))
                 } else {
                     (None, None)
                 };
 
             // skim off interesting artifacts required by the VMM tests job
-            match arch {
-                CommonArch::X86_64 => {
-                    vmm_tests_artifacts_windows_x86.use_openhcl_igvm_files =
-                        Some(use_openhcl_igvm.clone());
+            match (arch, mi_secure) {
+                (CommonArch::X86_64, false) => {
+                    vmm_tests_artifacts_windows_x86.use_openhcl_igvm_files = Some(use_openhcl_igvm);
                 }
-                CommonArch::Aarch64 => {
+                (CommonArch::X86_64, true) => {
+                    use_openhcl_igvm_files_mi_secure_x86 = Some(use_openhcl_igvm)
+                }
+                (CommonArch::Aarch64, false) => {
                     vmm_tests_artifacts_windows_aarch64.use_openhcl_igvm_files =
-                        Some(use_openhcl_igvm.clone());
+                        Some(use_openhcl_igvm);
                 }
+                _ => unreachable!(),
             }
-            let igvm_recipes = match arch {
-                CommonArch::X86_64 => vec![
+            let igvm_recipes = match (arch, mi_secure) {
+                (CommonArch::X86_64, false) => vec![
                     OpenhclIgvmRecipe::X64,
                     OpenhclIgvmRecipe::X64Devkern,
                     OpenhclIgvmRecipe::X64TestLinuxDirect,
                     OpenhclIgvmRecipe::X64TestLinuxDirectDevkern,
                     OpenhclIgvmRecipe::X64Cvm,
                 ],
-                CommonArch::Aarch64 => {
+                (CommonArch::X86_64, true) => vec![
+                    OpenhclIgvmRecipe::X64,
+                    OpenhclIgvmRecipe::X64TestLinuxDirect,
+                    OpenhclIgvmRecipe::X64Cvm,
+                ],
+                (CommonArch::Aarch64, false) => {
                     vec![
                         OpenhclIgvmRecipe::Aarch64,
                         OpenhclIgvmRecipe::Aarch64Devkern,
                     ]
                 }
+                _ => unreachable!(),
             };
 
-            let build_openhcl_job_tag = |arch_tag| format!("build openhcl [{arch_tag}-linux]");
+            let build_openhcl_job_tag = |arch_tag, mi_secure| {
+                format!(
+                    "build openhcl {}[{arch_tag}-linux]",
+                    if mi_secure { "(mi-secure) " } else { "" }
+                )
+            };
             let job = pipeline
                 .new_job(
                     FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                     FlowArch::X86_64,
-                    build_openhcl_job_tag(arch_tag),
+                    build_openhcl_job_tag(arch_tag, mi_secure),
                 )
                 .gh_set_pool(gh_pools::default_linux())
                 .ado_set_pool(ado_pools::default_linux())
@@ -999,8 +1025,15 @@ impl IntoPipeline for CheckinGatesCli {
                                 custom_target: Some(CommonTriple::Custom(openhcl_musl_target(
                                     arch,
                                 ))),
-                                extra_features: BTreeSet::new(),
-                                release_cfg: release,
+                                extra_features: if mi_secure {
+                                    [OpenvmmHclFeature::MiSecure].into()
+                                } else {
+                                    BTreeSet::new()
+                                },
+                                // mi secure uses release_cfg=false to select dev manifests (with larger
+                                // VTL2 memory) since mi-secure adds overhead that may not fit in
+                                // the tighter release memory budget.
+                                release_cfg: release && !mi_secure,
                             })
                             .collect(),
                         artifact_dir_openhcl_igvm: ctx.publish_artifact(pub_openhcl_igvm),
@@ -1016,6 +1049,7 @@ impl IntoPipeline for CheckinGatesCli {
             // TODO: Once we have a few runs of the openvmm-mirror PR pipeline, this job can be re-worked to use ADO artifacts instead of GH artifacts.
             if matches!(config, PipelineConfig::Pr)
                 && !matches!(backend_hint, PipelineBackendHint::Ado)
+                && !mi_secure
             {
                 let job = pipeline
                     .new_job(
@@ -1032,7 +1066,7 @@ impl IntoPipeline for CheckinGatesCli {
                             },
                             done,
                             pipeline_name: "openvmm-ci.yaml".into(),
-                            job_name: build_openhcl_job_tag(arch_tag),
+                            job_name: build_openhcl_job_tag(arch_tag, mi_secure),
                         }
                     });
                 all_jobs.push(job.finish());
@@ -1232,6 +1266,17 @@ impl IntoPipeline for CheckinGatesCli {
             .map_err(|missing| {
                 anyhow::anyhow!("missing required windows-intel vmm_tests artifact: {missing}")
             })?;
+        let vmm_tests_artifacts_windows_intel_mi_secure_x86 = {
+            let mut builder = vmm_tests_artifacts_windows_x86.clone();
+            builder.use_openhcl_igvm_files = use_openhcl_igvm_files_mi_secure_x86;
+            builder
+        }
+        .finish()
+        .map_err(|missing| {
+            anyhow::anyhow!(
+                "missing required windows-intel-mi-secure vmm_tests artifact: {missing}"
+            )
+        })?;
         let vmm_tests_artifacts_windows_intel_tdx_x86 = vmm_tests_artifacts_windows_x86
             .clone()
             .finish()
@@ -1386,6 +1431,20 @@ impl IntoPipeline for CheckinGatesCli {
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_x86,
                 nextest_filter_expr: standard_filter.clone(),
+                test_artifacts: standard_x64_test_artifacts.clone(),
+                needs_prep_run: false,
+                hugetlb_2mb_overcommit_pages: None,
+            },
+            VmmTestJobParams {
+                platform: FlowPlatform::Windows,
+                arch: FlowArch::X86_64,
+                gh_pool: gh_pools::windows_intel_1es(),
+                ado_pool: Some(ado_pools::windows_intel_1es()),
+                label: "x64-windows-intel-mi-secure",
+                target: CommonTriple::X86_64_WINDOWS_MSVC,
+                resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_mi_secure_x86,
+                nextest_filter_expr: "test(openhcl) & !test(servicing) & !test(cvm) & !test(memory_validation) & !test(very_heavy) & !test(hyperv_openhcl_pcat) & !test(prepped_vbs) & !test(256mb)"
+                    .to_string(),
                 test_artifacts: standard_x64_test_artifacts.clone(),
                 needs_prep_run: false,
                 hugetlb_2mb_overcommit_pages: None,
@@ -1555,128 +1614,7 @@ impl IntoPipeline for CheckinGatesCli {
             }
         }
 
-        // Emit a mi-secure build + test gate.
-        //
-        // This builds the X64 OpenHCL recipes with mimalloc secure mode
-        // enabled, then runs a subset of basic OpenHCL tests against them.
-        // Reuses the existing x64 pipette and tmk_vmm from the main build.
-        //
-        // Uses release_cfg=false to select dev manifests (with larger
-        // VTL2 memory) since mi-secure adds overhead that may not fit in
-        // the tighter release memory budget.
-        {
-            let mi_secure_profile = if release {
-                OpenvmmHclBuildProfile::OpenvmmHclShip
-            } else {
-                OpenvmmHclBuildProfile::Debug
-            };
-
-            let mi_secure_extra_features: BTreeSet<_> = [OpenvmmHclFeature::MiSecure].into();
-
-            let (pub_mi_secure_igvm, use_mi_secure_igvm) =
-                pipeline.new_artifact("x64-mi-secure-openhcl-igvm");
-            let (pub_mi_secure_igvm_extras, _use_mi_secure_igvm_extras) =
-                pipeline.new_artifact("x64-mi-secure-openhcl-igvm-extras");
-
-            let mi_secure_build_job = pipeline
-                .new_job(
-                    FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
-                    FlowArch::X86_64,
-                    "build openhcl (mi-secure) [x64-linux]",
-                )
-                .gh_set_pool(gh_pools::default_linux())
-                .ado_set_pool(ado_pools::default_linux())
-                .dep_on(|ctx| {
-                    flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe::Params {
-                        igvm_files: [
-                            OpenhclIgvmRecipe::X64,
-                            OpenhclIgvmRecipe::X64TestLinuxDirect,
-                            OpenhclIgvmRecipe::X64Cvm,
-                        ]
-                        .into_iter()
-                        .map(|recipe| OpenhclIgvmBuildParams {
-                            profile: mi_secure_profile,
-                            recipe,
-                            custom_target: Some(CommonTriple::Custom(openhcl_musl_target(
-                                CommonArch::X86_64,
-                            ))),
-                            extra_features: mi_secure_extra_features.clone(),
-                            release_cfg: false,
-                        })
-                        .collect(),
-                        artifact_dir_openhcl_igvm: ctx.publish_artifact(pub_mi_secure_igvm),
-                        artifact_dir_openhcl_igvm_extras: ctx
-                            .publish_artifact(pub_mi_secure_igvm_extras),
-                        artifact_openhcl_verify_size_baseline: None,
-                        done: ctx.new_done_handle(),
-                    }
-                });
-
-            all_jobs.push(mi_secure_build_job.finish());
-
-            // Clone the main Windows x86 builder — it already has the existing
-            // x64 pipette_linux_musl and tmk_vmm from the main OpenHCL build.
-            // Only override the IGVM files with the mi-secure variant.
-            let mut mi_secure_vmm_tests_builder = vmm_tests_artifacts_windows_x86;
-            mi_secure_vmm_tests_builder.use_openhcl_igvm_files = Some(use_mi_secure_igvm);
-            let mi_secure_vmm_tests_artifacts =
-                mi_secure_vmm_tests_builder.finish().map_err(|missing| {
-                    anyhow::anyhow!("missing required mi-secure vmm_tests artifact: {missing}")
-                })?;
-
-            let mi_secure_nextest_filter =
-                "test(openhcl) & !test(servicing) & !test(cvm) & !test(memory_validation) & !test(very_heavy) & !test(hyperv_openhcl_pcat) & !test(prepped_vbs) & !test(256mb)"
-                    .to_string();
-
-            let mi_secure_test_artifacts = standard_x64_test_artifacts;
-
-            let mi_secure_test_label = "x64-windows-intel-mi-secure-vmm-tests".to_string();
-            let pub_mi_secure_test_results = if matches!(backend_hint, PipelineBackendHint::Local) {
-                Some(pipeline.new_artifact(&mi_secure_test_label).0)
-            } else {
-                None
-            };
-
-            let mut mi_secure_test_job = pipeline
-                .new_job(
-                    FlowPlatform::Windows,
-                    FlowArch::X86_64,
-                    "run vmm-tests [x64-windows-intel-mi-secure]",
-                )
-                .gh_set_pool(gh_pools::windows_intel_1es())
-                .ado_set_pool(ado_pools::windows_intel_1es())
-                .dep_on(|ctx| {
-                    flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive::Params {
-                        junit_test_label: mi_secure_test_label,
-                        nextest_vmm_tests_archive: ctx
-                            .use_typed_artifact(&use_vmm_tests_archive_windows_x86),
-                        target: CommonTriple::X86_64_WINDOWS_MSVC.as_triple(),
-                        nextest_profile:
-                            flowey_lib_hvlite::run_cargo_nextest_run::NextestProfile::Ci,
-                        nextest_filter_expr: Some(mi_secure_nextest_filter),
-                        dep_artifact_dirs: mi_secure_vmm_tests_artifacts(ctx),
-                        test_artifacts: mi_secure_test_artifacts,
-                        fail_job_on_test_fail: true,
-                        artifact_dir: pub_mi_secure_test_results.map(|x| ctx.publish_artifact(x)),
-                        needs_prep_run: false,
-                        hugetlb_2mb_overcommit_pages: None,
-                        done: ctx.new_done_handle(),
-                    }
-                });
-
-            if let Some(vmm_tests_disk_cache_dir) = vmm_tests_disk_cache_dir.clone() {
-                mi_secure_test_job = mi_secure_test_job.config(
-                    flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts::Config {
-                        custom_cache_dir: Some(vmm_tests_disk_cache_dir),
-                        ..Default::default()
-                    },
-                );
-            }
-
-            all_jobs.push(mi_secure_test_job.finish());
-        }
-
-        // ── Wire phase 2: all jobs depend on the quick-check gate ──────────
+        // all jobs depend on the quick-check gate
         if let Some(ref quick_check) = quick_check_job {
             for job in all_jobs.iter() {
                 pipeline.non_artifact_dep(job, quick_check);


### PR DESCRIPTION
Building and testing openhcl with mi_secure mode was separate from the rest of the build and test code, increasing maintenance overhead. Integrate mi_secure variants into the existing loops to avoid drift in the flowey code.