### PR TITLE
WIP CI: Use modern pwsh.exe instead of legacy powershell.exe

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1053,7 +1053,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -2112,7 +2112,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=win-arm64
+    - 1ES.ImageOverride=win-arm64-pwsh-test
     - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3147,7 +3147,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3683,7 +3683,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3865,7 +3865,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -5698,7 +5698,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6481,7 +6481,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6696,7 +6696,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6998,7 +6998,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7217,7 +7217,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -972,7 +972,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1917,7 +1917,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=win-arm64
+    - 1ES.ImageOverride=win-arm64-pwsh-test
     - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -2958,7 +2958,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3496,7 +3496,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3680,7 +3680,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -5434,7 +5434,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6034,7 +6034,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6251,7 +6251,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6555,7 +6555,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6776,7 +6776,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1363,7 +1363,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -2308,7 +2308,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=win-arm64
+    - 1ES.ImageOverride=win-arm64-pwsh-test
     - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3349,7 +3349,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3533,7 +3533,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4071,7 +4071,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -5825,7 +5825,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job29-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6492,7 +6492,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6709,7 +6709,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7013,7 +7013,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7234,7 +7234,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-pwsh-test
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -1078,7 +1078,7 @@ jobs:
   displayName: clippy [x64-windows], unit tests [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-pwsh-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -2447,7 +2447,7 @@ jobs:
   displayName: build artifacts (for VMM tests) [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-pwsh-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -2726,7 +2726,7 @@ jobs:
   displayName: build artifacts (not for VMM tests) [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-pwsh-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -2927,7 +2927,7 @@ jobs:
   displayName: build artifacts (for VMM tests) [aarch64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-pwsh-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -3201,7 +3201,7 @@ jobs:
   displayName: build artifacts (not for VMM tests) [aarch64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-pwsh-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -3689,7 +3689,7 @@ jobs:
   displayName: build artifacts (shared VMM tests) [windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-pwsh-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -3859,7 +3859,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-intel-mi-secure]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-pwsh-test
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -4360,7 +4360,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-amd]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-pwsh-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -4631,7 +4631,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-intel]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-pwsh-test
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -4902,7 +4902,7 @@ jobs:
   displayName: xtask fmt (windows)
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-pwsh-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -9,8 +9,8 @@ pub const AMD_POOL_1ES: &str = "openvmm-gh-amd-westus3";
 pub const INTEL_POOL_1ES: &str = "openvmm-gh-intel-westus3";
 pub const ARM_POOL_1ES: &str = "openvmm-gh-arm-westus2";
 
-pub const WINDOWS_IMAGE_AMD64: &str = "win-amd64";
-pub const WINDOWS_IMAGE_ARM64: &str = "win-arm64";
+pub const WINDOWS_IMAGE_AMD64: &str = "win-amd64-pwsh-test";
+pub const WINDOWS_IMAGE_ARM64: &str = "win-arm64-pwsh-test";
 pub const LINUX_IMAGE_AMD64: &str = "ubuntu2404-amd64";
 pub const LINUX_IMAGE_ARM64: &str = "ubuntu2404-arm64";
 pub const MSHV_IMAGE_AMD64: &str = "azurelinux3-amd64-dom0";

--- a/support/powershell_builder/src/lib.rs
+++ b/support/powershell_builder/src/lib.rs
@@ -21,7 +21,7 @@ pub struct PowerShellBuilder(Command);
 impl PowerShellBuilder {
     /// Create a new PowerShell command
     pub fn new() -> Self {
-        PowerShellCmdletBuilder(Command::new("powershell.exe"))
+        PowerShellCmdletBuilder(Command::new("pwsh.exe"))
             .flag("NoProfile")
             .finish()
     }


### PR DESCRIPTION
## Problem

Petri-based VMM tests intermittently fail on Windows CI runners with `powershell.exe` crashing during session initialization:

```
exit code: 0xDEAD
System.AccessViolationException ... at EventLogLogProvider.LogProviderLifecycleEvent
```

## Approach

Switch to Powershell 7, which does not use the same logging pipeline, and so will not hit this error.

Alternative to https://github.com/microsoft/openvmm/pull/3457