### PR TITLE
consomme: add connection context to trace messages

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/icmp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/icmp.rs
@@ -102,7 +102,10 @@ impl IcmpConnection {
                 }) {
                 Poll::Ready(Ok((n, _))) => {
                     if n < IPV4_HEADER_LEN + ICMPV4_HEADER_LEN {
-                        tracelimit::warn_ratelimited!("dropping malformed ICMP incoming packet");
+                        tracelimit::warn_ratelimited!(
+                            guest_ip = %dst_addr.ip(),
+                            "dropping malformed ICMP incoming packet",
+                        );
                         continue;
                     }
 
@@ -121,7 +124,8 @@ impl IcmpConnection {
                 Poll::Ready(Err(err)) => {
                     tracelimit::error_ratelimited!(
                         error = &err as &dyn std::error::Error,
-                        "recv error"
+                        guest_ip = %dst_addr.ip(),
+                        "icmp recv error"
                     );
                     break;
                 }
@@ -254,7 +258,12 @@ impl<T: Client> Access<'_, T> {
                 let mut socket =
                     match Socket::new(Domain::IPV4, socket_type, Some(Protocol::ICMPV4)) {
                         Err(e) => {
-                            tracelimit::error_ratelimited!("socket creation failed, {}", e);
+                            tracelimit::error_ratelimited!(
+                                error = &e as &dyn std::error::Error,
+                                guest_ip = %addresses.src_addr,
+                                dst_ip = %addresses.dst_addr,
+                                "icmp socket creation failed",
+                            );
                             return Err(DropReason::Io(e));
                         }
                         Ok(s) => s,

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -293,7 +293,12 @@ impl<T: Client> Access<'_, T> {
                                 ) {
                                     Ok(conn) => conn,
                                     Err(err) => {
-                                        tracing::warn!(err = %err, "Failed to create connection from newly accepted socket");
+                                        tracing::warn!(
+                                            error = &err as &dyn std::error::Error,
+                                            src = %ft.src,
+                                            dst = %ft.dst,
+                                            "Failed to create connection from newly accepted socket",
+                                        );
                                         return true;
                                     }
                                 };
@@ -301,7 +306,8 @@ impl<T: Client> Access<'_, T> {
                             }
                             hash_map::Entry::Occupied(_) => {
                                 tracing::warn!(
-                                    address = ?ft.dst,
+                                    src = %ft.src,
+                                    dst = %ft.dst,
                                     "New client request ignored because it was already connected"
                                 );
                             }
@@ -336,7 +342,7 @@ impl<T: Client> Access<'_, T> {
     }
 
     pub(crate) fn refresh_tcp_driver(&mut self) {
-        self.inner.tcp.connections.retain(|_, conn| {
+        self.inner.tcp.connections.retain(|ft, conn| {
             let TcpBackend::Socket(opt_socket) = &mut conn.backend else {
                 // DNS connections have no real socket to refresh.
                 return true;
@@ -353,6 +359,8 @@ impl<T: Client> Access<'_, T> {
                 Err(err) => {
                     tracing::warn!(
                         error = &err as &dyn std::error::Error,
+                        src = %ft.src,
+                        dst = %ft.dst,
                         "failed to update driver for tcp connection"
                     );
                     false
@@ -632,7 +640,7 @@ impl TcpConnection {
             Ok(_) => unreachable!(),
             Err(err) if is_connect_incomplete_error(&err) => (),
             Err(err) => {
-                log_connect_error(&err);
+                log_connect_error(sender.ft, &err);
                 sender.rst(TcpSeqNumber(0), Some(tcp.seq_number + tcp.segment_len()));
                 return Err(DropReason::Io(err));
             }
@@ -640,7 +648,11 @@ impl TcpConnection {
         if let Ok(addr) = socket.get().local_addr() {
             match addr.as_socket() {
                 None => {
-                    tracing::warn!("unable to get local socket address");
+                    tracing::warn!(
+                        src = %sender.ft.src,
+                        dst = %sender.ft.dst,
+                        "unable to get local socket address",
+                    );
                 }
                 Some(addr) => {
                     if addr.ip().is_loopback() {
@@ -855,6 +867,8 @@ impl TcpConnectionInner {
                             ErrorKind::BrokenPipe | ErrorKind::ConnectionReset => {}
                             _ => tracelimit::warn_ratelimited!(
                                 error = &err as &dyn std::error::Error,
+                                src = %sender.ft.src,
+                                dst = %sender.ft.dst,
                                 "socket failure after fin"
                             ),
                         }
@@ -881,10 +895,14 @@ impl TcpConnectionInner {
                             match err.kind() {
                                 ErrorKind::ConnectionReset => tracing::trace!(
                                     error = &err as &dyn std::error::Error,
+                                    src = %sender.ft.src,
+                                    dst = %sender.ft.dst,
                                     "socket read error"
                                 ),
                                 _ => tracelimit::warn_ratelimited!(
                                     error = &err as &dyn std::error::Error,
+                                    src = %sender.ft.src,
+                                    dst = %sender.ft.dst,
                                     "socket read error"
                                 ),
                             }
@@ -913,6 +931,8 @@ impl TcpConnectionInner {
                             _ => {
                                 tracelimit::warn_ratelimited!(
                                     error = &err as &dyn std::error::Error,
+                                    src = %sender.ft.src,
+                                    dst = %sender.ft.dst,
                                     "socket write error"
                                 );
                             }
@@ -927,6 +947,8 @@ impl TcpConnectionInner {
                 if let Err(err) = socket.get().shutdown(Shutdown::Write) {
                     tracelimit::warn_ratelimited!(
                         error = &err as &dyn std::error::Error,
+                        src = %sender.ft.src,
+                        dst = %sender.ft.dst,
                         "shutdown error"
                     );
                     sender.rst(self.tx_send, Some(self.rx_seq));
@@ -958,7 +980,7 @@ impl TcpConnectionInner {
                 "connect timed out",
             );
         } else {
-            log_connect_error(&err);
+            log_connect_error(sender.ft, &err);
             sender.rst(self.tx_send, Some(self.rx_seq));
         }
     }
@@ -1463,20 +1485,32 @@ fn take_socket_error(socket: &PolledSocket<Socket>) -> io::Error {
 ///
 /// Connection refused and network/host unreachable are expected failures logged
 /// at debug level. Everything else is logged at warn.
-fn log_connect_error(err: &io::Error) {
+fn log_connect_error(ft: &FourTuple, err: &io::Error) {
     match err.kind() {
         ErrorKind::ConnectionRefused => {
-            tracing::debug!(error = err as &dyn std::error::Error, "connect refused");
+            tracing::debug!(
+                error = err as &dyn std::error::Error,
+                src = %ft.src,
+                dst = %ft.dst,
+                "connect refused",
+            );
         }
         ErrorKind::NetworkUnreachable | ErrorKind::HostUnreachable => {
             // FUTURE: send ICMP unreachable to guest
             tracing::debug!(
                 error = err as &dyn std::error::Error,
-                "connect failed, unreachable"
+                src = %ft.src,
+                dst = %ft.dst,
+                "connect failed, unreachable",
             );
         }
         _ => {
-            tracelimit::warn_ratelimited!(error = err as &dyn std::error::Error, "connect failed");
+            tracelimit::warn_ratelimited!(
+                error = err as &dyn std::error::Error,
+                src = %ft.src,
+                dst = %ft.dst,
+                "connect failed",
+            );
         }
     }
 }

--- a/vm/devices/net/net_consomme/consomme/src/udp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/udp.rs
@@ -199,7 +199,8 @@ impl UdpConnection {
                 Poll::Ready(Err(err)) => {
                     tracelimit::error_ratelimited!(
                         error = &err as &dyn std::error::Error,
-                        "recv error"
+                        guest = %dst_addr,
+                        "udp recv error"
                     );
                     break false;
                 }
@@ -299,6 +300,8 @@ impl UdpListener {
                 Poll::Ready(Err(err)) => {
                     tracelimit::error_ratelimited!(
                         error = &err as &dyn std::error::Error,
+                        local_addr = %local_addr,
+                        guest_port = self.guest_port,
                         "udp listener recv error"
                     );
                     break;
@@ -318,7 +321,7 @@ impl<T: Client> Access<'_, T> {
             // Check if connection has timed out
             if now.duration_since(conn.last_activity) > timeout {
                 tracing::debug!(
-                    addr = %dst_addr,
+                    guest = %dst_addr,
                     "UDP connection timed out"
                 );
                 return false;
@@ -347,7 +350,7 @@ impl<T: Client> Access<'_, T> {
     }
 
     pub(crate) fn refresh_udp_driver(&mut self) {
-        self.inner.udp.connections.retain(|_, conn| {
+        self.inner.udp.connections.retain(|dst_addr, conn| {
             let socket = conn.socket.take().unwrap().into_inner();
             match PolledSocket::new(self.client.driver(), socket) {
                 Ok(socket) => {
@@ -357,6 +360,7 @@ impl<T: Client> Access<'_, T> {
                 Err(err) => {
                     tracing::warn!(
                         error = &err as &dyn std::error::Error,
+                        guest = %dst_addr,
                         "failed to update driver for udp connection"
                     );
                     false
@@ -372,7 +376,7 @@ impl<T: Client> Access<'_, T> {
                 }
                 Err(err) => {
                     tracing::warn!(
-                        port,
+                        guest_port = port,
                         error = &err as &dyn std::error::Error,
                         "failed to update driver for udp listener"
                     );


### PR DESCRIPTION
Several error and warning log sites in consomme's UDP, TCP, and ICMP paths previously emitted just an error message without identifying which connection was affected, making it hard to interpret messages like "udp recv error". This adds the guest endpoint (and where available, the host destination) to those traces so a reader can immediately tell which NAT mapping or TCP four-tuple the message refers to.