### PR TITLE
crypto: Clean up aes-kwp

### DIFF
--- a/openhcl/underhill_attestation/src/key_protector.rs
+++ b/openhcl/underhill_attestation/src/key_protector.rs
@@ -50,15 +50,15 @@ pub(crate) enum GetKeysFromKeyProtectorError {
     #[error("failed to unwrap the ingress DEK entry with RSA-OAEP in KeyProtector")]
     IngressDekRsaUnwrap(#[source] crypto::rsa::RsaError),
     #[error("failed to unwrap the ingress DEK entry with AES-WRAP-WITH-PADDING in KeyProtector")]
-    IngressDekAesUnwrap(#[source] crypto::aes_key_wrap::AesKeyWrapError),
+    IngressDekAesUnwrap(#[source] crypto::aes_kwp::AesKeyWrapError),
     #[error("failed to unwrap the egress DEK entry with RSA-OAEP in KeyProtector")]
     EgressDekRsaUnwrap(#[source] crypto::rsa::RsaError),
     #[error("failed to unwrap the egress DEK entry with AES-WRAP-WITH-PADDING in KeyProtector")]
-    EgressDekAesUnwrap(#[source] crypto::aes_key_wrap::AesKeyWrapError),
+    EgressDekAesUnwrap(#[source] crypto::aes_kwp::AesKeyWrapError),
     #[error("failed to wrap the egress key with RSA-OAEP")]
     EgressKeyRsaWrap(#[source] crypto::rsa::RsaError),
     #[error("failed to wrap the egress key with AES-WRAP-WITH-PADDING")]
-    EgressKeyAesWrap(#[source] crypto::aes_key_wrap::AesKeyWrapError),
+    EgressKeyAesWrap(#[source] crypto::aes_kwp::AesKeyWrapError),
 }
 
 /// AES-Wrapped AES key size (32-byte with 8-byte padding)
@@ -163,13 +163,12 @@ impl KeyProtectorExt for KeyProtector {
 
                     // The DEK buffer should contain an AES-wrapped key.
                     let dek_buffer = &self.dek[ingress_idx].dek_buffer;
-                    let aes_unwrapped_key =
-                        crypto::aes_key_wrap::AesKeyWrap::new(&rsa_unwrapped_key)
-                            .and_then(|kw| {
-                                kw.unwrapper()?
-                                    .unwrap(&dek_buffer[..AES_WRAPPED_AES_KEY_LENGTH])
-                            })
-                            .map_err(GetKeysFromKeyProtectorError::IngressDekAesUnwrap)?;
+                    let aes_unwrapped_key = crypto::aes_kwp::AesKeyWrap::new(&rsa_unwrapped_key)
+                        .and_then(|kw| {
+                            kw.unwrapper()?
+                                .unwrap(&dek_buffer[..AES_WRAPPED_AES_KEY_LENGTH])
+                        })
+                        .map_err(GetKeysFromKeyProtectorError::IngressDekAesUnwrap)?;
 
                     if aes_unwrapped_key.len() != AES_GCM_KEY_LENGTH {
                         Err(GetKeysFromKeyProtectorError::InvalidAesUnwrapOutputSize {
@@ -208,7 +207,7 @@ impl KeyProtectorExt for KeyProtector {
             let dek_buffer = self.dek[egress_idx].dek_buffer;
             let old_egress_key = if let Some(unwrapping_key) = &des_key {
                 // The DEK buffer should contain an AES-wrapped key.
-                crypto::aes_key_wrap::AesKeyWrap::new(unwrapping_key)
+                crypto::aes_kwp::AesKeyWrap::new(unwrapping_key)
                     .and_then(|kw| {
                         kw.unwrapper()?
                             .unwrap(&dek_buffer[..AES_WRAPPED_AES_KEY_LENGTH])
@@ -235,7 +234,7 @@ impl KeyProtectorExt for KeyProtector {
 
         let new_egress_key = if let Some(wrapping_key) = des_key {
             // Create an AES wrapped key
-            crypto::aes_key_wrap::AesKeyWrap::new(&wrapping_key)
+            crypto::aes_kwp::AesKeyWrap::new(&wrapping_key)
                 .and_then(|kw| kw.wrapper()?.wrap(&encrypt_egress_key))
                 .map_err(GetKeysFromKeyProtectorError::EgressKeyAesWrap)?
         } else {
@@ -396,8 +395,7 @@ mod tests {
 
         // Test DEK wrapped by the test DES key (AES-256)
         let des = generate_aes_256();
-        let result =
-            crypto::aes_key_wrap::AesKeyWrap::new(&des).and_then(|kw| kw.wrapper()?.wrap(&dek));
+        let result = crypto::aes_kwp::AesKeyWrap::new(&des).and_then(|kw| kw.wrapper()?.wrap(&dek));
         assert!(result.is_ok());
         let aes_wrapped_dek = result.unwrap();
 
@@ -461,7 +459,7 @@ mod tests {
         assert!(result.is_ok());
         let des_key = result.unwrap();
 
-        let result = crypto::aes_key_wrap::AesKeyWrap::new(&des_key).and_then(|kw| {
+        let result = crypto::aes_kwp::AesKeyWrap::new(&des_key).and_then(|kw| {
             kw.unwrapper()?
                 .unwrap(&key_protector.dek[egress_index].dek_buffer[..AES_WRAPPED_AES_KEY_LENGTH])
         });
@@ -503,7 +501,7 @@ mod tests {
         assert!(result.is_ok());
         let des_key = result.unwrap();
 
-        let result = crypto::aes_key_wrap::AesKeyWrap::new(&des_key).and_then(|kw| {
+        let result = crypto::aes_kwp::AesKeyWrap::new(&des_key).and_then(|kw| {
             kw.unwrapper()?
                 .unwrap(&key_protector.dek[egress_index].dek_buffer[..AES_WRAPPED_AES_KEY_LENGTH])
         });
@@ -522,8 +520,7 @@ mod tests {
 
         // Test DEK wrapped by the test DES key (AES-256)
         let des = generate_aes_256();
-        let result =
-            crypto::aes_key_wrap::AesKeyWrap::new(&des).and_then(|kw| kw.wrapper()?.wrap(&dek));
+        let result = crypto::aes_kwp::AesKeyWrap::new(&des).and_then(|kw| kw.wrapper()?.wrap(&dek));
         assert!(result.is_ok());
         let mut aes_wrapped_dek = result.unwrap();
 

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -66,7 +66,7 @@ pub(crate) enum Pkcs11RsaAesKeyUnwrapError {
     #[error("RSA unwrap failed")]
     RsaUnwrap(#[source] crypto::rsa::RsaError),
     #[error("AES unwrap failed")]
-    AesUnwrap(#[source] crypto::aes_key_wrap::AesKeyWrapError),
+    AesUnwrap(#[source] crypto::aes_kwp::AesKeyWrapError),
     #[error("failed to parse PKCS#8 DER as RSA key")]
     ParsePkcs8Der(#[source] crypto::rsa::RsaError),
 }
@@ -94,7 +94,7 @@ fn pkcs11_rsa_aes_key_unwrap(
     let unwrapped_aes_key = unwrapping_rsa_key
         .oaep_decrypt(wrapped_aes_key, HashAlgorithm::Sha1)
         .map_err(Pkcs11RsaAesKeyUnwrapError::RsaUnwrap)?;
-    let unwrapped_rsa_key = crypto::aes_key_wrap::AesKeyWrap::new(&unwrapped_aes_key)
+    let unwrapped_rsa_key = crypto::aes_kwp::AesKeyWrap::new(&unwrapped_aes_key)
         .and_then(|kw| kw.unwrapper()?.unwrap(wrapped_rsa_key))
         .map_err(Pkcs11RsaAesKeyUnwrapError::AesUnwrap)?;
     let unwrapped_rsa_key = RsaKeyPair::from_pkcs8_der(&unwrapped_rsa_key)
@@ -421,7 +421,7 @@ mod tests {
         let wrapped_aes_key = wrapping_rsa_key
             .oaep_encrypt(&wrapping_aes_key, crypto::rsa::HashAlgorithm::Sha1)
             .unwrap();
-        let wrapped_target_key = crypto::aes_key_wrap::AesKeyWrap::new(&wrapping_aes_key)
+        let wrapped_target_key = crypto::aes_kwp::AesKeyWrap::new(&wrapping_aes_key)
             .unwrap()
             .wrapper()
             .unwrap()

--- a/support/crypto/src/aes_kwp/mod.rs
+++ b/support/crypto/src/aes_kwp/mod.rs
@@ -20,7 +20,7 @@ pub enum AesKeyWrapError {
     InvalidKeySize(usize),
     /// A backend cryptographic error occurred.
     #[error("AES key wrap error")]
-    #[expect(private_interfaces)] // Will go away after refactoring this algo
+    #[expect(private_interfaces)]
     Backend(#[source] super::BackendError),
 }
 

--- a/support/crypto/src/aes_kwp/ossl.rs
+++ b/support/crypto/src/aes_kwp/ossl.rs
@@ -60,29 +60,26 @@ impl AesKeyWrapInner {
 
 impl AesKeyWrapCtxInner<'_> {
     pub fn wrap(&mut self, payload: &[u8]) -> Result<Vec<u8>, AesKeyWrapError> {
-        let padding = 8 - payload.len() % 8;
-        let mut output = vec![0; payload.len() + padding + 16];
-        let count = self
-            .ctx
-            .cipher_update(payload, Some(&mut output))
+        let mut output = Vec::with_capacity(payload.len() + 24);
+        self.ctx
+            .cipher_update_vec(payload, &mut output)
             .map_err(|e| err(e, "wrapping key"))?;
-        // DEVNOTE: Skip the `cipher_final()`, which is effectively a no-op for this operation
-        // according to OpenSSL implementation.
-        output.truncate(count);
+        self.ctx
+            .cipher_final_vec(&mut output)
+            .map_err(|e| err(e, "finalizing key wrap"))?;
         Ok(output)
     }
 }
 
 impl AesKeyUnwrapCtxInner<'_> {
     pub fn unwrap(&mut self, wrapped_payload: &[u8]) -> Result<Vec<u8>, AesKeyWrapError> {
-        let mut output = vec![0; wrapped_payload.len() + 16];
-        let count = self
-            .ctx
-            .cipher_update(wrapped_payload, Some(&mut output))
+        let mut output = Vec::with_capacity(wrapped_payload.len() + 16);
+        self.ctx
+            .cipher_update_vec(wrapped_payload, &mut output)
             .map_err(|e| err(e, "unwrapping key"))?;
-        // DEVNOTE: Skip the `cipher_final()`, which is effectively a no-op for this operation
-        // according to OpenSSL implementation.
-        output.truncate(count);
+        self.ctx
+            .cipher_final_vec(&mut output)
+            .map_err(|e| err(e, "finalizing key unwrap"))?;
         Ok(output)
     }
 }

--- a/support/crypto/src/lib.rs
+++ b/support/crypto/src/lib.rs
@@ -15,7 +15,7 @@
 
 pub mod aes_256_cbc;
 pub mod aes_256_gcm;
-pub mod aes_key_wrap;
+pub mod aes_kwp;
 pub mod hmac_sha_256;
 pub mod kdf;
 pub mod pkcs7;


### PR DESCRIPTION
Symcrypt's PR to expose this algorithm isn't quite ready yet, but we can do a little cleanup to prep for it.