### PR TITLE
CXL emulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,8 +30,10 @@ name = "acpi"
 version = "0.0.0"
 dependencies = [
  "acpi_spec",
+ "cxl_spec",
  "guid",
  "memory_range",
+ "thiserror 2.0.16",
  "x86defs",
  "zerocopy",
 ]
@@ -1164,6 +1166,23 @@ version = "0.0.0"
 dependencies = [
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "cxl_spec"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bitfield-struct 0.11.0",
+ "chipset_device",
+ "inspect",
+ "mesh",
+ "pci_core",
+ "pci_resources",
+ "thiserror 2.0.16",
+ "tracing",
+ "vm_resource",
+ "vmcore",
 ]
 
 [[package]]
@@ -5348,6 +5367,7 @@ dependencies = [
  "chipset_resources",
  "closeable_mutex",
  "crc32fast",
+ "cxl_spec",
  "debug_ptr",
  "disk_backend",
  "fdt",
@@ -5463,6 +5483,7 @@ dependencies = [
  "clap_dyn_complete",
  "console_relay",
  "crypto",
+ "cxl_spec",
  "debug_worker_defs",
  "diag_client",
  "dirs",
@@ -5634,6 +5655,7 @@ dependencies = [
  "chipset",
  "chipset_legacy",
  "chipset_resources",
+ "cxl_spec",
  "debug_worker",
  "disk_blob",
  "disk_blockdevice",
@@ -5989,6 +6011,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "chipset_device",
+ "cxl_spec",
  "inspect",
  "memory_range",
  "mesh",
@@ -9598,6 +9621,7 @@ dependencies = [
  "aarch64defs",
  "build_rs_guest_arch",
  "cfg-if",
+ "cxl_spec",
  "inspect",
  "memory_range",
  "mesh_protobuf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,6 +255,7 @@ hyperv_ic_protocol = { path = "vm/devices/hyperv_ic_protocol" }
 hyperv_ic_resources = { path = "vm/devices/hyperv_ic_resources" }
 hyperv_ic_guest = { path = "vm/devices/hyperv_ic_guest" }
 input_core = { path = "vm/devices/input_core" }
+cxl_spec = { path = "vm/devices/cxl" }
 underhill_config = { path = "vm/devices/get/underhill_config" }
 missing_dev = { path = "vm/devices/missing_dev" }
 missing_dev_resources = { path = "vm/devices/missing_dev_resources" }

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -144,19 +144,45 @@ attached to a root port to appear as PCIe devices in the guest.
 --pcie-root-complex rc0 --pcie-root-port rc0:rp0
 ```
 
+`--pcie-root-complex` accepts optional comma-separated options after the root
+complex name:
+
+```sh
+--pcie-root-complex rc0,segment=0,start_bus=0,end_bus=255
+```
+
+- `segment=<N>`: PCIe segment number for the root complex.
+- `start_bus=<N>` and `end_bus=<N>`: inclusive bus range assigned to that
+  root complex.
+- `low_mmio=<SIZE>` and `high_mmio=<SIZE>`: low/high MMIO window sizes.
+- `hdm=<SIZE>`: CXL HDM decoder MMIO window size (CFMWS window). Default
+  is `1G`.
+- `hdm_window_restrictions=<MASK>`: CFMWS window restrictions bitmask
+  (`u16`, decimal or `0x`-prefixed hex). Default is `0x1`
+  (`DEVICE_COHERENT`, bit 0 set).
+  Defined bits:
+  0: device coherent
+  1: host-only coherent
+  2: volatile
+  3: persistent
+  4: fixed device configuration
+  5: BI
+  Bits 15:6 are reserved and rejected.
+
 ### Root port and switch options
 
 `--pcie-root-port` accepts optional comma-separated options after the port
 name:
 
 ```sh
---pcie-root-port rc0:rp0,hotplug,acs=0x005f
+--pcie-root-port rc0:rp0,hotplug,acs=0x005f,cxl
 ```
 
 - `hotplug`: enables hotplug support for that root port.
 - `acs=<mask>`: sets the Access Control Services capability mask for the
   root port. The value can be decimal or hexadecimal. Default is `0x005f`.
   Use `acs=0` to disable ACS for a root port.
+- `cxl`: marks the root port as CXL-capable.
 
 `--pcie-switch` accepts optional comma-separated options as well:
 
@@ -182,6 +208,16 @@ PCIe root port. The syntax varies slightly between device types:
 --nvme file:/path/to/disk.raw,pcie_port=rp0
 --disk file:/path/to/disk.raw,pcie_port=rp0
 ```
+
+**CXL test endpoint** (comma-separated option): `--cxl-test`
+
+```sh
+--cxl-test mem:1G,pcie_port=rp0
+```
+
+`--cxl-test` creates a CXL Type-3 test endpoint with one component-register
+BAR.
+The `mem:<len>` value sets the emulated HDM size and allocates backing memory.
 
 **NICs** (colon-prefixed): `--net`, `--virtio-net`, `--mana`
 

--- a/openvmm/openvmm_core/Cargo.toml
+++ b/openvmm/openvmm_core/Cargo.toml
@@ -27,6 +27,7 @@ vmgs_resources.workspace = true
 
 aarch64defs.workspace = true
 acpi.workspace = true
+cxl_spec.workspace = true
 floppy_resources.workspace = true
 hvdef.workspace = true
 ide_resources.workspace = true

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -15,6 +15,8 @@ use cfg_if::cfg_if;
 use chipset_device_resources::IRQ_LINE_SET;
 use chipset_resources::LEGACY_CHIPSET_PCI_BUS_NAME;
 use chipset_resources::cmos_rtc_time_source::SystemTimeClockHandle;
+use cxl_spec::pci_registers::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecCapability;
+use cxl_spec::spec::CXL_COMPONENT_REGISTERS_SIZE_BYTES;
 use debug_ptr::DebugPtr;
 use disk_backend::Disk;
 use disk_backend::resolve::ResolveDiskParameters;
@@ -59,6 +61,7 @@ use openvmm_defs::config::LoadMode;
 use openvmm_defs::config::MemoryConfig;
 use openvmm_defs::config::PcieDeviceConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
+use openvmm_defs::config::PcieRootPortConfig;
 use openvmm_defs::config::PcieSwitchConfig;
 use openvmm_defs::config::PmuGsivConfig;
 use openvmm_defs::config::ProcessorTopologyConfig;
@@ -112,8 +115,10 @@ use vm_resource::kind::KeyboardInputHandleKind;
 use vm_resource::kind::MouseInputHandleKind;
 use vm_resource::kind::VirtioDeviceHandle;
 use vm_resource::kind::VmbusDeviceHandleKind;
+use vm_topology::cxl::CfmwsWindowRestrictions;
 use vm_topology::memory::MemoryLayout;
 use vm_topology::pcie::PcieHostBridge;
+use vm_topology::pcie::PcieHostBridgeCxlInfo;
 use vm_topology::processor::ProcessorTopology;
 use vm_topology::processor::TopologyBuilder;
 use vm_topology::processor::aarch64::Aarch64Topology;
@@ -813,6 +818,34 @@ fn convert_vtl2_config(
     Ok(Some(config))
 }
 
+/// Builds root-port PCIe settings from manifest flags.
+///
+/// When CXL is enabled, emit a default Flex Bus capability advertising both
+/// cache and memory support.
+fn build_root_port_settings(rp_cfg: &PcieRootPortConfig) -> PciePortSettings {
+    PciePortSettings {
+        acs_capabilities_supported: rp_cfg
+            .acs_capabilities_supported
+            .unwrap_or(DEFAULT_ACS_CAP_MASK),
+        cxl_flex_bus_port_capability: rp_cfg.cxl.then_some(
+            CxlFlexBusPortDvsecCapability::new()
+                .with_cache_capable(true)
+                .with_mem_capable(true),
+        ),
+    }
+}
+
+/// Converts a manifest root-port entry into the runtime root-port definition.
+fn build_root_port_definition(rp_cfg: PcieRootPortConfig) -> GenericPcieRootPortDefinition {
+    let settings = build_root_port_settings(&rp_cfg);
+
+    GenericPcieRootPortDefinition {
+        name: rp_cfg.name.into(),
+        hotplug: rp_cfg.hotplug,
+        settings,
+    }
+}
+
 impl InitializedVm {
     /// Creates and initializes a VM using the given backend.
     async fn new(
@@ -942,7 +975,6 @@ impl InitializedVm {
             .iter()
             .filter(|(bus, _)| matches!(bus, VirtioBus::Mmio))
             .count();
-
         let resolved_layout = resolve_memory_layout(MemoryLayoutInput {
             mem_size: cfg.memory.mem_size,
             numa_mem_sizes: cfg.memory.numa_mem_sizes.as_deref(),
@@ -1799,6 +1831,44 @@ impl InitializedVm {
                 .into_iter()
                 .zip(resolved_pcie_root_complex_ranges)
             {
+                let cxl_port_count = rc.ports.iter().filter(|rp_cfg| rp_cfg.cxl).count() as u64;
+                let cxl_config = rc.cxl.as_ref();
+
+                // Note that for each CXL enabled root port, they need 64K of MMIO space for the component registers.
+                // We need to ensure that the PCI MMIO range reserved is sufficient for that.
+                if cxl_port_count != 0 {
+                    let required_cxl_component_bar_mmio = cxl_port_count
+                        .checked_mul(CXL_COMPONENT_REGISTERS_SIZE_BYTES)
+                        .context("cxl component register size overflow")?;
+                    if ranges.high_mmio.len() < required_cxl_component_bar_mmio {
+                        anyhow::bail!(
+                            "invalid CXL root complex '{}': high MMIO range {:#x} is too small for {} CXL root-port BAR apertures (requires {:#x})",
+                            rc.name,
+                            ranges.high_mmio.len(),
+                            cxl_port_count,
+                            required_cxl_component_bar_mmio
+                        );
+                    }
+                }
+
+                let hdm_range = (!ranges.hdm_range.is_empty()).then_some(ranges.hdm_range);
+                let chbcr_range = (!ranges.chbcr_range.is_empty()).then_some(ranges.chbcr_range);
+
+                if cxl_port_count != 0 {
+                    if cxl_config.is_none() {
+                        anyhow::bail!(
+                            "invalid CXL root complex '{}': CXL-capable root ports require both CHBCR and HDM ranges",
+                            rc.name
+                        );
+                    }
+                    if hdm_range.is_none() || chbcr_range.is_none() {
+                        anyhow::bail!(
+                            "invalid CXL root complex '{}': configured CXL CHBCR/HDM ranges were not resolved",
+                            rc.name
+                        );
+                    }
+                }
+
                 let device_name = format!("pcie-root:{}", rc.name);
 
                 // Create a static bus range for the root complex so that
@@ -1815,21 +1885,14 @@ impl InitializedVm {
                             let root_port_definitions = rc
                                 .ports
                                 .into_iter()
-                                .map(|rp_cfg| GenericPcieRootPortDefinition {
-                                    name: rp_cfg.name.into(),
-                                    hotplug: rp_cfg.hotplug,
-                                    settings: PciePortSettings {
-                                        acs_capabilities_supported: rp_cfg
-                                            .acs_capabilities_supported
-                                            .unwrap_or(DEFAULT_ACS_CAP_MASK),
-                                    },
-                                })
+                                .map(build_root_port_definition)
                                 .collect();
 
                             GenericPcieRootComplex::new(
                                 &mut services.register_mmio(),
                                 rc.start_bus,
                                 rc.end_bus,
+                                chbcr_range,
                                 ranges.ecam_range,
                                 root_port_definitions,
                                 msi_conn.target(),
@@ -1850,6 +1913,21 @@ impl InitializedVm {
                     }
                 }
 
+                let cxl = cxl_config
+                    .map(|cxl| -> anyhow::Result<PcieHostBridgeCxlInfo> {
+                        Ok(PcieHostBridgeCxlInfo {
+                            chbcr_range: chbcr_range
+                                .context("missing CHBCR range for CXL root complex")?,
+                            hdm_range: hdm_range
+                                .context("missing HDM range for CXL root complex")?,
+                            hdm_window_restrictions: CfmwsWindowRestrictions::try_from_bits(
+                                cxl.hdm_window_restrictions,
+                            )
+                            .context("invalid CFMWS HDM window restrictions")?,
+                        })
+                    })
+                    .transpose()?;
+
                 pcie_host_bridges.push(PcieHostBridge {
                     index: rc.index,
                     segment: rc.segment,
@@ -1858,6 +1936,7 @@ impl InitializedVm {
                     ecam_range: ranges.ecam_range,
                     low_mmio: ranges.low_mmio,
                     high_mmio: ranges.high_mmio,
+                    cxl,
                 });
 
                 pcie_root_complexes.push(root_complex.clone());
@@ -1944,6 +2023,7 @@ impl InitializedVm {
                             acs_capabilities_supported: switch
                                 .acs_capabilities_supported
                                 .unwrap_or(DEFAULT_ACS_CAP_MASK),
+                            cxl_flex_bus_port_capability: None,
                         },
                     };
                     GenericPcieSwitch::new(definition)

--- a/openvmm/openvmm_core/src/worker/memory_layout.rs
+++ b/openvmm/openvmm_core/src/worker/memory_layout.rs
@@ -19,6 +19,8 @@
 use super::vm_loaders::igvm::Vtl2MemoryLayoutRequest;
 use anyhow::Context;
 use anyhow::bail;
+use cxl_spec::spec::CXL_HOST_BRIDGE_COMPONENT_REGISTERS_SIZE_BYTES;
+use cxl_spec::spec::CXL_HPA_ALIGNMENT;
 use memory_range::MemoryRange;
 use openvmm_defs::config::PcieMmioRangeConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
@@ -68,6 +70,8 @@ pub(super) struct ResolvedPcieRootComplexRanges {
     pub ecam_range: MemoryRange,
     pub low_mmio: MemoryRange,
     pub high_mmio: MemoryRange,
+    pub chbcr_range: MemoryRange,
+    pub hdm_range: MemoryRange,
 }
 
 pub(super) struct MemoryLayoutInput<'a> {
@@ -111,6 +115,8 @@ pub(super) fn resolve_memory_layout(
             ecam_range: MemoryRange::EMPTY,
             low_mmio: MemoryRange::EMPTY,
             high_mmio: MemoryRange::EMPTY,
+            chbcr_range: MemoryRange::EMPTY,
+            hdm_range: MemoryRange::EMPTY,
         })
         .collect::<Vec<_>>();
 
@@ -215,6 +221,30 @@ pub(super) fn resolve_memory_layout(
             GB,
             Placement::Mmio64,
         )?;
+
+        if let Some(cxl) = &root_complex.cxl {
+            let hdm_config = PcieMmioRangeConfig::Dynamic { size: cxl.hdm_size };
+            add_mmio_range(
+                &mut builder,
+                format!("pcie-{}-cxl-hdm", root_complex.name),
+                &mut ranges.hdm_range,
+                &hdm_config,
+                CXL_HPA_ALIGNMENT,
+                Placement::Mmio64,
+            )?;
+
+            let chbcr_config = PcieMmioRangeConfig::Dynamic {
+                size: CXL_HOST_BRIDGE_COMPONENT_REGISTERS_SIZE_BYTES,
+            };
+            add_mmio_range(
+                &mut builder,
+                format!("pcie-{}-cxl-chbcr", root_complex.name),
+                &mut ranges.chbcr_range,
+                &chbcr_config,
+                CXL_HOST_BRIDGE_COMPONENT_REGISTERS_SIZE_BYTES,
+                Placement::Mmio64,
+            )?;
+        }
     }
 
     // Virtio-mmio: allocate one contiguous region for all slots. Each slot is
@@ -514,6 +544,7 @@ mod tests {
             low_mmio,
             high_mmio,
             ports: Vec::new(),
+            cxl: None,
         }
     }
 
@@ -625,6 +656,7 @@ mod tests {
                 low_mmio: PcieMmioRangeConfig::Dynamic { size: 32 * MB },
                 high_mmio: PcieMmioRangeConfig::Dynamic { size: GB },
                 ports: Vec::new(),
+                cxl: None,
             },
             PcieRootComplexConfig {
                 index: 1,
@@ -635,6 +667,7 @@ mod tests {
                 low_mmio: PcieMmioRangeConfig::Dynamic { size: 32 * MB },
                 high_mmio: PcieMmioRangeConfig::Dynamic { size: GB },
                 ports: Vec::new(),
+                cxl: None,
             },
         ];
         let mut config = input(2 * GB, None, None);
@@ -669,6 +702,7 @@ mod tests {
             low_mmio: PcieMmioRangeConfig::Dynamic { size: 64 * MB },
             high_mmio: PcieMmioRangeConfig::Dynamic { size: GB },
             ports: Vec::new(),
+            cxl: None,
         }];
         let mut config = input(2 * GB, None, None);
         config.pcie_root_complexes = &root_complexes;

--- a/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
@@ -25,6 +25,8 @@ pub enum Error {
     Loader(#[source] loader::uefi::Error),
     #[error("UEFI requires at least two MMIO ranges")]
     UnsupportedMmio,
+    #[error("failed to build PCIe ACPI tables")]
+    PcieAcpi(#[source] vmm_core::acpi_builder::PcieAcpiBuildError),
     #[cfg(guest_arch = "aarch64")]
     #[error("UEFI boot with GICv2 is not supported")]
     GicV2NotSupported,
@@ -52,7 +54,7 @@ pub fn load_uefi(
     gm: &GuestMemory,
     processor_topology: &ProcessorTopology,
     mem_layout: &MemoryLayout,
-    pcie_host_bridges: &Vec<PcieHostBridge>,
+    pcie_host_bridges: &[PcieHostBridge],
     load_settings: UefiLoadSettings,
     madt: &[u8],
     srat: &[u8],
@@ -179,19 +181,12 @@ pub fn load_uefi(
     }
 
     if !pcie_host_bridges.is_empty() {
-        let mut ssdt = acpi::ssdt::Ssdt::new();
-        for bridge in pcie_host_bridges {
-            ssdt.add_pcie(
-                bridge.index,
-                bridge.segment,
-                bridge.start_bus,
-                bridge.end_bus,
-                bridge.ecam_range,
-                bridge.low_mmio,
-                bridge.high_mmio,
-            );
+        let pcie_tables = vmm_core::acpi_builder::build_pcie_acpi_tables(pcie_host_bridges)
+            .map_err(Error::PcieAcpi)?;
+        cfg.add_raw(config::BlobStructureType::Ssdt, &pcie_tables.ssdt);
+        if let Some(cedt) = pcie_tables.cedt {
+            cfg.add_raw(config::BlobStructureType::AcpiTable, &cedt);
         }
-        cfg.add_raw(config::BlobStructureType::Ssdt, &ssdt.to_bytes());
     }
 
     if !pcie_host_bridges.is_empty() {

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -198,6 +198,14 @@ pub enum PcieMmioRangeConfig {
 }
 
 #[derive(Debug, MeshPayload)]
+pub struct RootComplexCxlConfig {
+    /// HDM window size in bytes for this CXL root complex.
+    pub hdm_size: u64,
+    /// CFMWS HDM window restrictions bitmask.
+    pub hdm_window_restrictions: u16,
+}
+
+#[derive(Debug, MeshPayload)]
 pub struct PcieRootComplexConfig {
     pub index: u32,
     pub name: String,
@@ -207,13 +215,23 @@ pub struct PcieRootComplexConfig {
     pub low_mmio: PcieMmioRangeConfig,
     pub high_mmio: PcieMmioRangeConfig,
     pub ports: Vec<PcieRootPortConfig>,
+    /// Optional CXL configuration for root-complex CXL mode.
+    pub cxl: Option<RootComplexCxlConfig>,
 }
 
 #[derive(Debug, MeshPayload)]
 pub struct PcieRootPortConfig {
+    /// Root-port name used for topology wiring and lookup.
     pub name: String,
+    /// Enables PCIe hotplug capabilities for this root port.
     pub hotplug: bool,
+    /// Optional ACS capability bitmask to expose on this root port.
     pub acs_capabilities_supported: Option<u16>,
+    /// Marks this root port as CXL-capable.
+    ///
+    /// Runtime port construction derives required BAR/subregion layout from
+    /// this flag (currently CXL component registers for BAR0).
+    pub cxl: bool,
 }
 
 #[derive(Debug, MeshPayload)]

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -17,6 +17,7 @@ ttrpc = []
 [dependencies]
 chipset_resources.workspace = true
 chipset_device_worker_defs.workspace = true
+cxl_spec.workspace = true
 debug_worker_defs.workspace = true
 vmotherboard.workspace = true
 diag_client.workspace = true

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -21,6 +21,7 @@
 use anyhow::Context;
 use clap::Parser;
 use clap::ValueEnum;
+use cxl_spec::spec::CfmwsWindowRestrictions;
 use openvmm_defs::config::DEFAULT_PCAT_BOOT_ORDER;
 use openvmm_defs::config::DeviceVtl;
 use openvmm_defs::config::PcatBootDevice;
@@ -271,6 +272,10 @@ options:
 "#)]
     #[clap(long)]
     pub nvme: Vec<DiskCli>,
+
+    /// attach a CXL Type-3 test endpoint on a PCIe root port
+    #[clap(long = "cxl-test", value_name = "mem:<len>,pcie_port=<name>")]
+    pub cxl_test: Vec<CxlTestDeviceCli>,
 
     /// attach a disk via a virtio-blk controller
     #[clap(long_help = r#"
@@ -803,6 +808,9 @@ Examples:
     # Attach root complex rc0 on segment 0 with bus and MMIO ranges
     --pcie-root-complex rc0,segment=0,start_bus=0,end_bus=255,low_mmio=4M,high_mmio=1G
 
+    # Configure HDM window size and restrictions (bitmask)
+    --pcie-root-complex rc1,hdm=2G,hdm_window_restrictions=0x21
+
 Syntax: <name>[,opt=arg,...]
 
 Options:
@@ -811,6 +819,9 @@ Options:
     `end_bus=<value>`              highest valid bus number, default 255
     `low_mmio=<size>`              low MMIO window size, default 64M
     `high_mmio=<size>`             high MMIO window size, default 1G
+    `hdm=<size>`                   HDM decoder MMIO window size (CFMWS window), default 1G
+    `hdm_window_restrictions=<m>`  CFMWS window restriction bitmask (u16, decimal or 0x-prefixed hex),
+                                   default DEVICE_COHERENT (bit 0, value 0x1)
 "#)]
     #[clap(long, conflicts_with("pcat"))]
     pub pcie_root_complex: Vec<PcieRootComplexCli>,
@@ -831,6 +842,7 @@ Syntax: <root_complex_name>:<name>[,opt,opt=arg,...]
 Options:
     `hotplug`                      enable hotplug support for this root port
     `acs=<mask>`                   ACS capability bitmask (u16, decimal or 0x-prefixed hex)
+    `cxl`                          configure this root port as CXL-capable
 "#)]
     #[clap(long, conflicts_with("pcat"))]
     pub pcie_root_port: Vec<PcieRootPortCli>,
@@ -1604,6 +1616,58 @@ impl FromStr for DiskCli {
     }
 }
 
+/// CLI arguments for a CXL Type-3 test endpoint.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CxlTestDeviceCli {
+    /// Size of HDM memory the test device should expose and back.
+    pub hdm_size: u64,
+    /// PCIe root port name where the device is attached.
+    pub pcie_port: String,
+}
+
+impl FromStr for CxlTestDeviceCli {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        let mut opts = s.split(',');
+        let first = opts.next().context("expected CXL test device config")?;
+        let (kind, arg) = first
+            .split_once(':')
+            .context("expected CXL test syntax: mem:<len>")?;
+
+        if kind != "mem" {
+            anyhow::bail!("unsupported CXL test backing kind '{kind}', expected 'mem'");
+        }
+
+        let hdm_size = parse_memory(arg).context("failed to parse CXL test HDM size")?;
+        let mut pcie_port = None;
+
+        for opt in opts {
+            let mut kv = opt.split('=');
+            let key = kv.next().unwrap_or_default();
+            match key {
+                "pcie_port" => {
+                    let val = kv.next();
+                    if val.is_none_or(|v| v.is_empty()) {
+                        anyhow::bail!("`pcie_port` requires a port name");
+                    }
+                    pcie_port = Some(val.unwrap().to_string());
+                }
+                _ => anyhow::bail!("unknown option: '{opt}'"),
+            }
+        }
+
+        let Some(pcie_port) = pcie_port else {
+            anyhow::bail!("`pcie_port=<name>` is required for `--cxl-test`");
+        };
+
+        Ok(Self {
+            hdm_size,
+            pcie_port,
+        })
+    }
+}
+
 // <kind>[,ro,s]
 #[derive(Clone)]
 pub struct IdeDiskCli {
@@ -2174,6 +2238,8 @@ pub struct PcieRootComplexCli {
     pub end_bus: u8,
     pub low_mmio: u32,
     pub high_mmio: u64,
+    pub hdm: u64,
+    pub hdm_window_restrictions: CfmwsWindowRestrictions,
 }
 
 impl FromStr for PcieRootComplexCli {
@@ -2182,6 +2248,9 @@ impl FromStr for PcieRootComplexCli {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         const DEFAULT_PCIE_CRS_LOW_SIZE: u32 = 64 * 1024 * 1024; // 64M
         const DEFAULT_PCIE_CRS_HIGH_SIZE: u64 = 1024 * 1024 * 1024; // 1G
+        const DEFAULT_PCIE_HDM_SIZE: u64 = 1024 * 1024 * 1024; // 1G
+        const DEFAULT_HDM_WINDOW_RESTRICTIONS: CfmwsWindowRestrictions =
+            CfmwsWindowRestrictions::DEVICE_COHERENT;
 
         let mut opts = s.split(',');
         let name = opts.next().context("expected root complex name")?;
@@ -2194,6 +2263,8 @@ impl FromStr for PcieRootComplexCli {
         let mut end_bus = 255;
         let mut low_mmio = DEFAULT_PCIE_CRS_LOW_SIZE;
         let mut high_mmio = DEFAULT_PCIE_CRS_HIGH_SIZE;
+        let mut hdm = DEFAULT_PCIE_HDM_SIZE;
+        let mut hdm_window_restrictions = DEFAULT_HDM_WINDOW_RESTRICTIONS;
         for opt in opts {
             let mut s = opt.split('=');
             let opt = s.next().context("expected option")?;
@@ -2222,6 +2293,18 @@ impl FromStr for PcieRootComplexCli {
                     high_mmio =
                         parse_memory(high_mmio_str).context("failed to parse high MMIO size")?;
                 }
+                "hdm" => {
+                    let hdm_str = s.next().context("expected HDM decoder size")?;
+                    hdm = parse_memory(hdm_str).context("failed to parse HDM decoder size")?;
+                }
+                "hdm_window_restrictions" => {
+                    let mask_str = s
+                        .next()
+                        .context("expected HDM window restrictions bitmask")?;
+                    hdm_window_restrictions =
+                        parse_cxl_cfmws_window_restriction_u16_bitmask(mask_str)
+                            .context("failed to parse HDM window restrictions bitmask")?;
+                }
                 opt => anyhow::bail!("unknown option: '{opt}'"),
             }
         }
@@ -2237,8 +2320,23 @@ impl FromStr for PcieRootComplexCli {
             end_bus,
             low_mmio,
             high_mmio,
+            hdm,
+            hdm_window_restrictions,
         })
     }
+}
+
+fn parse_cxl_cfmws_window_restriction_u16_bitmask(
+    s: &str,
+) -> anyhow::Result<CfmwsWindowRestrictions> {
+    let bits = if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        u16::from_str_radix(hex, 16).context("invalid hex bitmask")?
+    } else {
+        u16::from_str(s).context("invalid decimal bitmask")?
+    };
+
+    CfmwsWindowRestrictions::try_from_bits(bits)
+        .context("bitmask includes reserved CFMWS window restriction bits")
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -2247,6 +2345,7 @@ pub struct PcieRootPortCli {
     pub name: String,
     pub hotplug: bool,
     pub acs_capabilities_supported: Option<u16>,
+    pub cxl: bool,
 }
 
 impl FromStr for PcieRootPortCli {
@@ -2269,6 +2368,7 @@ impl FromStr for PcieRootPortCli {
 
         let mut hotplug = false;
         let mut acs_capabilities_supported = None;
+        let mut cxl = false;
 
         // Parse optional flags
         for opt in opts {
@@ -2290,6 +2390,12 @@ impl FromStr for PcieRootPortCli {
                     }
                     acs_capabilities_supported = Some(parse_acs_capability_mask(value)?);
                 }
+                "cxl" => {
+                    if value.is_some() {
+                        anyhow::bail!("cxl option does not take a value")
+                    }
+                    cxl = true;
+                }
                 _ => anyhow::bail!("unexpected option: '{opt}'"),
             }
         }
@@ -2299,6 +2405,7 @@ impl FromStr for PcieRootPortCli {
             name: rp_name.to_string(),
             hotplug,
             acs_capabilities_supported,
+            cxl,
         })
     }
 }
@@ -3334,6 +3441,20 @@ mod tests {
     }
 
     #[test]
+    fn test_cxl_test_device_cli_parse_valid() {
+        let cfg = CxlTestDeviceCli::from_str("mem:1G,pcie_port=rp0").unwrap();
+        assert_eq!(cfg.hdm_size, 1024 * 1024 * 1024);
+        assert_eq!(cfg.pcie_port, "rp0");
+    }
+
+    #[test]
+    fn test_cxl_test_device_cli_parse_invalid() {
+        assert!(CxlTestDeviceCli::from_str("file:disk.img,pcie_port=rp0").is_err());
+        assert!(CxlTestDeviceCli::from_str("mem:1G").is_err());
+        assert!(CxlTestDeviceCli::from_str("mem:1G,pcie_port=").is_err());
+    }
+
+    #[test]
     fn test_fs_args_pcie_port() {
         // Without pcie_port
         let args = FsArgs::from_str("myfs,/path").unwrap();
@@ -3452,6 +3573,9 @@ mod tests {
 
         const DEFAULT_LOW_MMIO: u32 = (64 * ONE_MB) as u32;
         const DEFAULT_HIGH_MMIO: u64 = ONE_GB;
+        const DEFAULT_HDM: u64 = ONE_GB;
+        const DEFAULT_HDM_WINDOW_RESTRICTIONS: CfmwsWindowRestrictions =
+            CfmwsWindowRestrictions::DEVICE_COHERENT;
 
         assert_eq!(
             PcieRootComplexCli::from_str("rc0").unwrap(),
@@ -3462,6 +3586,8 @@ mod tests {
                 end_bus: 255,
                 low_mmio: DEFAULT_LOW_MMIO,
                 high_mmio: DEFAULT_HIGH_MMIO,
+                hdm: DEFAULT_HDM,
+                hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
             }
         );
 
@@ -3474,6 +3600,8 @@ mod tests {
                 end_bus: 255,
                 low_mmio: DEFAULT_LOW_MMIO,
                 high_mmio: DEFAULT_HIGH_MMIO,
+                hdm: DEFAULT_HDM,
+                hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
             }
         );
 
@@ -3486,6 +3614,8 @@ mod tests {
                 end_bus: 255,
                 low_mmio: DEFAULT_LOW_MMIO,
                 high_mmio: DEFAULT_HIGH_MMIO,
+                hdm: DEFAULT_HDM,
+                hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
             }
         );
 
@@ -3498,6 +3628,8 @@ mod tests {
                 end_bus: 31,
                 low_mmio: DEFAULT_LOW_MMIO,
                 high_mmio: DEFAULT_HIGH_MMIO,
+                hdm: DEFAULT_HDM,
+                hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
             }
         );
 
@@ -3510,6 +3642,8 @@ mod tests {
                 end_bus: 127,
                 low_mmio: DEFAULT_LOW_MMIO,
                 high_mmio: 2 * ONE_GB,
+                hdm: DEFAULT_HDM,
+                hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
             }
         );
 
@@ -3522,6 +3656,8 @@ mod tests {
                 end_bus: 127,
                 low_mmio: DEFAULT_LOW_MMIO,
                 high_mmio: DEFAULT_HIGH_MMIO,
+                hdm: DEFAULT_HDM,
+                hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
             }
         );
 
@@ -3534,6 +3670,36 @@ mod tests {
                 end_bus: 255,
                 low_mmio: ONE_MB as u32,
                 high_mmio: 64 * ONE_GB,
+                hdm: DEFAULT_HDM,
+                hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
+            }
+        );
+
+        assert_eq!(
+            PcieRootComplexCli::from_str("rc7,hdm=2G").unwrap(),
+            PcieRootComplexCli {
+                name: "rc7".to_string(),
+                segment: 0,
+                start_bus: 0,
+                end_bus: 255,
+                low_mmio: DEFAULT_LOW_MMIO,
+                high_mmio: DEFAULT_HIGH_MMIO,
+                hdm: 2 * ONE_GB,
+                hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
+            }
+        );
+
+        assert_eq!(
+            PcieRootComplexCli::from_str("rc8,hdm_window_restrictions=0x21").unwrap(),
+            PcieRootComplexCli {
+                name: "rc8".to_string(),
+                segment: 0,
+                start_bus: 0,
+                end_bus: 255,
+                low_mmio: DEFAULT_LOW_MMIO,
+                high_mmio: DEFAULT_HIGH_MMIO,
+                hdm: DEFAULT_HDM,
+                hdm_window_restrictions: CfmwsWindowRestrictions::try_from_bits(0x21).unwrap(),
             }
         );
 
@@ -3549,6 +3715,11 @@ mod tests {
         assert!(PcieRootComplexCli::from_str("rc,low_mmio=aG").is_err());
         assert!(PcieRootComplexCli::from_str("rc,high_mmio=bad").is_err());
         assert!(PcieRootComplexCli::from_str("rc,high_mmio").is_err());
+        assert!(PcieRootComplexCli::from_str("rc,hdm=bad").is_err());
+        assert!(PcieRootComplexCli::from_str("rc,hdm").is_err());
+        assert!(PcieRootComplexCli::from_str("rc,hdm_window_restrictions=bad").is_err());
+        assert!(PcieRootComplexCli::from_str("rc,hdm_window_restrictions").is_err());
+        assert!(PcieRootComplexCli::from_str("rc,cxl").is_err());
     }
 
     #[test]
@@ -3560,6 +3731,7 @@ mod tests {
                 name: "rc0rp0".to_string(),
                 hotplug: false,
                 acs_capabilities_supported: None,
+                cxl: false,
             }
         );
 
@@ -3570,6 +3742,7 @@ mod tests {
                 name: "port2".to_string(),
                 hotplug: false,
                 acs_capabilities_supported: None,
+                cxl: false,
             }
         );
 
@@ -3581,6 +3754,7 @@ mod tests {
                 name: "port2".to_string(),
                 hotplug: true,
                 acs_capabilities_supported: None,
+                cxl: false,
             }
         );
 
@@ -3591,6 +3765,7 @@ mod tests {
                 name: "port3".to_string(),
                 hotplug: false,
                 acs_capabilities_supported: Some(0),
+                cxl: false,
             }
         );
 
@@ -3601,6 +3776,18 @@ mod tests {
                 name: "port3".to_string(),
                 hotplug: false,
                 acs_capabilities_supported: Some(0x005f),
+                cxl: false,
+            }
+        );
+
+        assert_eq!(
+            PcieRootPortCli::from_str("my_rc:port4,cxl").unwrap(),
+            PcieRootPortCli {
+                root_complex_name: "my_rc".to_string(),
+                name: "port4".to_string(),
+                hotplug: false,
+                acs_capabilities_supported: None,
+                cxl: true,
             }
         );
 
@@ -3610,6 +3797,7 @@ mod tests {
         assert!(PcieRootPortCli::from_str("rp0,opt").is_err());
         assert!(PcieRootPortCli::from_str("rc0:rp0:rp3").is_err());
         assert!(PcieRootPortCli::from_str("rc0:rp0,invalid_option").is_err());
+        assert!(PcieRootPortCli::from_str("rc0:rp0,cxl=true").is_err());
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -38,6 +38,7 @@ use cli_args::UefiConsoleModeCli;
 use cli_args::VirtioBusCli;
 use cli_args::VmgsCli;
 use crash_dump::spawn_dump_handler;
+use cxl_spec::test::CxlTestDeviceHandle;
 use disk_backend_resources::DelayDiskHandle;
 use disk_backend_resources::DiskLayerDescription;
 use disk_backend_resources::layer::DiskLayerHandle;
@@ -78,6 +79,7 @@ use openvmm_defs::config::PcieRootComplexConfig;
 use openvmm_defs::config::PcieRootPortConfig;
 use openvmm_defs::config::PcieSwitchConfig;
 use openvmm_defs::config::ProcessorTopologyConfig;
+use openvmm_defs::config::RootComplexCxlConfig;
 use openvmm_defs::config::SerialInformation;
 use openvmm_defs::config::VirtioBus;
 use openvmm_defs::config::VmbusConfig;
@@ -714,14 +716,24 @@ async fn vm_config_from_command_line(
             }),
     );
 
-    let mut pcie_root_complexes = Vec::new();
+    for cxl_test in &opt.cxl_test {
+        pcie_devices.push(PcieDeviceConfig {
+            port_name: cxl_test.pcie_port.clone(),
+            resource: CxlTestDeviceHandle {
+                hdm_size_bytes: cxl_test.hdm_size,
+            }
+            .into_resource(),
+        });
+    }
 
     #[cfg(guest_arch = "aarch64")]
     let arch = MachineArch::Aarch64;
     #[cfg(guest_arch = "x86_64")]
     let arch = MachineArch::X86_64;
+
+    let mut pcie_root_complexes = Vec::new();
     for (i, rc_cli) in opt.pcie_root_complex.iter().enumerate() {
-        let ports = opt
+        let ports: Vec<PcieRootPortConfig> = opt
             .pcie_root_port
             .iter()
             .filter(|port_cli| port_cli.root_complex_name == rc_cli.name)
@@ -729,15 +741,29 @@ async fn vm_config_from_command_line(
                 name: port_cli.name.clone(),
                 hotplug: port_cli.hotplug,
                 acs_capabilities_supported: port_cli.acs_capabilities_supported,
+                cxl: port_cli.cxl,
             })
             .collect();
 
         const ONE_MB: u64 = 1024 * 1024;
+        // Keep all PCI windows 1MB-granular to match layout and downstream placement rules.
         let low_mmio_size = (rc_cli.low_mmio as u64).next_multiple_of(ONE_MB);
         let high_mmio_size = rc_cli
             .high_mmio
             .checked_next_multiple_of(ONE_MB)
             .context("high mmio rounding error")?;
+
+        // Count CXL-capable ports under the root bus. If the root bus has CXL root ports, it needs CHBCR.
+        let cxl_port_count = ports.iter().filter(|port| port.cxl).count() as u64;
+
+        let cxl = if cxl_port_count != 0 {
+            Some(RootComplexCxlConfig {
+                hdm_size: rc_cli.hdm,
+                hdm_window_restrictions: rc_cli.hdm_window_restrictions.bits(),
+            })
+        } else {
+            None
+        };
         pcie_root_complexes.push(PcieRootComplexConfig {
             index: i as u32,
             name: rc_cli.name.clone(),
@@ -750,6 +776,7 @@ async fn vm_config_from_command_line(
             high_mmio: PcieMmioRangeConfig::Dynamic {
                 size: high_mmio_size,
             },
+            cxl,
             ports,
         });
     }

--- a/openvmm/openvmm_resources/Cargo.toml
+++ b/openvmm/openvmm_resources/Cargo.toml
@@ -58,6 +58,7 @@ vmcore.workspace = true
 vmgs_broker.workspace = true
 
 # PCI devices
+cxl_spec.workspace = true
 gdma.workspace = true
 nvme.workspace = true
 nvme_test.workspace = true

--- a/openvmm/openvmm_resources/src/lib.rs
+++ b/openvmm/openvmm_resources/src/lib.rs
@@ -80,6 +80,7 @@ vm_resource::register_static_resolvers! {
     disklayer_sqlite::resolver::SqliteDiskLayerResolver,
 
     // PCI devices
+    cxl_spec::test::resolver::CxlTestDeviceResolver,
     gdma::resolver::GdmaDeviceResolver,
     nvme::resolver::NvmeControllerResolver,
     nvme_test::resolver::NvmeFaultControllerResolver,

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -260,6 +260,7 @@ impl PetriVmConfigOpenVmm {
                         name: format!("s{}rc{}rp{}", segment, rc_index_in_segment, i),
                         hotplug: true,
                         acs_capabilities_supported: Some(0),
+                        cxl: false,
                     })
                     .collect();
 
@@ -275,6 +276,7 @@ impl PetriVmConfigOpenVmm {
                     high_mmio: PcieMmioRangeConfig::Dynamic {
                         size: HIGH_MMIO_SIZE,
                     },
+                    cxl: None,
                     ports,
                 });
             }

--- a/vm/acpi/Cargo.toml
+++ b/vm/acpi/Cargo.toml
@@ -8,8 +8,10 @@ rust-version.workspace = true
 
 [dependencies]
 acpi_spec.workspace = true
+cxl_spec.workspace = true
 guid.workspace = true
 memory_range.workspace = true
+thiserror.workspace = true
 x86defs.workspace = true
 
 zerocopy.workspace = true

--- a/vm/acpi/src/cedt.rs
+++ b/vm/acpi/src/cedt.rs
@@ -1,0 +1,346 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! CXL Early Discovery Table (CEDT) builder.
+
+use core::mem::size_of;
+use cxl_spec::spec::CEDT_STRUCTURE_TYPE_CFMWS;
+use cxl_spec::spec::CEDT_STRUCTURE_TYPE_CHBS;
+use cxl_spec::spec::CXL_HOST_BRIDGE_COMPONENT_REGISTERS_SIZE_BYTES;
+use cxl_spec::spec::CXL_HPA_ALIGNMENT;
+use cxl_spec::spec::InterleaveArithmetic;
+use cxl_spec::spec::InterleaveGranularity;
+use cxl_spec::spec::InterleaveWays;
+use memory_range::MemoryRange;
+use thiserror::Error;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+
+/// Validation errors when adding CHBS/CFMWS CXL host-bridge entries.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum CedtHostBridgeError {
+    /// HDM range is empty.
+    #[error("HDM range must be non-empty")]
+    EmptyHdmRange,
+    /// CHBCR range is empty.
+    #[error("CHBCR range must be non-empty")]
+    EmptyChbcrRange,
+    /// CHBCR range length does not match the spec-defined size.
+    #[error("CHBCR range has invalid length {actual:#x}, expected {expected:#x}")]
+    InvalidChbcrRangeLength { actual: u64, expected: u64 },
+    /// CHBCR base is not aligned to the CHBCR aperture size.
+    #[error("CHBCR base {base:#x} is not aligned to {alignment:#x}")]
+    InvalidChbcrBaseAlignment { base: u64, alignment: u64 },
+    /// HDM base is not aligned to CXL HPA alignment.
+    #[error("HDM base {base:#x} is not aligned to {alignment:#x}")]
+    InvalidHdmBaseAlignment { base: u64, alignment: u64 },
+    /// HDM size is not aligned to CXL HPA alignment.
+    #[error("HDM size {size:#x} is not aligned to {alignment:#x}")]
+    InvalidHdmSizeAlignment { size: u64, alignment: u64 },
+}
+
+/// Errors while serializing CEDT bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum CedtSerializeError {
+    /// Serialized CEDT size exceeded ACPI header u32 length field capacity.
+    #[error("CEDT length {actual:#x} exceeds u32 length field")]
+    LengthOverflow { actual: usize },
+}
+
+#[repr(C, packed)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct DescriptionHeader {
+    pub signature: u32,
+    _length: u32, // placeholder, filled in during serialization to bytes
+    pub revision: u8,
+    _checksum: u8, // placeholder, filled in during serialization to bytes
+    pub oem_id: [u8; 6],
+    pub oem_table_id: u64,
+    pub oem_revision: u32,
+    pub creator_id: u32,
+    pub creator_rev: u32,
+}
+
+#[repr(C, packed)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+struct ChbsStructure {
+    structure_type: u8,
+    reserved0: u8,
+    record_length: u16,
+    uid: u32,
+    cxl_version: u32,
+    reserved1: u32,
+    base: u64,
+    length: u64,
+}
+
+#[repr(C, packed)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+struct CfmwsStructure {
+    structure_type: u8,
+    reserved0: u8,
+    record_length: u16,
+    reserved1: u32,
+    base_hpa: u64,
+    window_size: u64,
+    eniw: u8,
+    interleave_arithmetic: u8,
+    reserved2: u16,
+    hbig: u32,
+    window_restrictions: u16,
+    qtg_id: u16,
+}
+
+/// CXL Early Discovery Table (CEDT).
+pub struct Cedt {
+    description_header: DescriptionHeader,
+    structures: Vec<u8>,
+}
+
+impl Cedt {
+    /// Create an empty CEDT.
+    pub fn new() -> Self {
+        Self {
+            description_header: DescriptionHeader {
+                signature: u32::from_le_bytes(*b"CEDT"),
+                _length: 0,
+                revision: 2,
+                _checksum: 0,
+                oem_id: *b"MSFTVM",
+                oem_table_id: u64::from_le_bytes(*b"CEDT01\0\0"),
+                oem_revision: 1,
+                creator_id: u32::from_le_bytes(*b"MSFT"),
+                creator_rev: 0x01000000,
+            },
+            structures: Vec::new(),
+        }
+    }
+
+    /// Add one CXL host bridge to CEDT.
+    ///
+    /// This appends:
+    /// 1) One CHBS structure.
+    /// 2) One CFMWS structure where only base HPA and window size are set,
+    ///    with one Interleave Target List entry for ENIW=0 (1-way interleave, default).
+    pub fn add_cxl_host_bridge(
+        &mut self,
+        uid: u32,
+        hdm_range: MemoryRange,
+        chbcr_range: MemoryRange,
+        hdm_window_restrictions: u16,
+    ) -> Result<(), CedtHostBridgeError> {
+        if hdm_range.is_empty() {
+            return Err(CedtHostBridgeError::EmptyHdmRange);
+        }
+        if chbcr_range.is_empty() {
+            return Err(CedtHostBridgeError::EmptyChbcrRange);
+        }
+        if chbcr_range.len() != CXL_HOST_BRIDGE_COMPONENT_REGISTERS_SIZE_BYTES {
+            return Err(CedtHostBridgeError::InvalidChbcrRangeLength {
+                actual: chbcr_range.len(),
+                expected: CXL_HOST_BRIDGE_COMPONENT_REGISTERS_SIZE_BYTES,
+            });
+        }
+        if !chbcr_range
+            .start()
+            .is_multiple_of(CXL_HOST_BRIDGE_COMPONENT_REGISTERS_SIZE_BYTES)
+        {
+            return Err(CedtHostBridgeError::InvalidChbcrBaseAlignment {
+                base: chbcr_range.start(),
+                alignment: CXL_HOST_BRIDGE_COMPONENT_REGISTERS_SIZE_BYTES,
+            });
+        }
+        if !hdm_range.start().is_multiple_of(CXL_HPA_ALIGNMENT) {
+            return Err(CedtHostBridgeError::InvalidHdmBaseAlignment {
+                base: hdm_range.start(),
+                alignment: CXL_HPA_ALIGNMENT,
+            });
+        }
+        if !hdm_range.len().is_multiple_of(CXL_HPA_ALIGNMENT) {
+            return Err(CedtHostBridgeError::InvalidHdmSizeAlignment {
+                size: hdm_range.len(),
+                alignment: CXL_HPA_ALIGNMENT,
+            });
+        }
+
+        let chbs = ChbsStructure {
+            structure_type: CEDT_STRUCTURE_TYPE_CHBS,
+            reserved0: 0,
+            record_length: size_of::<ChbsStructure>() as u16,
+            uid,
+            // Host bridge associated with one or more CXL root ports.
+            cxl_version: 1,
+            reserved1: 0,
+            base: chbcr_range.start(),
+            length: chbcr_range.len(),
+        };
+        self.structures.extend_from_slice(chbs.as_bytes());
+
+        let cfmws = CfmwsStructure {
+            structure_type: CEDT_STRUCTURE_TYPE_CFMWS,
+            reserved0: 0,
+            // ENIW=0 means 1-way interleave, so include one 32-bit target entry.
+            record_length: (size_of::<CfmwsStructure>() + size_of::<u32>()) as u16,
+            reserved1: 0,
+            base_hpa: hdm_range.start(),
+            window_size: hdm_range.len(),
+            eniw: InterleaveWays::WAY_1,
+            interleave_arithmetic: InterleaveArithmetic::STANDARD_MODULO,
+            reserved2: 0,
+            hbig: InterleaveGranularity::BYTES_256 as u32,
+            window_restrictions: hdm_window_restrictions,
+            qtg_id: 0,
+        };
+        self.structures.extend_from_slice(cfmws.as_bytes());
+        self.structures.extend_from_slice(&uid.to_le_bytes());
+
+        Ok(())
+    }
+
+    /// Serialize CEDT to bytes.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, CedtSerializeError> {
+        let mut byte_stream = Vec::new();
+        byte_stream.extend_from_slice(self.description_header.as_bytes());
+        byte_stream.extend_from_slice(&self.structures);
+
+        let length = byte_stream.len();
+        let length = u32::try_from(length).map_err(|_| CedtSerializeError::LengthOverflow {
+            actual: byte_stream.len(),
+        })?;
+
+        let (header, _) = DescriptionHeader::mut_from_prefix(byte_stream.as_mut_slice())
+            .expect("serialized CEDT must start with a complete description header");
+        header._length = length;
+        // Checksum is computed with this field set to zero.
+        header._checksum = 0;
+
+        let mut checksum: u8 = 0;
+        for byte in &byte_stream {
+            checksum = checksum.wrapping_add(*byte);
+        }
+        DescriptionHeader::mut_from_prefix(byte_stream.as_mut_slice())
+            .expect("serialized CEDT must start with a complete description header")
+            .0
+            ._checksum = (!checksum).wrapping_add(1);
+
+        Ok(byte_stream)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cedt_header_signature_and_revision() {
+        let cedt = Cedt::new();
+        let bytes = cedt.to_bytes().expect("serialize CEDT");
+        assert_eq!(&bytes[0..4], b"CEDT");
+        assert_eq!(bytes[8], 2);
+    }
+
+    #[test]
+    fn add_cxl_host_bridge_adds_chbs_and_cfmws() {
+        let mut cedt = Cedt::new();
+        cedt.add_cxl_host_bridge(
+            7,
+            MemoryRange::new(0x4000_0000..0x8000_0000),
+            MemoryRange::new(0x1000_0000..0x1001_0000),
+            cxl_spec::spec::CfmwsWindowRestrictions::DEVICE_COHERENT.bits(),
+        )
+        .expect("valid CXL host bridge ranges");
+        let bytes = cedt.to_bytes().expect("serialize CEDT");
+
+        // Header is 36 bytes. First structure should be CHBS type 0.
+        assert_eq!(bytes[36], CEDT_STRUCTURE_TYPE_CHBS);
+        // CHBS record length should be 0x20.
+        assert_eq!(u16::from_le_bytes([bytes[38], bytes[39]]), 0x20);
+
+        // Second structure should be CFMWS type 1 at offset 36 + 0x20.
+        assert_eq!(bytes[36 + 0x20], CEDT_STRUCTURE_TYPE_CFMWS);
+        // CFMWS record length should be 0x28 (base structure + one target entry).
+        assert_eq!(
+            u16::from_le_bytes([bytes[36 + 0x20 + 2], bytes[36 + 0x20 + 3]]),
+            0x28
+        );
+
+        // Interleave Target List[0] should contain the CHBS UID for ENIW=0.
+        assert_eq!(
+            u32::from_le_bytes([
+                bytes[36 + 0x20 + 0x24],
+                bytes[36 + 0x20 + 0x25],
+                bytes[36 + 0x20 + 0x26],
+                bytes[36 + 0x20 + 0x27],
+            ]),
+            7
+        );
+    }
+
+    #[test]
+    fn add_cxl_host_bridge_rejects_unaligned_chbcr_base() {
+        let mut cedt = Cedt::new();
+        let err = cedt
+            .add_cxl_host_bridge(
+                0,
+                MemoryRange::new(0x4000_0000..0x5000_0000),
+                // 4K-aligned but not 64K-aligned.
+                MemoryRange::new(0x1000_1000..0x1001_1000),
+                cxl_spec::spec::CfmwsWindowRestrictions::DEVICE_COHERENT.bits(),
+            )
+            .expect_err("unaligned CHBCR base should be rejected");
+
+        assert_eq!(
+            err,
+            CedtHostBridgeError::InvalidChbcrBaseAlignment {
+                base: 0x1000_1000,
+                alignment: CXL_HOST_BRIDGE_COMPONENT_REGISTERS_SIZE_BYTES,
+            }
+        );
+    }
+
+    #[test]
+    fn add_cxl_host_bridge_rejects_unaligned_hdm_base() {
+        let mut cedt = Cedt::new();
+        let err = cedt
+            .add_cxl_host_bridge(
+                0,
+                // 4K-aligned but not 256MiB-aligned.
+                MemoryRange::new(0x4000_1000..0x5000_1000),
+                MemoryRange::new(0x1000_0000..0x1001_0000),
+                cxl_spec::spec::CfmwsWindowRestrictions::DEVICE_COHERENT.bits(),
+            )
+            .expect_err("unaligned HDM base should be rejected");
+
+        assert_eq!(
+            err,
+            CedtHostBridgeError::InvalidHdmBaseAlignment {
+                base: 0x4000_1000,
+                alignment: CXL_HPA_ALIGNMENT,
+            }
+        );
+    }
+
+    #[test]
+    fn add_cxl_host_bridge_rejects_unaligned_hdm_size() {
+        let mut cedt = Cedt::new();
+        let err = cedt
+            .add_cxl_host_bridge(
+                0,
+                // Base is 256MiB-aligned, but size is not.
+                MemoryRange::new(0x4000_0000..0x5000_1000),
+                MemoryRange::new(0x1000_0000..0x1001_0000),
+                cxl_spec::spec::CfmwsWindowRestrictions::DEVICE_COHERENT.bits(),
+            )
+            .expect_err("unaligned HDM size should be rejected");
+
+        assert_eq!(
+            err,
+            CedtHostBridgeError::InvalidHdmSizeAlignment {
+                size: 0x1000_1000,
+                alignment: CXL_HPA_ALIGNMENT,
+            }
+        );
+    }
+}

--- a/vm/acpi/src/lib.rs
+++ b/vm/acpi/src/lib.rs
@@ -8,5 +8,6 @@
 
 mod aml;
 pub mod builder;
+pub mod cedt;
 pub mod dsdt;
 pub mod ssdt;

--- a/vm/acpi/src/ssdt.rs
+++ b/vm/acpi/src/ssdt.rs
@@ -124,38 +124,52 @@ impl Ssdt {
         ecam_range: MemoryRange,
         low_mmio: MemoryRange,
         high_mmio: MemoryRange,
+        cxl: bool,
     ) {
         let mut pcie = Device::new(encode_pcie_name(index).as_slice());
-        pcie.add_object(&NamedObject::new(b"_HID", &EisaId(*b"PNP0A08")));
-        pcie.add_object(&NamedObject::new(b"_CID", &EisaId(*b"PNP0A03")));
+        if cxl {
+            // As recommended by the CXL specification, describe CXL host bridges with _HID "ACPI0016"
+            // and both PNP0A03 and PNP0A08 in _CID to maximize compatibility with different OSes.
+            pcie.add_object(&NamedString::new(b"_HID", b"ACPI0016"));
+            let mut cid_data = Vec::new();
+            cid_data.extend_from_slice(&EisaId(*b"PNP0A03").to_bytes());
+            cid_data.extend_from_slice(&EisaId(*b"PNP0A08").to_bytes());
+            pcie.add_object(&NamedObject::new(
+                b"_CID",
+                &StructuredPackage {
+                    elem_count: 2,
+                    elem_data: cid_data,
+                },
+            ));
+        } else {
+            pcie.add_object(&NamedObject::new(b"_HID", &EisaId(*b"PNP0A08")));
+            pcie.add_object(&NamedObject::new(b"_CID", &EisaId(*b"PNP0A03")));
+        }
         pcie.add_object(&NamedInteger::new(b"_UID", index.into()));
         pcie.add_object(&NamedInteger::new(b"_SEG", segment.into()));
         pcie.add_object(&NamedInteger::new(b"_BBN", start_bus.into()));
         pcie.add_object(&NamedInteger::new(b"_CCA", 1));
 
-        // _OSC method: grant native PCIe control to the OS.
+        // _OSC method: negotiate native control with the guest OS.
         //
         // Per ACPI spec §6.2.11 (_OSC, Operating System Capabilities), the OS
-        // calls _OSC to negotiate platform feature control. For PCIe root
-        // complexes, the UUID and capability definitions are specified in the
-        // PCI Firmware Specification §4.5.1 (_OSC Implementation for PCI Host
-        // Bridge Devices).
+        // calls _OSC to negotiate platform feature control.
         //
-        // UUID: 33DB4D5B-1FF7-401C-9657-7441C03DD766
+        // Supported UUIDs:
+        // - PCIe: 33DB4D5B-1FF7-401C-9657-7441C03DD766
         //   (PCI Firmware Spec §4.5.1, Table 4-3)
+        // - CXL:  68F2D50B-C469-4D8A-BD3D-941A103FD3FC (CXL host bridge mode)
         //
-        // Status DWORD[0] bit 2: "Unrecognized UUID"
+        // Status DWORD[0] bits used here:
+        // - bit 1 (0x02): unrecognized revision (CXL path, Arg1 != 1)
+        // - bit 2 (0x04): unrecognized UUID
         //   (ACPI spec §6.2.11.1, Table 6.15)
         //
-        // Method(_OSC, 4) {
-        //   CreateDWordField(Arg3, 0, STS0)
-        //   If (LEqual(Arg0, ToUUID("33DB4D5B-1FF7-401C-9657-7441C03DD766"))) {
-        //     Store(0, STS0)  // clear status — grant everything
-        //   } Else {
-        //     Or(STS0, 0x04, STS0)  // unrecognized UUID
-        //   }
-        //   Return(Arg3)
-        // }
+        // Behavior:
+        // - PCIe UUID: clear status (grant all requested control)
+        // - CXL UUID: if Arg1 == 1 clear status; else set bit 1
+        // - Any other UUID: set bit 2
+        // - Return Arg3
         let mut osc_method = Method::new(b"_OSC");
         osc_method.set_arg_count(4);
 
@@ -174,14 +188,78 @@ impl Ssdt {
             right: uuid_buffer,
         };
 
-        // Else { Or(STS0, 0x04, STS0) }
-        let or_op = OrOp {
-            operand1: b"STS0".to_vec(),
-            operand2: encode_integer(0x04),
-            target_name: b"STS0".to_vec(),
-        };
-        let else_body = ElseOp {
-            body: or_op.to_bytes(),
+        let else_body = if cxl {
+            // CXL _OSC UUID: 68f2d50b-c469-4d8a-bd3d-941a103fd3fc
+            // Rev 1 is currently supported; unsupported revisions set STS0 bit 1.
+            let cxl_osc_uuid = guid::guid!("68f2d50b-c469-4d8a-bd3d-941a103fd3fc");
+            let cxl_uuid_buffer = Buffer(cxl_osc_uuid.as_bytes()).to_bytes();
+            let cxl_uuid_match = LEqualOp {
+                left: encode_arg(0),
+                right: cxl_uuid_buffer,
+            };
+
+            let cxl_revision_match = LEqualOp {
+                left: encode_arg(1),
+                right: encode_integer(1),
+            };
+
+            let cxl_store_zero = StoreOp {
+                source: encode_integer(0),
+                destination: b"STS0".to_vec(),
+            };
+            let cxl_rev_if_op = IfOp {
+                predicate: cxl_revision_match.to_bytes(),
+                body: cxl_store_zero.to_bytes(),
+            };
+
+            // STS0 bit 1: unrecognized revision.
+            let cxl_revision_or = OrOp {
+                operand1: b"STS0".to_vec(),
+                operand2: encode_integer(0x02),
+                target_name: b"STS0".to_vec(),
+            };
+            let cxl_revision_else = ElseOp {
+                body: cxl_revision_or.to_bytes(),
+            };
+
+            // STS0 bit 2: unrecognized UUID.
+            let uuid_or = OrOp {
+                operand1: b"STS0".to_vec(),
+                operand2: encode_integer(0x04),
+                target_name: b"STS0".to_vec(),
+            };
+            let unknown_uuid_else = ElseOp {
+                body: uuid_or.to_bytes(),
+            };
+
+            let cxl_if_op = IfOp {
+                predicate: cxl_uuid_match.to_bytes(),
+                body: {
+                    let mut body = Vec::new();
+                    cxl_rev_if_op.append_to_vec(&mut body);
+                    cxl_revision_else.append_to_vec(&mut body);
+                    body
+                },
+            };
+
+            ElseOp {
+                body: {
+                    let mut body = Vec::new();
+                    cxl_if_op.append_to_vec(&mut body);
+                    unknown_uuid_else.append_to_vec(&mut body);
+                    body
+                },
+            }
+        } else {
+            // STS0 bit 2: unrecognized UUID.
+            let uuid_or = OrOp {
+                operand1: b"STS0".to_vec(),
+                operand2: encode_integer(0x04),
+                target_name: b"STS0".to_vec(),
+            };
+            ElseOp {
+                body: uuid_or.to_bytes(),
+            }
         };
 
         // If block: UUID matches — clear status and grant everything
@@ -314,6 +392,7 @@ mod tests {
             MemoryRange::new(0x1000_0000..0x2000_0000),
             MemoryRange::new(0xdc00_0000..0xe000_0000),
             MemoryRange::new(0x10_0000_0000..0x10_4000_0000),
+            false,
         );
 
         let bytes = ssdt.to_bytes();

--- a/vm/devices/cxl/Cargo.toml
+++ b/vm/devices/cxl/Cargo.toml
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "cxl_spec"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+bitfield-struct.workspace = true
+chipset_device.workspace = true
+inspect.workspace = true
+mesh.workspace = true
+pci_resources.workspace = true
+pci_core.workspace = true
+thiserror.workspace = true
+vm_resource.workspace = true
+tracing.workspace = true
+vmcore.workspace = true
+
+[lints]
+workspace = true

--- a/vm/devices/cxl/src/component_registers/hdm_cap.rs
+++ b/vm/devices/cxl/src/component_registers/hdm_cap.rs
@@ -1,0 +1,771 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! CXL HDM Decoder component capability implementation.
+
+use super::CxlComponentRegister;
+use super::spec::hdm_decoder::CXL_HDM_DECODER_BASE_OFFSET;
+use super::spec::hdm_decoder::CXL_HDM_DECODER_BLOCK_LENGTH;
+use super::spec::hdm_decoder::CXL_HDM_DECODER_CAPABILITY_ID;
+use super::spec::hdm_decoder::CXL_HDM_DECODER_CAPABILITY_OFFSET;
+use super::spec::hdm_decoder::CXL_HDM_DECODER_CAPABILITY_VERSION;
+use super::spec::hdm_decoder::CXL_HDM_DECODER_GLOBAL_CONTROL_OFFSET;
+use super::spec::hdm_decoder::CXL_HDM_DECODER_GLOBAL_CONTROL_WRITABLE_MASK;
+use super::spec::hdm_decoder::CXL_HDM_DECODER_HEADER_LENGTH;
+use super::spec::hdm_decoder::CXL_HDM_DECODER_RESERVED0_OFFSET;
+use super::spec::hdm_decoder::CXL_HDM_DECODER_RESERVED1_OFFSET;
+use super::spec::hdm_decoder::CXL_HDM_DECODER_STRIDE_BYTES;
+use super::spec::hdm_decoder::CxlHdmDecoderBaseLowRegister;
+use super::spec::hdm_decoder::CxlHdmDecoderCapabilityRegister;
+use super::spec::hdm_decoder::CxlHdmDecoderControlRegister;
+use super::spec::hdm_decoder::CxlHdmDecoderDpaSkipLowRegister;
+use super::spec::hdm_decoder::CxlHdmDecoderGlobalControlRegister;
+use super::spec::hdm_decoder::CxlHdmDecoderInterleaveGranularity;
+use super::spec::hdm_decoder::CxlHdmDecoderInterleaveWays;
+use super::spec::hdm_decoder::CxlHdmDecoderRegisterOffset;
+use super::spec::hdm_decoder::CxlHdmDecoderSizeLowRegister;
+use super::spec::hdm_decoder::CxlHdmSupportedCoherencyModes;
+use super::spec::hdm_decoder::encode_decoder_count;
+use crate::spec::CXL_HPA_ALIGNMENT;
+use crate::spec::CxlComponentRegisterType;
+use inspect::Inspect;
+use thiserror::Error;
+use tracing::info;
+
+/// Fixed HDM range and interleave configuration for Decoder 0.
+#[derive(Debug, Copy, Clone)]
+pub struct CxlHdmDecoderFixedConfig {
+    /// Host physical base address of the HDM range.
+    pub hdm_base: u64,
+    /// Length in bytes of the HDM range.
+    pub hdm_size: u64,
+    /// Fixed Decoder 0 interleave granularity.
+    pub interleave_granularity: CxlHdmDecoderInterleaveGranularity,
+    /// Fixed Decoder 0 interleave ways.
+    pub interleave_ways: CxlHdmDecoderInterleaveWays,
+}
+
+/// Configures static capability bits for the HDM Decoder capability register.
+#[derive(Debug, Copy, Clone)]
+pub struct CxlHdmDecoderCapabilityOptions {
+    /// Raw Target Count encoding for Capability bits 7:4.
+    pub target_count_encoding: u8,
+    /// Capability bit 8: supports address-bit interleave `11:8`.
+    pub a11to8_interleave_capable: bool,
+    /// Capability bit 9: supports address-bit interleave `14:12`.
+    pub a14to12_interleave_capable: bool,
+    /// Capability bit 10: supports poison decode responses on errors.
+    pub poison_on_decode_error_capable: bool,
+    /// Capability bit 11: supports 3/6/12-way interleave modes.
+    pub interleave_3_6_12_way_capable: bool,
+    /// Capability bit 12: supports 16-way interleave mode.
+    pub interleave_16_way_capable: bool,
+    /// Capability bit 13: supports UIO decode semantics.
+    pub uio_capable: bool,
+    /// Raw UIO-capable decoder count encoding for capability bits 19:16.
+    pub uio_capable_decoder_count: u8,
+    /// Capability bit 20: supports MemData-NXM responses.
+    pub mem_data_nxm_capable: bool,
+    /// Capability bits 22:21: supported coherency mode encoding.
+    pub supported_coherency_modes: CxlHdmSupportedCoherencyModes,
+}
+
+impl Default for CxlHdmDecoderCapabilityOptions {
+    fn default() -> Self {
+        Self {
+            target_count_encoding: 0,
+            a11to8_interleave_capable: true,
+            a14to12_interleave_capable: true,
+            poison_on_decode_error_capable: false,
+            interleave_3_6_12_way_capable: false,
+            interleave_16_way_capable: false,
+            uio_capable: true,
+            uio_capable_decoder_count: 0,
+            mem_data_nxm_capable: true,
+            supported_coherency_modes: CxlHdmSupportedCoherencyModes::DeviceCoherent,
+        }
+    }
+}
+
+/// Error returned while constructing an HDM Decoder capability block.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Error)]
+pub enum CxlHdmDecoderCapabilityError {
+    /// Fixed range is invalid (must be non-zero and 256-MiB aligned).
+    #[error("fixed HDM range must be non-zero and 256-MiB aligned")]
+    InvalidFixedRange,
+    /// Too many fixed decoder ranges were configured.
+    #[error("too many fixed HDM decoders configured")]
+    TooManyFixedDecoders,
+}
+
+#[derive(Default, Copy, Clone, Inspect)]
+struct CxlHdmDecoderRegisterBlock {
+    base_low: CxlHdmDecoderBaseLowRegister,
+    base_high: u32,
+    size_low: CxlHdmDecoderSizeLowRegister,
+    size_high: u32,
+    control: CxlHdmDecoderControlRegister,
+    dpa_skip_low: CxlHdmDecoderDpaSkipLowRegister,
+    dpa_skip_high: u32,
+}
+
+/// CXL HDM Decoder capability register block.
+#[derive(Inspect)]
+pub struct CxlHdmDecoderCapability {
+    capability: CxlHdmDecoderCapabilityRegister,
+    global_control: CxlHdmDecoderGlobalControlRegister,
+    #[inspect(skip)]
+    decoders: Vec<CxlHdmDecoderRegisterBlock>,
+}
+
+impl CxlHdmDecoderCapability {
+    /// Creates an HDM Decoder capability with default capability bits.
+    ///
+    /// No fixed HDM decoders are added by default. Use `with_hdm` to add one
+    /// or more fixed decoder ranges after construction.
+    pub fn new() -> Result<Self, CxlHdmDecoderCapabilityError> {
+        let options = CxlHdmDecoderCapabilityOptions::default();
+        let this = Self {
+            capability: CxlHdmDecoderCapabilityRegister::new()
+                .with_decoder_count(0)
+                .with_target_count(options.target_count_encoding & 0xF)
+                .with_a11to8_interleave_capable(options.a11to8_interleave_capable)
+                .with_a14to12_interleave_capable(options.a14to12_interleave_capable)
+                .with_poison_on_decode_error_capable(options.poison_on_decode_error_capable)
+                .with_interleave_3_6_12_way_capable(options.interleave_3_6_12_way_capable)
+                .with_interleave_16_way_capable(options.interleave_16_way_capable)
+                .with_uio_capable(options.uio_capable)
+                .with_uio_capable_decoder_count(options.uio_capable_decoder_count & 0xF)
+                .with_mem_data_nxm_capable(options.mem_data_nxm_capable)
+                .with_supported_coherency_modes(options.supported_coherency_modes.bits()),
+            global_control: CxlHdmDecoderGlobalControlRegister::new()
+                .with_poison_on_decode_error_enable(false)
+                .with_hdm_decoder_enable(false),
+            decoders: Vec::new(),
+        };
+        Ok(this)
+    }
+
+    fn push_decoder(
+        &mut self,
+        block: CxlHdmDecoderRegisterBlock,
+    ) -> Result<(), CxlHdmDecoderCapabilityError> {
+        let decoder_count = self.decoders.len() + 1;
+        let decoder_count_encoding = encode_decoder_count(decoder_count)
+            .ok_or(CxlHdmDecoderCapabilityError::TooManyFixedDecoders)?;
+
+        self.capability = self.capability.with_decoder_count(decoder_count_encoding);
+        self.decoders.push(block);
+        Ok(())
+    }
+
+    /// Adds a programmable HDM decoder slot.
+    pub fn with_decoder_slot(
+        &mut self,
+        interleave_granularity: CxlHdmDecoderInterleaveGranularity,
+        interleave_ways: CxlHdmDecoderInterleaveWays,
+    ) -> Result<(), CxlHdmDecoderCapabilityError> {
+        self.push_decoder(CxlHdmDecoderRegisterBlock {
+            base_low: CxlHdmDecoderBaseLowRegister::new(),
+            base_high: 0,
+            size_low: CxlHdmDecoderSizeLowRegister::new(),
+            size_high: 0,
+            control: CxlHdmDecoderControlRegister::new()
+                .with_interleave_granularity(interleave_granularity.bits())
+                .with_interleave_ways(interleave_ways.bits())
+                .with_lock_on_commit(true)
+                .with_commit(false)
+                .with_committed(false)
+                .with_error_not_committed(false),
+            dpa_skip_low: CxlHdmDecoderDpaSkipLowRegister::new(),
+            dpa_skip_high: 0,
+        })
+    }
+
+    /// Adds one fixed HDM decoder range.
+    pub fn with_hdm(
+        &mut self,
+        fixed: CxlHdmDecoderFixedConfig,
+    ) -> Result<(), CxlHdmDecoderCapabilityError> {
+        if fixed.hdm_size == 0
+            || !fixed.hdm_base.is_multiple_of(CXL_HPA_ALIGNMENT)
+            || !fixed.hdm_size.is_multiple_of(CXL_HPA_ALIGNMENT)
+        {
+            return Err(CxlHdmDecoderCapabilityError::InvalidFixedRange);
+        }
+
+        let fixed_decoder = CxlHdmDecoderRegisterBlock {
+            base_low: CxlHdmDecoderBaseLowRegister::new()
+                .with_memory_base_low(((fixed.hdm_base >> 28) & 0xF) as u8),
+            base_high: (fixed.hdm_base >> 32) as u32,
+            size_low: CxlHdmDecoderSizeLowRegister::new()
+                .with_memory_size_low(((fixed.hdm_size >> 28) & 0xF) as u8),
+            size_high: (fixed.hdm_size >> 32) as u32,
+            control: CxlHdmDecoderControlRegister::new()
+                .with_interleave_granularity(fixed.interleave_granularity.bits())
+                .with_interleave_ways(fixed.interleave_ways.bits())
+                .with_lock_on_commit(true)
+                .with_commit(true)
+                .with_committed(true)
+                .with_error_not_committed(false),
+            dpa_skip_low: CxlHdmDecoderDpaSkipLowRegister::new(),
+            dpa_skip_high: 0,
+        };
+
+        self.push_decoder(fixed_decoder)
+    }
+
+    fn decoder_base_and_size(block: &CxlHdmDecoderRegisterBlock) -> Option<(u64, u64)> {
+        let base = (u64::from(block.base_high) << 32)
+            | (u64::from(block.base_low.memory_base_low()) << 28);
+        let size = (u64::from(block.size_high) << 32)
+            | (u64::from(block.size_low.memory_size_low()) << 28);
+        if size == 0 {
+            return None;
+        }
+
+        Some((base, size))
+    }
+
+    /// Resolves an MMIO access to an enabled committed decoder.
+    ///
+    /// Returns the decoder index and offset within that decoder's range when
+    /// `addr..addr+len` is fully contained in an enabled committed range.
+    pub fn find_enabled_decoder_for_access(&self, addr: u64, len: usize) -> Option<(usize, u64)> {
+        if !self.global_control.hdm_decoder_enable() {
+            return None;
+        }
+
+        let access_len = u64::try_from(len).ok()?;
+        let access_end = addr.checked_add(access_len)?;
+
+        for (index, block) in self.decoders.iter().enumerate() {
+            if !block.control.committed() {
+                continue;
+            }
+
+            let Some((base, size)) = Self::decoder_base_and_size(block) else {
+                continue;
+            };
+            let Some(range_end) = base.checked_add(size) else {
+                continue;
+            };
+
+            if addr >= base && access_end <= range_end {
+                return Some((index, addr - base));
+            }
+        }
+
+        None
+    }
+    fn len_for_decoder_count(decoder_count: usize) -> u16 {
+        CXL_HDM_DECODER_HEADER_LENGTH + (decoder_count as u16) * CXL_HDM_DECODER_BLOCK_LENGTH
+    }
+
+    fn decode_decoder_offset(offset: u16) -> Option<(usize, u16)> {
+        let relative = offset.checked_sub(CXL_HDM_DECODER_BASE_OFFSET)?;
+        let index = usize::from(relative / CXL_HDM_DECODER_STRIDE_BYTES);
+        let within = relative % CXL_HDM_DECODER_STRIDE_BYTES;
+        Some((index, within))
+    }
+
+    fn read_decoder_u32(block: &CxlHdmDecoderRegisterBlock, within: u16) -> Option<u32> {
+        match within {
+            CxlHdmDecoderRegisterOffset::BASE_LOW => Some(block.base_low.into_bits()),
+            CxlHdmDecoderRegisterOffset::BASE_HIGH => Some(block.base_high),
+            CxlHdmDecoderRegisterOffset::SIZE_LOW => Some(block.size_low.into_bits()),
+            CxlHdmDecoderRegisterOffset::SIZE_HIGH => Some(block.size_high),
+            CxlHdmDecoderRegisterOffset::CONTROL => Some(block.control.into_bits()),
+            CxlHdmDecoderRegisterOffset::DPA_SKIP_LOW => Some(block.dpa_skip_low.into_bits()),
+            CxlHdmDecoderRegisterOffset::DPA_SKIP_HIGH => Some(block.dpa_skip_high),
+            _ => None,
+        }
+    }
+
+    fn write_decoder_u32(block: &mut CxlHdmDecoderRegisterBlock, within: u16, value: u32) -> bool {
+        // When lock-on-commit is active and the decoder is committed, all
+        // decoder-register writes are blocked (BASE/SIZE/CONTROL/DPA_SKIP).
+        if block.control.lock_on_commit() && block.control.committed() {
+            info!(
+                register_offset = within,
+                value,
+                "HDM decoder write rejected: decoder is lock-on-commit and already committed"
+            );
+            return false;
+        }
+
+        match within {
+            CxlHdmDecoderRegisterOffset::BASE_LOW => {
+                block.base_low = CxlHdmDecoderBaseLowRegister::from_bits(value);
+                info!(
+                    register = "BASE_LOW",
+                    raw_value = value,
+                    memory_base_low = block.base_low.memory_base_low(),
+                    "HDM decoder BASE_LOW programmed"
+                );
+                true
+            }
+            CxlHdmDecoderRegisterOffset::BASE_HIGH => {
+                block.base_high = value;
+                info!(
+                    register = "BASE_HIGH",
+                    raw_value = value,
+                    "HDM decoder BASE_HIGH programmed"
+                );
+                true
+            }
+            CxlHdmDecoderRegisterOffset::SIZE_LOW => {
+                block.size_low = CxlHdmDecoderSizeLowRegister::from_bits(value);
+                info!(
+                    register = "SIZE_LOW",
+                    raw_value = value,
+                    memory_size_low = block.size_low.memory_size_low(),
+                    "HDM decoder SIZE_LOW programmed"
+                );
+                true
+            }
+            CxlHdmDecoderRegisterOffset::SIZE_HIGH => {
+                block.size_high = value;
+                info!(
+                    register = "SIZE_HIGH",
+                    raw_value = value,
+                    "HDM decoder SIZE_HIGH programmed"
+                );
+                true
+            }
+            CxlHdmDecoderRegisterOffset::CONTROL => {
+                let requested = CxlHdmDecoderControlRegister::from_bits(value);
+                let commit_requested = requested.commit();
+                let committed = block.control.committed() || commit_requested;
+                block.control = CxlHdmDecoderControlRegister::new()
+                    .with_interleave_granularity(requested.interleave_granularity())
+                    .with_interleave_ways(requested.interleave_ways())
+                    .with_lock_on_commit(block.control.lock_on_commit())
+                    .with_commit(block.control.commit() || commit_requested)
+                    .with_committed(committed)
+                    .with_error_not_committed(false);
+                info!(
+                    register = "CONTROL",
+                    raw_value = value,
+                    commit_requested,
+                    commit = block.control.commit(),
+                    committed = block.control.committed(),
+                    lock_on_commit = block.control.lock_on_commit(),
+                    interleave_granularity = block.control.interleave_granularity(),
+                    interleave_ways = block.control.interleave_ways(),
+                    "HDM decoder CONTROL programmed"
+                );
+                true
+            }
+            CxlHdmDecoderRegisterOffset::DPA_SKIP_LOW => {
+                block.dpa_skip_low = CxlHdmDecoderDpaSkipLowRegister::from_bits(value);
+                info!(
+                    register = "DPA_SKIP_LOW",
+                    raw_value = value,
+                    "HDM decoder DPA_SKIP_LOW programmed"
+                );
+                true
+            }
+            CxlHdmDecoderRegisterOffset::DPA_SKIP_HIGH => {
+                block.dpa_skip_high = value;
+                info!(
+                    register = "DPA_SKIP_HIGH",
+                    raw_value = value,
+                    "HDM decoder DPA_SKIP_HIGH programmed"
+                );
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+impl CxlComponentRegister for CxlHdmDecoderCapability {
+    fn label(&self) -> &str {
+        "cxl-hdm-decoder-capability"
+    }
+
+    fn register_type(&self) -> CxlComponentRegisterType {
+        CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER
+    }
+
+    fn capability_id(&self) -> u16 {
+        CXL_HDM_DECODER_CAPABILITY_ID
+    }
+
+    fn capability_version(&self) -> u8 {
+        CXL_HDM_DECODER_CAPABILITY_VERSION
+    }
+
+    fn len(&self) -> u16 {
+        Self::len_for_decoder_count(self.decoders.len())
+    }
+
+    fn read_u32(&self, offset: u16) -> Option<u32> {
+        if offset >= self.len() || !offset.is_multiple_of(4) {
+            return None;
+        }
+
+        match offset {
+            CXL_HDM_DECODER_CAPABILITY_OFFSET => Some(self.capability.into_bits()),
+            CXL_HDM_DECODER_GLOBAL_CONTROL_OFFSET => Some(self.global_control.into_bits()),
+            CXL_HDM_DECODER_RESERVED0_OFFSET | CXL_HDM_DECODER_RESERVED1_OFFSET => Some(0),
+            x if x >= CXL_HDM_DECODER_BASE_OFFSET => {
+                let (index, within) = Self::decode_decoder_offset(x)?;
+                let block = self.decoders.get(index)?;
+                Self::read_decoder_u32(block, within)
+            }
+            _ => None,
+        }
+    }
+
+    fn write_u32(&mut self, offset: u16, value: u32) -> bool {
+        if offset >= self.len() || !offset.is_multiple_of(4) {
+            return false;
+        }
+
+        match offset {
+            CXL_HDM_DECODER_GLOBAL_CONTROL_OFFSET => {
+                self.global_control = CxlHdmDecoderGlobalControlRegister::from_bits(
+                    value & CXL_HDM_DECODER_GLOBAL_CONTROL_WRITABLE_MASK,
+                );
+                info!(
+                    raw_value = value,
+                    masked_value = value & CXL_HDM_DECODER_GLOBAL_CONTROL_WRITABLE_MASK,
+                    hdm_decoder_enable = self.global_control.hdm_decoder_enable(),
+                    poison_on_decode_error_enable =
+                        self.global_control.poison_on_decode_error_enable(),
+                    "HDM global control programmed"
+                );
+                true
+            }
+            CXL_HDM_DECODER_RESERVED0_OFFSET | CXL_HDM_DECODER_RESERVED1_OFFSET => false,
+            x if x >= CXL_HDM_DECODER_BASE_OFFSET => {
+                let Some((index, within)) = Self::decode_decoder_offset(x) else {
+                    return false;
+                };
+                let Some(block) = self.decoders.get_mut(index) else {
+                    return false;
+                };
+                Self::write_decoder_u32(block, within, value)
+            }
+            _ => false,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.global_control = CxlHdmDecoderGlobalControlRegister::new()
+            .with_poison_on_decode_error_enable(false)
+            .with_hdm_decoder_enable(false);
+    }
+}
+
+mod save_restore {
+    use super::*;
+    use vmcore::save_restore::RestoreError;
+    use vmcore::save_restore::SaveError;
+    use vmcore::save_restore::SaveRestore;
+
+    mod state {
+        use mesh::payload::Protobuf;
+        use vmcore::save_restore::SavedStateRoot;
+
+        #[derive(Protobuf, SavedStateRoot)]
+        #[mesh(package = "cxl.component_registers.hdm_cap")]
+        pub struct SavedDecoderState {
+            #[mesh(1)]
+            pub base_low: u32,
+            #[mesh(2)]
+            pub base_high: u32,
+            #[mesh(3)]
+            pub size_low: u32,
+            #[mesh(4)]
+            pub size_high: u32,
+            #[mesh(5)]
+            pub control: u32,
+            #[mesh(6)]
+            pub dpa_skip_low: u32,
+            #[mesh(7)]
+            pub dpa_skip_high: u32,
+        }
+
+        #[derive(Protobuf, SavedStateRoot)]
+        #[mesh(package = "cxl.component_registers.hdm_cap")]
+        pub struct SavedState {
+            #[mesh(1)]
+            pub global_control: u32,
+            #[mesh(2)]
+            pub decoders: Vec<SavedDecoderState>,
+        }
+    }
+
+    impl SaveRestore for CxlHdmDecoderCapability {
+        type SavedState = state::SavedState;
+
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            Ok(state::SavedState {
+                global_control: self.global_control.into_bits(),
+                decoders: self
+                    .decoders
+                    .iter()
+                    .map(|decoder| state::SavedDecoderState {
+                        base_low: decoder.base_low.into_bits(),
+                        base_high: decoder.base_high,
+                        size_low: decoder.size_low.into_bits(),
+                        size_high: decoder.size_high,
+                        control: decoder.control.into_bits(),
+                        dpa_skip_low: decoder.dpa_skip_low.into_bits(),
+                        dpa_skip_high: decoder.dpa_skip_high,
+                    })
+                    .collect(),
+            })
+        }
+
+        fn restore(&mut self, state: Self::SavedState) -> Result<(), RestoreError> {
+            if state.decoders.len() != self.decoders.len() {
+                return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
+                    "hdm decoder count mismatch: saved {}, current {}",
+                    state.decoders.len(),
+                    self.decoders.len()
+                )));
+            }
+
+            self.global_control =
+                CxlHdmDecoderGlobalControlRegister::from_bits(state.global_control);
+
+            for (decoder, saved) in self.decoders.iter_mut().zip(state.decoders) {
+                decoder.base_low = CxlHdmDecoderBaseLowRegister::from_bits(saved.base_low);
+                decoder.base_high = saved.base_high;
+                decoder.size_low = CxlHdmDecoderSizeLowRegister::from_bits(saved.size_low);
+                decoder.size_high = saved.size_high;
+                decoder.control = CxlHdmDecoderControlRegister::from_bits(saved.control);
+                decoder.dpa_skip_low =
+                    CxlHdmDecoderDpaSkipLowRegister::from_bits(saved.dpa_skip_low);
+                decoder.dpa_skip_high = saved.dpa_skip_high;
+            }
+
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vmcore::save_restore::SaveRestore;
+
+    fn fixed_config() -> CxlHdmDecoderFixedConfig {
+        CxlHdmDecoderFixedConfig {
+            hdm_base: 0x1000_0000,
+            hdm_size: 0x1000_0000,
+            interleave_granularity: CxlHdmDecoderInterleaveGranularity::Bytes256,
+            interleave_ways: CxlHdmDecoderInterleaveWays::Way1,
+        }
+    }
+
+    #[test]
+    fn metadata_and_capability_dword() {
+        let mut cap = CxlHdmDecoderCapability::new().expect("new should succeed");
+        cap.with_hdm(fixed_config()).expect("fixed config valid");
+        assert_eq!(
+            cap.register_type(),
+            CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER
+        );
+        assert_eq!(cap.capability_id(), CXL_HDM_DECODER_CAPABILITY_ID);
+        assert_eq!(cap.capability_version(), CXL_HDM_DECODER_CAPABILITY_VERSION);
+        assert_eq!(
+            cap.len(),
+            CXL_HDM_DECODER_HEADER_LENGTH + CXL_HDM_DECODER_BLOCK_LENGTH
+        );
+
+        let cap_dword = cap
+            .read_u32(CXL_HDM_DECODER_CAPABILITY_OFFSET)
+            .expect("capability dword should exist");
+        assert_eq!(cap_dword & 0xF, 0x0);
+    }
+
+    #[test]
+    fn fixed_decoder_control_exposes_read_only_committed_state() {
+        let mut cap = CxlHdmDecoderCapability::new().expect("new should succeed");
+        cap.with_hdm(fixed_config()).expect("fixed config valid");
+        let control_offset = CXL_HDM_DECODER_BASE_OFFSET + CxlHdmDecoderRegisterOffset::CONTROL;
+
+        let control = cap
+            .read_u32(control_offset)
+            .expect("control dword should exist");
+        assert_ne!(control & (1u32 << 8), 0);
+        assert_ne!(control & (1u32 << 9), 0);
+        assert_ne!(control & (1u32 << 10), 0);
+    }
+
+    #[test]
+    fn fixed_decoder_rejects_programming_writes() {
+        let mut cap = CxlHdmDecoderCapability::new().expect("new should succeed");
+        cap.with_hdm(fixed_config()).expect("fixed config valid");
+        let base_high_offset = CXL_HDM_DECODER_BASE_OFFSET + CxlHdmDecoderRegisterOffset::BASE_HIGH;
+        let control_offset = CXL_HDM_DECODER_BASE_OFFSET + CxlHdmDecoderRegisterOffset::CONTROL;
+
+        assert!(!cap.write_u32(base_high_offset, 0xfeed_beef));
+        assert!(!cap.write_u32(control_offset, 0xffff_ffff));
+        let base_high = cap
+            .read_u32(base_high_offset)
+            .expect("base high should exist");
+        assert_eq!(base_high, 0x0);
+    }
+
+    #[test]
+    fn save_restore_roundtrip_preserves_decoder_state() {
+        let mut cap = CxlHdmDecoderCapability::new().expect("new should succeed");
+        cap.with_hdm(fixed_config()).expect("fixed config valid");
+
+        let saved = cap.save().expect("save should succeed");
+
+        let mut restored = CxlHdmDecoderCapability::new().expect("new should succeed");
+        restored
+            .with_hdm(fixed_config())
+            .expect("fixed config valid");
+        restored.restore(saved).expect("restore should succeed");
+        assert_eq!(
+            restored.read_u32(CXL_HDM_DECODER_GLOBAL_CONTROL_OFFSET),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn save_restore_should_preserve_global_control_runtime_state() {
+        let mut cap = CxlHdmDecoderCapability::new().expect("new should succeed");
+        cap.with_hdm(fixed_config()).expect("fixed config valid");
+
+        let enabled = CxlHdmDecoderGlobalControlRegister::new()
+            .with_hdm_decoder_enable(true)
+            .into_bits();
+        assert!(cap.write_u32(CXL_HDM_DECODER_GLOBAL_CONTROL_OFFSET, enabled));
+        assert_eq!(
+            cap.read_u32(CXL_HDM_DECODER_GLOBAL_CONTROL_OFFSET),
+            Some(enabled)
+        );
+
+        let saved = cap.save().expect("save should succeed");
+        let mut restored = CxlHdmDecoderCapability::new().expect("new should succeed");
+        restored
+            .with_hdm(fixed_config())
+            .expect("fixed config valid");
+        restored.restore(saved).expect("restore should succeed");
+
+        // This currently fails: restore forces global control back to defaults.
+        assert_eq!(
+            restored.read_u32(CXL_HDM_DECODER_GLOBAL_CONTROL_OFFSET),
+            Some(enabled)
+        );
+    }
+
+    #[test]
+    fn enabled_decoder_lookup_requires_global_enable() {
+        let mut cap = CxlHdmDecoderCapability::new().expect("new should succeed");
+        cap.with_hdm(fixed_config()).expect("fixed config valid");
+        assert_eq!(cap.find_enabled_decoder_for_access(0x1000_0100, 4), None);
+
+        assert!(cap.write_u32(CXL_HDM_DECODER_GLOBAL_CONTROL_OFFSET, 1u32 << 1));
+        assert_eq!(
+            cap.find_enabled_decoder_for_access(0x1000_0100, 4),
+            Some((0, 0x100))
+        );
+    }
+
+    #[test]
+    fn with_hdm_can_add_multiple_fixed_ranges() {
+        let mut cap = CxlHdmDecoderCapability::new().expect("new should succeed");
+
+        cap.with_hdm(fixed_config()).expect("fixed config valid");
+        assert!(cap.write_u32(CXL_HDM_DECODER_GLOBAL_CONTROL_OFFSET, 1u32 << 1));
+
+        cap.with_hdm(CxlHdmDecoderFixedConfig {
+            hdm_base: 0x2000_0000,
+            hdm_size: 0x1000_0000,
+            interleave_granularity: CxlHdmDecoderInterleaveGranularity::Bytes256,
+            interleave_ways: CxlHdmDecoderInterleaveWays::Way1,
+        })
+        .expect("adding a second fixed range should succeed");
+
+        assert_eq!(
+            cap.len(),
+            CXL_HDM_DECODER_HEADER_LENGTH + (2 * CXL_HDM_DECODER_BLOCK_LENGTH)
+        );
+
+        assert_eq!(
+            cap.find_enabled_decoder_for_access(0x2000_0100, 4),
+            Some((1, 0x100))
+        );
+    }
+
+    #[test]
+    fn programmable_decoder_commit_sets_committed_and_locks_when_configured() {
+        let mut cap = CxlHdmDecoderCapability::new().expect("new should succeed");
+        cap.with_decoder_slot(
+            CxlHdmDecoderInterleaveGranularity::Bytes256,
+            CxlHdmDecoderInterleaveWays::Way1,
+        )
+        .expect("slot creation should succeed");
+
+        let base_low_offset = CXL_HDM_DECODER_BASE_OFFSET + CxlHdmDecoderRegisterOffset::BASE_LOW;
+        let control_offset = CXL_HDM_DECODER_BASE_OFFSET + CxlHdmDecoderRegisterOffset::CONTROL;
+
+        assert!(cap.write_u32(base_low_offset, 0x1));
+        let control_commit = CxlHdmDecoderControlRegister::new()
+            .with_commit(true)
+            .into_bits();
+        assert!(cap.write_u32(control_offset, control_commit));
+
+        let control_bits = cap
+            .read_u32(control_offset)
+            .expect("control dword should exist");
+        let control = CxlHdmDecoderControlRegister::from_bits(control_bits);
+        assert!(control.commit());
+        assert!(control.committed());
+        assert!(control.lock_on_commit());
+
+        assert!(!cap.write_u32(base_low_offset, 0x2));
+        assert!(!cap.write_u32(control_offset, 0));
+    }
+
+    #[test]
+    fn programmable_decoder_lock_blocks_base_size_and_dpa_programming() {
+        let mut cap = CxlHdmDecoderCapability::new().expect("new should succeed");
+        cap.with_decoder_slot(
+            CxlHdmDecoderInterleaveGranularity::Bytes256,
+            CxlHdmDecoderInterleaveWays::Way1,
+        )
+        .expect("slot creation should succeed");
+
+        let base_low_offset = CXL_HDM_DECODER_BASE_OFFSET + CxlHdmDecoderRegisterOffset::BASE_LOW;
+        let base_high_offset = CXL_HDM_DECODER_BASE_OFFSET + CxlHdmDecoderRegisterOffset::BASE_HIGH;
+        let size_low_offset = CXL_HDM_DECODER_BASE_OFFSET + CxlHdmDecoderRegisterOffset::SIZE_LOW;
+        let size_high_offset = CXL_HDM_DECODER_BASE_OFFSET + CxlHdmDecoderRegisterOffset::SIZE_HIGH;
+        let dpa_skip_low_offset =
+            CXL_HDM_DECODER_BASE_OFFSET + CxlHdmDecoderRegisterOffset::DPA_SKIP_LOW;
+        let dpa_skip_high_offset =
+            CXL_HDM_DECODER_BASE_OFFSET + CxlHdmDecoderRegisterOffset::DPA_SKIP_HIGH;
+        let control_offset = CXL_HDM_DECODER_BASE_OFFSET + CxlHdmDecoderRegisterOffset::CONTROL;
+
+        // Program once before commit to prove writes are accepted while unlocked.
+        assert!(cap.write_u32(base_low_offset, 0x1));
+        assert!(cap.write_u32(base_high_offset, 0x2));
+        assert!(cap.write_u32(size_low_offset, 0x3));
+        assert!(cap.write_u32(size_high_offset, 0x4));
+        assert!(cap.write_u32(dpa_skip_low_offset, 0x5));
+        assert!(cap.write_u32(dpa_skip_high_offset, 0x6));
+
+        let control_commit = CxlHdmDecoderControlRegister::new()
+            .with_commit(true)
+            .into_bits();
+        assert!(cap.write_u32(control_offset, control_commit));
+
+        // Once committed with lock-on-commit set, all decoder-programming writes reject.
+        assert!(!cap.write_u32(base_low_offset, 0x11));
+        assert!(!cap.write_u32(base_high_offset, 0x22));
+        assert!(!cap.write_u32(size_low_offset, 0x33));
+        assert!(!cap.write_u32(size_high_offset, 0x44));
+        assert!(!cap.write_u32(dpa_skip_low_offset, 0x55));
+        assert!(!cap.write_u32(dpa_skip_high_offset, 0x66));
+    }
+}

--- a/vm/devices/cxl/src/component_registers/mod.rs
+++ b/vm/devices/cxl/src/component_registers/mod.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! CXL component register abstractions.
+
+use inspect::Inspect;
+use vmcore::save_restore::ProtobufSaveRestore;
+
+mod hdm_cap;
+mod registers;
+pub mod spec;
+/// Reusable in-memory register blocks for unit tests.
+pub mod test_helper;
+
+pub use hdm_cap::CxlHdmDecoderCapability;
+pub use hdm_cap::CxlHdmDecoderCapabilityError;
+pub use hdm_cap::CxlHdmDecoderCapabilityOptions;
+pub use hdm_cap::CxlHdmDecoderFixedConfig;
+pub use registers::CxlComponentRegisters;
+
+/// A generic CXL component register space.
+pub trait CxlComponentRegister: Send + Sync + Inspect + ProtobufSaveRestore {
+    /// A descriptive label for use in Save/Restore + Inspect output.
+    fn label(&self) -> &str;
+
+    /// Returns the register block type.
+    fn register_type(&self) -> crate::spec::CxlComponentRegisterType;
+
+    /// Returns the CXL capability ID for this register block.
+    fn capability_id(&self) -> u16;
+
+    /// Returns the CXL capability-version value for this register block.
+    fn capability_version(&self) -> u8;
+
+    /// Returns the component register aperture length in bytes.
+    fn len(&self) -> u16;
+
+    /// Reads a 32-bit value at a register-block-relative offset.
+    fn read_u32(&self, offset: u16) -> Option<u32>;
+
+    /// Writes a 32-bit value at a register-block-relative offset.
+    ///
+    /// Returns `true` when the write is accepted.
+    fn write_u32(&mut self, offset: u16, val: u32) -> bool;
+
+    /// Resets the register space.
+    fn reset(&mut self);
+}

--- a/vm/devices/cxl/src/component_registers/registers.rs
+++ b/vm/devices/cxl/src/component_registers/registers.rs
@@ -1,0 +1,818 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::CxlComponentRegister;
+use crate::spec;
+use crate::spec::CxlComponentRegisterType;
+use chipset_device::io::IoError;
+use chipset_device::io::IoResult;
+use inspect::Inspect;
+use std::collections::BTreeMap;
+
+/// Returns the absolute byte offset where the primary cache/mem section begins.
+fn cachemem_primary_section_start() -> usize {
+    spec::CXL_COMPONENT_REG_RANGE_CACHEMEM_PRIMARY_OFFSET as usize
+}
+
+/// Returns the total byte length of the primary cache/mem section.
+fn cachemem_primary_section_len() -> usize {
+    spec::CXL_COMPONENT_REG_RANGE_CACHEMEM_PRIMARY_SIZE_BYTES as usize
+}
+
+/// Sparse representation of a 64-KiB CXL component register aperture.
+pub struct CxlComponentRegisters {
+    registers: Vec<MappedComponentRegister>,
+    cachemem_primary_entries: BTreeMap<u16, Vec<CacheMemDirectoryEntry>>,
+}
+
+struct MappedComponentRegister {
+    start_offset: u16,
+    register: Box<dyn CxlComponentRegister>,
+}
+
+struct CacheMemRegionUsage {
+    entry_count: usize,
+    data_start: usize,
+    data_end: usize,
+}
+
+#[derive(Copy, Clone)]
+struct CacheMemDirectoryEntry {
+    capability_id: u16,
+    capability_version: u8,
+    start_offset: u16,
+    len: u16,
+}
+
+/// Size of one cache/mem region page used by the capability directory model.
+fn cachemem_region_size() -> usize {
+    spec::CXL_CACHEMEM_REGION_SIZE_BYTES as usize
+}
+
+/// End (exclusive) of a 4-KiB cache/mem region page.
+fn cachemem_region_end(region_base: usize) -> usize {
+    region_base + cachemem_region_size()
+}
+
+/// End (exclusive) of the capability-directory area inside one cache/mem region.
+fn cachemem_directory_end(region_base: usize, entry_count: usize) -> usize {
+    let header_size = spec::CXL_CACHEMEM_CAPABILITY_ARRAY_ENTRY_SIZE_BYTES as usize;
+    region_base + header_size * (entry_count + 1)
+}
+
+/// Iterates each 4-KiB cache/mem region base within the primary section.
+fn cachemem_region_bases() -> impl Iterator<Item = usize> {
+    let start = cachemem_primary_section_start();
+    let end = start + cachemem_primary_section_len();
+    (start..end).step_by(cachemem_region_size())
+}
+
+/// Returns the 4-KiB primary cachemem page base containing `offset`.
+fn cachemem_region_base_for_offset(offset: usize) -> Option<usize> {
+    let section_start = cachemem_primary_section_start();
+    let section_end = section_start + cachemem_primary_section_len();
+    let end = offset.checked_add(4)?;
+    if offset < section_start || end > section_end {
+        return None;
+    }
+
+    let page_size = cachemem_region_size();
+    let within = offset - section_start;
+    Some(section_start + (within / page_size) * page_size)
+}
+
+impl CxlComponentRegisters {
+    /// Creates an empty CXL component register space.
+    pub fn new() -> Self {
+        Self {
+            registers: Vec::new(),
+            cachemem_primary_entries: BTreeMap::new(),
+        }
+    }
+
+    fn cachemem_entries_for_region(
+        &self,
+        region_base: u16,
+    ) -> Option<&Vec<CacheMemDirectoryEntry>> {
+        self.cachemem_primary_entries.get(&region_base)
+    }
+
+    fn cachemem_entries_for_region_mut(
+        &mut self,
+        region_base: u16,
+    ) -> &mut Vec<CacheMemDirectoryEntry> {
+        self.cachemem_primary_entries
+            .entry(region_base)
+            .or_default()
+    }
+
+    /// Adds one emulated register block to the component aperture.
+    ///
+    /// Placement is computed from the block type and current section usage.
+    /// Returns `false` if the block is unaligned, zero-sized, out of section
+    /// capacity, or would overlap an existing block.
+    pub fn add_register(&mut self, register: Box<dyn CxlComponentRegister>) -> bool {
+        let register_type = register.register_type();
+        let capability_id = register.capability_id();
+        let capability_version = register.capability_version();
+        let len = usize::from(register.len());
+
+        // The register type can be either cache/mem primary or cache/mem extended.
+        // TODO: Add support for other register types (e.g. ARB/MUX).
+        // TODO: Support placement into the extended cache/mem section.
+        // For now, both register types are placed only in the 4-KiB primary section.
+        if !matches!(
+            register_type,
+            CxlComponentRegisterType::CacheMemRegister
+                | CxlComponentRegisterType::CacheMemExtendedRegister
+        ) {
+            return false;
+        }
+
+        if len == 0 || !len.is_multiple_of(4) {
+            return false;
+        }
+
+        let section_start = cachemem_primary_section_start();
+        let section_len = cachemem_primary_section_len();
+        let Some(section_end) = section_start.checked_add(section_len) else {
+            return false;
+        };
+
+        // Find a 4-KiB cache/mem page where we can fit both:
+        // 1) the grown directory (existing entries + this new one), and
+        // 2) the actual register block payload.
+        let mut selected: Option<(usize, usize)> = None;
+        for base in cachemem_region_bases() {
+            let usage = self.cachemem_region_usage(base as u16);
+            let directory_end = cachemem_directory_end(base, usage.entry_count + 1);
+
+            // Directory growth must not consume already-placed payload bytes.
+            if directory_end > usage.data_start {
+                continue;
+            }
+
+            // Data begins after both current payload usage and directory growth.
+            let candidate_start = usage.data_end.max(directory_end);
+            let Some(candidate_end) = candidate_start.checked_add(len) else {
+                continue;
+            };
+
+            if candidate_end <= cachemem_region_end(base) {
+                selected = Some((base, candidate_start));
+                break;
+            }
+        }
+
+        let Some((base, start)) = selected else {
+            return false;
+        };
+        let region_base = base as u16;
+
+        if !start.is_multiple_of(4) {
+            return false;
+        }
+
+        let Some(end) = start.checked_add(len) else {
+            return false;
+        };
+
+        if end > spec::CXL_COMPONENT_REGISTERS_SIZE_BYTES as usize {
+            return false;
+        }
+
+        if start < section_start || end > section_end {
+            return false;
+        }
+
+        // Final safety check: no overlap with any previously mapped block.
+        for reg in &self.registers {
+            let reg_start = usize::from(reg.start_offset);
+            let reg_end = reg_start + usize::from(reg.register.len());
+
+            if start < reg_end && reg_start < end {
+                return false;
+            }
+        }
+
+        self.registers.push(MappedComponentRegister {
+            start_offset: start as u16,
+            register,
+        });
+
+        // Keep a per-page cachemem directory view sorted by payload start offset.
+        let entries = self.cachemem_entries_for_region_mut(region_base);
+        let entry = CacheMemDirectoryEntry {
+            capability_id,
+            capability_version,
+            start_offset: start as u16,
+            len: len as u16,
+        };
+
+        let insert_at = entries.partition_point(|e| e.start_offset <= entry.start_offset);
+        entries.insert(insert_at, entry);
+        true
+    }
+
+    /// Scans one cache/mem 4-KiB page and reports directory entry count + data end.
+    fn cachemem_region_usage(&self, region_base: u16) -> CacheMemRegionUsage {
+        let Some(entries) = self.cachemem_entries_for_region(region_base) else {
+            return CacheMemRegionUsage {
+                entry_count: 0,
+                data_start: cachemem_region_end(usize::from(region_base)),
+                data_end: usize::from(region_base),
+            };
+        };
+
+        let entry_count = entries.len();
+        let data_start = entries
+            .iter()
+            .map(|e| usize::from(e.start_offset))
+            .min()
+            .unwrap_or(cachemem_region_end(usize::from(region_base)));
+        let data_end = entries
+            .iter()
+            .map(|e| usize::from(e.start_offset) + usize::from(e.len))
+            .max()
+            .unwrap_or(usize::from(region_base));
+
+        CacheMemRegionUsage {
+            entry_count,
+            data_start,
+            data_end,
+        }
+    }
+
+    /// Serves synthetic cache/mem directory dwords when `offset` targets that area.
+    fn read_cachemem_directory_u32(&self, offset: usize) -> Option<u32> {
+        // TODO: Add synthetic directory support for extended cache/mem section.
+        // For now, only primary cache/mem section reads are synthesized.
+        // Compute the page directly from offset to avoid scanning all pages.
+        let region_base = cachemem_region_base_for_offset(offset)?;
+
+        // Convert absolute aperture address -> dword index within this page.
+        let index = (offset - region_base)
+            / (spec::CXL_CACHEMEM_CAPABILITY_ARRAY_ENTRY_SIZE_BYTES as usize);
+
+        let entry_count = self
+            .cachemem_entries_for_region(region_base as u16)
+            .map(Vec::len)
+            .unwrap_or(0);
+
+        // Index 0 is always the required CXL Capability Header.
+        if index == 0 {
+            return spec::CxlCacheMemCapabilityHeader::encode(entry_count);
+        }
+
+        // Use precomputed per-page sorted entries instead of filtering all registers.
+        let entries = self.cachemem_entries_for_region(region_base as u16)?;
+
+        if entries.len() > spec::CXL_CACHEMEM_CAPABILITY_ARRAY_MAX_ENTRIES {
+            return None;
+        }
+
+        // Only offsets that fall in the directory window are synthetic.
+        let directory_end = cachemem_directory_end(region_base, entries.len());
+        if offset >= directory_end {
+            return None;
+        }
+
+        // Capability-array entries are 1-based in address space but 0-based in Vec.
+        let entry = entries[index - 1];
+
+        // Pointer is encoded as an offset inside this 4-KiB page.
+        let pointer = entry.start_offset - region_base as u16;
+        spec::CxlCacheMemCapabilityArrayEntry::encode(
+            entry.capability_id,
+            entry.capability_version,
+            pointer,
+        )
+    }
+
+    /// Validates that an aperture access is either 4 or 8 bytes,
+    /// is naturally aligned to its length, and is in-bounds.
+    fn checked_access_offset(offset: u16, len: usize) -> Option<usize> {
+        let offset = usize::from(offset);
+        let end = offset.checked_add(len)?;
+        if !matches!(len, 4 | 8)
+            || !offset.is_multiple_of(len)
+            || end > spec::CXL_COMPONENT_REGISTERS_SIZE_BYTES as usize
+        {
+            return None;
+        }
+        Some(offset)
+    }
+
+    fn read_u32(&self, offset: usize, val: &mut u32) -> IoResult {
+        // Directory space is synthesized; it is not backed by a register object.
+        if let Some(value) = self.read_cachemem_directory_u32(offset) {
+            *val = value;
+            return IoResult::Ok;
+        }
+
+        let Some((index, rel)) = self.find_block_index_for_access(offset) else {
+            return IoResult::Err(IoError::InvalidRegister);
+        };
+
+        let Some(value) = self.registers[index].register.read_u32(rel) else {
+            return IoResult::Err(IoError::InvalidRegister);
+        };
+
+        *val = value;
+        IoResult::Ok
+    }
+
+    fn write_u32(&mut self, offset: usize, val: u32) -> IoResult {
+        // Directory spaces are read-only by definition.
+        if self.read_cachemem_directory_u32(offset).is_some() {
+            return IoResult::Err(IoError::InvalidRegister);
+        }
+
+        let Some((index, rel)) = self.find_block_index_for_access(offset) else {
+            return IoResult::Err(IoError::InvalidRegister);
+        };
+
+        if self.registers[index].register.write_u32(rel, val) {
+            IoResult::Ok
+        } else {
+            IoResult::Err(IoError::InvalidRegister)
+        }
+    }
+
+    /// Locates the mapped register block that owns an absolute component offset.
+    fn find_block_index_for_access(&self, offset: usize) -> Option<(usize, u16)> {
+        for (index, reg) in self.registers.iter().enumerate() {
+            let start = usize::from(reg.start_offset);
+            let end = start + usize::from(reg.register.len());
+            if offset >= start && offset + 4 <= end {
+                let rel = offset - start;
+                return Some((index, rel as u16));
+            }
+        }
+
+        None
+    }
+
+    /// Returns the component register aperture length in bytes.
+    pub fn len(&self) -> usize {
+        spec::CXL_COMPONENT_REGISTERS_SIZE_BYTES as usize
+    }
+
+    /// Returns the absolute component offset for a capability id.
+    pub fn capability_offset(&self, capability_id: u16) -> Option<u16> {
+        self.registers
+            .iter()
+            .find(|reg| reg.register.capability_id() == capability_id)
+            .map(|reg| reg.start_offset)
+    }
+
+    /// Reads bytes at a component-register-relative offset.
+    pub fn read(&self, offset: u16, data: &mut [u8]) -> IoResult {
+        let Some(offset) = Self::checked_access_offset(offset, data.len()) else {
+            return IoResult::Err(IoError::InvalidRegister);
+        };
+
+        // checked_access_offset constrains accesses to 4 or 8 bytes, so splitting
+        // into 4-byte chunks is always exact and safe here.
+        for (i, chunk) in data.chunks_exact_mut(4).enumerate() {
+            let mut value = 0;
+            match self.read_u32(offset + i * 4, &mut value) {
+                IoResult::Ok => {}
+                err => return err,
+            }
+            chunk.copy_from_slice(&value.to_le_bytes());
+        }
+
+        IoResult::Ok
+    }
+
+    /// Writes bytes at a component-register-relative offset.
+    pub fn write(&mut self, offset: u16, data: &[u8]) -> IoResult {
+        let Some(offset) = Self::checked_access_offset(offset, data.len()) else {
+            return IoResult::Err(IoError::InvalidRegister);
+        };
+
+        // checked_access_offset constrains accesses to 4 or 8 bytes, so splitting
+        // into 4-byte chunks is always exact and safe here.
+        for (i, chunk) in data.chunks_exact(4).enumerate() {
+            let value = u32::from_le_bytes(chunk.try_into().expect("4-byte dword chunk"));
+            match self.write_u32(offset + i * 4, value) {
+                IoResult::Ok => {}
+                err => return err,
+            }
+        }
+
+        IoResult::Ok
+    }
+
+    /// Resets all registered component register blocks.
+    pub fn reset(&mut self) {
+        for reg in &mut self.registers {
+            reg.register.reset();
+        }
+    }
+}
+
+impl Default for CxlComponentRegisters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Inspect for CxlComponentRegisters {
+    fn inspect(&self, req: inspect::Request<'_>) {
+        let mut resp = req.respond();
+        resp.field("aperture_len", self.len());
+        resp.field("mapped_register_count", self.registers.len());
+        resp.field(
+            "cachemem_primary_page_count",
+            self.cachemem_primary_entries.len(),
+        );
+    }
+}
+
+mod save_restore {
+    use super::*;
+    use thiserror::Error;
+    use vmcore::save_restore::RestoreError;
+    use vmcore::save_restore::SaveError;
+    use vmcore::save_restore::SaveRestore;
+
+    mod state {
+        use mesh::payload::Protobuf;
+        use vmcore::save_restore::SavedStateBlob;
+        use vmcore::save_restore::SavedStateRoot;
+
+        #[derive(Protobuf, SavedStateRoot)]
+        #[mesh(package = "cxl.component_registers")]
+        pub struct SavedState {
+            #[mesh(1)]
+            pub registers: Vec<(String, SavedStateBlob)>,
+        }
+    }
+
+    #[derive(Debug, Error)]
+    enum CxlComponentRegistersRestoreError {
+        #[error("found unexpected component register {0}")]
+        InvalidRegister(String),
+    }
+
+    impl SaveRestore for CxlComponentRegisters {
+        type SavedState = state::SavedState;
+
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            Ok(state::SavedState {
+                registers: self
+                    .registers
+                    .iter_mut()
+                    .map(|mapped| {
+                        let id = mapped.register.label().to_owned();
+                        Ok((id, mapped.register.save()?))
+                    })
+                    .collect::<Result<_, _>>()?,
+            })
+        }
+
+        fn restore(&mut self, state: Self::SavedState) -> Result<(), RestoreError> {
+            let state::SavedState { registers } = state;
+
+            for (id, entry) in registers {
+                tracing::debug!(save_id = id.as_str(), "restoring cxl component register");
+
+                let mut restored = false;
+                for mapped in &mut self.registers {
+                    if mapped.register.label() == id {
+                        mapped.register.restore(entry)?;
+                        restored = true;
+                        break;
+                    }
+                }
+
+                if !restored {
+                    return Err(RestoreError::InvalidSavedState(
+                        CxlComponentRegistersRestoreError::InvalidRegister(id).into(),
+                    ));
+                }
+            }
+
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::component_registers::test_helper::TestCxlComponentRegisterBlock;
+    use crate::spec;
+    use chipset_device::io::IoResult;
+    use vmcore::save_restore::SaveRestore;
+
+    use super::CxlComponentRegisterType;
+    use super::CxlComponentRegisters;
+
+    #[test]
+    fn component_register_space_metadata() {
+        // The aperture is always the fixed 64-KiB CXL component-register window.
+        let regs = CxlComponentRegisters::new();
+        assert_eq!(regs.len(), 64 * 1024);
+    }
+
+    #[test]
+    fn component_register_space_read_write_and_reset() {
+        // Data reads/writes target payload space after the directory dwords.
+        let mut regs = CxlComponentRegisters::new();
+        assert!(
+            regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                16,
+            )))
+        );
+        assert!(matches!(
+            regs.write(0x1008, &0x1122_3344u32.to_le_bytes()),
+            IoResult::Ok
+        ));
+
+        let mut read_bytes = [0u8; 4];
+        assert!(matches!(regs.read(0x1008, &mut read_bytes), IoResult::Ok));
+        let read = u32::from_le_bytes(read_bytes);
+        assert_eq!(read, 0x1122_3344);
+
+        regs.reset();
+        assert!(matches!(regs.read(0x1008, &mut read_bytes), IoResult::Ok));
+        let read = u32::from_le_bytes(read_bytes);
+        assert_eq!(read, 0);
+    }
+
+    #[test]
+    fn cachemem_directory_header_exists_even_with_zero_entries() {
+        // Index 0 must always expose the CXL Capability Header.
+        let regs = CxlComponentRegisters::new();
+        let mut header_bytes = [0u8; 4];
+        assert!(matches!(regs.read(0x1000, &mut header_bytes), IoResult::Ok));
+        let header = u32::from_le_bytes(header_bytes);
+        assert_eq!(header, 0x0011_0001);
+    }
+
+    #[test]
+    fn component_register_space_rejects_invalid_offsets() {
+        // Directory dwords are writable=false, and unmapped/out-of-bounds reads fail.
+        let mut regs = CxlComponentRegisters::new();
+        assert!(
+            regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                16,
+            )))
+        );
+        assert!(matches!(
+            regs.write(0x1000, &1u32.to_le_bytes()),
+            IoResult::Err(_)
+        ));
+
+        assert!(matches!(
+            regs.write(u16::MAX, &1u32.to_le_bytes()),
+            IoResult::Err(_)
+        ));
+        let mut value_bytes = [0u8; 4];
+        assert!(matches!(
+            regs.read(u16::MAX, &mut value_bytes),
+            IoResult::Err(_)
+        ));
+
+        // Address is valid in aperture but unmapped by any register block.
+        assert!(matches!(
+            regs.write(0x2000, &1u32.to_le_bytes()),
+            IoResult::Err(_)
+        ));
+        assert!(matches!(
+            regs.read(0x2000, &mut value_bytes),
+            IoResult::Err(_)
+        ));
+    }
+
+    #[test]
+    fn component_register_space_rejects_partial_and_unaligned_accesses() {
+        // Spec requires full-width accesses only (4-byte for 32-bit, 8-byte for 64-bit).
+        let mut regs = CxlComponentRegisters::new();
+        assert!(
+            regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                16,
+            )))
+        );
+
+        let mut one = [0u8; 1];
+        assert!(matches!(regs.read(0x1008, &mut one), IoResult::Err(_)));
+        assert!(matches!(regs.write(0x1008, &one), IoResult::Err(_)));
+
+        let mut two = [0u8; 2];
+        assert!(matches!(regs.read(0x1008, &mut two), IoResult::Err(_)));
+        assert!(matches!(regs.write(0x1008, &two), IoResult::Err(_)));
+
+        let mut four = [0u8; 4];
+        assert!(matches!(regs.read(0x100a, &mut four), IoResult::Err(_)));
+        assert!(matches!(regs.write(0x100a, &four), IoResult::Err(_)));
+
+        let mut eight = [0u8; 8];
+        assert!(matches!(regs.read(0x100c, &mut eight), IoResult::Err(_)));
+        assert!(matches!(regs.write(0x100c, &eight), IoResult::Err(_)));
+    }
+
+    #[test]
+    fn component_register_space_rejects_second_block_when_directory_growth_would_overlap() {
+        // TODO: Teach allocator to repack/relocate payloads so additional capabilities
+        // can be added in the same 4-KiB primary page without directory overlap.
+        let mut regs = CxlComponentRegisters::new();
+        assert!(
+            regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                16,
+            )))
+        );
+        assert!(
+            !regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                16,
+            )))
+        );
+
+        // Existing register remains unchanged at its original offset.
+        let mut value_bytes = [0u8; 4];
+        assert!(matches!(regs.read(0x1008, &mut value_bytes), IoResult::Ok));
+        let value = u32::from_le_bytes(value_bytes);
+        assert_eq!(value, 0);
+    }
+
+    #[test]
+    fn component_register_space_rejects_bad_block_params() {
+        // Zero-sized and unaligned-size payloads are rejected.
+        let mut regs = CxlComponentRegisters::new();
+        assert!(
+            !regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                0,
+            )))
+        );
+        assert!(
+            !regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                10,
+            )))
+        );
+    }
+
+    #[test]
+    fn component_register_space_rejects_when_section_capacity_is_exhausted() {
+        // Fill every 4-KiB primary cachemem page with one max-sized payload block.
+        let mut regs = CxlComponentRegisters::new();
+        let page_count = (spec::CXL_COMPONENT_REG_RANGE_CACHEMEM_PRIMARY_SIZE_BYTES as usize)
+            / (spec::CXL_CACHEMEM_REGION_SIZE_BYTES as usize);
+        let max_payload_len = (spec::CXL_CACHEMEM_REGION_SIZE_BYTES as usize)
+            - (2 * spec::CXL_CACHEMEM_CAPABILITY_ARRAY_ENTRY_SIZE_BYTES as usize);
+
+        for _ in 0..page_count {
+            assert!(
+                regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                    CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                    max_payload_len,
+                )))
+            );
+        }
+
+        assert!(
+            !regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                16,
+            )))
+        );
+    }
+
+    #[test]
+    fn component_register_space_supports_both_cachemem_register_types_in_primary_section() {
+        // Extended register type is supported and placed in the primary section.
+        // TODO: Add support for placement/synthesis in the extended section itself.
+        let mut primary_regs = CxlComponentRegisters::new();
+        assert!(
+            primary_regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                16,
+            )))
+        );
+
+        let mut extended_type_regs = CxlComponentRegisters::new();
+        assert!(
+            extended_type_regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_CACHE_MEM_EXTENDED_REGISTER,
+                16,
+            )))
+        );
+
+        // CXL RAB/MUX placement is intentionally unsupported for now.
+        assert!(
+            !primary_regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_ARB_MUX_REGISTER,
+                16,
+            )))
+        );
+    }
+
+    #[test]
+    fn cachemem_directory_exposes_header_and_capability_pointer_entries() {
+        // Directory layout must expose header first, then capability pointer entries.
+        let mut regs = CxlComponentRegisters::new();
+        assert!(
+            regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                16,
+            )))
+        );
+
+        // First dword: CXL Capability Header with Array_Size=1.
+        let mut header_bytes = [0u8; 4];
+        assert!(matches!(regs.read(0x1000, &mut header_bytes), IoResult::Ok));
+        let header = u32::from_le_bytes(header_bytes);
+        assert_eq!(header, 0x0111_0001);
+
+        // Second dword: capability header, pointer should resolve to 0x8 in this region.
+        let mut entry_bytes = [0u8; 4];
+        assert!(matches!(regs.read(0x1004, &mut entry_bytes), IoResult::Ok));
+        let entry = u32::from_le_bytes(entry_bytes);
+        assert_eq!(entry & 0xFFFF, 0x20);
+        assert_eq!((entry >> 16) & 0xF, 1);
+        assert_eq!((entry >> 20) & 0xFFF, 0x2);
+    }
+
+    #[test]
+    fn component_register_space_accepts_extended_cachemem_register_type() {
+        // Extended register type is accepted, but still mapped into primary section.
+        let mut regs = CxlComponentRegisters::new();
+        assert!(
+            regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_CACHE_MEM_EXTENDED_REGISTER,
+                16,
+            )))
+        );
+
+        // First payload still starts in primary page after synthetic directory words.
+        let mut value_bytes = [0u8; 4];
+        assert!(matches!(regs.read(0x1008, &mut value_bytes), IoResult::Ok));
+        let value = u32::from_le_bytes(value_bytes);
+        assert_eq!(value, 0);
+    }
+
+    #[test]
+    fn component_register_space_save_restore_preserves_payload_state() {
+        let mut regs = CxlComponentRegisters::new();
+        assert!(
+            regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                16,
+            )))
+        );
+
+        let original = 0xdead_beefu32;
+        assert!(matches!(
+            regs.write(0x1008, &original.to_le_bytes()),
+            IoResult::Ok
+        ));
+
+        let saved = regs.save().expect("save should succeed");
+
+        let mut restored = CxlComponentRegisters::new();
+        assert!(
+            restored.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                16,
+            )))
+        );
+
+        restored.restore(saved).expect("restore should succeed");
+
+        let mut value_bytes = [0u8; 4];
+        assert!(matches!(
+            restored.read(0x1008, &mut value_bytes),
+            IoResult::Ok
+        ));
+        let value = u32::from_le_bytes(value_bytes);
+        assert_eq!(value, original);
+    }
+
+    #[test]
+    fn component_register_space_restore_rejects_layout_mismatch() {
+        let mut regs = CxlComponentRegisters::new();
+        assert!(
+            regs.add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                16,
+            )))
+        );
+
+        let saved = regs.save().expect("save should succeed");
+
+        let mut restored = CxlComponentRegisters::new();
+        let err = restored.restore(saved).expect_err("restore must fail");
+        match err {
+            vmcore::save_restore::RestoreError::InvalidSavedState(_) => {}
+            _ => panic!("unexpected restore error variant"),
+        }
+    }
+}

--- a/vm/devices/cxl/src/component_registers/spec.rs
+++ b/vm/devices/cxl/src/component_registers/spec.rs
@@ -1,0 +1,280 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! CXL component-register capability definitions.
+
+/// CXL HDM Decoder capability definitions.
+#[expect(missing_docs)] // keep grouped spec modules concise
+pub mod hdm_decoder {
+    use bitfield_struct::bitfield;
+    use inspect::Inspect;
+
+    /// CXL capability ID for the HDM Decoder capability.
+    pub const CXL_HDM_DECODER_CAPABILITY_ID: u16 = 0x0005;
+
+    /// CXL capability version for the HDM Decoder capability.
+    pub const CXL_HDM_DECODER_CAPABILITY_VERSION: u8 = 0x3;
+
+    /// Byte offset of the HDM Decoder Capability register.
+    pub const CXL_HDM_DECODER_CAPABILITY_OFFSET: u16 = 0x00;
+
+    /// Byte offset of the HDM Decoder Global Control register.
+    pub const CXL_HDM_DECODER_GLOBAL_CONTROL_OFFSET: u16 = 0x04;
+
+    /// Byte offset of reserved dword after Global Control.
+    pub const CXL_HDM_DECODER_RESERVED0_OFFSET: u16 = 0x08;
+
+    /// Byte offset of reserved dword before Decoder 0.
+    pub const CXL_HDM_DECODER_RESERVED1_OFFSET: u16 = 0x0C;
+
+    /// Byte offset where Decoder 0 begins.
+    pub const CXL_HDM_DECODER_BASE_OFFSET: u16 = 0x10;
+
+    /// Per-decoder register block stride in bytes.
+    pub const CXL_HDM_DECODER_STRIDE_BYTES: u16 = 0x20;
+
+    /// Fixed register bytes preceding the first decoder block.
+    pub const CXL_HDM_DECODER_HEADER_LENGTH: u16 = 0x10;
+
+    /// Length in bytes of one decoder register block.
+    pub const CXL_HDM_DECODER_BLOCK_LENGTH: u16 = 0x20;
+
+    /// Maximum HDM decoder count advertised for CXL devices.
+    pub const CXL_HDM_DECODER_MAX_DEVICE_DECODER_COUNT: usize = 10;
+
+    /// Interleave granularity encoding values for Decoder Control.IG.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum CxlHdmDecoderInterleaveGranularity {
+        Bytes256,
+        Bytes512,
+        Bytes1024,
+        Bytes2048,
+        Bytes4096,
+        Bytes8192,
+        Bytes16384,
+    }
+
+    impl CxlHdmDecoderInterleaveGranularity {
+        pub const fn bits(self) -> u8 {
+            match self {
+                Self::Bytes256 => 0x0,
+                Self::Bytes512 => 0x1,
+                Self::Bytes1024 => 0x2,
+                Self::Bytes2048 => 0x3,
+                Self::Bytes4096 => 0x4,
+                Self::Bytes8192 => 0x5,
+                Self::Bytes16384 => 0x6,
+            }
+        }
+    }
+
+    /// Interleave ways encoding values for Decoder Control.IW.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum CxlHdmDecoderInterleaveWays {
+        Way1,
+        Way2,
+        Way4,
+        Way8,
+        Way16,
+        Way3,
+        Way6,
+        Way12,
+    }
+
+    impl CxlHdmDecoderInterleaveWays {
+        pub const fn bits(self) -> u8 {
+            match self {
+                Self::Way1 => 0x0,
+                Self::Way2 => 0x1,
+                Self::Way4 => 0x2,
+                Self::Way8 => 0x3,
+                Self::Way16 => 0x4,
+                Self::Way3 => 0x8,
+                Self::Way6 => 0x9,
+                Self::Way12 => 0xA,
+            }
+        }
+    }
+
+    /// Coherency mode encoding values for Capability.Supported_Coherency_Modes.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum CxlHdmSupportedCoherencyModes {
+        Unknown,
+        DeviceCoherent,
+        HostOnlyCoherent,
+        HostOnlyOrDeviceCoherent,
+    }
+
+    impl CxlHdmSupportedCoherencyModes {
+        pub const fn bits(self) -> u8 {
+            match self {
+                Self::Unknown => 0b00,
+                Self::DeviceCoherent => 0b01,
+                Self::HostOnlyCoherent => 0b10,
+                Self::HostOnlyOrDeviceCoherent => 0b11,
+            }
+        }
+    }
+
+    /// Returns the Decoder Count field encoding for the given decoder count.
+    pub const fn encode_decoder_count(decoder_count: usize) -> Option<u8> {
+        match decoder_count {
+            1 => Some(0x0),
+            2 => Some(0x1),
+            4 => Some(0x2),
+            6 => Some(0x3),
+            8 => Some(0x4),
+            10 => Some(0x5),
+            12 => Some(0x6),
+            14 => Some(0x7),
+            16 => Some(0x8),
+            20 => Some(0x9),
+            24 => Some(0xA),
+            28 => Some(0xB),
+            32 => Some(0xC),
+            _ => None,
+        }
+    }
+
+    /// HDM Decoder Capability register at offset 0x00.
+    #[derive(Inspect)]
+    #[bitfield(u32)]
+    pub struct CxlHdmDecoderCapabilityRegister {
+        #[bits(4)]
+        pub decoder_count: u8,
+        #[bits(4)]
+        pub target_count: u8,
+        pub a11to8_interleave_capable: bool,
+        pub a14to12_interleave_capable: bool,
+        pub poison_on_decode_error_capable: bool,
+        pub interleave_3_6_12_way_capable: bool,
+        pub interleave_16_way_capable: bool,
+        pub uio_capable: bool,
+        #[bits(2)]
+        _reserved0: u8,
+        #[bits(4)]
+        pub uio_capable_decoder_count: u8,
+        pub mem_data_nxm_capable: bool,
+        #[bits(2)]
+        pub supported_coherency_modes: u8,
+        #[bits(9)]
+        _reserved1: u16,
+    }
+
+    /// HDM Decoder Global Control register at offset 0x04.
+    #[derive(Inspect)]
+    #[bitfield(u32)]
+    pub struct CxlHdmDecoderGlobalControlRegister {
+        pub poison_on_decode_error_enable: bool,
+        pub hdm_decoder_enable: bool,
+        #[bits(30)]
+        _reserved: u32,
+    }
+
+    /// Writable mask for HDM Decoder Global Control.
+    pub const CXL_HDM_DECODER_GLOBAL_CONTROL_WRITABLE_MASK: u32 =
+        CxlHdmDecoderGlobalControlRegister::new()
+            .with_poison_on_decode_error_enable(true)
+            .with_hdm_decoder_enable(true)
+            .into_bits();
+
+    /// Per-decoder register offsets within one decoder block.
+    pub struct CxlHdmDecoderRegisterOffset;
+
+    impl CxlHdmDecoderRegisterOffset {
+        pub const BASE_LOW: u16 = 0x00;
+        pub const BASE_HIGH: u16 = 0x04;
+        pub const SIZE_LOW: u16 = 0x08;
+        pub const SIZE_HIGH: u16 = 0x0C;
+        pub const CONTROL: u16 = 0x10;
+        pub const DPA_SKIP_LOW: u16 = 0x14;
+        pub const DPA_SKIP_HIGH: u16 = 0x18;
+    }
+
+    /// HDM Decoder n Base Low register.
+    #[derive(Inspect)]
+    #[bitfield(u32)]
+    pub struct CxlHdmDecoderBaseLowRegister {
+        #[bits(28)]
+        _reserved0: u32,
+        #[bits(4)]
+        pub memory_base_low: u8,
+    }
+
+    /// Writable mask for Base Low.
+    pub const CXL_HDM_DECODER_BASE_LOW_WRITABLE_MASK: u32 = CxlHdmDecoderBaseLowRegister::new()
+        .with_memory_base_low(0xF)
+        .into_bits();
+
+    /// HDM Decoder n Size Low register.
+    #[derive(Inspect)]
+    #[bitfield(u32)]
+    pub struct CxlHdmDecoderSizeLowRegister {
+        #[bits(28)]
+        _reserved0: u32,
+        #[bits(4)]
+        pub memory_size_low: u8,
+    }
+
+    /// Writable mask for Size Low.
+    pub const CXL_HDM_DECODER_SIZE_LOW_WRITABLE_MASK: u32 = CxlHdmDecoderSizeLowRegister::new()
+        .with_memory_size_low(0xF)
+        .into_bits();
+
+    /// HDM Decoder n Control register.
+    #[derive(Inspect)]
+    #[bitfield(u32)]
+    pub struct CxlHdmDecoderControlRegister {
+        #[bits(4)]
+        pub interleave_granularity: u8,
+        #[bits(4)]
+        pub interleave_ways: u8,
+        pub lock_on_commit: bool,
+        pub commit: bool,
+        pub committed: bool,
+        pub error_not_committed: bool,
+        pub target_range_type: bool,
+        pub bi: bool,
+        pub uio: bool,
+        #[bits(1)]
+        _reserved0: u8,
+        #[bits(4)]
+        pub upstream_interleave_granularity: u8,
+        #[bits(4)]
+        pub upstream_interleave_ways: u8,
+        #[bits(4)]
+        pub interleave_set_position: u8,
+        #[bits(4)]
+        _reserved1: u8,
+    }
+
+    /// Writable mask for Decoder Control RWL fields.
+    pub const CXL_HDM_DECODER_CONTROL_WRITABLE_MASK: u32 = CxlHdmDecoderControlRegister::new()
+        .with_interleave_granularity(0xF)
+        .with_interleave_ways(0xF)
+        .with_lock_on_commit(true)
+        .with_commit(true)
+        .with_target_range_type(true)
+        .with_bi(true)
+        .with_uio(true)
+        .with_upstream_interleave_granularity(0xF)
+        .with_upstream_interleave_ways(0xF)
+        .with_interleave_set_position(0xF)
+        .into_bits();
+
+    /// HDM Decoder n DPA Skip Low register.
+    #[derive(Inspect)]
+    #[bitfield(u32)]
+    pub struct CxlHdmDecoderDpaSkipLowRegister {
+        #[bits(28)]
+        _reserved0: u32,
+        #[bits(4)]
+        pub dpa_skip_low: u8,
+    }
+
+    /// Writable mask for DPA Skip Low.
+    pub const CXL_HDM_DECODER_DPA_SKIP_LOW_WRITABLE_MASK: u32 =
+        CxlHdmDecoderDpaSkipLowRegister::new()
+            .with_dpa_skip_low(0xF)
+            .into_bits();
+}

--- a/vm/devices/cxl/src/component_registers/test_helper.rs
+++ b/vm/devices/cxl/src/component_registers/test_helper.rs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::CxlComponentRegister;
+use crate::spec::CxlComponentRegisterType;
+use inspect::Inspect;
+
+/// Simple in-memory component register block used by unit tests.
+#[derive(Inspect)]
+pub struct TestCxlComponentRegisterBlock {
+    register_type: CxlComponentRegisterType,
+    bytes: Vec<u8>,
+}
+
+impl TestCxlComponentRegisterBlock {
+    /// Creates an in-memory register block used by unit tests.
+    pub fn new(register_type: CxlComponentRegisterType, len: usize) -> Self {
+        Self {
+            register_type,
+            bytes: vec![0; len],
+        }
+    }
+}
+
+impl CxlComponentRegister for TestCxlComponentRegisterBlock {
+    fn label(&self) -> &str {
+        "test-register-block"
+    }
+
+    fn register_type(&self) -> CxlComponentRegisterType {
+        self.register_type
+    }
+
+    fn capability_id(&self) -> u16 {
+        0x20
+    }
+
+    fn capability_version(&self) -> u8 {
+        1
+    }
+
+    fn len(&self) -> u16 {
+        self.bytes.len() as u16
+    }
+
+    fn read_u32(&self, offset: u16) -> Option<u32> {
+        let offset = usize::from(offset);
+        let end = offset.checked_add(4)?;
+        if !offset.is_multiple_of(4) || end > self.bytes.len() {
+            return None;
+        }
+
+        Some(u32::from_le_bytes(self.bytes[offset..end].try_into().ok()?))
+    }
+
+    fn write_u32(&mut self, offset: u16, val: u32) -> bool {
+        let offset = usize::from(offset);
+        let Some(end) = offset.checked_add(4) else {
+            return false;
+        };
+
+        if !offset.is_multiple_of(4) || end > self.bytes.len() {
+            return false;
+        }
+
+        self.bytes[offset..end].copy_from_slice(&val.to_le_bytes());
+        true
+    }
+
+    fn reset(&mut self) {
+        self.bytes.fill(0);
+    }
+}
+
+mod save_restore {
+    use super::*;
+    use vmcore::save_restore::RestoreError;
+    use vmcore::save_restore::SaveError;
+    use vmcore::save_restore::SaveRestore;
+
+    mod state {
+        use mesh::payload::Protobuf;
+        use vmcore::save_restore::SavedStateRoot;
+
+        #[derive(Protobuf, SavedStateRoot)]
+        #[mesh(package = "cxl.component_registers.test_helper")]
+        pub struct SavedState {
+            #[mesh(1)]
+            pub bytes: Vec<u8>,
+        }
+    }
+
+    impl SaveRestore for TestCxlComponentRegisterBlock {
+        type SavedState = state::SavedState;
+
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            Ok(state::SavedState {
+                bytes: self.bytes.clone(),
+            })
+        }
+
+        fn restore(&mut self, state: Self::SavedState) -> Result<(), RestoreError> {
+            if state.bytes.len() != self.bytes.len() {
+                return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
+                    "test register size mismatch: saved {}, current {}",
+                    state.bytes.len(),
+                    self.bytes.len()
+                )));
+            }
+
+            self.bytes.copy_from_slice(&state.bytes);
+            Ok(())
+        }
+    }
+}

--- a/vm/devices/cxl/src/lib.rs
+++ b/vm/devices/cxl/src/lib.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![forbid(unsafe_code)]
+
+//! CXL specification definitions.
+
+pub mod component_registers;
+pub mod pci_registers;
+pub mod spec;
+pub mod test;
+
+pub use component_registers::CxlComponentRegister;
+pub use component_registers::CxlComponentRegisters;
+pub use pci_registers::CxlDeviceDevsecExtendedCapability;
+pub use pci_registers::CxlFlexBusPortDvsecExtendedCapability;
+pub use pci_registers::CxlPortDvsecExtendedCapability;
+pub use pci_registers::CxlRegisterLocatorDvsecExtendedCapability;
+pub use spec::CfmwsWindowRestrictions;
+pub use spec::CxlComponentRegisterType;

--- a/vm/devices/cxl/src/pci_registers/cxl_device_dvsec.rs
+++ b/vm/devices/cxl/src/pci_registers/cxl_device_dvsec.rs
@@ -1,0 +1,1206 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! CXL PCIe DVSEC extended capability implementation.
+
+use pci_core::capabilities::extended::PciExtendedCapability;
+use pci_core::spec::caps::ExtendedCapabilityId;
+use pci_core::spec::caps::dvsec::DvsecExtendedCapabilityHeader;
+use pci_core::spec::caps::dvsec::DvsecHeader1;
+use pci_core::spec::caps::dvsec::DvsecHeader2;
+use std::sync::Arc;
+
+use super::spec::CXL_DVSEC_VENDOR_ID;
+use super::spec::cxl_device_dvsec::CXL_DEVICE_DVSEC_CONTROL_WRITABLE_MASK;
+use super::spec::cxl_device_dvsec::CXL_DEVICE_DVSEC_CONTROL2_WRITABLE_MASK;
+use super::spec::cxl_device_dvsec::CXL_DEVICE_DVSEC_ID;
+use super::spec::cxl_device_dvsec::CXL_DEVICE_DVSEC_LENGTH;
+use super::spec::cxl_device_dvsec::CXL_DEVICE_DVSEC_RANGE_BASE_LOW_WRITABLE_MASK;
+use super::spec::cxl_device_dvsec::CXL_DEVICE_DVSEC_REVISION;
+use super::spec::cxl_device_dvsec::CXL_DEVICE_DVSEC_STATUS_RW1C_MASK;
+use super::spec::cxl_device_dvsec::CXL_DEVICE_DVSEC_STATUS2_RW1C_MASK;
+use super::spec::cxl_device_dvsec::CXL_DEVICE_DVSEC_STATUS2_VOLATILE_HDM_PRESERVATION_ERROR_RW1C_MASK;
+use super::spec::cxl_device_dvsec::CxlCacheWriteBackAndInvalidateHandler;
+use super::spec::cxl_device_dvsec::CxlDeviceDevsecExtendedCapability;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecCacheSizeUnit;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecCapability;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecCapability2;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecCapability3;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecControl;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecControl2;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecDesiredInterleave;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecLock;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecMediaType;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecMemoryActiveTimeout;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecMemoryClass;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecRangeBaseLow;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecRangeSizeLow;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecRegisterOffset;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecResetTimeout;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecStatus;
+use super::spec::cxl_device_dvsec::CxlDeviceDvsecStatus2;
+use super::spec::cxl_device_dvsec::CxlResetHandler;
+use thiserror::Error;
+
+const CXL_RANGE_GRANULARITY: u64 = 256 * 1024 * 1024;
+
+/// Optional CXL memory range programming input for `with_cxl_memory`.
+#[derive(Debug, Copy, Clone)]
+pub struct CxlMemoryRange {
+    /// Base address of the CXL range.
+    pub base: u64,
+    /// Size of the CXL range.
+    pub size: u64,
+}
+
+/// Errors returned when configuring CXL memory ranges.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Error)]
+pub enum CxlMemoryConfigError {
+    /// Both DVSEC HDM range slots are already configured.
+    #[error("both DVSEC HDM range slots are already configured")]
+    TooManyHdmRanges,
+}
+
+impl Default for CxlDeviceDevsecExtendedCapability {
+    fn default() -> Self {
+        let capability = CxlDeviceDvsecCapability::new()
+            .with_io_capable(true)
+            .with_cxl_reset_capable(true)
+            .with_cxl_reset_timeout(CxlDeviceDvsecResetTimeout::Seconds1.bits())
+            .with_cxl_reset_mem_clr_capable(true);
+        let capability2 = CxlDeviceDvsecCapability2::new();
+        let capability3 = CxlDeviceDvsecCapability3::new();
+        let range1_base_low = CxlDeviceDvsecRangeBaseLow::new();
+        let range2_base_low = CxlDeviceDvsecRangeBaseLow::new();
+        Self {
+            control: CxlDeviceDvsecControl::new().with_io_enable(true),
+            status: CxlDeviceDvsecStatus::new(),
+            control2: CxlDeviceDvsecControl2::new(),
+            status2: CxlDeviceDvsecStatus2::new(),
+            lock: CxlDeviceDvsecLock::new(),
+            capability,
+            capability2,
+            capability3,
+            range1_size_high: 0,
+            range1_size_low: 0,
+            range1_base_high: 0,
+            range1_base_low,
+            range2_size_high: 0,
+            range2_size_low: 0,
+            range2_base_high: 0,
+            range2_base_low,
+            cxl_reset_handler: None,
+            cxl_cache_write_back_and_invalidate_handler: None,
+            reset_baseline_capability: capability,
+            reset_baseline_capability2: capability2,
+            reset_baseline_capability3: capability3,
+            reset_baseline_range1_size_high: 0,
+            reset_baseline_range1_size_low: 0,
+            reset_baseline_range1_base_high: 0,
+            reset_baseline_range1_base_low: range1_base_low,
+            reset_baseline_range2_size_high: 0,
+            reset_baseline_range2_size_low: 0,
+            reset_baseline_range2_base_high: 0,
+            reset_baseline_range2_base_low: range2_base_low,
+        }
+    }
+}
+
+impl CxlDeviceDevsecExtendedCapability {
+    /// Creates a new CXL DVSEC capability.
+    ///
+    /// When `cxl_reset_handler` is provided, it is invoked when software
+    /// requests a new CXL reset via DVSEC Control2.
+    pub fn new(
+        cxl_reset_handler: Option<Arc<dyn CxlResetHandler>>,
+        cxl_cache_write_back_and_invalidate_handler: Option<
+            Arc<dyn CxlCacheWriteBackAndInvalidateHandler>,
+        >,
+    ) -> Self {
+        Self {
+            cxl_reset_handler,
+            cxl_cache_write_back_and_invalidate_handler,
+            ..Self::default()
+        }
+    }
+
+    /// Enables CXL.cache support and programs Capability2 cache size encoding.
+    pub fn with_cxl_cache(
+        mut self,
+        cache_size_unit: CxlDeviceDvsecCacheSizeUnit,
+        cache_size: u8,
+    ) -> Self {
+        self.capability = self
+            .capability
+            .with_cache_capable(true)
+            .with_cache_writeback_and_invalidate_capable(true);
+        let programmed_cache_size = if cache_size_unit == CxlDeviceDvsecCacheSizeUnit::NotReported {
+            0
+        } else {
+            cache_size
+        };
+        self.capability2 = self
+            .capability2
+            .with_cache_size_unit(cache_size_unit.bits())
+            .with_cache_size(programmed_cache_size);
+        self.reset_baseline_capability = self.capability;
+        self.reset_baseline_capability2 = self.capability2;
+        self.reset_baseline_capability3 = self.capability3;
+        self
+    }
+
+    /// Enables CXL.mem support when `hdm_size` is valid.
+    ///
+    /// `range` programming is optional; when present, the range base registers
+    /// are updated only if the range encoding is valid.
+    pub fn with_cxl_memory(
+        mut self,
+        hdm_size: u64,
+        range: Option<CxlMemoryRange>,
+        media_type: CxlDeviceDvsecMediaType,
+        memory_class: CxlDeviceDvsecMemoryClass,
+        desired_interleave: CxlDeviceDvsecDesiredInterleave,
+        memory_active_timeout: CxlDeviceDvsecMemoryActiveTimeout,
+    ) -> Result<Self, CxlMemoryConfigError> {
+        if !Self::is_valid_memory_size(hdm_size) {
+            return Ok(self);
+        }
+
+        let range1_enabled = Self::range_is_enabled(self.range1_size_low);
+        let range2_enabled = Self::range_is_enabled(self.range2_size_low);
+        if range1_enabled && range2_enabled {
+            return Err(CxlMemoryConfigError::TooManyHdmRanges);
+        }
+
+        let size_low = ((hdm_size >> 28) & 0xf) as u8;
+        let range_size_high = (hdm_size >> 32) as u32;
+        let range_size_low = CxlDeviceDvsecRangeSizeLow::new()
+            .with_memory_info_valid(true)
+            .with_memory_active(true)
+            .with_media_type(media_type.bits())
+            .with_memory_class(memory_class.bits())
+            .with_desired_interleave(desired_interleave.bits())
+            .with_memory_active_timeout(memory_active_timeout.bits())
+            .with_memory_size_low(size_low)
+            .into_bits();
+
+        let mut range_base_high = 0;
+        let mut range_base_low = CxlDeviceDvsecRangeBaseLow::new();
+        if let Some(r) = range {
+            if Self::is_valid_memory_range(r) {
+                range_base_high = (r.base >> 32) as u32;
+                range_base_low = CxlDeviceDvsecRangeBaseLow::new().with_memory_base_low(size_low);
+            }
+        }
+
+        if !range1_enabled {
+            self.range1_size_high = range_size_high;
+            self.range1_size_low = range_size_low;
+            self.range1_base_high = range_base_high;
+            self.range1_base_low = range_base_low;
+        } else {
+            self.range2_size_high = range_size_high;
+            self.range2_size_low = range_size_low;
+            self.range2_base_high = range_base_high;
+            self.range2_base_low = range_base_low;
+        }
+
+        self.refresh_mem_capability();
+        self.reset_baseline_capability = self.capability;
+        self.reset_baseline_capability2 = self.capability2;
+        self.reset_baseline_capability3 = self.capability3;
+        self.reset_baseline_range1_size_high = self.range1_size_high;
+        self.reset_baseline_range1_size_low = self.range1_size_low;
+        self.reset_baseline_range1_base_high = self.range1_base_high;
+        self.reset_baseline_range1_base_low = self.range1_base_low;
+        self.reset_baseline_range2_size_high = self.range2_size_high;
+        self.reset_baseline_range2_size_low = self.range2_size_low;
+        self.reset_baseline_range2_base_high = self.range2_base_high;
+        self.reset_baseline_range2_base_low = self.range2_base_low;
+        Ok(self)
+    }
+
+    fn dvsec_len(&self) -> usize {
+        usize::from(CXL_DEVICE_DVSEC_LENGTH)
+    }
+
+    fn read_dvsec_u32(&self, offset: u16) -> u32 {
+        const DVSEC_HEADER1_OFFSET: u16 = DvsecExtendedCapabilityHeader::DVSEC_HEADER1.0;
+        const DVSEC_HEADER2_OFFSET: u16 = DvsecExtendedCapabilityHeader::DVSEC_HEADER2.0;
+
+        match offset {
+            DVSEC_HEADER1_OFFSET => Self::dvsec_header1().into_bits(),
+            DVSEC_HEADER2_OFFSET => {
+                u32::from(Self::dvsec_header2().into_bits())
+                    | (u32::from(self.capability.into_bits()) << 16)
+            }
+            CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL_STATUS => {
+                u32::from(self.control.into_bits()) | (u32::from(self.status.into_bits()) << 16)
+            }
+            CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL2_STATUS2 => {
+                u32::from(self.control2.into_bits()) | (u32::from(self.status2.into_bits()) << 16)
+            }
+            CxlDeviceDvsecRegisterOffset::DVSEC_LOCK_CAPABILITY2 => {
+                u32::from(self.lock.into_bits()) | (u32::from(self.capability2.into_bits()) << 16)
+            }
+            CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_SIZE_HIGH => self.range1_size_high,
+            CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_SIZE_LOW => self.range1_size_low,
+            CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_BASE_HIGH => self.range1_base_high,
+            CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_BASE_LOW => self.range1_base_low.into_bits(),
+            CxlDeviceDvsecRegisterOffset::DVSEC_RANGE2_SIZE_HIGH => self.range2_size_high,
+            CxlDeviceDvsecRegisterOffset::DVSEC_RANGE2_SIZE_LOW => self.range2_size_low,
+            CxlDeviceDvsecRegisterOffset::DVSEC_RANGE2_BASE_HIGH => self.range2_base_high,
+            CxlDeviceDvsecRegisterOffset::DVSEC_RANGE2_BASE_LOW => self.range2_base_low.into_bits(),
+            CxlDeviceDvsecRegisterOffset::DVSEC_CAPABILITY3 => {
+                u32::from(self.capability3.into_bits())
+            }
+            _ => !0,
+        }
+    }
+
+    fn write_dvsec_u32(&mut self, offset: u16, value: u32) {
+        if offset == CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL_STATUS {
+            self.handle_control_status_write(value);
+            return;
+        }
+
+        if offset == CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL2_STATUS2 {
+            self.handle_control2_status2_write(value);
+            return;
+        }
+
+        if offset == CxlDeviceDvsecRegisterOffset::DVSEC_LOCK_CAPABILITY2 {
+            let requested_lock = (value as u16) & 0x1;
+            if requested_lock != 0 {
+                self.lock = self.lock.with_config_lock(true);
+            }
+            return;
+        }
+
+        if self.lock.config_lock() {
+            return;
+        }
+
+        match offset {
+            CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_BASE_HIGH => {
+                self.range1_base_high = value;
+            }
+            CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_BASE_LOW => {
+                let preserved = self.range1_base_low.into_bits()
+                    & !CXL_DEVICE_DVSEC_RANGE_BASE_LOW_WRITABLE_MASK;
+                let writable = value & CXL_DEVICE_DVSEC_RANGE_BASE_LOW_WRITABLE_MASK;
+                self.range1_base_low = CxlDeviceDvsecRangeBaseLow::from_bits(preserved | writable);
+            }
+            CxlDeviceDvsecRegisterOffset::DVSEC_RANGE2_BASE_HIGH => {
+                self.range2_base_high = value;
+            }
+            CxlDeviceDvsecRegisterOffset::DVSEC_RANGE2_BASE_LOW => {
+                let preserved = self.range2_base_low.into_bits()
+                    & !CXL_DEVICE_DVSEC_RANGE_BASE_LOW_WRITABLE_MASK;
+                let writable = value & CXL_DEVICE_DVSEC_RANGE_BASE_LOW_WRITABLE_MASK;
+                self.range2_base_low = CxlDeviceDvsecRangeBaseLow::from_bits(preserved | writable);
+            }
+            _ => {}
+        }
+    }
+
+    fn reset_state(&mut self) {
+        self.control = CxlDeviceDvsecControl::new()
+            .with_io_enable(self.reset_baseline_capability.io_capable());
+        self.status = CxlDeviceDvsecStatus::new();
+        self.control2 = CxlDeviceDvsecControl2::new();
+        self.status2 = CxlDeviceDvsecStatus2::new();
+        self.lock = CxlDeviceDvsecLock::new();
+        self.capability = self.reset_baseline_capability;
+        self.capability2 = self.reset_baseline_capability2;
+        self.capability3 = self.reset_baseline_capability3;
+        self.range1_size_high = self.reset_baseline_range1_size_high;
+        self.range1_size_low = self.reset_baseline_range1_size_low;
+        self.range1_base_high = self.reset_baseline_range1_base_high;
+        self.range1_base_low = self.reset_baseline_range1_base_low;
+        self.range2_size_high = self.reset_baseline_range2_size_high;
+        self.range2_size_low = self.reset_baseline_range2_size_low;
+        self.range2_base_high = self.reset_baseline_range2_base_high;
+        self.range2_base_low = self.reset_baseline_range2_base_low;
+    }
+
+    fn dvsec_header1() -> DvsecHeader1 {
+        DvsecHeader1::new()
+            .with_dvsec_vendor_id(CXL_DVSEC_VENDOR_ID)
+            .with_dvsec_revision(CXL_DEVICE_DVSEC_REVISION)
+            .with_dvsec_length(CXL_DEVICE_DVSEC_LENGTH)
+    }
+
+    fn dvsec_header2() -> DvsecHeader2 {
+        DvsecHeader2::new().with_dvsec_id(CXL_DEVICE_DVSEC_ID)
+    }
+
+    fn is_valid_memory_size(hdm_size: u64) -> bool {
+        hdm_size != 0 && hdm_size.is_multiple_of(CXL_RANGE_GRANULARITY)
+    }
+
+    fn is_valid_memory_range(range: CxlMemoryRange) -> bool {
+        range.base.is_multiple_of(CXL_RANGE_GRANULARITY)
+            && range.size != 0
+            && range.size.is_multiple_of(CXL_RANGE_GRANULARITY)
+    }
+
+    fn range_is_enabled(range_size_low: u32) -> bool {
+        CxlDeviceDvsecRangeSizeLow::from_bits(range_size_low).memory_info_valid()
+    }
+
+    fn refresh_mem_capability(&mut self) {
+        let r1_enabled = Self::range_is_enabled(self.range1_size_low);
+        let r2_enabled = Self::range_is_enabled(self.range2_size_low);
+
+        let (mem_capable, hdm_count) = match (r1_enabled, r2_enabled) {
+            (false, false) => (false, 0),
+            (true, false) | (false, true) => (true, 0x1),
+            (true, true) => (true, 0x2),
+        };
+
+        self.capability = self
+            .capability
+            .with_mem_capable(mem_capable)
+            .with_hdm_count(hdm_count);
+    }
+
+    fn handle_control_status_write(&mut self, value: u32) {
+        if !self.lock.config_lock() {
+            let requested = (value as u16) & CXL_DEVICE_DVSEC_CONTROL_WRITABLE_MASK;
+            let mut next = CxlDeviceDvsecControl::from_bits(requested);
+
+            if !self.capability.cache_capable() {
+                next = next.with_cache_enable(false);
+            }
+            // CXL.io is required to remain enabled.
+            next = next.with_io_enable(true);
+            if !self.capability.mem_capable() {
+                next = next.with_mem_enable(false);
+            }
+            if !self.capability3.direct_p2p_mem_capable() {
+                next = next.with_direct_p2p_mem_enable(false);
+            }
+            if !self.capability.viral_capable() {
+                next = next.with_viral_enable(false);
+            }
+
+            self.control = next;
+        }
+
+        let clear_mask = ((value >> 16) as u16) & CXL_DEVICE_DVSEC_STATUS_RW1C_MASK;
+        if clear_mask != 0 {
+            let next_bits = self.status.into_bits() & !clear_mask;
+            self.status = CxlDeviceDvsecStatus::from_bits(next_bits);
+        }
+    }
+
+    fn handle_control2_status2_write(&mut self, value: u32) {
+        // Control2 is RW (not RWL), so config_lock must not gate writes here.
+        let requested = (value as u16) & CXL_DEVICE_DVSEC_CONTROL2_WRITABLE_MASK;
+        let mut next = CxlDeviceDvsecControl2::from_bits(requested);
+        let old_cwbi = self.control2.initiate_cache_writeback_and_invalidation();
+        let new_cwbi = next.initiate_cache_writeback_and_invalidation();
+        let old_reset = self.control2.initiate_cxl_reset();
+        let new_reset = next.initiate_cxl_reset();
+
+        if self.capability.cache_writeback_and_invalidate_capable() && new_cwbi && !old_cwbi {
+            if let Some(handler) = &self.cxl_cache_write_back_and_invalidate_handler {
+                handler.initiate_cache_write_back_and_invalidate();
+            }
+        }
+
+        if self.capability.cxl_reset_capable() && new_reset && !old_reset {
+            if let Some(handler) = &self.cxl_reset_handler {
+                handler.initiate_cxl_reset();
+            }
+        }
+
+        if !self.capability.cxl_reset_mem_clr_capable() {
+            next = next.with_cxl_reset_mem_clr_enable(false);
+        }
+        if !self.capability.cache_writeback_and_invalidate_capable() {
+            next = next.with_initiate_cache_writeback_and_invalidation(false);
+        }
+        if !self
+            .capability3
+            .volatile_hdm_state_after_hot_reset_configurability()
+        {
+            next = next.with_desired_volatile_hdm_state_after_hot_reset_configurable(false);
+        }
+        if !self.capability2.modified_completion_capable() {
+            next = next.with_modified_completion_enable(false);
+        }
+
+        self.control2 = next
+            .with_initiate_cache_writeback_and_invalidation(false)
+            .with_initiate_cxl_reset(false);
+
+        let mut clear_mask = ((value >> 16) as u16) & CXL_DEVICE_DVSEC_STATUS2_RW1C_MASK;
+        if !self
+            .capability3
+            .volatile_hdm_state_after_hot_reset_configurability()
+        {
+            clear_mask &= !CXL_DEVICE_DVSEC_STATUS2_VOLATILE_HDM_PRESERVATION_ERROR_RW1C_MASK;
+        }
+        if clear_mask != 0 {
+            let next_bits = self.status2.into_bits() & !clear_mask;
+            self.status2 = CxlDeviceDvsecStatus2::from_bits(next_bits);
+        }
+    }
+}
+
+impl PciExtendedCapability for CxlDeviceDevsecExtendedCapability {
+    fn label(&self) -> &str {
+        "cxl_device_dvsec"
+    }
+
+    fn extended_capability_id(&self) -> u16 {
+        ExtendedCapabilityId::DVSEC.0
+    }
+
+    fn capability_version(&self) -> u8 {
+        1
+    }
+
+    fn len(&self) -> usize {
+        self.dvsec_len()
+    }
+
+    fn read_u32(&self, offset: u16) -> u32 {
+        if offset == 0 {
+            u32::from(self.extended_capability_id()) | (u32::from(self.capability_version()) << 16)
+        } else {
+            self.read_dvsec_u32(offset)
+        }
+    }
+
+    fn write_u32(&mut self, offset: u16, val: u32) {
+        if offset != 0 {
+            self.write_dvsec_u32(offset, val);
+        }
+    }
+
+    fn reset(&mut self) {
+        self.reset_state();
+    }
+}
+
+mod save_restore {
+    use super::*;
+    use vmcore::save_restore::RestoreError;
+    use vmcore::save_restore::SaveError;
+    use vmcore::save_restore::SaveRestore;
+
+    mod state {
+        use mesh::payload::Protobuf;
+        use vmcore::save_restore::SavedStateRoot;
+
+        #[derive(Protobuf, SavedStateRoot)]
+        #[mesh(package = "cxl.pci_registers.cxl_device_dvsec")]
+        pub struct SavedState {
+            #[mesh(1)]
+            pub control: u32,
+            #[mesh(2)]
+            pub status: u32,
+            #[mesh(3)]
+            pub control2: u32,
+            #[mesh(4)]
+            pub status2: u32,
+            #[mesh(5)]
+            pub lock: u32,
+            #[mesh(6)]
+            pub capability: u32,
+            #[mesh(7)]
+            pub capability2: u32,
+            #[mesh(8)]
+            pub capability3: u32,
+            #[mesh(9)]
+            pub range1_size_high: u32,
+            #[mesh(10)]
+            pub range1_size_low: u32,
+            #[mesh(11)]
+            pub range1_base_high: u32,
+            #[mesh(12)]
+            pub range1_base_low: u32,
+            #[mesh(13)]
+            pub range2_size_high: u32,
+            #[mesh(14)]
+            pub range2_size_low: u32,
+            #[mesh(15)]
+            pub range2_base_high: u32,
+            #[mesh(16)]
+            pub range2_base_low: u32,
+            #[mesh(17)]
+            pub reset_baseline_capability: u32,
+            #[mesh(18)]
+            pub reset_baseline_capability2: u32,
+            #[mesh(19)]
+            pub reset_baseline_capability3: u32,
+            #[mesh(20)]
+            pub reset_baseline_range1_size_high: u32,
+            #[mesh(21)]
+            pub reset_baseline_range1_size_low: u32,
+            #[mesh(22)]
+            pub reset_baseline_range1_base_high: u32,
+            #[mesh(23)]
+            pub reset_baseline_range1_base_low: u32,
+            #[mesh(24)]
+            pub reset_baseline_range2_size_high: u32,
+            #[mesh(25)]
+            pub reset_baseline_range2_size_low: u32,
+            #[mesh(26)]
+            pub reset_baseline_range2_base_high: u32,
+            #[mesh(27)]
+            pub reset_baseline_range2_base_low: u32,
+        }
+    }
+
+    impl SaveRestore for CxlDeviceDevsecExtendedCapability {
+        type SavedState = state::SavedState;
+
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            Ok(state::SavedState {
+                control: u32::from(self.control.into_bits()),
+                status: u32::from(self.status.into_bits()),
+                control2: u32::from(self.control2.into_bits()),
+                status2: u32::from(self.status2.into_bits()),
+                lock: u32::from(self.lock.into_bits()),
+                capability: u32::from(self.capability.into_bits()),
+                capability2: u32::from(self.capability2.into_bits()),
+                capability3: u32::from(self.capability3.into_bits()),
+                range1_size_high: self.range1_size_high,
+                range1_size_low: self.range1_size_low,
+                range1_base_high: self.range1_base_high,
+                range1_base_low: self.range1_base_low.into_bits(),
+                range2_size_high: self.range2_size_high,
+                range2_size_low: self.range2_size_low,
+                range2_base_high: self.range2_base_high,
+                range2_base_low: self.range2_base_low.into_bits(),
+                reset_baseline_capability: u32::from(self.reset_baseline_capability.into_bits()),
+                reset_baseline_capability2: u32::from(self.reset_baseline_capability2.into_bits()),
+                reset_baseline_capability3: u32::from(self.reset_baseline_capability3.into_bits()),
+                reset_baseline_range1_size_high: self.reset_baseline_range1_size_high,
+                reset_baseline_range1_size_low: self.reset_baseline_range1_size_low,
+                reset_baseline_range1_base_high: self.reset_baseline_range1_base_high,
+                reset_baseline_range1_base_low: self.reset_baseline_range1_base_low.into_bits(),
+                reset_baseline_range2_size_high: self.reset_baseline_range2_size_high,
+                reset_baseline_range2_size_low: self.reset_baseline_range2_size_low,
+                reset_baseline_range2_base_high: self.reset_baseline_range2_base_high,
+                reset_baseline_range2_base_low: self.reset_baseline_range2_base_low.into_bits(),
+            })
+        }
+
+        fn restore(&mut self, state: Self::SavedState) -> Result<(), RestoreError> {
+            self.control = CxlDeviceDvsecControl::from_bits(state.control as u16);
+            self.status = CxlDeviceDvsecStatus::from_bits(state.status as u16);
+            self.control2 = CxlDeviceDvsecControl2::from_bits(state.control2 as u16);
+            self.status2 = CxlDeviceDvsecStatus2::from_bits(state.status2 as u16);
+            self.lock = CxlDeviceDvsecLock::from_bits(state.lock as u16);
+            self.capability = CxlDeviceDvsecCapability::from_bits(state.capability as u16);
+            self.capability2 = CxlDeviceDvsecCapability2::from_bits(state.capability2 as u16);
+            self.capability3 = CxlDeviceDvsecCapability3::from_bits(state.capability3 as u16);
+            self.range1_size_high = state.range1_size_high;
+            self.range1_size_low = state.range1_size_low;
+            self.range1_base_high = state.range1_base_high;
+            self.range1_base_low = CxlDeviceDvsecRangeBaseLow::from_bits(state.range1_base_low);
+            self.range2_size_high = state.range2_size_high;
+            self.range2_size_low = state.range2_size_low;
+            self.range2_base_high = state.range2_base_high;
+            self.range2_base_low = CxlDeviceDvsecRangeBaseLow::from_bits(state.range2_base_low);
+            self.reset_baseline_capability =
+                CxlDeviceDvsecCapability::from_bits(state.reset_baseline_capability as u16);
+            self.reset_baseline_capability2 =
+                CxlDeviceDvsecCapability2::from_bits(state.reset_baseline_capability2 as u16);
+            self.reset_baseline_capability3 =
+                CxlDeviceDvsecCapability3::from_bits(state.reset_baseline_capability3 as u16);
+            self.reset_baseline_range1_size_high = state.reset_baseline_range1_size_high;
+            self.reset_baseline_range1_size_low = state.reset_baseline_range1_size_low;
+            self.reset_baseline_range1_base_high = state.reset_baseline_range1_base_high;
+            self.reset_baseline_range1_base_low =
+                CxlDeviceDvsecRangeBaseLow::from_bits(state.reset_baseline_range1_base_low);
+            self.reset_baseline_range2_size_high = state.reset_baseline_range2_size_high;
+            self.reset_baseline_range2_size_low = state.reset_baseline_range2_size_low;
+            self.reset_baseline_range2_base_high = state.reset_baseline_range2_base_high;
+            self.reset_baseline_range2_base_low =
+                CxlDeviceDvsecRangeBaseLow::from_bits(state.reset_baseline_range2_base_low);
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use inspect::Inspect;
+    use pci_core::capabilities::extended::PciExtendedCapability;
+    use pci_core::spec::caps::dvsec::DvsecExtendedCapabilityHeader;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use vmcore::save_restore::SaveRestore;
+
+    use super::CxlCacheWriteBackAndInvalidateHandler;
+    use super::CxlDeviceDevsecExtendedCapability;
+    use super::CxlDeviceDvsecCacheSizeUnit;
+    use super::CxlDeviceDvsecCapability;
+    use super::CxlDeviceDvsecCapability2;
+    use super::CxlDeviceDvsecControl;
+    use super::CxlDeviceDvsecControl2;
+    use super::CxlDeviceDvsecDesiredInterleave;
+    use super::CxlDeviceDvsecMediaType;
+    use super::CxlDeviceDvsecMemoryActiveTimeout;
+    use super::CxlDeviceDvsecMemoryClass;
+    use super::CxlDeviceDvsecRangeSizeLow;
+    use super::CxlDeviceDvsecRegisterOffset;
+    use super::CxlDeviceDvsecStatus2;
+    use super::CxlMemoryConfigError;
+    use super::CxlMemoryRange;
+    use super::CxlResetHandler;
+
+    static CXL_RESET_HANDLER_CALLS: AtomicUsize = AtomicUsize::new(0);
+    static CXL_CWBI_HANDLER_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Inspect)]
+    struct TestCxlResetHandler;
+
+    impl CxlResetHandler for TestCxlResetHandler {
+        fn initiate_cxl_reset(&self) {
+            CXL_RESET_HANDLER_CALLS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[derive(Inspect)]
+    struct TestCxlCacheWriteBackAndInvalidateHandler;
+
+    impl CxlCacheWriteBackAndInvalidateHandler for TestCxlCacheWriteBackAndInvalidateHandler {
+        fn initiate_cache_write_back_and_invalidate(&self) {
+            CXL_CWBI_HANDLER_CALLS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn header_registers_match_required_constants() {
+        let cap = CxlDeviceDevsecExtendedCapability::new(None, None);
+
+        assert_eq!(
+            cap.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER1.0),
+            0x03c3_1e98
+        );
+        assert_eq!(
+            cap.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER2.0) & 0xffff,
+            0x0000
+        );
+    }
+
+    #[test]
+    fn label_is_cxl_dvsec() {
+        let cap = CxlDeviceDevsecExtendedCapability::new(None, None);
+        assert_eq!(cap.label(), "cxl_device_dvsec");
+    }
+
+    #[test]
+    fn default_only_enables_cxl_io() {
+        let cap = CxlDeviceDevsecExtendedCapability::new(None, None);
+        let header2 = cap.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER2.0);
+        let capability = CxlDeviceDvsecCapability::from_bits((header2 >> 16) as u16);
+
+        assert!(capability.io_capable());
+        assert!(!capability.cache_capable());
+        assert!(!capability.mem_capable());
+        assert_eq!(capability.hdm_count(), 0);
+    }
+
+    #[test]
+    fn with_cxl_cache_sets_cache_capable() {
+        let cap = CxlDeviceDevsecExtendedCapability::new(None, None)
+            .with_cxl_cache(CxlDeviceDvsecCacheSizeUnit::Kib64, 0x20);
+        let header2 = cap.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER2.0);
+        let capability = CxlDeviceDvsecCapability::from_bits((header2 >> 16) as u16);
+        let lock_cap2 = cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_LOCK_CAPABILITY2);
+        let capability2 = CxlDeviceDvsecCapability2::from_bits((lock_cap2 >> 16) as u16);
+
+        assert!(capability.cache_capable());
+        assert_eq!(
+            capability2.cache_size_unit(),
+            CxlDeviceDvsecCacheSizeUnit::Kib64.bits()
+        );
+        assert_eq!(capability2.cache_size(), 0x20);
+    }
+
+    #[test]
+    fn with_cxl_memory_enables_mem_for_valid_range() {
+        let cap = CxlDeviceDevsecExtendedCapability::new(None, None)
+            .with_cxl_memory(
+                0x4000_0000,
+                Some(CxlMemoryRange {
+                    base: 0x8000_0000,
+                    size: 0x4000_0000,
+                }),
+                CxlDeviceDvsecMediaType::Cdat,
+                CxlDeviceDvsecMemoryClass::Cdat,
+                CxlDeviceDvsecDesiredInterleave::Interleave4Kb,
+                CxlDeviceDvsecMemoryActiveTimeout::Seconds16,
+            )
+            .expect("valid range should configure CXL.mem");
+
+        let header2 = cap.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER2.0);
+        let capability = CxlDeviceDvsecCapability::from_bits((header2 >> 16) as u16);
+
+        assert!(capability.mem_capable());
+        assert_eq!(capability.hdm_count(), 0x1);
+
+        let size_low = CxlDeviceDvsecRangeSizeLow::from_bits(
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_SIZE_LOW),
+        );
+        assert!(size_low.memory_info_valid());
+        assert!(size_low.memory_active());
+        assert_eq!(size_low.media_type(), CxlDeviceDvsecMediaType::Cdat.bits());
+        assert_eq!(
+            size_low.memory_class(),
+            CxlDeviceDvsecMemoryClass::Cdat.bits()
+        );
+        assert_eq!(
+            size_low.desired_interleave(),
+            CxlDeviceDvsecDesiredInterleave::Interleave4Kb.bits()
+        );
+        assert_eq!(
+            size_low.memory_active_timeout(),
+            CxlDeviceDvsecMemoryActiveTimeout::Seconds16.bits()
+        );
+        assert_eq!(size_low.memory_size_low(), 0x4);
+    }
+
+    #[test]
+    fn reset_preserves_configured_mem_capability_and_ranges() {
+        let mut cap = CxlDeviceDevsecExtendedCapability::new(None, None)
+            .with_cxl_memory(
+                0x4000_0000,
+                None,
+                CxlDeviceDvsecMediaType::VolatileMemory,
+                CxlDeviceDvsecMemoryClass::Memory,
+                CxlDeviceDvsecDesiredInterleave::NoInterleave,
+                CxlDeviceDvsecMemoryActiveTimeout::Seconds1,
+            )
+            .expect("memory configuration should succeed");
+
+        cap.write_u32(
+            CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL_STATUS,
+            u32::from(
+                CxlDeviceDvsecControl::new()
+                    .with_io_enable(true)
+                    .with_mem_enable(true)
+                    .into_bits(),
+            ),
+        );
+
+        cap.reset();
+
+        let header2 = cap.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER2.0);
+        let capability = CxlDeviceDvsecCapability::from_bits((header2 >> 16) as u16);
+        let control = CxlDeviceDvsecControl::from_bits(
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL_STATUS) as u16,
+        );
+
+        assert!(capability.mem_capable());
+        assert_eq!(capability.hdm_count(), 0x1);
+        assert!(!control.mem_enable());
+        assert_eq!(
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_SIZE_LOW),
+            0x4000_0003
+        );
+    }
+
+    #[test]
+    fn with_cxl_memory_ignores_invalid_range_programming() {
+        let cap = CxlDeviceDevsecExtendedCapability::new(None, None)
+            .with_cxl_memory(
+                0x4000_0000,
+                Some(CxlMemoryRange {
+                    base: 0x8000_1000,
+                    size: 0x4000_0000,
+                }),
+                CxlDeviceDvsecMediaType::VolatileMemory,
+                CxlDeviceDvsecMemoryClass::Memory,
+                CxlDeviceDvsecDesiredInterleave::NoInterleave,
+                CxlDeviceDvsecMemoryActiveTimeout::Seconds1,
+            )
+            .expect("invalid optional range should not fail CXL.mem enable");
+
+        let header2 = cap.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER2.0);
+        let capability = CxlDeviceDvsecCapability::from_bits((header2 >> 16) as u16);
+
+        assert!(capability.mem_capable());
+        assert_eq!(
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_BASE_HIGH),
+            0
+        );
+    }
+
+    #[test]
+    fn with_cxl_memory_enables_mem_without_range() {
+        let cap = CxlDeviceDevsecExtendedCapability::new(None, None)
+            .with_cxl_memory(
+                0x4000_0000,
+                None,
+                CxlDeviceDvsecMediaType::NonVolatileMemory,
+                CxlDeviceDvsecMemoryClass::Storage,
+                CxlDeviceDvsecDesiredInterleave::Bytes1024,
+                CxlDeviceDvsecMemoryActiveTimeout::Seconds4,
+            )
+            .expect("range-less CXL.mem should configure successfully");
+
+        let header2 = cap.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER2.0);
+        let capability = CxlDeviceDvsecCapability::from_bits((header2 >> 16) as u16);
+
+        assert!(capability.mem_capable());
+        assert_eq!(capability.hdm_count(), 0x1);
+    }
+
+    #[test]
+    fn with_cxl_memory_second_call_programs_range2() {
+        let cap = CxlDeviceDevsecExtendedCapability::new(None, None)
+            .with_cxl_memory(
+                0x4000_0000,
+                Some(CxlMemoryRange {
+                    base: 0x8000_0000,
+                    size: 0x4000_0000,
+                }),
+                CxlDeviceDvsecMediaType::Cdat,
+                CxlDeviceDvsecMemoryClass::Cdat,
+                CxlDeviceDvsecDesiredInterleave::Interleave4Kb,
+                CxlDeviceDvsecMemoryActiveTimeout::Seconds16,
+            )
+            .expect("first range should configure")
+            .with_cxl_memory(
+                0x4000_0000,
+                Some(CxlMemoryRange {
+                    base: 0x1_0000_0000,
+                    size: 0x4000_0000,
+                }),
+                CxlDeviceDvsecMediaType::Cdat,
+                CxlDeviceDvsecMemoryClass::Cdat,
+                CxlDeviceDvsecDesiredInterleave::Interleave4Kb,
+                CxlDeviceDvsecMemoryActiveTimeout::Seconds16,
+            )
+            .expect("second range should configure");
+
+        let header2 = cap.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER2.0);
+        let capability = CxlDeviceDvsecCapability::from_bits((header2 >> 16) as u16);
+
+        assert!(capability.mem_capable());
+        assert_eq!(capability.hdm_count(), 0x2);
+        assert_ne!(
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_RANGE2_SIZE_LOW),
+            0
+        );
+    }
+
+    #[test]
+    fn with_cxl_memory_on_both_ranges_sets_hdm_count_two() {
+        let cap = CxlDeviceDevsecExtendedCapability::new(None, None)
+            .with_cxl_memory(
+                0x4000_0000,
+                None,
+                CxlDeviceDvsecMediaType::VolatileMemory,
+                CxlDeviceDvsecMemoryClass::Memory,
+                CxlDeviceDvsecDesiredInterleave::NoInterleave,
+                CxlDeviceDvsecMemoryActiveTimeout::Seconds1,
+            )
+            .expect("first range should configure")
+            .with_cxl_memory(
+                0x4000_0000,
+                None,
+                CxlDeviceDvsecMediaType::NonVolatileMemory,
+                CxlDeviceDvsecMemoryClass::Storage,
+                CxlDeviceDvsecDesiredInterleave::Bytes1024,
+                CxlDeviceDvsecMemoryActiveTimeout::Seconds4,
+            )
+            .expect("second range should configure");
+
+        let header2 = cap.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER2.0);
+        let capability = CxlDeviceDvsecCapability::from_bits((header2 >> 16) as u16);
+
+        assert!(capability.mem_capable());
+        assert_eq!(capability.hdm_count(), 0x2);
+    }
+
+    #[test]
+    fn with_cxl_memory_third_call_fails() {
+        let cap = CxlDeviceDevsecExtendedCapability::new(None, None)
+            .with_cxl_memory(
+                0x4000_0000,
+                None,
+                CxlDeviceDvsecMediaType::Cdat,
+                CxlDeviceDvsecMemoryClass::Cdat,
+                CxlDeviceDvsecDesiredInterleave::Interleave4Kb,
+                CxlDeviceDvsecMemoryActiveTimeout::Seconds16,
+            )
+            .expect("first range should configure")
+            .with_cxl_memory(
+                0x4000_0000,
+                None,
+                CxlDeviceDvsecMediaType::Cdat,
+                CxlDeviceDvsecMemoryClass::Cdat,
+                CxlDeviceDvsecDesiredInterleave::Interleave4Kb,
+                CxlDeviceDvsecMemoryActiveTimeout::Seconds16,
+            )
+            .expect("second range should configure");
+
+        let result = cap.with_cxl_memory(
+            0x4000_0000,
+            None,
+            CxlDeviceDvsecMediaType::Cdat,
+            CxlDeviceDvsecMemoryClass::Cdat,
+            CxlDeviceDvsecDesiredInterleave::Interleave4Kb,
+            CxlDeviceDvsecMemoryActiveTimeout::Seconds16,
+        );
+
+        assert!(matches!(
+            result,
+            Err(CxlMemoryConfigError::TooManyHdmRanges)
+        ));
+    }
+
+    #[test]
+    fn config_lock_blocks_rw_fields() {
+        let mut cap = CxlDeviceDevsecExtendedCapability::new(None, None);
+
+        cap.write_u32(
+            CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_BASE_HIGH,
+            0xaaaa_5555,
+        );
+        assert_eq!(
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_BASE_HIGH),
+            0xaaaa_5555
+        );
+
+        cap.write_u32(CxlDeviceDvsecRegisterOffset::DVSEC_LOCK_CAPABILITY2, 0x1);
+        cap.write_u32(
+            CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_BASE_HIGH,
+            0x1234_5678,
+        );
+
+        assert_eq!(
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_BASE_HIGH),
+            0xaaaa_5555
+        );
+    }
+
+    #[test]
+    fn config_lock_does_not_block_control2_rw_fields() {
+        let mut cap = CxlDeviceDevsecExtendedCapability::new(None, None);
+
+        cap.write_u32(CxlDeviceDvsecRegisterOffset::DVSEC_LOCK_CAPABILITY2, 0x1);
+        cap.write_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL2_STATUS2, 1 << 0);
+
+        let control2 = CxlDeviceDvsecControl2::from_bits(
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL2_STATUS2) as u16,
+        );
+        assert!(control2.disable_caching());
+    }
+
+    #[test]
+    fn control_enables_require_corresponding_capabilities() {
+        let mut cap = CxlDeviceDevsecExtendedCapability::new(None, None);
+
+        let value = u32::from(
+            CxlDeviceDvsecControl::new()
+                .with_cache_enable(true)
+                .with_mem_enable(true)
+                .with_viral_enable(true)
+                .into_bits(),
+        );
+
+        cap.write_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL_STATUS, value);
+        let control = CxlDeviceDvsecControl::from_bits(
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL_STATUS) as u16,
+        );
+
+        assert!(!control.cache_enable());
+        assert!(!control.mem_enable());
+        assert!(!control.viral_enable());
+    }
+
+    #[test]
+    fn io_enable_is_always_set() {
+        let mut cap = CxlDeviceDevsecExtendedCapability::new(None, None);
+
+        let default_control = CxlDeviceDvsecControl::from_bits(
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL_STATUS) as u16,
+        );
+        assert!(default_control.io_enable());
+
+        // Attempt to clear io_enable; implementation must keep it enabled.
+        cap.write_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL_STATUS, 0);
+        let control_after_write = CxlDeviceDvsecControl::from_bits(
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL_STATUS) as u16,
+        );
+        assert!(control_after_write.io_enable());
+    }
+
+    #[test]
+    fn control2_reset_request_calls_handler() {
+        CXL_RESET_HANDLER_CALLS.store(0, Ordering::SeqCst);
+
+        let mut cap =
+            CxlDeviceDevsecExtendedCapability::new(Some(Arc::new(TestCxlResetHandler)), None);
+        cap.write_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL2_STATUS2, 1 << 2);
+
+        assert_eq!(CXL_RESET_HANDLER_CALLS.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn control2_reset_request_does_not_call_handler_when_not_capable() {
+        CXL_RESET_HANDLER_CALLS.store(0, Ordering::SeqCst);
+
+        let mut cap =
+            CxlDeviceDevsecExtendedCapability::new(Some(Arc::new(TestCxlResetHandler)), None);
+        cap.capability = cap.capability.with_cxl_reset_capable(false);
+        cap.write_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL2_STATUS2, 1 << 2);
+
+        assert_eq!(CXL_RESET_HANDLER_CALLS.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn control2_cwbi_request_calls_handler_when_capable() {
+        CXL_CWBI_HANDLER_CALLS.store(0, Ordering::SeqCst);
+
+        let mut cap = CxlDeviceDevsecExtendedCapability::new(
+            None,
+            Some(Arc::new(TestCxlCacheWriteBackAndInvalidateHandler)),
+        )
+        .with_cxl_cache(CxlDeviceDvsecCacheSizeUnit::Kib64, 0x1);
+
+        cap.write_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL2_STATUS2, 1 << 1);
+
+        assert_eq!(CXL_CWBI_HANDLER_CALLS.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn control2_cwbi_request_does_not_call_handler_when_not_capable() {
+        CXL_CWBI_HANDLER_CALLS.store(0, Ordering::SeqCst);
+
+        let mut cap = CxlDeviceDevsecExtendedCapability::new(
+            None,
+            Some(Arc::new(TestCxlCacheWriteBackAndInvalidateHandler)),
+        );
+        cap.write_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL2_STATUS2, 1 << 1);
+
+        assert_eq!(CXL_CWBI_HANDLER_CALLS.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn status2_volatile_hdm_preservation_error_clear_requires_capability3_configurable() {
+        let mut cap = CxlDeviceDevsecExtendedCapability::new(None, None);
+        cap.status2 = cap.status2.with_volatile_hdm_preservation_error(true);
+
+        // Capability is false by default, so RW1C clear should be ignored.
+        cap.write_u32(
+            CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL2_STATUS2,
+            1 << (16 + 3),
+        );
+        assert!(cap.status2.volatile_hdm_preservation_error());
+
+        // Once the capability is set, the same RW1C write clears the status bit.
+        cap.capability3 = cap
+            .capability3
+            .with_volatile_hdm_state_after_hot_reset_configurability(true);
+        cap.write_u32(
+            CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL2_STATUS2,
+            1 << (16 + 3),
+        );
+        assert!(!cap.status2.volatile_hdm_preservation_error());
+    }
+
+    #[test]
+    fn status2_clear_bit_only_targets_rw1c_field() {
+        let mut cap = CxlDeviceDevsecExtendedCapability::new(None, None);
+        cap.capability3 = cap
+            .capability3
+            .with_volatile_hdm_state_after_hot_reset_configurability(true);
+        cap.status2 = CxlDeviceDvsecStatus2::new()
+            .with_volatile_hdm_preservation_error(true)
+            .with_cxl_reset_error(true)
+            .with_cxl_reset_complete(true);
+
+        cap.write_u32(
+            CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL2_STATUS2,
+            1 << (16 + 3),
+        );
+
+        assert!(!cap.status2.volatile_hdm_preservation_error());
+        assert!(cap.status2.cxl_reset_error());
+        assert!(cap.status2.cxl_reset_complete());
+    }
+
+    #[test]
+    fn save_restore_round_trips_state() {
+        let mut cap = CxlDeviceDevsecExtendedCapability::new(None, None)
+            .with_cxl_cache(CxlDeviceDvsecCacheSizeUnit::Kib64, 0x20)
+            .with_cxl_memory(
+                0x4000_0000,
+                Some(CxlMemoryRange {
+                    base: 0x8000_0000,
+                    size: 0x4000_0000,
+                }),
+                CxlDeviceDvsecMediaType::Cdat,
+                CxlDeviceDvsecMemoryClass::Cdat,
+                CxlDeviceDvsecDesiredInterleave::Interleave4Kb,
+                CxlDeviceDvsecMemoryActiveTimeout::Seconds16,
+            )
+            .expect("valid range should configure CXL.mem");
+
+        cap.write_u32(
+            CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL_STATUS,
+            u32::from(
+                CxlDeviceDvsecControl::new()
+                    .with_cache_enable(true)
+                    .with_mem_enable(true)
+                    .with_viral_enable(true)
+                    .into_bits(),
+            ),
+        );
+        cap.write_u32(CxlDeviceDvsecRegisterOffset::DVSEC_LOCK_CAPABILITY2, 0x1);
+
+        let saved = cap.save().expect("save should succeed");
+        let mut restored = CxlDeviceDevsecExtendedCapability::new(None, None);
+        restored.restore(saved).expect("restore should succeed");
+
+        assert_eq!(
+            restored.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER2.0),
+            cap.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER2.0)
+        );
+        assert_eq!(
+            restored.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL_STATUS),
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL_STATUS)
+        );
+        assert_eq!(
+            restored.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL2_STATUS2),
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CONTROL2_STATUS2)
+        );
+        assert_eq!(
+            restored.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_LOCK_CAPABILITY2),
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_LOCK_CAPABILITY2)
+        );
+        assert_eq!(
+            restored.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_SIZE_HIGH),
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_SIZE_HIGH)
+        );
+        assert_eq!(
+            restored.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_SIZE_LOW),
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_SIZE_LOW)
+        );
+        assert_eq!(
+            restored.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_BASE_HIGH),
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_BASE_HIGH)
+        );
+        assert_eq!(
+            restored.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_BASE_LOW),
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_RANGE1_BASE_LOW)
+        );
+        assert_eq!(
+            restored.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CAPABILITY3),
+            cap.read_u32(CxlDeviceDvsecRegisterOffset::DVSEC_CAPABILITY3)
+        );
+    }
+}

--- a/vm/devices/cxl/src/pci_registers/cxl_port_dvsec.rs
+++ b/vm/devices/cxl/src/pci_registers/cxl_port_dvsec.rs
@@ -1,0 +1,472 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! CXL Port PCIe DVSEC extended capability implementation.
+
+use pci_core::capabilities::extended::PciExtendedCapability;
+use pci_core::spec::caps::ExtendedCapabilityId;
+use pci_core::spec::caps::dvsec::DvsecExtendedCapabilityHeader;
+use pci_core::spec::caps::dvsec::DvsecHeader1;
+use pci_core::spec::caps::dvsec::DvsecHeader2;
+
+use super::spec::CXL_DVSEC_VENDOR_ID;
+use super::spec::cxl_port_dvsec::CXL_PORT_DVSEC_ALT_MEMORY_BASE_LIMIT_WRITABLE_MASK;
+use super::spec::cxl_port_dvsec::CXL_PORT_DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_LIMIT_WRITABLE_MASK;
+use super::spec::cxl_port_dvsec::CXL_PORT_DVSEC_CONTROL_WRITABLE_MASK;
+use super::spec::cxl_port_dvsec::CXL_PORT_DVSEC_CXL_RCRB_BASE_WRITABLE_MASK;
+use super::spec::cxl_port_dvsec::CXL_PORT_DVSEC_ID;
+use super::spec::cxl_port_dvsec::CXL_PORT_DVSEC_LENGTH;
+use super::spec::cxl_port_dvsec::CXL_PORT_DVSEC_REVISION;
+use super::spec::cxl_port_dvsec::CXL_PORT_DVSEC_STATUS_RW1C_MASK;
+use super::spec::cxl_port_dvsec::CxlPortDvsecAltMemoryBase;
+use super::spec::cxl_port_dvsec::CxlPortDvsecAltMemoryLimit;
+use super::spec::cxl_port_dvsec::CxlPortDvsecAltPrefetchableMemoryBase;
+use super::spec::cxl_port_dvsec::CxlPortDvsecAltPrefetchableMemoryLimit;
+use super::spec::cxl_port_dvsec::CxlPortDvsecControl;
+use super::spec::cxl_port_dvsec::CxlPortDvsecExtendedCapability;
+use super::spec::cxl_port_dvsec::CxlPortDvsecRcrbBase;
+use super::spec::cxl_port_dvsec::CxlPortDvsecRegisterOffset;
+use super::spec::cxl_port_dvsec::CxlPortDvsecStatus;
+
+impl Default for CxlPortDvsecExtendedCapability {
+    fn default() -> Self {
+        Self {
+            status: CxlPortDvsecStatus::new(),
+            control: CxlPortDvsecControl::new(),
+            alt_bus_base: 0,
+            alt_bus_limit: 0,
+            alt_mem_base: CxlPortDvsecAltMemoryBase::new(),
+            alt_mem_limit: CxlPortDvsecAltMemoryLimit::new(),
+            alt_prefetch_mem_base: CxlPortDvsecAltPrefetchableMemoryBase::new(),
+            alt_prefetch_mem_limit: CxlPortDvsecAltPrefetchableMemoryLimit::new(),
+            alt_prefetch_mem_base_high: 0,
+            alt_prefetch_mem_limit_high: 0,
+            cxl_rcrb_base: CxlPortDvsecRcrbBase::new(),
+            cxl_rcrb_base_high: 0,
+            supports_uio_to_hdm_enable: false,
+            supports_viral: false,
+        }
+    }
+}
+
+impl CxlPortDvsecExtendedCapability {
+    /// Creates a new CXL Port DVSEC capability.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enables support for the `uio_to_hdm_enable` control bit.
+    pub fn with_uio_to_hdm_enable(mut self, supported: bool) -> Self {
+        self.supports_uio_to_hdm_enable = supported;
+        self
+    }
+
+    /// Enables support for viral control and status bits.
+    pub fn with_viral_support(mut self, supported: bool) -> Self {
+        self.supports_viral = supported;
+        self
+    }
+
+    /// Sets `Port Power Management Initialization Complete` in status.
+    pub fn set_port_power_management_initialization_complete(&mut self, complete: bool) {
+        self.status = self
+            .status
+            .with_port_power_management_initialization_complete(complete);
+    }
+
+    /// Sets `Viral Status` in status when this port type supports it.
+    pub fn set_viral_status(&mut self, viral: bool) {
+        if self.supports_viral {
+            self.status = self.status.with_viral_status(viral);
+        }
+    }
+
+    fn dvsec_len(&self) -> usize {
+        usize::from(CXL_PORT_DVSEC_LENGTH)
+    }
+
+    fn read_dvsec_u32(&self, offset: u16) -> u32 {
+        const DVSEC_HEADER1_OFFSET: u16 = DvsecExtendedCapabilityHeader::DVSEC_HEADER1.0;
+
+        match offset {
+            DVSEC_HEADER1_OFFSET => Self::dvsec_header1().into_bits(),
+            CxlPortDvsecRegisterOffset::DVSEC_HEADER2_PORT_EXTENSION_STATUS => {
+                u32::from(Self::dvsec_header2().into_bits())
+                    | (u32::from(self.status.into_bits()) << 16)
+            }
+            CxlPortDvsecRegisterOffset::DVSEC_PORT_CONTROL_EXTENSIONS_ALT_BUS_BASE_LIMIT => {
+                u32::from(self.control.into_bits())
+                    | (u32::from(self.alt_bus_base) << 16)
+                    | (u32::from(self.alt_bus_limit) << 24)
+            }
+            CxlPortDvsecRegisterOffset::DVSEC_ALT_MEMORY_BASE_LIMIT => {
+                u32::from(self.alt_mem_base.into_bits())
+                    | (u32::from(self.alt_mem_limit.into_bits()) << 16)
+            }
+            CxlPortDvsecRegisterOffset::DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_LIMIT => {
+                u32::from(self.alt_prefetch_mem_base.into_bits())
+                    | (u32::from(self.alt_prefetch_mem_limit.into_bits()) << 16)
+            }
+            CxlPortDvsecRegisterOffset::DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_HIGH => {
+                self.alt_prefetch_mem_base_high
+            }
+            CxlPortDvsecRegisterOffset::DVSEC_ALT_PREFETCHABLE_MEMORY_LIMIT_HIGH => {
+                self.alt_prefetch_mem_limit_high
+            }
+            CxlPortDvsecRegisterOffset::DVSEC_CXL_RCRB_BASE => self.cxl_rcrb_base.into_bits(),
+            CxlPortDvsecRegisterOffset::DVSEC_CXL_RCRB_BASE_HIGH => self.cxl_rcrb_base_high,
+            _ => !0,
+        }
+    }
+
+    fn write_dvsec_u32(&mut self, offset: u16, value: u32) {
+        match offset {
+            CxlPortDvsecRegisterOffset::DVSEC_HEADER2_PORT_EXTENSION_STATUS => {
+                let mut clear_mask = ((value >> 16) as u16) & CXL_PORT_DVSEC_STATUS_RW1C_MASK;
+                if !self.supports_viral {
+                    clear_mask &= !CxlPortDvsecStatus::new()
+                        .with_viral_status(true)
+                        .into_bits();
+                }
+                if clear_mask != 0 {
+                    let next_bits = self.status.into_bits() & !clear_mask;
+                    self.status = CxlPortDvsecStatus::from_bits(next_bits);
+                }
+            }
+            CxlPortDvsecRegisterOffset::DVSEC_PORT_CONTROL_EXTENSIONS_ALT_BUS_BASE_LIMIT => {
+                let requested = (value as u16) & CXL_PORT_DVSEC_CONTROL_WRITABLE_MASK;
+                let mut next_control = CxlPortDvsecControl::from_bits(requested);
+                if !self.supports_uio_to_hdm_enable {
+                    next_control = next_control.with_uio_to_hdm_enable(false);
+                }
+                if !self.supports_viral {
+                    next_control = next_control.with_viral_enable(false);
+                }
+                self.control = next_control;
+                self.alt_bus_base = (value >> 16) as u8;
+                self.alt_bus_limit = (value >> 24) as u8;
+            }
+            CxlPortDvsecRegisterOffset::DVSEC_ALT_MEMORY_BASE_LIMIT => {
+                let base_bits = (value as u16) & CXL_PORT_DVSEC_ALT_MEMORY_BASE_LIMIT_WRITABLE_MASK;
+                let limit_bits =
+                    ((value >> 16) as u16) & CXL_PORT_DVSEC_ALT_MEMORY_BASE_LIMIT_WRITABLE_MASK;
+                self.alt_mem_base = CxlPortDvsecAltMemoryBase::from_bits(base_bits);
+                self.alt_mem_limit = CxlPortDvsecAltMemoryLimit::from_bits(limit_bits);
+            }
+            CxlPortDvsecRegisterOffset::DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_LIMIT => {
+                let base_bits = (value as u16)
+                    & CXL_PORT_DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_LIMIT_WRITABLE_MASK;
+                let limit_bits = ((value >> 16) as u16)
+                    & CXL_PORT_DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_LIMIT_WRITABLE_MASK;
+                self.alt_prefetch_mem_base =
+                    CxlPortDvsecAltPrefetchableMemoryBase::from_bits(base_bits);
+                self.alt_prefetch_mem_limit =
+                    CxlPortDvsecAltPrefetchableMemoryLimit::from_bits(limit_bits);
+            }
+            CxlPortDvsecRegisterOffset::DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_HIGH => {
+                self.alt_prefetch_mem_base_high = value;
+            }
+            CxlPortDvsecRegisterOffset::DVSEC_ALT_PREFETCHABLE_MEMORY_LIMIT_HIGH => {
+                self.alt_prefetch_mem_limit_high = value;
+            }
+            CxlPortDvsecRegisterOffset::DVSEC_CXL_RCRB_BASE => {
+                let bits = value & CXL_PORT_DVSEC_CXL_RCRB_BASE_WRITABLE_MASK;
+                self.cxl_rcrb_base = CxlPortDvsecRcrbBase::from_bits(bits);
+            }
+            CxlPortDvsecRegisterOffset::DVSEC_CXL_RCRB_BASE_HIGH => {
+                self.cxl_rcrb_base_high = value;
+            }
+            _ => {}
+        }
+    }
+
+    fn reset_state(&mut self) {
+        *self = Self::default();
+    }
+
+    fn dvsec_header1() -> DvsecHeader1 {
+        DvsecHeader1::new()
+            .with_dvsec_vendor_id(CXL_DVSEC_VENDOR_ID)
+            .with_dvsec_revision(CXL_PORT_DVSEC_REVISION)
+            .with_dvsec_length(CXL_PORT_DVSEC_LENGTH)
+    }
+
+    fn dvsec_header2() -> DvsecHeader2 {
+        DvsecHeader2::new().with_dvsec_id(CXL_PORT_DVSEC_ID)
+    }
+}
+
+impl PciExtendedCapability for CxlPortDvsecExtendedCapability {
+    fn label(&self) -> &str {
+        "cxl_port_dvsec"
+    }
+
+    fn extended_capability_id(&self) -> u16 {
+        ExtendedCapabilityId::DVSEC.0
+    }
+
+    fn capability_version(&self) -> u8 {
+        1
+    }
+
+    fn len(&self) -> usize {
+        self.dvsec_len()
+    }
+
+    fn read_u32(&self, offset: u16) -> u32 {
+        if offset == 0 {
+            u32::from(self.extended_capability_id()) | (u32::from(self.capability_version()) << 16)
+        } else {
+            self.read_dvsec_u32(offset)
+        }
+    }
+
+    fn write_u32(&mut self, offset: u16, val: u32) {
+        if offset != 0 {
+            self.write_dvsec_u32(offset, val);
+        }
+    }
+
+    fn reset(&mut self) {
+        self.reset_state();
+    }
+}
+
+mod save_restore {
+    use super::*;
+    use vmcore::save_restore::RestoreError;
+    use vmcore::save_restore::SaveError;
+    use vmcore::save_restore::SaveRestore;
+
+    mod state {
+        use mesh::payload::Protobuf;
+        use vmcore::save_restore::SavedStateRoot;
+
+        #[derive(Protobuf, SavedStateRoot)]
+        #[mesh(package = "cxl.pci_registers.cxl_port_dvsec")]
+        pub struct SavedState {
+            #[mesh(1)]
+            pub status: u32,
+            #[mesh(2)]
+            pub control: u32,
+            #[mesh(3)]
+            pub alt_bus_base: u32,
+            #[mesh(4)]
+            pub alt_bus_limit: u32,
+            #[mesh(5)]
+            pub alt_mem_base: u32,
+            #[mesh(6)]
+            pub alt_mem_limit: u32,
+            #[mesh(7)]
+            pub alt_prefetch_mem_base: u32,
+            #[mesh(8)]
+            pub alt_prefetch_mem_limit: u32,
+            #[mesh(9)]
+            pub alt_prefetch_mem_base_high: u32,
+            #[mesh(10)]
+            pub alt_prefetch_mem_limit_high: u32,
+            #[mesh(11)]
+            pub cxl_rcrb_base: u32,
+            #[mesh(12)]
+            pub cxl_rcrb_base_high: u32,
+            #[mesh(13)]
+            pub supports_uio_to_hdm_enable: bool,
+            #[mesh(14)]
+            pub supports_viral: bool,
+        }
+    }
+
+    impl SaveRestore for CxlPortDvsecExtendedCapability {
+        type SavedState = state::SavedState;
+
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            Ok(state::SavedState {
+                status: u32::from(self.status.into_bits()),
+                control: u32::from(self.control.into_bits()),
+                alt_bus_base: u32::from(self.alt_bus_base),
+                alt_bus_limit: u32::from(self.alt_bus_limit),
+                alt_mem_base: u32::from(self.alt_mem_base.into_bits()),
+                alt_mem_limit: u32::from(self.alt_mem_limit.into_bits()),
+                alt_prefetch_mem_base: u32::from(self.alt_prefetch_mem_base.into_bits()),
+                alt_prefetch_mem_limit: u32::from(self.alt_prefetch_mem_limit.into_bits()),
+                alt_prefetch_mem_base_high: self.alt_prefetch_mem_base_high,
+                alt_prefetch_mem_limit_high: self.alt_prefetch_mem_limit_high,
+                cxl_rcrb_base: self.cxl_rcrb_base.into_bits(),
+                cxl_rcrb_base_high: self.cxl_rcrb_base_high,
+                supports_uio_to_hdm_enable: self.supports_uio_to_hdm_enable,
+                supports_viral: self.supports_viral,
+            })
+        }
+
+        fn restore(&mut self, state: Self::SavedState) -> Result<(), RestoreError> {
+            self.status = CxlPortDvsecStatus::from_bits(state.status as u16);
+            self.control = CxlPortDvsecControl::from_bits(state.control as u16);
+            self.alt_bus_base = state.alt_bus_base as u8;
+            self.alt_bus_limit = state.alt_bus_limit as u8;
+            self.alt_mem_base = CxlPortDvsecAltMemoryBase::from_bits(state.alt_mem_base as u16);
+            self.alt_mem_limit = CxlPortDvsecAltMemoryLimit::from_bits(state.alt_mem_limit as u16);
+            self.alt_prefetch_mem_base = CxlPortDvsecAltPrefetchableMemoryBase::from_bits(
+                state.alt_prefetch_mem_base as u16,
+            );
+            self.alt_prefetch_mem_limit = CxlPortDvsecAltPrefetchableMemoryLimit::from_bits(
+                state.alt_prefetch_mem_limit as u16,
+            );
+            self.alt_prefetch_mem_base_high = state.alt_prefetch_mem_base_high;
+            self.alt_prefetch_mem_limit_high = state.alt_prefetch_mem_limit_high;
+            self.cxl_rcrb_base = CxlPortDvsecRcrbBase::from_bits(state.cxl_rcrb_base);
+            self.cxl_rcrb_base_high = state.cxl_rcrb_base_high;
+            self.supports_uio_to_hdm_enable = state.supports_uio_to_hdm_enable;
+            self.supports_viral = state.supports_viral;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pci_core::capabilities::extended::PciExtendedCapability;
+    use pci_core::spec::caps::dvsec::DvsecExtendedCapabilityHeader;
+    use vmcore::save_restore::SaveRestore;
+
+    use super::CxlPortDvsecControl;
+    use super::CxlPortDvsecExtendedCapability;
+    use super::CxlPortDvsecRegisterOffset;
+    use super::CxlPortDvsecStatus;
+
+    #[test]
+    fn header_registers_match_required_constants() {
+        let cap = CxlPortDvsecExtendedCapability::new();
+
+        assert_eq!(
+            cap.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER1.0),
+            0x0280_1e98
+        );
+        assert_eq!(
+            cap.read_u32(CxlPortDvsecRegisterOffset::DVSEC_HEADER2_PORT_EXTENSION_STATUS) & 0xffff,
+            0x0003
+        );
+    }
+
+    #[test]
+    fn label_is_cxl_port_dvsec() {
+        let cap = CxlPortDvsecExtendedCapability::new();
+        assert_eq!(cap.label(), "cxl_port_dvsec");
+    }
+
+    #[test]
+    fn unsupported_optional_control_bits_are_forced_zero() {
+        let mut cap = CxlPortDvsecExtendedCapability::new();
+        let requested = CxlPortDvsecControl::new()
+            .with_uio_to_hdm_enable(true)
+            .with_viral_enable(true)
+            .into_bits();
+
+        cap.write_u32(
+            CxlPortDvsecRegisterOffset::DVSEC_PORT_CONTROL_EXTENSIONS_ALT_BUS_BASE_LIMIT,
+            u32::from(requested),
+        );
+
+        let control =
+            CxlPortDvsecControl::from_bits(cap.read_u32(
+                CxlPortDvsecRegisterOffset::DVSEC_PORT_CONTROL_EXTENSIONS_ALT_BUS_BASE_LIMIT,
+            ) as u16);
+        assert!(!control.uio_to_hdm_enable());
+        assert!(!control.viral_enable());
+    }
+
+    #[test]
+    fn status_viral_rw1c_is_gated_by_support() {
+        let mut cap = CxlPortDvsecExtendedCapability::new().with_viral_support(true);
+        cap.set_viral_status(true);
+
+        cap.write_u32(
+            CxlPortDvsecRegisterOffset::DVSEC_HEADER2_PORT_EXTENSION_STATUS,
+            u32::from(
+                CxlPortDvsecStatus::new()
+                    .with_viral_status(true)
+                    .into_bits(),
+            ) << 16,
+        );
+
+        let status = CxlPortDvsecStatus::from_bits(
+            (cap.read_u32(CxlPortDvsecRegisterOffset::DVSEC_HEADER2_PORT_EXTENSION_STATUS) >> 16)
+                as u16,
+        );
+        assert!(!status.viral_status());
+    }
+
+    #[test]
+    fn save_restore_round_trips_state() {
+        let mut cap = CxlPortDvsecExtendedCapability::new()
+            .with_uio_to_hdm_enable(true)
+            .with_viral_support(true);
+        cap.write_u32(
+            CxlPortDvsecRegisterOffset::DVSEC_PORT_CONTROL_EXTENSIONS_ALT_BUS_BASE_LIMIT,
+            0xa55a_001f,
+        );
+        cap.write_u32(
+            CxlPortDvsecRegisterOffset::DVSEC_ALT_MEMORY_BASE_LIMIT,
+            0x1234_5678,
+        );
+        cap.write_u32(
+            CxlPortDvsecRegisterOffset::DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_LIMIT,
+            0x9abc_def0,
+        );
+        cap.write_u32(
+            CxlPortDvsecRegisterOffset::DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_HIGH,
+            0x1020_3040,
+        );
+        cap.write_u32(
+            CxlPortDvsecRegisterOffset::DVSEC_ALT_PREFETCHABLE_MEMORY_LIMIT_HIGH,
+            0x5060_7080,
+        );
+        cap.write_u32(CxlPortDvsecRegisterOffset::DVSEC_CXL_RCRB_BASE, 0x3fff_e001);
+        cap.write_u32(
+            CxlPortDvsecRegisterOffset::DVSEC_CXL_RCRB_BASE_HIGH,
+            0x1111_2222,
+        );
+        cap.set_port_power_management_initialization_complete(true);
+        cap.set_viral_status(true);
+
+        let saved = cap.save().expect("save should succeed");
+        let mut restored = CxlPortDvsecExtendedCapability::new();
+        restored.restore(saved).expect("restore should succeed");
+
+        assert_eq!(
+            restored.read_u32(CxlPortDvsecRegisterOffset::DVSEC_HEADER2_PORT_EXTENSION_STATUS),
+            cap.read_u32(CxlPortDvsecRegisterOffset::DVSEC_HEADER2_PORT_EXTENSION_STATUS)
+        );
+        assert_eq!(
+            restored.read_u32(
+                CxlPortDvsecRegisterOffset::DVSEC_PORT_CONTROL_EXTENSIONS_ALT_BUS_BASE_LIMIT
+            ),
+            cap.read_u32(
+                CxlPortDvsecRegisterOffset::DVSEC_PORT_CONTROL_EXTENSIONS_ALT_BUS_BASE_LIMIT
+            )
+        );
+        assert_eq!(
+            restored.read_u32(CxlPortDvsecRegisterOffset::DVSEC_ALT_MEMORY_BASE_LIMIT),
+            cap.read_u32(CxlPortDvsecRegisterOffset::DVSEC_ALT_MEMORY_BASE_LIMIT)
+        );
+        assert_eq!(
+            restored.read_u32(CxlPortDvsecRegisterOffset::DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_LIMIT),
+            cap.read_u32(CxlPortDvsecRegisterOffset::DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_LIMIT)
+        );
+        assert_eq!(
+            restored.read_u32(CxlPortDvsecRegisterOffset::DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_HIGH),
+            cap.read_u32(CxlPortDvsecRegisterOffset::DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_HIGH)
+        );
+        assert_eq!(
+            restored.read_u32(CxlPortDvsecRegisterOffset::DVSEC_ALT_PREFETCHABLE_MEMORY_LIMIT_HIGH),
+            cap.read_u32(CxlPortDvsecRegisterOffset::DVSEC_ALT_PREFETCHABLE_MEMORY_LIMIT_HIGH)
+        );
+        assert_eq!(
+            restored.read_u32(CxlPortDvsecRegisterOffset::DVSEC_CXL_RCRB_BASE),
+            cap.read_u32(CxlPortDvsecRegisterOffset::DVSEC_CXL_RCRB_BASE)
+        );
+        assert_eq!(
+            restored.read_u32(CxlPortDvsecRegisterOffset::DVSEC_CXL_RCRB_BASE_HIGH),
+            cap.read_u32(CxlPortDvsecRegisterOffset::DVSEC_CXL_RCRB_BASE_HIGH)
+        );
+    }
+}

--- a/vm/devices/cxl/src/pci_registers/flex_bus_port_dvsec.rs
+++ b/vm/devices/cxl/src/pci_registers/flex_bus_port_dvsec.rs
@@ -1,0 +1,542 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! CXL Flex Bus Port PCIe DVSEC extended capability implementation.
+
+use pci_core::capabilities::extended::PciExtendedCapability;
+use pci_core::spec::caps::ExtendedCapabilityId;
+use pci_core::spec::caps::dvsec::DvsecExtendedCapabilityHeader;
+use pci_core::spec::caps::dvsec::DvsecHeader1;
+use pci_core::spec::caps::dvsec::DvsecHeader2;
+
+use super::spec::CXL_DVSEC_VENDOR_ID;
+use super::spec::flex_bus_port_dvsec::CXL_FLEX_BUS_PORT_DVSEC_CONTROL_WRITABLE_MASK;
+use super::spec::flex_bus_port_dvsec::CXL_FLEX_BUS_PORT_DVSEC_CONTROL2_WRITABLE_MASK;
+use super::spec::flex_bus_port_dvsec::CXL_FLEX_BUS_PORT_DVSEC_ID;
+use super::spec::flex_bus_port_dvsec::CXL_FLEX_BUS_PORT_DVSEC_LENGTH;
+use super::spec::flex_bus_port_dvsec::CXL_FLEX_BUS_PORT_DVSEC_REVISION;
+use super::spec::flex_bus_port_dvsec::CXL_FLEX_BUS_PORT_DVSEC_STATUS_RW1CS_MASK;
+use super::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecCapability;
+use super::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecCapability2;
+use super::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecControl;
+use super::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecControl2;
+use super::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecExtendedCapability;
+use super::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecReceivedModifiedTsDataPhase1;
+use super::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecRegisterOffset;
+use super::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecStatus;
+use super::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecStatus2;
+
+impl Default for CxlFlexBusPortDvsecExtendedCapability {
+    fn default() -> Self {
+        let capability = CxlFlexBusPortDvsecCapability::new().with_io_capable(true);
+        let capability2 = CxlFlexBusPortDvsecCapability2::new();
+        Self {
+            capability,
+            control: CxlFlexBusPortDvsecControl::new().with_io_enable(true),
+            status: CxlFlexBusPortDvsecStatus::new(),
+            received_modified_ts_data_phase1: CxlFlexBusPortDvsecReceivedModifiedTsDataPhase1::new(
+            ),
+            capability2,
+            control2: CxlFlexBusPortDvsecControl2::new(),
+            status2: CxlFlexBusPortDvsecStatus2::new(),
+            reset_baseline_capability: capability,
+            reset_baseline_capability2: capability2,
+        }
+    }
+}
+
+impl CxlFlexBusPortDvsecExtendedCapability {
+    /// Creates a new CXL Flex Bus Port DVSEC capability.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Configures optional Flex Bus Port capabilities.
+    #[expect(clippy::fn_params_excessive_bools)]
+    pub fn with_optional_capabilities(
+        mut self,
+        cache_capable: bool,
+        cxl_68b_flit_and_vh_capable: bool,
+        cxl_multi_logical_device_capable: bool,
+        cxl_latency_optimized_256b_flit_capable: bool,
+        cxl_pbr_flit_capable: bool,
+    ) -> Self {
+        self.capability = self
+            .capability
+            .with_cache_capable(cache_capable)
+            .with_cxl_68b_flit_and_vh_capable(cxl_68b_flit_and_vh_capable)
+            .with_cxl_multi_logical_device_capable(cxl_multi_logical_device_capable)
+            .with_cxl_latency_optimized_256b_flit_capable(cxl_latency_optimized_256b_flit_capable)
+            .with_cxl_pbr_flit_capable(cxl_pbr_flit_capable);
+        self.reset_baseline_capability = self.capability;
+        self
+    }
+
+    /// Configures whether this port advertises CXL.mem capability.
+    pub fn with_mem_capable(mut self, mem_capable: bool) -> Self {
+        self.capability = self.capability.with_mem_capable(mem_capable);
+        self.reset_baseline_capability = self.capability;
+        self
+    }
+
+    /// Configures whether this port advertises CXL.cache capability.
+    pub fn with_cache_capable(mut self, cache_capable: bool) -> Self {
+        self.capability = self.capability.with_cache_capable(cache_capable);
+        self.reset_baseline_capability = self.capability;
+        self
+    }
+
+    /// Configures Flex Bus Port Capability2 bits.
+    pub fn with_capability2(mut self, nop_hint_capable: bool, streamlined_port: bool) -> Self {
+        self.capability2 = self
+            .capability2
+            .with_nop_hint_capable(nop_hint_capable)
+            .with_streamlined_port(streamlined_port);
+        self.reset_baseline_capability2 = self.capability2;
+        self
+    }
+
+    /// Updates status bits that are reported by the physical layer.
+    pub fn set_status(
+        &mut self,
+        status: CxlFlexBusPortDvsecStatus,
+        received_modified_ts_data_phase1: u32,
+        status2: CxlFlexBusPortDvsecStatus2,
+    ) {
+        self.status = status;
+        self.received_modified_ts_data_phase1 =
+            CxlFlexBusPortDvsecReceivedModifiedTsDataPhase1::new()
+                .with_received_flex_bus_data_phase1(received_modified_ts_data_phase1 & 0x00ff_ffff);
+        self.status2 = status2;
+    }
+
+    fn dvsec_len(&self) -> usize {
+        usize::from(CXL_FLEX_BUS_PORT_DVSEC_LENGTH)
+    }
+
+    fn read_dvsec_u32(&self, offset: u16) -> u32 {
+        const DVSEC_HEADER1_OFFSET: u16 = DvsecExtendedCapabilityHeader::DVSEC_HEADER1.0;
+
+        match offset {
+            DVSEC_HEADER1_OFFSET => Self::dvsec_header1().into_bits(),
+            CxlFlexBusPortDvsecRegisterOffset::DVSEC_HEADER2_CAPABILITY => {
+                u32::from(Self::dvsec_header2().into_bits())
+                    | (u32::from(self.capability.into_bits()) << 16)
+            }
+            CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL_STATUS => {
+                u32::from(self.control.into_bits()) | (u32::from(self.status.into_bits()) << 16)
+            }
+            CxlFlexBusPortDvsecRegisterOffset::DVSEC_RECEIVED_MODIFIED_TS_DATA_PHASE1 => {
+                self.received_modified_ts_data_phase1.into_bits()
+            }
+            CxlFlexBusPortDvsecRegisterOffset::DVSEC_CAPABILITY2 => self.capability2.into_bits(),
+            CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL2 => self.control2.into_bits(),
+            CxlFlexBusPortDvsecRegisterOffset::DVSEC_STATUS2 => self.status2.into_bits(),
+            _ => !0,
+        }
+    }
+
+    fn write_dvsec_u32(&mut self, offset: u16, value: u32) {
+        match offset {
+            CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL_STATUS => {
+                self.handle_control_status_write(value)
+            }
+            CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL2 => self.handle_control2_write(value),
+            _ => {}
+        }
+    }
+
+    fn reset_state(&mut self) {
+        self.capability = self.reset_baseline_capability;
+        self.control =
+            CxlFlexBusPortDvsecControl::new().with_io_enable(self.capability.io_capable());
+        self.status = CxlFlexBusPortDvsecStatus::new();
+        self.received_modified_ts_data_phase1 =
+            CxlFlexBusPortDvsecReceivedModifiedTsDataPhase1::new();
+        self.capability2 = self.reset_baseline_capability2;
+        self.control2 = CxlFlexBusPortDvsecControl2::new();
+        self.status2 = CxlFlexBusPortDvsecStatus2::new();
+    }
+
+    fn dvsec_header1() -> DvsecHeader1 {
+        DvsecHeader1::new()
+            .with_dvsec_vendor_id(CXL_DVSEC_VENDOR_ID)
+            .with_dvsec_revision(CXL_FLEX_BUS_PORT_DVSEC_REVISION)
+            .with_dvsec_length(CXL_FLEX_BUS_PORT_DVSEC_LENGTH)
+    }
+
+    fn dvsec_header2() -> DvsecHeader2 {
+        DvsecHeader2::new().with_dvsec_id(CXL_FLEX_BUS_PORT_DVSEC_ID)
+    }
+
+    fn handle_control_status_write(&mut self, value: u32) {
+        let requested = (value as u16) & CXL_FLEX_BUS_PORT_DVSEC_CONTROL_WRITABLE_MASK;
+        let mut next = CxlFlexBusPortDvsecControl::from_bits(requested);
+
+        // IO Enable is RO and tied to IO capability.
+        next = next.with_io_enable(self.capability.io_capable());
+
+        // Writable bits are still capability-gated.
+        if !self.capability.cache_capable() {
+            next = next.with_cache_enable(false);
+        }
+        if !self.capability.mem_capable() {
+            next = next.with_mem_enable(false);
+        }
+        if !self.capability.cxl_68b_flit_and_vh_capable() {
+            next = next.with_cxl_68b_flit_and_vh_enable(false);
+        }
+        if !self.capability.cxl_multi_logical_device_capable() {
+            next = next.with_cxl_multi_logical_device_enable(false);
+        }
+        if !self.capability.cxl_latency_optimized_256b_flit_capable() {
+            next = next.with_cxl_latency_optimized_256b_flit_enable(false);
+        }
+        if !self.capability.cxl_pbr_flit_capable() {
+            next = next.with_cxl_pbr_flit_enable(false);
+        }
+
+        // HwInit-only bits remain unchanged.
+        next = next
+            .with_cxl_sync_hdr_bypass_enable(self.control.cxl_sync_hdr_bypass_enable())
+            .with_drift_buffer_enable(self.control.drift_buffer_enable());
+
+        self.control = next;
+
+        let clear_mask = ((value >> 16) as u16) & CXL_FLEX_BUS_PORT_DVSEC_STATUS_RW1CS_MASK;
+        if clear_mask != 0 {
+            let next_bits = self.status.into_bits() & !clear_mask;
+            self.status = CxlFlexBusPortDvsecStatus::from_bits(next_bits);
+        }
+    }
+
+    fn handle_control2_write(&mut self, value: u32) {
+        let requested = value & CXL_FLEX_BUS_PORT_DVSEC_CONTROL2_WRITABLE_MASK;
+        let mut next = CxlFlexBusPortDvsecControl2::from_bits(requested);
+        if !self.capability2.nop_hint_capable() {
+            next = next.with_nop_hint_enable(false);
+        }
+        self.control2 = next;
+    }
+}
+
+impl PciExtendedCapability for CxlFlexBusPortDvsecExtendedCapability {
+    fn label(&self) -> &str {
+        "flex_bus_port_dvsec"
+    }
+
+    fn extended_capability_id(&self) -> u16 {
+        ExtendedCapabilityId::DVSEC.0
+    }
+
+    fn capability_version(&self) -> u8 {
+        1
+    }
+
+    fn len(&self) -> usize {
+        self.dvsec_len()
+    }
+
+    fn read_u32(&self, offset: u16) -> u32 {
+        if offset == 0 {
+            u32::from(self.extended_capability_id()) | (u32::from(self.capability_version()) << 16)
+        } else {
+            self.read_dvsec_u32(offset)
+        }
+    }
+
+    fn write_u32(&mut self, offset: u16, val: u32) {
+        if offset != 0 {
+            self.write_dvsec_u32(offset, val);
+        }
+    }
+
+    fn reset(&mut self) {
+        self.reset_state();
+    }
+}
+
+mod save_restore {
+    use super::*;
+    use vmcore::save_restore::RestoreError;
+    use vmcore::save_restore::SaveError;
+    use vmcore::save_restore::SaveRestore;
+
+    mod state {
+        use mesh::payload::Protobuf;
+        use vmcore::save_restore::SavedStateRoot;
+
+        #[derive(Protobuf, SavedStateRoot)]
+        #[mesh(package = "cxl.pci_registers.flex_bus_port_dvsec")]
+        pub struct SavedState {
+            #[mesh(1)]
+            pub capability: u32,
+            #[mesh(2)]
+            pub control: u32,
+            #[mesh(3)]
+            pub status: u32,
+            #[mesh(4)]
+            pub received_modified_ts_data_phase1: u32,
+            #[mesh(5)]
+            pub capability2: u32,
+            #[mesh(6)]
+            pub control2: u32,
+            #[mesh(7)]
+            pub status2: u32,
+            #[mesh(8)]
+            pub reset_baseline_capability: u32,
+            #[mesh(9)]
+            pub reset_baseline_capability2: u32,
+        }
+    }
+
+    impl SaveRestore for CxlFlexBusPortDvsecExtendedCapability {
+        type SavedState = state::SavedState;
+
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            Ok(state::SavedState {
+                capability: u32::from(self.capability.into_bits()),
+                control: u32::from(self.control.into_bits()),
+                status: u32::from(self.status.into_bits()),
+                received_modified_ts_data_phase1: self.received_modified_ts_data_phase1.into_bits(),
+                capability2: self.capability2.into_bits(),
+                control2: self.control2.into_bits(),
+                status2: self.status2.into_bits(),
+                reset_baseline_capability: u32::from(self.reset_baseline_capability.into_bits()),
+                reset_baseline_capability2: self.reset_baseline_capability2.into_bits(),
+            })
+        }
+
+        fn restore(&mut self, state: Self::SavedState) -> Result<(), RestoreError> {
+            self.capability = CxlFlexBusPortDvsecCapability::from_bits(state.capability as u16);
+            self.control = CxlFlexBusPortDvsecControl::from_bits(state.control as u16);
+            self.status = CxlFlexBusPortDvsecStatus::from_bits(state.status as u16);
+            self.received_modified_ts_data_phase1 =
+                CxlFlexBusPortDvsecReceivedModifiedTsDataPhase1::from_bits(
+                    state.received_modified_ts_data_phase1,
+                );
+            self.capability2 = CxlFlexBusPortDvsecCapability2::from_bits(state.capability2);
+            self.control2 = CxlFlexBusPortDvsecControl2::from_bits(state.control2);
+            self.status2 = CxlFlexBusPortDvsecStatus2::from_bits(state.status2);
+            self.reset_baseline_capability =
+                CxlFlexBusPortDvsecCapability::from_bits(state.reset_baseline_capability as u16);
+            self.reset_baseline_capability2 =
+                CxlFlexBusPortDvsecCapability2::from_bits(state.reset_baseline_capability2);
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pci_core::capabilities::extended::PciExtendedCapability;
+    use pci_core::spec::caps::dvsec::DvsecExtendedCapabilityHeader;
+    use vmcore::save_restore::SaveRestore;
+
+    use super::CxlFlexBusPortDvsecCapability;
+    use super::CxlFlexBusPortDvsecControl;
+    use super::CxlFlexBusPortDvsecControl2;
+    use super::CxlFlexBusPortDvsecExtendedCapability;
+    use super::CxlFlexBusPortDvsecRegisterOffset;
+    use super::CxlFlexBusPortDvsecStatus;
+
+    #[test]
+    fn header_registers_match_required_constants() {
+        let cap = CxlFlexBusPortDvsecExtendedCapability::new();
+
+        assert_eq!(
+            cap.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER1.0),
+            0x0203_1e98
+        );
+        assert_eq!(
+            cap.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_HEADER2_CAPABILITY) & 0xffff,
+            0x0007
+        );
+    }
+
+    #[test]
+    fn label_is_flex_bus_port_dvsec() {
+        let cap = CxlFlexBusPortDvsecExtendedCapability::new();
+        assert_eq!(cap.label(), "flex_bus_port_dvsec");
+    }
+
+    #[test]
+    fn control_write_is_capability_gated() {
+        let mut cap = CxlFlexBusPortDvsecExtendedCapability::new().with_mem_capable(true);
+
+        let requested = CxlFlexBusPortDvsecControl::new()
+            .with_cache_enable(true)
+            .with_mem_enable(true)
+            .with_cxl_68b_flit_and_vh_enable(true)
+            .with_cxl_multi_logical_device_enable(true)
+            .with_cxl_latency_optimized_256b_flit_enable(true)
+            .with_cxl_pbr_flit_enable(true)
+            .into_bits();
+
+        cap.write_u32(
+            CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL_STATUS,
+            u32::from(requested),
+        );
+
+        let control = CxlFlexBusPortDvsecControl::from_bits(
+            cap.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL_STATUS) as u16,
+        );
+
+        assert!(!control.cache_enable());
+        assert!(control.mem_enable());
+        assert!(!control.cxl_68b_flit_and_vh_enable());
+        assert!(!control.cxl_multi_logical_device_enable());
+        assert!(!control.cxl_latency_optimized_256b_flit_enable());
+        assert!(!control.cxl_pbr_flit_enable());
+        assert!(control.io_enable());
+    }
+
+    #[test]
+    fn reset_preserves_configured_mem_capability() {
+        let mut cap = CxlFlexBusPortDvsecExtendedCapability::new().with_mem_capable(true);
+
+        cap.write_u32(
+            CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL_STATUS,
+            u32::from(
+                CxlFlexBusPortDvsecControl::new()
+                    .with_mem_enable(true)
+                    .into_bits(),
+            ),
+        );
+
+        cap.reset();
+
+        let header2_cap = cap.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_HEADER2_CAPABILITY);
+        let capability = CxlFlexBusPortDvsecCapability::from_bits((header2_cap >> 16) as u16);
+        let control = CxlFlexBusPortDvsecControl::from_bits(
+            cap.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL_STATUS) as u16,
+        );
+
+        assert!(capability.mem_capable());
+        assert!(!control.mem_enable());
+        assert!(control.io_enable());
+    }
+
+    #[test]
+    fn status_rw1cs_clears_target_bits() {
+        let mut cap = CxlFlexBusPortDvsecExtendedCapability::new();
+        let status = CxlFlexBusPortDvsecStatus::new()
+            .with_even_half_failed(true)
+            .with_cxl_correctable_protocol_id_framing_error(true)
+            .with_cxl_unexpected_protocol_id_dropped(true);
+        cap.set_status(status, 0, cap.status2);
+
+        // clear bits 7 and 10
+        cap.write_u32(
+            CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL_STATUS,
+            (1u32 << (16 + 7)) | (1u32 << (16 + 10)),
+        );
+
+        let next = CxlFlexBusPortDvsecStatus::from_bits(
+            (cap.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL_STATUS) >> 16) as u16,
+        );
+        assert!(!next.even_half_failed());
+        assert!(next.cxl_correctable_protocol_id_framing_error());
+        assert!(!next.cxl_unexpected_protocol_id_dropped());
+    }
+
+    #[test]
+    fn control2_is_gated_by_capability2() {
+        let mut cap = CxlFlexBusPortDvsecExtendedCapability::new();
+        cap.write_u32(
+            CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL2,
+            CxlFlexBusPortDvsecControl2::new()
+                .with_nop_hint_enable(true)
+                .into_bits(),
+        );
+        let control2 = CxlFlexBusPortDvsecControl2::from_bits(
+            cap.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL2),
+        );
+        assert!(!control2.nop_hint_enable());
+
+        let mut cap = CxlFlexBusPortDvsecExtendedCapability::new().with_capability2(true, false);
+        cap.write_u32(
+            CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL2,
+            CxlFlexBusPortDvsecControl2::new()
+                .with_nop_hint_enable(true)
+                .into_bits(),
+        );
+        let control2 = CxlFlexBusPortDvsecControl2::from_bits(
+            cap.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL2),
+        );
+        assert!(control2.nop_hint_enable());
+    }
+
+    #[test]
+    fn save_restore_round_trips_state() {
+        let mut cap = CxlFlexBusPortDvsecExtendedCapability::new()
+            .with_mem_capable(true)
+            .with_optional_capabilities(true, true, true, true, true)
+            .with_capability2(true, true);
+        cap.write_u32(
+            CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL_STATUS,
+            u32::from(
+                CxlFlexBusPortDvsecControl::new()
+                    .with_cache_enable(true)
+                    .with_mem_enable(true)
+                    .with_cxl_68b_flit_and_vh_enable(true)
+                    .with_cxl_multi_logical_device_enable(true)
+                    .with_cxl_latency_optimized_256b_flit_enable(true)
+                    .with_cxl_pbr_flit_enable(true)
+                    .into_bits(),
+            ),
+        );
+        cap.set_status(
+            CxlFlexBusPortDvsecStatus::new().with_cxl_retimers_present_mismatch(true),
+            0x00ab_cdef,
+            super::CxlFlexBusPortDvsecStatus2::new()
+                .with_nop_hint_info(0x2)
+                .with_streamlined_port(true),
+        );
+        cap.write_u32(
+            CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL2,
+            CxlFlexBusPortDvsecControl2::new()
+                .with_nop_hint_enable(true)
+                .into_bits(),
+        );
+
+        let saved = cap.save().expect("save should succeed");
+        let mut restored = CxlFlexBusPortDvsecExtendedCapability::new();
+        restored.restore(saved).expect("restore should succeed");
+
+        assert_eq!(
+            restored.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_HEADER2_CAPABILITY),
+            cap.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_HEADER2_CAPABILITY)
+        );
+        assert_eq!(
+            restored.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL_STATUS),
+            cap.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL_STATUS)
+        );
+        assert_eq!(
+            restored.read_u32(
+                CxlFlexBusPortDvsecRegisterOffset::DVSEC_RECEIVED_MODIFIED_TS_DATA_PHASE1
+            ),
+            cap.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_RECEIVED_MODIFIED_TS_DATA_PHASE1)
+        );
+        assert_eq!(
+            restored.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_CAPABILITY2),
+            cap.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_CAPABILITY2)
+        );
+        assert_eq!(
+            restored.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL2),
+            cap.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_CONTROL2)
+        );
+        assert_eq!(
+            restored.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_STATUS2),
+            cap.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_STATUS2)
+        );
+
+        let capability = CxlFlexBusPortDvsecCapability::from_bits(
+            (cap.read_u32(CxlFlexBusPortDvsecRegisterOffset::DVSEC_HEADER2_CAPABILITY) >> 16)
+                as u16,
+        );
+        assert!(capability.cache_capable());
+        assert!(capability.cxl_68b_flit_and_vh_capable());
+        assert!(capability.cxl_multi_logical_device_capable());
+    }
+}

--- a/vm/devices/cxl/src/pci_registers/mod.rs
+++ b/vm/devices/cxl/src/pci_registers/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! CXL DVSEC register abstractions.
+
+mod cxl_device_dvsec;
+mod cxl_port_dvsec;
+mod flex_bus_port_dvsec;
+mod register_locator_dvsec;
+pub mod spec;
+
+pub use spec::cxl_device_dvsec::CxlDeviceDevsecExtendedCapability;
+pub use spec::cxl_port_dvsec::CxlPortDvsecExtendedCapability;
+pub use spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecExtendedCapability;
+pub use spec::register_locator_dvsec::CxlRegisterLocatorDvsecExtendedCapability;

--- a/vm/devices/cxl/src/pci_registers/register_locator_dvsec.rs
+++ b/vm/devices/cxl/src/pci_registers/register_locator_dvsec.rs
@@ -1,0 +1,396 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! CXL Register Locator PCIe DVSEC extended capability implementation.
+
+use pci_core::capabilities::extended::PciExtendedCapability;
+use pci_core::spec::caps::ExtendedCapabilityId;
+use pci_core::spec::caps::dvsec::DvsecExtendedCapabilityHeader;
+use pci_core::spec::caps::dvsec::DvsecHeader1;
+use pci_core::spec::caps::dvsec::DvsecHeader2;
+
+use super::spec::CXL_DVSEC_VENDOR_ID;
+use super::spec::register_locator_dvsec::CXL_REGISTER_LOCATOR_DVSEC_ID;
+use super::spec::register_locator_dvsec::CXL_REGISTER_LOCATOR_DVSEC_REVISION;
+use super::spec::register_locator_dvsec::CxlRegisterLocatorDvsecExtendedCapability;
+use super::spec::register_locator_dvsec::CxlRegisterLocatorDvsecRegisterBlockEntry;
+use super::spec::register_locator_dvsec::CxlRegisterLocatorDvsecRegisterOffset;
+use super::spec::register_locator_dvsec::CxlRegisterLocatorDvsecRegisterOffsetLow;
+use super::spec::register_locator_dvsec::CxlRegisterLocatorRegisterBir;
+use super::spec::register_locator_dvsec::CxlRegisterLocatorRegisterBlockIdentifier;
+use crate::spec::CXL_COMPONENT_REGISTERS_SIZE_BYTES;
+use thiserror::Error;
+
+/// Register block offset encoding shift: DVSEC stores A[63:16], not byte address A[63:0].
+const REGISTER_BLOCK_OFFSET_ENCODING_SHIFT: u32 = 16;
+
+/// Errors returned when configuring Register Locator entries.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Error)]
+pub enum RegisterLocatorConfigError {
+    /// Register block offset must be aligned to `CXL_COMPONENT_REGISTERS_SIZE_BYTES`.
+    #[error("register block offset must be aligned to CXL component-register size")]
+    RegisterBlockOffsetUnaligned,
+}
+
+impl CxlRegisterLocatorDvsecExtendedCapability {
+    /// Creates a new Register Locator DVSEC capability.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Appends one register-block entry to the Register Locator DVSEC.
+    pub fn with_register_block(
+        mut self,
+        register_bir: CxlRegisterLocatorRegisterBir,
+        register_block_identifier: CxlRegisterLocatorRegisterBlockIdentifier,
+        register_block_offset: u64,
+    ) -> Result<Self, RegisterLocatorConfigError> {
+        if !register_block_offset.is_multiple_of(CXL_COMPONENT_REGISTERS_SIZE_BYTES) {
+            return Err(RegisterLocatorConfigError::RegisterBlockOffsetUnaligned);
+        }
+
+        // The spec encodes register block offsets as A[63:16], so convert byte offset here.
+        let register_block_offset_encoded =
+            register_block_offset >> REGISTER_BLOCK_OFFSET_ENCODING_SHIFT;
+
+        let offset_low = CxlRegisterLocatorDvsecRegisterOffsetLow::new()
+            .with_register_bir(register_bir.bits())
+            .with_register_block_identifier(register_block_identifier.bits())
+            .with_register_block_offset_low(register_block_offset_encoded as u16);
+        let offset_high =
+            (register_block_offset_encoded >> REGISTER_BLOCK_OFFSET_ENCODING_SHIFT) as u32;
+
+        self.register_blocks
+            .push(CxlRegisterLocatorDvsecRegisterBlockEntry {
+                offset_low,
+                offset_high,
+            });
+        self.reset_baseline_register_blocks = self.register_blocks.clone();
+
+        Ok(self)
+    }
+
+    fn dvsec_len(&self) -> usize {
+        usize::from(self.encoded_length())
+    }
+
+    fn read_dvsec_u32(&self, offset: u16) -> u32 {
+        if offset == DvsecExtendedCapabilityHeader::DVSEC_HEADER1.0 {
+            return self.dvsec_header1().into_bits();
+        }
+
+        if offset == CxlRegisterLocatorDvsecRegisterOffset::DVSEC_HEADER2 {
+            return u32::from(Self::dvsec_header2().into_bits());
+        }
+
+        if offset < CxlRegisterLocatorDvsecRegisterOffset::FIRST_REGISTER_BLOCK_OFFSET_LOW {
+            return !0;
+        }
+
+        let rel = offset - CxlRegisterLocatorDvsecRegisterOffset::FIRST_REGISTER_BLOCK_OFFSET_LOW;
+        let index = usize::from(rel / CxlRegisterLocatorDvsecRegisterOffset::REGISTER_BLOCK_STRIDE);
+        let within = rel % CxlRegisterLocatorDvsecRegisterOffset::REGISTER_BLOCK_STRIDE;
+
+        let Some(entry) = self.register_blocks.get(index) else {
+            return !0;
+        };
+
+        match within {
+            0x0 => entry.offset_low.into_bits(),
+            0x4 => entry.offset_high,
+            _ => !0,
+        }
+    }
+
+    fn write_dvsec_u32(&mut self, _offset: u16, _value: u32) {
+        // Register Locator fields are HwInit/RO from software perspective.
+    }
+
+    fn reset_state(&mut self) {
+        self.register_blocks = self.reset_baseline_register_blocks.clone();
+    }
+
+    fn encoded_length(&self) -> u16 {
+        let blocks = self.register_blocks.len() as u16;
+        CxlRegisterLocatorDvsecRegisterOffset::BASE_LENGTH.saturating_add(
+            blocks.saturating_mul(CxlRegisterLocatorDvsecRegisterOffset::REGISTER_BLOCK_STRIDE),
+        )
+    }
+
+    fn dvsec_header1(&self) -> DvsecHeader1 {
+        DvsecHeader1::new()
+            .with_dvsec_vendor_id(CXL_DVSEC_VENDOR_ID)
+            .with_dvsec_revision(CXL_REGISTER_LOCATOR_DVSEC_REVISION)
+            .with_dvsec_length(self.encoded_length())
+    }
+
+    fn dvsec_header2() -> DvsecHeader2 {
+        DvsecHeader2::new().with_dvsec_id(CXL_REGISTER_LOCATOR_DVSEC_ID)
+    }
+}
+
+impl PciExtendedCapability for CxlRegisterLocatorDvsecExtendedCapability {
+    fn label(&self) -> &str {
+        "register_locator_dvsec"
+    }
+
+    fn extended_capability_id(&self) -> u16 {
+        ExtendedCapabilityId::DVSEC.0
+    }
+
+    fn capability_version(&self) -> u8 {
+        1
+    }
+
+    fn len(&self) -> usize {
+        self.dvsec_len()
+    }
+
+    fn read_u32(&self, offset: u16) -> u32 {
+        if offset == 0 {
+            u32::from(self.extended_capability_id()) | (u32::from(self.capability_version()) << 16)
+        } else {
+            self.read_dvsec_u32(offset)
+        }
+    }
+
+    fn write_u32(&mut self, offset: u16, val: u32) {
+        if offset != 0 {
+            self.write_dvsec_u32(offset, val);
+        }
+    }
+
+    fn reset(&mut self) {
+        self.reset_state();
+    }
+}
+
+mod save_restore {
+    use super::*;
+    use vmcore::save_restore::RestoreError;
+    use vmcore::save_restore::SaveError;
+    use vmcore::save_restore::SaveRestore;
+
+    mod state {
+        use mesh::payload::Protobuf;
+        use vmcore::save_restore::SavedStateRoot;
+
+        #[derive(Protobuf, SavedStateRoot)]
+        #[mesh(package = "cxl.pci_registers.register_locator_dvsec")]
+        pub struct SavedState {
+            #[mesh(1)]
+            pub register_blocks: Vec<u64>,
+            #[mesh(2)]
+            pub reset_baseline_register_blocks: Vec<u64>,
+        }
+    }
+
+    impl SaveRestore for CxlRegisterLocatorDvsecExtendedCapability {
+        type SavedState = state::SavedState;
+
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            let register_blocks = self
+                .register_blocks
+                .iter()
+                .map(|entry| {
+                    ((u64::from(entry.offset_high)) << 32) | u64::from(entry.offset_low.into_bits())
+                })
+                .collect();
+            let reset_baseline_register_blocks = self
+                .reset_baseline_register_blocks
+                .iter()
+                .map(|entry| {
+                    ((u64::from(entry.offset_high)) << 32) | u64::from(entry.offset_low.into_bits())
+                })
+                .collect();
+            Ok(state::SavedState {
+                register_blocks,
+                reset_baseline_register_blocks,
+            })
+        }
+
+        fn restore(&mut self, state: Self::SavedState) -> Result<(), RestoreError> {
+            self.register_blocks = state
+                .register_blocks
+                .into_iter()
+                .map(|packed| CxlRegisterLocatorDvsecRegisterBlockEntry {
+                    offset_low: CxlRegisterLocatorDvsecRegisterOffsetLow::from_bits(packed as u32),
+                    offset_high: (packed >> 32) as u32,
+                })
+                .collect();
+            self.reset_baseline_register_blocks = state
+                .reset_baseline_register_blocks
+                .into_iter()
+                .map(|packed| CxlRegisterLocatorDvsecRegisterBlockEntry {
+                    offset_low: CxlRegisterLocatorDvsecRegisterOffsetLow::from_bits(packed as u32),
+                    offset_high: (packed >> 32) as u32,
+                })
+                .collect();
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pci_core::capabilities::extended::PciExtendedCapability;
+    use pci_core::spec::caps::dvsec::DvsecExtendedCapabilityHeader;
+    use vmcore::save_restore::SaveRestore;
+
+    use super::CxlRegisterLocatorDvsecExtendedCapability;
+    use super::CxlRegisterLocatorDvsecRegisterOffset;
+    use super::CxlRegisterLocatorRegisterBir;
+    use super::CxlRegisterLocatorRegisterBlockIdentifier;
+    use super::RegisterLocatorConfigError;
+    use crate::spec::CXL_COMPONENT_REGISTERS_SIZE_BYTES;
+
+    #[test]
+    fn header_registers_match_required_constants() {
+        let cap = CxlRegisterLocatorDvsecExtendedCapability::new()
+            .with_register_block(
+                CxlRegisterLocatorRegisterBir::BAR_10H,
+                CxlRegisterLocatorRegisterBlockIdentifier::COMPONENT_REGISTERS,
+                CXL_COMPONENT_REGISTERS_SIZE_BYTES,
+            )
+            .expect("first block should configure")
+            .with_register_block(
+                CxlRegisterLocatorRegisterBir::BAR_10H,
+                CxlRegisterLocatorRegisterBlockIdentifier::CXL_DEVICE_REGISTERS,
+                CXL_COMPONENT_REGISTERS_SIZE_BYTES * 2,
+            )
+            .expect("second block should configure")
+            .with_register_block(
+                CxlRegisterLocatorRegisterBir::BAR_14H,
+                CxlRegisterLocatorRegisterBlockIdentifier::DESIGNATED_VENDOR_SPECIFIC,
+                CXL_COMPONENT_REGISTERS_SIZE_BYTES * 3,
+            )
+            .expect("third block should configure");
+
+        assert_eq!(
+            cap.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER1.0),
+            0x0240_1e98
+        );
+        assert_eq!(
+            cap.read_u32(CxlRegisterLocatorDvsecRegisterOffset::DVSEC_HEADER2) & 0xffff,
+            0x0008
+        );
+    }
+
+    #[test]
+    fn label_is_register_locator_dvsec() {
+        let cap = CxlRegisterLocatorDvsecExtendedCapability::new();
+        assert_eq!(cap.label(), "register_locator_dvsec");
+    }
+
+    #[test]
+    fn unaligned_register_block_offset_is_rejected() {
+        let result = CxlRegisterLocatorDvsecExtendedCapability::new().with_register_block(
+            CxlRegisterLocatorRegisterBir::BAR_10H,
+            CxlRegisterLocatorRegisterBlockIdentifier::CXL_DEVICE_REGISTERS,
+            CXL_COMPONENT_REGISTERS_SIZE_BYTES + 1,
+        );
+        assert!(matches!(
+            result,
+            Err(RegisterLocatorConfigError::RegisterBlockOffsetUnaligned)
+        ));
+    }
+
+    #[test]
+    fn register_block_entries_are_encoded() {
+        let cap = CxlRegisterLocatorDvsecExtendedCapability::new()
+            .with_register_block(
+                CxlRegisterLocatorRegisterBir::BAR_10H,
+                CxlRegisterLocatorRegisterBlockIdentifier::COMPONENT_REGISTERS,
+                CXL_COMPONENT_REGISTERS_SIZE_BYTES,
+            )
+            .expect("block should configure")
+            .with_register_block(
+                CxlRegisterLocatorRegisterBir::BAR_18H,
+                CxlRegisterLocatorRegisterBlockIdentifier::CXL_DEVICE_REGISTERS,
+                CXL_COMPONENT_REGISTERS_SIZE_BYTES * 2,
+            )
+            .expect("block should configure");
+
+        assert_eq!(
+            cap.read_u32(CxlRegisterLocatorDvsecRegisterOffset::FIRST_REGISTER_BLOCK_OFFSET_LOW),
+            0x0001_0100
+        );
+        assert_eq!(
+            cap.read_u32(
+                CxlRegisterLocatorDvsecRegisterOffset::FIRST_REGISTER_BLOCK_OFFSET_LOW + 0x04
+            ),
+            0x0000_0000
+        );
+
+        assert_eq!(
+            cap.read_u32(
+                CxlRegisterLocatorDvsecRegisterOffset::FIRST_REGISTER_BLOCK_OFFSET_LOW + 0x08
+            ),
+            0x0002_0302
+        );
+    }
+
+    #[test]
+    fn save_restore_round_trips_state() {
+        let mut cap = CxlRegisterLocatorDvsecExtendedCapability::new()
+            .with_register_block(
+                CxlRegisterLocatorRegisterBir::BAR_10H,
+                CxlRegisterLocatorRegisterBlockIdentifier::COMPONENT_REGISTERS,
+                CXL_COMPONENT_REGISTERS_SIZE_BYTES,
+            )
+            .expect("block should configure")
+            .with_register_block(
+                CxlRegisterLocatorRegisterBir::BAR_1CH,
+                CxlRegisterLocatorRegisterBlockIdentifier::CHMU_REGISTERS,
+                CXL_COMPONENT_REGISTERS_SIZE_BYTES * 4,
+            )
+            .expect("block should configure");
+
+        let saved = cap.save().expect("save should succeed");
+        let mut restored = CxlRegisterLocatorDvsecExtendedCapability::new();
+        restored.restore(saved).expect("restore should succeed");
+
+        assert_eq!(
+            restored.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER1.0),
+            cap.read_u32(DvsecExtendedCapabilityHeader::DVSEC_HEADER1.0)
+        );
+        assert_eq!(
+            restored.read_u32(CxlRegisterLocatorDvsecRegisterOffset::DVSEC_HEADER2),
+            cap.read_u32(CxlRegisterLocatorDvsecRegisterOffset::DVSEC_HEADER2)
+        );
+        assert_eq!(
+            restored
+                .read_u32(CxlRegisterLocatorDvsecRegisterOffset::FIRST_REGISTER_BLOCK_OFFSET_LOW),
+            cap.read_u32(CxlRegisterLocatorDvsecRegisterOffset::FIRST_REGISTER_BLOCK_OFFSET_LOW)
+        );
+        assert_eq!(
+            restored.read_u32(
+                CxlRegisterLocatorDvsecRegisterOffset::FIRST_REGISTER_BLOCK_OFFSET_LOW + 0x08
+            ),
+            cap.read_u32(
+                CxlRegisterLocatorDvsecRegisterOffset::FIRST_REGISTER_BLOCK_OFFSET_LOW + 0x08
+            )
+        );
+    }
+
+    #[test]
+    fn reset_preserves_configured_register_blocks() {
+        let mut cap = CxlRegisterLocatorDvsecExtendedCapability::new()
+            .with_register_block(
+                CxlRegisterLocatorRegisterBir::BAR_10H,
+                CxlRegisterLocatorRegisterBlockIdentifier::COMPONENT_REGISTERS,
+                0,
+            )
+            .expect("block should configure");
+
+        let before = cap.read_u32(CxlRegisterLocatorDvsecRegisterOffset::DVSEC_HEADER2);
+        cap.reset();
+        let after = cap.read_u32(CxlRegisterLocatorDvsecRegisterOffset::DVSEC_HEADER2);
+
+        assert_eq!(before, after);
+        assert_eq!(
+            cap.read_u32(CxlRegisterLocatorDvsecRegisterOffset::FIRST_REGISTER_BLOCK_OFFSET_LOW),
+            0x0000_0100
+        );
+    }
+}

--- a/vm/devices/cxl/src/pci_registers/spec.rs
+++ b/vm/devices/cxl/src/pci_registers/spec.rs
@@ -1,0 +1,915 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! CXL PCIe DVSEC register definitions.
+
+/// Common CXL DVSEC vendor ID.
+pub const CXL_DVSEC_VENDOR_ID: u16 = 0x1e98;
+
+/// CXL Designated Vendor-Specific Extended Capability (DVSEC).
+#[expect(missing_docs)] // keep parity with grouped spec modules without forcing doc lint churn
+pub mod cxl_device_dvsec {
+    use bitfield_struct::bitfield;
+    use inspect::Inspect;
+    use std::sync::Arc;
+
+    /// Callback interface for handling CXL reset requests.
+    pub trait CxlResetHandler: Send + Sync + Inspect {
+        /// Called when a new CXL reset request is initiated.
+        fn initiate_cxl_reset(&self);
+    }
+
+    /// Callback interface for handling cache writeback+invalidate requests.
+    pub trait CxlCacheWriteBackAndInvalidateHandler: Send + Sync + Inspect {
+        /// Called when cache writeback+invalidate is initiated.
+        fn initiate_cache_write_back_and_invalidate(&self);
+    }
+
+    /// Media_Type encodings for DVSEC CXL Range Size Low.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum CxlDeviceDvsecMediaType {
+        /// 000b = Volatile memory.
+        VolatileMemory,
+        /// 001b = Non-volatile memory.
+        NonVolatileMemory,
+        /// 010b = Memory characteristics via CDAT.
+        Cdat,
+    }
+
+    impl CxlDeviceDvsecMediaType {
+        pub const fn bits(self) -> u8 {
+            match self {
+                Self::VolatileMemory => 0b000,
+                Self::NonVolatileMemory => 0b001,
+                Self::Cdat => 0b010,
+            }
+        }
+    }
+
+    /// Memory_Class encodings for DVSEC CXL Range Size Low.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum CxlDeviceDvsecMemoryClass {
+        /// 000b = Memory class (e.g. DRAM).
+        Memory,
+        /// 001b = Storage class.
+        Storage,
+        /// 010b = Characteristics via CDAT.
+        Cdat,
+    }
+
+    impl CxlDeviceDvsecMemoryClass {
+        pub const fn bits(self) -> u8 {
+            match self {
+                Self::Memory => 0b000,
+                Self::Storage => 0b001,
+                Self::Cdat => 0b010,
+            }
+        }
+    }
+
+    /// Desired_Interleave encodings for DVSEC CXL Range Size Low.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum CxlDeviceDvsecDesiredInterleave {
+        /// 00h = No Interleave.
+        NoInterleave,
+        /// 01h = 256-byte granularity.
+        Granularity256Bytes,
+        /// 02h = 4-KB interleave.
+        Interleave4Kb,
+        /// 03h = 512 bytes.
+        Bytes512,
+        /// 04h = 1024 bytes.
+        Bytes1024,
+        /// 05h = 2048 bytes.
+        Bytes2048,
+        /// 06h = 8192 bytes.
+        Bytes8192,
+        /// 07h = 16384 bytes.
+        Bytes16384,
+    }
+
+    impl CxlDeviceDvsecDesiredInterleave {
+        pub const fn bits(self) -> u8 {
+            match self {
+                Self::NoInterleave => 0x00,
+                Self::Granularity256Bytes => 0x01,
+                Self::Interleave4Kb => 0x02,
+                Self::Bytes512 => 0x03,
+                Self::Bytes1024 => 0x04,
+                Self::Bytes2048 => 0x05,
+                Self::Bytes8192 => 0x06,
+                Self::Bytes16384 => 0x07,
+            }
+        }
+    }
+
+    /// Memory_Active_Timeout encodings for DVSEC CXL Range Size Low.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum CxlDeviceDvsecMemoryActiveTimeout {
+        /// 000b = 1 second.
+        Seconds1,
+        /// 001b = 4 seconds.
+        Seconds4,
+        /// 010b = 16 seconds.
+        Seconds16,
+        /// 011b = 64 seconds.
+        Seconds64,
+        /// 100b = 256 seconds.
+        Seconds256,
+    }
+
+    impl CxlDeviceDvsecMemoryActiveTimeout {
+        pub const fn bits(self) -> u8 {
+            match self {
+                Self::Seconds1 => 0b000,
+                Self::Seconds4 => 0b001,
+                Self::Seconds16 => 0b010,
+                Self::Seconds64 => 0b011,
+                Self::Seconds256 => 0b100,
+            }
+        }
+    }
+
+    /// CXL reset timeout encodings for DVSEC CXL Capability.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum CxlDeviceDvsecResetTimeout {
+        /// 000b = 10 ms.
+        Milliseconds10,
+        /// 001b = 100 ms.
+        Milliseconds100,
+        /// 010b = 1 second.
+        Seconds1,
+        /// 011b = 10 seconds.
+        Seconds10,
+        /// 100b = 100 seconds.
+        Seconds100,
+    }
+
+    impl CxlDeviceDvsecResetTimeout {
+        pub const fn bits(self) -> u8 {
+            match self {
+                Self::Milliseconds10 => 0b000,
+                Self::Milliseconds100 => 0b001,
+                Self::Seconds1 => 0b010,
+                Self::Seconds10 => 0b011,
+                Self::Seconds100 => 0b100,
+            }
+        }
+    }
+
+    /// Cache size unit encodings for DVSEC CXL Capability2.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum CxlDeviceDvsecCacheSizeUnit {
+        /// 0h = Cache size is not reported.
+        NotReported,
+        /// 1h = 64 KB.
+        Kib64,
+        /// 2h = 1 MB.
+        Mib1,
+    }
+
+    impl CxlDeviceDvsecCacheSizeUnit {
+        pub const fn bits(self) -> u8 {
+            match self {
+                Self::NotReported => 0x0,
+                Self::Kib64 => 0x1,
+                Self::Mib1 => 0x2,
+            }
+        }
+    }
+
+    /// Dword offsets in the CXL DVSEC register block.
+    ///
+    /// The PCIe Extended Capability Header at offset `0x00` is managed by the
+    /// caller. DVSEC Header1 (`0x04`) and DVSEC Header2 (`0x08`) are defined in
+    /// `pci_core::spec::caps::dvsec::DvsecExtendedCapabilityHeader`.
+    ///
+    /// This table starts at the first CXL-specific packed dword (`0x0C`).
+    pub struct CxlDeviceDvsecRegisterOffset;
+
+    impl CxlDeviceDvsecRegisterOffset {
+        /// Packed CXL Control + CXL Status dword offset.
+        pub const DVSEC_CONTROL_STATUS: u16 = 0x0c;
+        /// Packed CXL Control2 + CXL Status2 dword offset.
+        pub const DVSEC_CONTROL2_STATUS2: u16 = 0x10;
+        /// Packed CXL Lock + CXL Capability2 dword offset.
+        pub const DVSEC_LOCK_CAPABILITY2: u16 = 0x14;
+        /// CXL Range1 Size High dword offset.
+        pub const DVSEC_RANGE1_SIZE_HIGH: u16 = 0x18;
+        /// CXL Range1 Size Low dword offset.
+        pub const DVSEC_RANGE1_SIZE_LOW: u16 = 0x1c;
+        /// CXL Range1 Base High dword offset.
+        pub const DVSEC_RANGE1_BASE_HIGH: u16 = 0x20;
+        /// CXL Range1 Base Low dword offset.
+        pub const DVSEC_RANGE1_BASE_LOW: u16 = 0x24;
+        /// CXL Range2 Size High dword offset.
+        pub const DVSEC_RANGE2_SIZE_HIGH: u16 = 0x28;
+        /// CXL Range2 Size Low dword offset.
+        pub const DVSEC_RANGE2_SIZE_LOW: u16 = 0x2c;
+        /// CXL Range2 Base High dword offset.
+        pub const DVSEC_RANGE2_BASE_HIGH: u16 = 0x30;
+        /// CXL Range2 Base Low dword offset.
+        pub const DVSEC_RANGE2_BASE_LOW: u16 = 0x34;
+        /// CXL Capability3 dword offset.
+        pub const DVSEC_CAPABILITY3: u16 = 0x38;
+    }
+
+    /// CXL DVSEC revision.
+    pub const CXL_DEVICE_DVSEC_REVISION: u8 = 0x3;
+    /// CXL DVSEC structure length in bytes.
+    pub const CXL_DEVICE_DVSEC_LENGTH: u16 = 0x3c;
+    /// CXL DVSEC ID value.
+    pub const CXL_DEVICE_DVSEC_ID: u16 = 0x0000;
+
+    /// Writable mask for the DVSEC CXL Control register.
+    ///
+    /// Defined from the writable fields in `CxlDeviceDvsecControl` for readability.
+    pub const CXL_DEVICE_DVSEC_CONTROL_WRITABLE_MASK: u16 = CxlDeviceDvsecControl::new()
+        .with_cache_enable(true)
+        .with_mem_enable(true)
+        .with_cache_sf_coverage(0x1f)
+        .with_cache_sf_granularity(0x07)
+        .with_cache_clean_eviction(true)
+        .with_direct_p2p_mem_enable(true)
+        .with_viral_enable(true)
+        .into_bits();
+
+    /// Writable mask for the DVSEC CXL Control2 register.
+    ///
+    /// Defined from the writable fields in `CxlDeviceDvsecControl2` for readability.
+    pub const CXL_DEVICE_DVSEC_CONTROL2_WRITABLE_MASK: u16 = CxlDeviceDvsecControl2::new()
+        .with_disable_caching(true)
+        .with_initiate_cache_writeback_and_invalidation(true)
+        .with_initiate_cxl_reset(true)
+        .with_cxl_reset_mem_clr_enable(true)
+        .with_desired_volatile_hdm_state_after_hot_reset_configurable(true)
+        .with_modified_completion_enable(true)
+        .into_bits();
+
+    /// Writable mask for the DVSEC CXL Range Base Low register.
+    ///
+    /// Defined from the writable fields in `CxlDeviceDvsecRangeBaseLow` for readability.
+    pub const CXL_DEVICE_DVSEC_RANGE_BASE_LOW_WRITABLE_MASK: u32 =
+        CxlDeviceDvsecRangeBaseLow::new()
+            .with_memory_base_low(0x0f)
+            .into_bits();
+
+    /// RW1C mask for the DVSEC CXL Status register.
+    ///
+    /// Defined from the RW1C fields in `CxlDeviceDvsecStatus` for readability.
+    pub const CXL_DEVICE_DVSEC_STATUS_RW1C_MASK: u16 = CxlDeviceDvsecStatus::new()
+        .with_viral_status(true)
+        .into_bits();
+
+    /// RW1C mask for the DVSEC CXL Status2 register.
+    ///
+    /// Defined from the RW1C fields in `CxlDeviceDvsecStatus2` for readability.
+    pub const CXL_DEVICE_DVSEC_STATUS2_RW1C_MASK: u16 = CxlDeviceDvsecStatus2::new()
+        .with_volatile_hdm_preservation_error(true)
+        .into_bits();
+
+    /// RW1C mask for DVSEC Status2 `volatile_hdm_preservation_error`.
+    pub const CXL_DEVICE_DVSEC_STATUS2_VOLATILE_HDM_PRESERVATION_ERROR_RW1C_MASK: u16 =
+        CxlDeviceDvsecStatus2::new()
+            .with_volatile_hdm_preservation_error(true)
+            .into_bits();
+
+    /// DVSEC CXL Capability register (offset `0x0A`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlDeviceDvsecCapability {
+        pub cache_capable: bool,
+        pub io_capable: bool,
+        pub mem_capable: bool,
+        pub mem_hwinit_mode: bool,
+        #[bits(2)]
+        pub hdm_count: u8,
+        pub cache_writeback_and_invalidate_capable: bool,
+        pub cxl_reset_capable: bool,
+        /// Encoded using `CxlDeviceDvsecResetTimeout::bits()`.
+        #[bits(3)]
+        pub cxl_reset_timeout: u8,
+        pub cxl_reset_mem_clr_capable: bool,
+        pub tsp_capable: bool,
+        pub multiple_logical_device: bool,
+        pub viral_capable: bool,
+        pub pm_init_completion_reporting_capable: bool,
+    }
+
+    /// DVSEC CXL Control register (offset `0x0C`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlDeviceDvsecControl {
+        pub cache_enable: bool,
+        pub io_enable: bool,
+        pub mem_enable: bool,
+        #[bits(5)]
+        pub cache_sf_coverage: u8,
+        #[bits(3)]
+        pub cache_sf_granularity: u8,
+        pub cache_clean_eviction: bool,
+        pub direct_p2p_mem_enable: bool,
+        #[bits(1)]
+        _reserved0: u8,
+        pub viral_enable: bool,
+        #[bits(1)]
+        _reserved1: u8,
+    }
+
+    /// DVSEC CXL Status register (offset `0x0E`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlDeviceDvsecStatus {
+        #[bits(14)]
+        _reserved0: u16,
+        pub viral_status: bool,
+        _reserved1: bool,
+    }
+
+    /// DVSEC CXL Control2 register (offset `0x10`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlDeviceDvsecControl2 {
+        pub disable_caching: bool,
+        pub initiate_cache_writeback_and_invalidation: bool,
+        pub initiate_cxl_reset: bool,
+        pub cxl_reset_mem_clr_enable: bool,
+        pub desired_volatile_hdm_state_after_hot_reset_configurable: bool,
+        pub modified_completion_enable: bool,
+        #[bits(10)]
+        _reserved: u16,
+    }
+
+    /// DVSEC CXL Status2 register (offset `0x12`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlDeviceDvsecStatus2 {
+        pub cache_invalid: bool,
+        pub cxl_reset_complete: bool,
+        pub cxl_reset_error: bool,
+        pub volatile_hdm_preservation_error: bool,
+        #[bits(11)]
+        _reserved: u16,
+        pub power_management_initialization_complete: bool,
+    }
+
+    /// DVSEC CXL Lock register (offset `0x14`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlDeviceDvsecLock {
+        pub config_lock: bool,
+        #[bits(15)]
+        _reserved: u16,
+    }
+
+    /// DVSEC CXL Capability2 register (offset `0x16`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlDeviceDvsecCapability2 {
+        #[bits(4)]
+        pub cache_size_unit: u8,
+        #[bits(2)]
+        pub fallback_capability: u8,
+        pub modified_completion_capable: bool,
+        pub no_clean_writeback: bool,
+        #[bits(8)]
+        pub cache_size: u8,
+    }
+
+    /// DVSEC CXL Range Size Low register layout (offset `0x1C`/`0x2C`).
+    #[derive(Inspect)]
+    #[bitfield(u32)]
+    pub struct CxlDeviceDvsecRangeSizeLow {
+        pub memory_info_valid: bool,
+        pub memory_active: bool,
+        #[bits(3)]
+        pub media_type: u8,
+        #[bits(3)]
+        pub memory_class: u8,
+        #[bits(5)]
+        pub desired_interleave: u8,
+        #[bits(3)]
+        pub memory_active_timeout: u8,
+        pub memory_active_degraded: bool,
+        #[bits(11)]
+        _reserved: u16,
+        #[bits(4)]
+        pub memory_size_low: u8,
+    }
+
+    /// DVSEC CXL Range Base Low register layout (offset `0x24`/`0x34`).
+    #[derive(Inspect)]
+    #[bitfield(u32)]
+    pub struct CxlDeviceDvsecRangeBaseLow {
+        #[bits(28)]
+        _reserved: u32,
+        #[bits(4)]
+        pub memory_base_low: u8,
+    }
+
+    /// DVSEC CXL Capability3 register (offset `0x38`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlDeviceDvsecCapability3 {
+        pub default_volatile_hdm_state_after_cold_reset: bool,
+        pub default_volatile_hdm_state_after_warm_reset: bool,
+        pub default_volatile_hdm_state_after_hot_reset: bool,
+        pub volatile_hdm_state_after_hot_reset_configurability: bool,
+        pub direct_p2p_mem_capable: bool,
+        #[bits(11)]
+        _reserved: u16,
+    }
+
+    /// CXL PCIe Designated Vendor-Specific Extended Capability (DVSEC).
+    #[derive(Clone, Inspect)]
+    pub struct CxlDeviceDevsecExtendedCapability {
+        pub(crate) control: CxlDeviceDvsecControl,
+        pub(crate) status: CxlDeviceDvsecStatus,
+        pub(crate) control2: CxlDeviceDvsecControl2,
+        pub(crate) status2: CxlDeviceDvsecStatus2,
+        pub(crate) lock: CxlDeviceDvsecLock,
+        pub(crate) capability: CxlDeviceDvsecCapability,
+        pub(crate) capability2: CxlDeviceDvsecCapability2,
+        pub(crate) capability3: CxlDeviceDvsecCapability3,
+        pub(crate) range1_size_high: u32,
+        pub(crate) range1_size_low: u32,
+        pub(crate) range1_base_high: u32,
+        pub(crate) range1_base_low: CxlDeviceDvsecRangeBaseLow,
+        pub(crate) range2_size_high: u32,
+        pub(crate) range2_size_low: u32,
+        pub(crate) range2_base_high: u32,
+        pub(crate) range2_base_low: CxlDeviceDvsecRangeBaseLow,
+        pub(crate) cxl_reset_handler: Option<Arc<dyn CxlResetHandler>>,
+        pub(crate) cxl_cache_write_back_and_invalidate_handler:
+            Option<Arc<dyn CxlCacheWriteBackAndInvalidateHandler>>,
+        pub(crate) reset_baseline_capability: CxlDeviceDvsecCapability,
+        pub(crate) reset_baseline_capability2: CxlDeviceDvsecCapability2,
+        pub(crate) reset_baseline_capability3: CxlDeviceDvsecCapability3,
+        pub(crate) reset_baseline_range1_size_high: u32,
+        pub(crate) reset_baseline_range1_size_low: u32,
+        pub(crate) reset_baseline_range1_base_high: u32,
+        pub(crate) reset_baseline_range1_base_low: CxlDeviceDvsecRangeBaseLow,
+        pub(crate) reset_baseline_range2_size_high: u32,
+        pub(crate) reset_baseline_range2_size_low: u32,
+        pub(crate) reset_baseline_range2_base_high: u32,
+        pub(crate) reset_baseline_range2_base_low: CxlDeviceDvsecRangeBaseLow,
+    }
+}
+
+/// CXL Port Designated Vendor-Specific Extended Capability (DVSEC).
+pub mod cxl_port_dvsec {
+    use bitfield_struct::bitfield;
+    use inspect::Inspect;
+
+    /// Dword offsets in the CXL Port DVSEC register block.
+    ///
+    /// The PCIe Extended Capability Header at offset `0x00` is managed by the
+    /// caller. DVSEC Header1 (`0x04`) and DVSEC Header2 (`0x08`) are defined in
+    /// `pci_core::spec::caps::dvsec::DvsecExtendedCapabilityHeader`.
+    pub struct CxlPortDvsecRegisterOffset;
+
+    impl CxlPortDvsecRegisterOffset {
+        /// Packed DVSEC Header2 + CXL Port Extension Status dword offset.
+        pub const DVSEC_HEADER2_PORT_EXTENSION_STATUS: u16 = 0x08;
+        /// Packed CXL Port Control Extensions + Alternate Bus Base/Limit dword offset.
+        pub const DVSEC_PORT_CONTROL_EXTENSIONS_ALT_BUS_BASE_LIMIT: u16 = 0x0c;
+        /// Packed Alternate Memory Base + Alternate Memory Limit dword offset.
+        pub const DVSEC_ALT_MEMORY_BASE_LIMIT: u16 = 0x10;
+        /// Packed Alternate Prefetchable Memory Base + Limit dword offset.
+        pub const DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_LIMIT: u16 = 0x14;
+        /// Alternate Prefetchable Memory Base High dword offset.
+        pub const DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_HIGH: u16 = 0x18;
+        /// Alternate Prefetchable Memory Limit High dword offset.
+        pub const DVSEC_ALT_PREFETCHABLE_MEMORY_LIMIT_HIGH: u16 = 0x1c;
+        /// CXL RCRB Base dword offset.
+        pub const DVSEC_CXL_RCRB_BASE: u16 = 0x20;
+        /// CXL RCRB Base High dword offset.
+        pub const DVSEC_CXL_RCRB_BASE_HIGH: u16 = 0x24;
+    }
+
+    /// CXL Port DVSEC revision.
+    pub const CXL_PORT_DVSEC_REVISION: u8 = 0x0;
+    /// CXL Port DVSEC structure length in bytes.
+    pub const CXL_PORT_DVSEC_LENGTH: u16 = 0x28;
+    /// CXL Port DVSEC ID value.
+    pub const CXL_PORT_DVSEC_ID: u16 = 0x0003;
+
+    /// Writable mask for the CXL Port Control Extensions register.
+    pub const CXL_PORT_DVSEC_CONTROL_WRITABLE_MASK: u16 = CxlPortDvsecControl::new()
+        .with_unmask_sbr(true)
+        .with_unmask_link_disable(true)
+        .with_alt_memory_and_id_space_enable(true)
+        .with_alt_bme(true)
+        .with_uio_to_hdm_enable(true)
+        .with_viral_enable(true)
+        .into_bits();
+
+    /// RW1C mask for the CXL Port Extension Status register.
+    pub const CXL_PORT_DVSEC_STATUS_RW1C_MASK: u16 = CxlPortDvsecStatus::new()
+        .with_viral_status(true)
+        .into_bits();
+
+    /// Writable mask for Alternate Memory Base and Limit low bits.
+    pub const CXL_PORT_DVSEC_ALT_MEMORY_BASE_LIMIT_WRITABLE_MASK: u16 =
+        CxlPortDvsecAltMemoryBase::new()
+            .with_alt_mem_base(0x0fff)
+            .into_bits();
+
+    /// Writable mask for Alternate Prefetchable Memory Base and Limit low bits.
+    pub const CXL_PORT_DVSEC_ALT_PREFETCHABLE_MEMORY_BASE_LIMIT_WRITABLE_MASK: u16 =
+        CxlPortDvsecAltPrefetchableMemoryBase::new()
+            .with_alt_prefetch_mem_base(0x0fff)
+            .into_bits();
+
+    /// Writable mask for CXL RCRB Base.
+    pub const CXL_PORT_DVSEC_CXL_RCRB_BASE_WRITABLE_MASK: u32 = CxlPortDvsecRcrbBase::new()
+        .with_cxl_rcrb_enable(true)
+        .with_cxl_rcrb_base_address_low(0x7ffff)
+        .into_bits();
+
+    /// CXL Port Extension Status register (offset `0x0A`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlPortDvsecStatus {
+        pub port_power_management_initialization_complete: bool,
+        #[bits(13)]
+        _reserved0: u16,
+        pub viral_status: bool,
+        _reserved1: bool,
+    }
+
+    /// CXL Port Control Extensions register (offset `0x0C`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlPortDvsecControl {
+        pub unmask_sbr: bool,
+        pub unmask_link_disable: bool,
+        pub alt_memory_and_id_space_enable: bool,
+        pub alt_bme: bool,
+        pub uio_to_hdm_enable: bool,
+        #[bits(9)]
+        _reserved0: u16,
+        pub viral_enable: bool,
+        _reserved1: bool,
+    }
+
+    /// Alternate Memory Base register (offset `0x10`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlPortDvsecAltMemoryBase {
+        #[bits(4)]
+        _reserved: u8,
+        #[bits(12)]
+        pub alt_mem_base: u16,
+    }
+
+    /// Alternate Memory Limit register (offset `0x12`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlPortDvsecAltMemoryLimit {
+        #[bits(4)]
+        _reserved: u8,
+        #[bits(12)]
+        pub alt_mem_limit: u16,
+    }
+
+    /// Alternate Prefetchable Memory Base register (offset `0x14`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlPortDvsecAltPrefetchableMemoryBase {
+        #[bits(4)]
+        _reserved: u8,
+        #[bits(12)]
+        pub alt_prefetch_mem_base: u16,
+    }
+
+    /// Alternate Prefetchable Memory Limit register (offset `0x16`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlPortDvsecAltPrefetchableMemoryLimit {
+        #[bits(4)]
+        _reserved: u8,
+        #[bits(12)]
+        pub alt_prefetch_mem_limit: u16,
+    }
+
+    /// CXL RCRB Base register (offset `0x20`).
+    #[derive(Inspect)]
+    #[bitfield(u32)]
+    pub struct CxlPortDvsecRcrbBase {
+        pub cxl_rcrb_enable: bool,
+        #[bits(12)]
+        _reserved: u16,
+        #[bits(19)]
+        pub cxl_rcrb_base_address_low: u32,
+    }
+
+    /// CXL Port PCIe Designated Vendor-Specific Extended Capability (DVSEC).
+    #[derive(Clone, Inspect)]
+    pub struct CxlPortDvsecExtendedCapability {
+        pub(crate) status: CxlPortDvsecStatus,
+        pub(crate) control: CxlPortDvsecControl,
+        pub(crate) alt_bus_base: u8,
+        pub(crate) alt_bus_limit: u8,
+        pub(crate) alt_mem_base: CxlPortDvsecAltMemoryBase,
+        pub(crate) alt_mem_limit: CxlPortDvsecAltMemoryLimit,
+        pub(crate) alt_prefetch_mem_base: CxlPortDvsecAltPrefetchableMemoryBase,
+        pub(crate) alt_prefetch_mem_limit: CxlPortDvsecAltPrefetchableMemoryLimit,
+        pub(crate) alt_prefetch_mem_base_high: u32,
+        pub(crate) alt_prefetch_mem_limit_high: u32,
+        pub(crate) cxl_rcrb_base: CxlPortDvsecRcrbBase,
+        pub(crate) cxl_rcrb_base_high: u32,
+        pub(crate) supports_uio_to_hdm_enable: bool,
+        pub(crate) supports_viral: bool,
+    }
+}
+
+/// CXL Flex Bus Port Designated Vendor-Specific Extended Capability (DVSEC).
+pub mod flex_bus_port_dvsec {
+    use bitfield_struct::bitfield;
+    use inspect::Inspect;
+
+    /// Dword offsets in the CXL Flex Bus Port DVSEC register block.
+    ///
+    /// The PCIe Extended Capability Header at offset `0x00` is managed by the
+    /// caller. DVSEC Header1 (`0x04`) and DVSEC Header2 (`0x08`) are defined in
+    /// `pci_core::spec::caps::dvsec::DvsecExtendedCapabilityHeader`.
+    pub struct CxlFlexBusPortDvsecRegisterOffset;
+
+    impl CxlFlexBusPortDvsecRegisterOffset {
+        /// Packed DVSEC Header2 + Flex Bus Port Capability dword offset.
+        pub const DVSEC_HEADER2_CAPABILITY: u16 = 0x08;
+        /// Packed Flex Bus Port Control + Flex Bus Port Status dword offset.
+        pub const DVSEC_CONTROL_STATUS: u16 = 0x0c;
+        /// Flex Bus Port Received Modified TS Data Phase1 dword offset.
+        pub const DVSEC_RECEIVED_MODIFIED_TS_DATA_PHASE1: u16 = 0x10;
+        /// Flex Bus Port Capability2 dword offset.
+        pub const DVSEC_CAPABILITY2: u16 = 0x14;
+        /// Flex Bus Port Control2 dword offset.
+        pub const DVSEC_CONTROL2: u16 = 0x18;
+        /// Flex Bus Port Status2 dword offset.
+        pub const DVSEC_STATUS2: u16 = 0x1c;
+    }
+
+    /// CXL Flex Bus Port DVSEC revision.
+    pub const CXL_FLEX_BUS_PORT_DVSEC_REVISION: u8 = 0x3;
+    /// CXL Flex Bus Port DVSEC structure length in bytes.
+    pub const CXL_FLEX_BUS_PORT_DVSEC_LENGTH: u16 = 0x20;
+    /// CXL Flex Bus Port DVSEC ID value.
+    pub const CXL_FLEX_BUS_PORT_DVSEC_ID: u16 = 0x0007;
+
+    /// Writable mask for the Flex Bus Port Control register.
+    pub const CXL_FLEX_BUS_PORT_DVSEC_CONTROL_WRITABLE_MASK: u16 =
+        CxlFlexBusPortDvsecControl::new()
+            .with_cache_enable(true)
+            .with_mem_enable(true)
+            .with_cxl_68b_flit_and_vh_enable(true)
+            .with_cxl_multi_logical_device_enable(true)
+            .with_disable_rcd_training(true)
+            .with_retimer1_present(true)
+            .with_retimer2_present(true)
+            .with_cxl_latency_optimized_256b_flit_enable(true)
+            .with_cxl_pbr_flit_enable(true)
+            .into_bits();
+
+    /// RW1CS mask for the Flex Bus Port Status register.
+    pub const CXL_FLEX_BUS_PORT_DVSEC_STATUS_RW1CS_MASK: u16 = CxlFlexBusPortDvsecStatus::new()
+        .with_even_half_failed(true)
+        .with_cxl_correctable_protocol_id_framing_error(true)
+        .with_cxl_uncorrectable_protocol_id_framing_error(true)
+        .with_cxl_unexpected_protocol_id_dropped(true)
+        .with_cxl_retimers_present_mismatch(true)
+        .with_flex_bus_enables_phase2_mismatched(true)
+        .into_bits();
+
+    /// Writable mask for the Flex Bus Port Control2 register.
+    pub const CXL_FLEX_BUS_PORT_DVSEC_CONTROL2_WRITABLE_MASK: u32 =
+        CxlFlexBusPortDvsecControl2::new()
+            .with_nop_hint_enable(true)
+            .into_bits();
+
+    /// Flex Bus Port Capability register (offset `0x0A`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlFlexBusPortDvsecCapability {
+        pub cache_capable: bool,
+        pub io_capable: bool,
+        pub mem_capable: bool,
+        #[bits(2)]
+        _reserved0: u8,
+        pub cxl_68b_flit_and_vh_capable: bool,
+        pub cxl_multi_logical_device_capable: bool,
+        #[bits(6)]
+        _reserved1: u8,
+        pub cxl_latency_optimized_256b_flit_capable: bool,
+        pub cxl_pbr_flit_capable: bool,
+        _reserved2: bool,
+    }
+
+    /// Flex Bus Port Control register (offset `0x0C`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlFlexBusPortDvsecControl {
+        pub cache_enable: bool,
+        pub io_enable: bool,
+        pub mem_enable: bool,
+        pub cxl_sync_hdr_bypass_enable: bool,
+        pub drift_buffer_enable: bool,
+        pub cxl_68b_flit_and_vh_enable: bool,
+        pub cxl_multi_logical_device_enable: bool,
+        pub disable_rcd_training: bool,
+        pub retimer1_present: bool,
+        pub retimer2_present: bool,
+        #[bits(3)]
+        _reserved0: u8,
+        pub cxl_latency_optimized_256b_flit_enable: bool,
+        pub cxl_pbr_flit_enable: bool,
+        _reserved1: bool,
+    }
+
+    /// Flex Bus Port Status register (offset `0x0E`).
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    pub struct CxlFlexBusPortDvsecStatus {
+        pub cache_enabled: bool,
+        pub io_enabled: bool,
+        pub mem_enabled: bool,
+        pub cxl_sync_hdr_bypass_enabled: bool,
+        pub drift_buffer_enabled: bool,
+        pub cxl_68b_flit_and_vh_enabled: bool,
+        pub cxl_multi_logical_device_enabled: bool,
+        pub even_half_failed: bool,
+        pub cxl_correctable_protocol_id_framing_error: bool,
+        pub cxl_uncorrectable_protocol_id_framing_error: bool,
+        pub cxl_unexpected_protocol_id_dropped: bool,
+        pub cxl_retimers_present_mismatch: bool,
+        pub flex_bus_enables_phase2_mismatched: bool,
+        pub cxl_latency_optimized_256b_flit_enabled: bool,
+        pub cxl_pbr_flit_enabled: bool,
+        pub cxl_io_throttle_required_at_64gt: bool,
+    }
+
+    /// Flex Bus Port Received Modified TS Data Phase1 register (offset `0x10`).
+    #[derive(Inspect)]
+    #[bitfield(u32)]
+    pub struct CxlFlexBusPortDvsecReceivedModifiedTsDataPhase1 {
+        #[bits(24)]
+        pub received_flex_bus_data_phase1: u32,
+        #[bits(8)]
+        _reserved: u8,
+    }
+
+    /// Flex Bus Port Capability2 register (offset `0x14`).
+    #[derive(Inspect)]
+    #[bitfield(u32)]
+    pub struct CxlFlexBusPortDvsecCapability2 {
+        pub nop_hint_capable: bool,
+        pub streamlined_port: bool,
+        #[bits(30)]
+        _reserved: u32,
+    }
+
+    /// Flex Bus Port Control2 register (offset `0x18`).
+    #[derive(Inspect)]
+    #[bitfield(u32)]
+    pub struct CxlFlexBusPortDvsecControl2 {
+        pub nop_hint_enable: bool,
+        #[bits(31)]
+        _reserved: u32,
+    }
+
+    /// Flex Bus Port Status2 register (offset `0x1C`).
+    #[derive(Inspect)]
+    #[bitfield(u32)]
+    pub struct CxlFlexBusPortDvsecStatus2 {
+        #[bits(2)]
+        pub nop_hint_info: u8,
+        pub streamlined_port: bool,
+        #[bits(29)]
+        _reserved: u32,
+    }
+
+    /// CXL Flex Bus Port PCIe Designated Vendor-Specific Extended Capability (DVSEC).
+    #[derive(Clone, Inspect)]
+    pub struct CxlFlexBusPortDvsecExtendedCapability {
+        pub(crate) capability: CxlFlexBusPortDvsecCapability,
+        pub(crate) control: CxlFlexBusPortDvsecControl,
+        pub(crate) status: CxlFlexBusPortDvsecStatus,
+        pub(crate) received_modified_ts_data_phase1:
+            CxlFlexBusPortDvsecReceivedModifiedTsDataPhase1,
+        pub(crate) capability2: CxlFlexBusPortDvsecCapability2,
+        pub(crate) control2: CxlFlexBusPortDvsecControl2,
+        pub(crate) status2: CxlFlexBusPortDvsecStatus2,
+        pub(crate) reset_baseline_capability: CxlFlexBusPortDvsecCapability,
+        pub(crate) reset_baseline_capability2: CxlFlexBusPortDvsecCapability2,
+    }
+}
+
+/// CXL Register Locator Designated Vendor-Specific Extended Capability (DVSEC).
+pub mod register_locator_dvsec {
+    use bitfield_struct::bitfield;
+    use inspect::Inspect;
+
+    /// Register BIR encodings used in Register Locator entries.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub struct CxlRegisterLocatorRegisterBir(u8);
+
+    impl CxlRegisterLocatorRegisterBir {
+        /// 000b = Base Address Register 10h.
+        pub const BAR_10H: Self = Self(0b000);
+        /// 001b = Base Address Register 14h.
+        pub const BAR_14H: Self = Self(0b001);
+        /// 010b = Base Address Register 18h.
+        pub const BAR_18H: Self = Self(0b010);
+        /// 011b = Base Address Register 1Ch.
+        pub const BAR_1CH: Self = Self(0b011);
+        /// 100b = Base Address Register 20h.
+        pub const BAR_20H: Self = Self(0b100);
+        /// 101b = Base Address Register 24h.
+        pub const BAR_24H: Self = Self(0b101);
+
+        /// Returns the encoded BIR bits.
+        pub const fn bits(self) -> u8 {
+            self.0
+        }
+    }
+
+    /// Register block identifiers used in Register Locator entries.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub struct CxlRegisterLocatorRegisterBlockIdentifier(u8);
+
+    impl CxlRegisterLocatorRegisterBlockIdentifier {
+        /// Entry is empty/invalid.
+        pub const EMPTY: Self = Self(0x00);
+        /// Component Register block.
+        pub const COMPONENT_REGISTERS: Self = Self(0x01);
+        /// BAR Virtualization ACL registers.
+        pub const BAR_VIRTUALIZATION_ACL_REGISTERS: Self = Self(0x02);
+        /// CXL Device registers.
+        pub const CXL_DEVICE_REGISTERS: Self = Self(0x03);
+        /// CPMU registers.
+        pub const CPMU_REGISTERS: Self = Self(0x04);
+        /// CHMU registers.
+        pub const CHMU_REGISTERS: Self = Self(0x05);
+        /// Designated Vendor Specific register block.
+        pub const DESIGNATED_VENDOR_SPECIFIC: Self = Self(0xff);
+
+        /// Returns the encoded register-block identifier bits.
+        pub const fn bits(self) -> u8 {
+            self.0
+        }
+    }
+
+    /// Dword offsets in the CXL Register Locator DVSEC register block.
+    ///
+    /// The PCIe Extended Capability Header at offset `0x00` is managed by the
+    /// caller. DVSEC Header1 (`0x04`) and DVSEC Header2 (`0x08`) are defined in
+    /// `pci_core::spec::caps::dvsec::DvsecExtendedCapabilityHeader`.
+    pub struct CxlRegisterLocatorDvsecRegisterOffset;
+
+    impl CxlRegisterLocatorDvsecRegisterOffset {
+        /// Packed reserved upper-half + DVSEC Header2 lower-half.
+        pub const DVSEC_HEADER2: u16 = 0x08;
+        /// First Register Block Offset Low dword.
+        pub const FIRST_REGISTER_BLOCK_OFFSET_LOW: u16 = 0x0c;
+        /// Byte stride for each Register Block entry (`low` + `high`).
+        pub const REGISTER_BLOCK_STRIDE: u16 = 0x08;
+        /// Base structure length in bytes with no entries.
+        pub const BASE_LENGTH: u16 = 0x0c;
+    }
+
+    /// CXL Register Locator DVSEC revision.
+    pub const CXL_REGISTER_LOCATOR_DVSEC_REVISION: u8 = 0x0;
+    /// CXL Register Locator DVSEC ID value.
+    pub const CXL_REGISTER_LOCATOR_DVSEC_ID: u16 = 0x0008;
+
+    /// Register Offset Low register layout.
+    #[derive(Inspect)]
+    #[bitfield(u32)]
+    pub struct CxlRegisterLocatorDvsecRegisterOffsetLow {
+        #[bits(3)]
+        pub register_bir: u8,
+        #[bits(5)]
+        _reserved0: u8,
+        #[bits(8)]
+        pub register_block_identifier: u8,
+        #[bits(16)]
+        pub register_block_offset_low: u16,
+    }
+
+    /// One Register Locator register-block entry.
+    #[derive(Clone, Inspect)]
+    pub struct CxlRegisterLocatorDvsecRegisterBlockEntry {
+        pub(crate) offset_low: CxlRegisterLocatorDvsecRegisterOffsetLow,
+        pub(crate) offset_high: u32,
+    }
+
+    /// CXL Register Locator PCIe Designated Vendor-Specific Extended Capability (DVSEC).
+    #[derive(Clone, Default, Inspect)]
+    pub struct CxlRegisterLocatorDvsecExtendedCapability {
+        #[inspect(skip)]
+        pub(crate) register_blocks: Vec<CxlRegisterLocatorDvsecRegisterBlockEntry>,
+        #[inspect(skip)]
+        pub(crate) reset_baseline_register_blocks: Vec<CxlRegisterLocatorDvsecRegisterBlockEntry>,
+    }
+}

--- a/vm/devices/cxl/src/spec.rs
+++ b/vm/devices/cxl/src/spec.rs
@@ -1,0 +1,445 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! CXL specification constants.
+
+use bitfield_struct::bitfield;
+use inspect::Inspect;
+
+/// CFMWS window restrictions bitfield.
+#[bitfield(u16)]
+pub struct CfmwsWindowRestrictions {
+    /// Bit 0: Device Coherent (HDM-D / HDM-DB when BI is set).
+    pub device_coherent: bool,
+    /// Bit 1: Host-only Coherent (HDM-H).
+    pub host_only_coherent: bool,
+    /// Bit 2: Window is configured for volatile memory.
+    pub volatile: bool,
+    /// Bit 3: Window is configured for persistent memory.
+    pub persistent: bool,
+    /// Bit 4: Fixed Device Configuration.
+    pub fixed_device_configuration: bool,
+    /// Bit 5: Back-Invalidate (BI) enabled.
+    pub bi: bool,
+    #[bits(10)]
+    _reserved: u16,
+}
+
+impl CfmwsWindowRestrictions {
+    /// No restrictions set.
+    pub const NONE: Self = Self::new();
+
+    /// Bit 0: Device Coherent (HDM-D / HDM-DB when BI is set).
+    pub const DEVICE_COHERENT: Self = Self::new().with_device_coherent(true);
+    /// Bit 1: Host-only Coherent (HDM-H).
+    pub const HOST_ONLY_COHERENT: Self = Self::new().with_host_only_coherent(true);
+    /// Bit 2: Window is configured for volatile memory.
+    pub const VOLATILE: Self = Self::new().with_volatile(true);
+    /// Bit 3: Window is configured for persistent memory.
+    pub const PERSISTENT: Self = Self::new().with_persistent(true);
+    /// Bit 4: Fixed Device Configuration.
+    pub const FIXED_DEVICE_CONFIGURATION: Self = Self::new().with_fixed_device_configuration(true);
+    /// Bit 5: Back-Invalidate (BI) enabled.
+    pub const BI: Self = Self::new().with_bi(true);
+
+    /// Mask of all currently defined CFMWS window restriction bits.
+    pub const VALID_BITS_MASK: u16 = (1 << 6) - 1;
+
+    /// Returns the raw 16-bit bitmap value.
+    pub const fn bits(self) -> u16 {
+        self.0
+    }
+
+    /// Creates a restrictions value from a raw 16-bit bitmap.
+    ///
+    /// Returns `None` when any reserved bit (15:6) is set.
+    pub const fn try_from_bits(bits: u16) -> Option<Self> {
+        if Self::is_valid_bits(bits) {
+            Some(Self(bits))
+        } else {
+            None
+        }
+    }
+
+    /// Returns true if `bits` only contains currently defined restriction bits.
+    pub const fn is_valid_bits(bits: u16) -> bool {
+        (bits & !Self::VALID_BITS_MASK) == 0
+    }
+
+    /// True when all bits in `other` are present in `self`.
+    pub const fn contains(self, other: Self) -> bool {
+        (self.bits() & other.bits()) == other.bits()
+    }
+}
+
+impl core::ops::BitOr for CfmwsWindowRestrictions {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.bits() | rhs.bits())
+    }
+}
+
+impl core::ops::BitOrAssign for CfmwsWindowRestrictions {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = Self(self.bits() | rhs.bits());
+    }
+}
+
+impl PartialEq for CfmwsWindowRestrictions {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for CfmwsWindowRestrictions {}
+
+/// CFMWS Interleave Ways (IW) encoding values.
+pub struct InterleaveWays;
+
+impl InterleaveWays {
+    /// 0h = 1-way (no interleaving).
+    pub const WAY_1: u8 = 0x0;
+    /// 1h = 2-way interleaving.
+    pub const WAY_2: u8 = 0x1;
+    /// 2h = 4-way interleaving.
+    pub const WAY_4: u8 = 0x2;
+    /// 3h = 8-way interleaving.
+    pub const WAY_8: u8 = 0x3;
+    /// 4h = 16-way interleaving (CXL.mem only).
+    pub const WAY_16: u8 = 0x4;
+    /// 8h = 3-way interleaving (CXL.mem only).
+    pub const WAY_3: u8 = 0x8;
+    /// 9h = 6-way interleaving (CXL.mem only).
+    pub const WAY_6: u8 = 0x9;
+    /// Ah = 12-way interleaving (CXL.mem only).
+    pub const WAY_12: u8 = 0xA;
+}
+
+/// CFMWS Interleave Granularity (IG) encoding values.
+pub struct InterleaveGranularity;
+
+impl InterleaveGranularity {
+    /// 0h = 256 bytes.
+    pub const BYTES_256: u8 = 0x0;
+    /// 1h = 512 bytes.
+    pub const BYTES_512: u8 = 0x1;
+    /// 2h = 1024 bytes (1 KiB).
+    pub const BYTES_1024: u8 = 0x2;
+    /// 3h = 2048 bytes (2 KiB).
+    pub const BYTES_2048: u8 = 0x3;
+    /// 4h = 4096 bytes (4 KiB).
+    pub const BYTES_4096: u8 = 0x4;
+    /// 5h = 8192 bytes (8 KiB).
+    pub const BYTES_8192: u8 = 0x5;
+    /// 6h = 16384 bytes (16 KiB).
+    pub const BYTES_16384: u8 = 0x6;
+}
+
+/// CFMWS Interleave Arithmetic encoding values.
+pub struct InterleaveArithmetic;
+
+impl InterleaveArithmetic {
+    /// 00h = Standard Modulo arithmetic.
+    pub const STANDARD_MODULO: u8 = 0x00;
+    /// 01h = Modulo arithmetic combined with XOR.
+    pub const MODULO_XOR: u8 = 0x01;
+}
+
+/// CXL HDM decoder HPA alignment in bytes.
+pub const CXL_HPA_ALIGNMENT: u64 = 256 * 1024 * 1024;
+
+/// CXL Host Bridge Component Registers (CHBCR) aperture size in bytes.
+pub const CXL_HOST_BRIDGE_COMPONENT_REGISTERS_SIZE_BYTES: u64 = 64 * 1024;
+
+/// CXL Component Registers aperture size in bytes.
+pub const CXL_COMPONENT_REGISTERS_SIZE_BYTES: u64 = 64 * 1024;
+
+/// CXL Component Register Range: CXL.io reserved window start.
+pub const CXL_COMPONENT_REG_RANGE_CXL_IO_RESERVED_OFFSET: u64 = 0x0000;
+/// CXL Component Register Range: CXL.io reserved window size.
+pub const CXL_COMPONENT_REG_RANGE_CXL_IO_RESERVED_SIZE_BYTES: u64 = 0x1000;
+
+/// CXL Component Register Range: CXL.cachemem primary range start.
+pub const CXL_COMPONENT_REG_RANGE_CACHEMEM_PRIMARY_OFFSET: u64 = 0x1000;
+/// CXL Component Register Range: CXL.cachemem primary range size.
+pub const CXL_COMPONENT_REG_RANGE_CACHEMEM_PRIMARY_SIZE_BYTES: u64 = 0x1000;
+
+/// CXL Component Register Range: CXL.cachemem extended ranges start.
+pub const CXL_COMPONENT_REG_RANGE_CACHEMEM_EXTENDED_OFFSET: u64 = 0x2000;
+/// CXL Component Register Range: CXL.cachemem extended ranges size.
+pub const CXL_COMPONENT_REG_RANGE_CACHEMEM_EXTENDED_SIZE_BYTES: u64 = 0xC000;
+
+/// CXL Component Register Range: CXL RAB/MUX register block start.
+pub const CXL_COMPONENT_REG_RANGE_RAB_MUX_OFFSET: u64 = 0xE000;
+/// CXL Component Register Range: CXL RAB/MUX register block size.
+pub const CXL_COMPONENT_REG_RANGE_RAB_MUX_SIZE_BYTES: u64 = 0x0400;
+
+/// CXL.cachemem architectural register-directory region size (one 4-KiB page).
+pub const CXL_CACHEMEM_REGION_SIZE_BYTES: u64 = 0x1000;
+
+/// Offset of the CXL.cachemem capability-array header within a 4-KiB region.
+pub const CXL_CACHEMEM_CAPABILITY_ARRAY_HEADER_OFFSET: u64 = 0x0000;
+
+/// Offset of the first CXL.cachemem capability header entry within a 4-KiB region.
+pub const CXL_CACHEMEM_CAPABILITY_ARRAY_FIRST_ENTRY_OFFSET: u64 = 0x0004;
+
+/// Size of one CXL.cachemem capability header entry.
+pub const CXL_CACHEMEM_CAPABILITY_ARRAY_ENTRY_SIZE_BYTES: u64 = 4;
+
+/// Maximum `Array_Size` representable in the cachemem capability header.
+pub const CXL_CACHEMEM_CAPABILITY_ARRAY_MAX_ENTRIES: usize = u8::MAX as usize;
+
+/// Capability IDs in this inclusive range are disallowed in extended ranges.
+pub const CXL_CACHEMEM_EXTENDED_FORBIDDEN_CAPABILITY_ID_MIN: u16 = 0x0001;
+
+/// Capability IDs in this inclusive range are disallowed in extended ranges.
+pub const CXL_CACHEMEM_EXTENDED_FORBIDDEN_CAPABILITY_ID_MAX: u16 = 0x000A;
+
+/// CXL cache/mem capability header (offset 0x0 in each 4-KiB cachemem page).
+pub struct CxlCacheMemCapabilityHeader;
+
+impl CxlCacheMemCapabilityHeader {
+    /// `CXL_Capability_ID` value for the header itself.
+    pub const CAPABILITY_ID: u8 = 0x01;
+
+    /// `CXL_Capability_Version` value for this header format.
+    pub const CAPABILITY_VERSION: u8 = 0x01;
+
+    /// `CXL_Cache_Mem_Version` value for this implementation.
+    pub const CACHE_MEM_VERSION: u8 = 0x01;
+
+    /// Encodes the header dword with the given capability entry count.
+    ///
+    /// Returns `None` if `array_size` exceeds the 8-bit `Array_Size` field.
+    pub fn encode(array_size: usize) -> Option<u32> {
+        let array_size = u8::try_from(array_size).ok()?;
+        Some(
+            u32::from(Self::CAPABILITY_ID)
+                | (u32::from(Self::CAPABILITY_VERSION) << 16)
+                | (u32::from(Self::CACHE_MEM_VERSION) << 20)
+                | (u32::from(array_size) << 24),
+        )
+    }
+}
+
+/// One cache/mem capability-array entry dword (after the page header).
+pub struct CxlCacheMemCapabilityArrayEntry;
+
+impl CxlCacheMemCapabilityArrayEntry {
+    /// Encodes one capability entry.
+    ///
+    /// - `capability_id` maps to bits 15:0
+    /// - `capability_version` maps to bits 19:16
+    /// - `pointer` is a byte offset in the page and maps as DW offset in bits 31:20
+    ///
+    /// Returns `None` when `capability_version` exceeds 4 bits, `pointer` is not
+    /// dword-aligned, or pointer DW offset exceeds 12 bits.
+    pub fn encode(capability_id: u16, capability_version: u8, pointer: u16) -> Option<u32> {
+        if capability_version > 0x0f || !pointer.is_multiple_of(4) {
+            return None;
+        }
+
+        let pointer_dw = u32::from(pointer >> 2);
+        if pointer_dw > 0x0fff {
+            return None;
+        }
+
+        Some(u32::from(capability_id) | (u32::from(capability_version) << 16) | (pointer_dw << 20))
+    }
+}
+
+/// CXL Component Register Range: trailing reserved window start.
+pub const CXL_COMPONENT_REG_RANGE_TRAILING_RESERVED_OFFSET: u64 = 0xE400;
+/// CXL Component Register Range: trailing reserved window size.
+pub const CXL_COMPONENT_REG_RANGE_TRAILING_RESERVED_SIZE_BYTES: u64 = 0x1C00;
+
+/// CXL component register block type.
+///
+/// Each type is constrained to a fixed section of the 64-KiB CXL component
+/// register aperture.
+#[expect(clippy::enum_variant_names)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Inspect)]
+pub enum CxlComponentRegisterType {
+    /// CXL.cachemem primary register section.
+    CacheMemRegister,
+    /// CXL.cachemem extended register section.
+    CacheMemExtendedRegister,
+    /// CXL RAB/MUX register section.
+    CxlArbMuxRegister,
+}
+
+impl CxlComponentRegisterType {
+    /// Register type for the CXL.cachemem primary section.
+    pub const CXL_CACHE_MEM_REGISTER: Self = Self::CacheMemRegister;
+
+    /// Register type for the CXL.cachemem extended section.
+    pub const CXL_CACHE_MEM_EXTENDED_REGISTER: Self = Self::CacheMemExtendedRegister;
+
+    /// Register type for the CXL RAB/MUX section.
+    pub const CXL_ARB_MUX_REGISTER: Self = Self::CxlArbMuxRegister;
+}
+
+/// CEDT CHBS structure type.
+pub const CEDT_STRUCTURE_TYPE_CHBS: u8 = 0;
+
+/// CEDT CFMWS structure type.
+pub const CEDT_STRUCTURE_TYPE_CFMWS: u8 = 1;
+
+#[cfg(test)]
+mod tests {
+    use super::CEDT_STRUCTURE_TYPE_CFMWS;
+    use super::CEDT_STRUCTURE_TYPE_CHBS;
+    use super::CXL_CACHEMEM_CAPABILITY_ARRAY_MAX_ENTRIES;
+    use super::CXL_COMPONENT_REG_RANGE_CACHEMEM_EXTENDED_OFFSET;
+    use super::CXL_COMPONENT_REG_RANGE_CACHEMEM_EXTENDED_SIZE_BYTES;
+    use super::CXL_COMPONENT_REG_RANGE_CACHEMEM_PRIMARY_OFFSET;
+    use super::CXL_COMPONENT_REG_RANGE_CACHEMEM_PRIMARY_SIZE_BYTES;
+    use super::CXL_COMPONENT_REG_RANGE_CXL_IO_RESERVED_OFFSET;
+    use super::CXL_COMPONENT_REG_RANGE_CXL_IO_RESERVED_SIZE_BYTES;
+    use super::CXL_COMPONENT_REG_RANGE_RAB_MUX_OFFSET;
+    use super::CXL_COMPONENT_REG_RANGE_RAB_MUX_SIZE_BYTES;
+    use super::CXL_COMPONENT_REG_RANGE_TRAILING_RESERVED_OFFSET;
+    use super::CXL_COMPONENT_REG_RANGE_TRAILING_RESERVED_SIZE_BYTES;
+    use super::CXL_COMPONENT_REGISTERS_SIZE_BYTES;
+    use super::CfmwsWindowRestrictions;
+    use super::CxlCacheMemCapabilityArrayEntry;
+    use super::CxlCacheMemCapabilityHeader;
+    use super::CxlComponentRegisterType;
+    use super::InterleaveArithmetic;
+    use super::InterleaveGranularity;
+    use super::InterleaveWays;
+
+    #[test]
+    fn cfmws_window_restriction_bits() {
+        assert_eq!(CfmwsWindowRestrictions::DEVICE_COHERENT.bits(), 1 << 0);
+        assert_eq!(CfmwsWindowRestrictions::HOST_ONLY_COHERENT.bits(), 1 << 1);
+        assert_eq!(CfmwsWindowRestrictions::VOLATILE.bits(), 1 << 2);
+        assert_eq!(CfmwsWindowRestrictions::PERSISTENT.bits(), 1 << 3);
+        assert_eq!(
+            CfmwsWindowRestrictions::FIXED_DEVICE_CONFIGURATION.bits(),
+            1 << 4
+        );
+        assert_eq!(CfmwsWindowRestrictions::BI.bits(), 1 << 5);
+    }
+
+    #[test]
+    fn cfmws_window_restriction_combine_and_contains() {
+        let restrictions = CfmwsWindowRestrictions::DEVICE_COHERENT
+            | CfmwsWindowRestrictions::VOLATILE
+            | CfmwsWindowRestrictions::BI;
+
+        assert!(restrictions.contains(CfmwsWindowRestrictions::DEVICE_COHERENT));
+        assert!(restrictions.contains(CfmwsWindowRestrictions::VOLATILE));
+        assert!(restrictions.contains(CfmwsWindowRestrictions::BI));
+        assert!(!restrictions.contains(CfmwsWindowRestrictions::PERSISTENT));
+    }
+
+    #[test]
+    fn cfmws_window_restriction_from_bits_checks_reserved_bits() {
+        assert!(CfmwsWindowRestrictions::try_from_bits(0x003f).is_some());
+        assert!(CfmwsWindowRestrictions::try_from_bits(0x0000).is_some());
+        assert!(CfmwsWindowRestrictions::try_from_bits(0x0040).is_none());
+        assert!(CfmwsWindowRestrictions::try_from_bits(0x8000).is_none());
+    }
+
+    #[test]
+    fn cfmws_interleave_way_encodings() {
+        assert_eq!(InterleaveWays::WAY_1, 0x0);
+        assert_eq!(InterleaveWays::WAY_2, 0x1);
+        assert_eq!(InterleaveWays::WAY_4, 0x2);
+        assert_eq!(InterleaveWays::WAY_8, 0x3);
+        assert_eq!(InterleaveWays::WAY_16, 0x4);
+        assert_eq!(InterleaveWays::WAY_3, 0x8);
+        assert_eq!(InterleaveWays::WAY_6, 0x9);
+        assert_eq!(InterleaveWays::WAY_12, 0xA);
+    }
+
+    #[test]
+    fn cfmws_interleave_granularity_encodings() {
+        assert_eq!(InterleaveGranularity::BYTES_256, 0x0);
+        assert_eq!(InterleaveGranularity::BYTES_512, 0x1);
+        assert_eq!(InterleaveGranularity::BYTES_1024, 0x2);
+        assert_eq!(InterleaveGranularity::BYTES_2048, 0x3);
+        assert_eq!(InterleaveGranularity::BYTES_4096, 0x4);
+        assert_eq!(InterleaveGranularity::BYTES_8192, 0x5);
+        assert_eq!(InterleaveGranularity::BYTES_16384, 0x6);
+    }
+
+    #[test]
+    fn cfmws_interleave_arithmetic_encodings() {
+        assert_eq!(InterleaveArithmetic::STANDARD_MODULO, 0x00);
+        assert_eq!(InterleaveArithmetic::MODULO_XOR, 0x01);
+    }
+
+    #[test]
+    fn cedt_structure_type_encodings() {
+        assert_eq!(CEDT_STRUCTURE_TYPE_CHBS, 0);
+        assert_eq!(CEDT_STRUCTURE_TYPE_CFMWS, 1);
+    }
+
+    #[test]
+    fn cxl_component_register_type_aliases() {
+        assert_eq!(
+            CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+            CxlComponentRegisterType::CacheMemRegister
+        );
+        assert_eq!(
+            CxlComponentRegisterType::CXL_CACHE_MEM_EXTENDED_REGISTER,
+            CxlComponentRegisterType::CacheMemExtendedRegister
+        );
+        assert_eq!(
+            CxlComponentRegisterType::CXL_ARB_MUX_REGISTER,
+            CxlComponentRegisterType::CxlArbMuxRegister
+        );
+    }
+
+    #[test]
+    fn cxl_cachemem_capability_header_encoding() {
+        let encoded = CxlCacheMemCapabilityHeader::encode(1).expect("valid header");
+        assert_eq!(encoded, 0x0111_0001);
+    }
+
+    #[test]
+    fn cxl_cachemem_capability_header_rejects_large_array_size() {
+        assert!(
+            CxlCacheMemCapabilityHeader::encode(CXL_CACHEMEM_CAPABILITY_ARRAY_MAX_ENTRIES + 1)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn cxl_cachemem_capability_array_entry_encoding() {
+        let encoded =
+            CxlCacheMemCapabilityArrayEntry::encode(0x20, 1, 0x0008).expect("valid entry");
+        assert_eq!(encoded, 0x0021_0020);
+    }
+
+    #[test]
+    fn cxl_cachemem_capability_array_entry_rejects_invalid_fields() {
+        assert!(CxlCacheMemCapabilityArrayEntry::encode(0x20, 0x10, 0x0008).is_none());
+        assert!(CxlCacheMemCapabilityArrayEntry::encode(0x20, 1, 0x0002).is_none());
+    }
+
+    #[test]
+    fn cxl_component_register_ranges_cover_full_aperture() {
+        assert_eq!(CXL_COMPONENT_REG_RANGE_CXL_IO_RESERVED_OFFSET, 0x0000);
+        assert_eq!(CXL_COMPONENT_REG_RANGE_CACHEMEM_PRIMARY_OFFSET, 0x1000);
+        assert_eq!(CXL_COMPONENT_REG_RANGE_CACHEMEM_EXTENDED_OFFSET, 0x2000);
+        assert_eq!(CXL_COMPONENT_REG_RANGE_RAB_MUX_OFFSET, 0xE000);
+        assert_eq!(CXL_COMPONENT_REG_RANGE_TRAILING_RESERVED_OFFSET, 0xE400);
+
+        assert_eq!(CXL_COMPONENT_REG_RANGE_CXL_IO_RESERVED_SIZE_BYTES, 0x1000);
+        assert_eq!(CXL_COMPONENT_REG_RANGE_CACHEMEM_PRIMARY_SIZE_BYTES, 0x1000);
+        assert_eq!(CXL_COMPONENT_REG_RANGE_CACHEMEM_EXTENDED_SIZE_BYTES, 0xC000);
+        assert_eq!(CXL_COMPONENT_REG_RANGE_RAB_MUX_SIZE_BYTES, 0x0400);
+        assert_eq!(CXL_COMPONENT_REG_RANGE_TRAILING_RESERVED_SIZE_BYTES, 0x1C00);
+
+        let total = CXL_COMPONENT_REG_RANGE_CXL_IO_RESERVED_SIZE_BYTES
+            + CXL_COMPONENT_REG_RANGE_CACHEMEM_PRIMARY_SIZE_BYTES
+            + CXL_COMPONENT_REG_RANGE_CACHEMEM_EXTENDED_SIZE_BYTES
+            + CXL_COMPONENT_REG_RANGE_RAB_MUX_SIZE_BYTES
+            + CXL_COMPONENT_REG_RANGE_TRAILING_RESERVED_SIZE_BYTES;
+        assert_eq!(total, CXL_COMPONENT_REGISTERS_SIZE_BYTES);
+    }
+}

--- a/vm/devices/cxl/src/test/cxl_test_device.rs
+++ b/vm/devices/cxl/src/test/cxl_test_device.rs
@@ -1,0 +1,530 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! CXL Type-3 test endpoint device.
+
+use chipset_device::ChipsetDevice;
+use chipset_device::io::IoError::InvalidRegister;
+use chipset_device::io::IoResult;
+use chipset_device::mmio::ControlMmioIntercept;
+use chipset_device::mmio::MmioIntercept;
+use chipset_device::mmio::RegisterMmioIntercept;
+use chipset_device::pci::PciConfigSpace;
+use inspect::InspectMut;
+use mesh::MeshPayload;
+use pci_core::capabilities::pci_express::PciExpressCapability;
+use pci_core::cfg_space_emu::BarMemoryKind;
+use pci_core::cfg_space_emu::ConfigSpaceType0Emulator;
+use pci_core::cfg_space_emu::DeviceBars;
+use pci_core::spec::caps::pci_express::DevicePortType;
+use pci_core::spec::hwid::ClassCode;
+use pci_core::spec::hwid::HardwareIds;
+use pci_core::spec::hwid::ProgrammingInterface;
+use pci_core::spec::hwid::Subclass;
+use pci_resources::ResolvePciDeviceHandleParams;
+use pci_resources::ResolvedPciDevice;
+use thiserror::Error;
+use tracing::debug;
+use vm_resource::ResolveResource;
+use vm_resource::ResourceId;
+use vm_resource::declare_static_resolver;
+use vm_resource::kind::PciDeviceHandleKind;
+use vmcore::device_state::ChangeDeviceState;
+use vmcore::save_restore::RestoreError;
+use vmcore::save_restore::SaveError;
+use vmcore::save_restore::SaveRestore;
+use vmcore::save_restore::SavedStateNotSupported;
+
+use crate::CxlComponentRegisters;
+use crate::CxlDeviceDevsecExtendedCapability;
+use crate::CxlFlexBusPortDvsecExtendedCapability;
+use crate::CxlRegisterLocatorDvsecExtendedCapability;
+use crate::component_registers::CxlHdmDecoderCapability;
+use crate::component_registers::spec::hdm_decoder::CXL_HDM_DECODER_BASE_OFFSET;
+use crate::component_registers::spec::hdm_decoder::CXL_HDM_DECODER_CAPABILITY_ID;
+use crate::component_registers::spec::hdm_decoder::CXL_HDM_DECODER_GLOBAL_CONTROL_OFFSET;
+use crate::component_registers::spec::hdm_decoder::CxlHdmDecoderBaseLowRegister;
+use crate::component_registers::spec::hdm_decoder::CxlHdmDecoderControlRegister;
+use crate::component_registers::spec::hdm_decoder::CxlHdmDecoderGlobalControlRegister;
+use crate::component_registers::spec::hdm_decoder::CxlHdmDecoderInterleaveGranularity;
+use crate::component_registers::spec::hdm_decoder::CxlHdmDecoderInterleaveWays;
+use crate::component_registers::spec::hdm_decoder::CxlHdmDecoderRegisterOffset;
+use crate::component_registers::spec::hdm_decoder::CxlHdmDecoderSizeLowRegister;
+use crate::pci_registers::spec::cxl_device_dvsec::CxlDeviceDvsecDesiredInterleave;
+use crate::pci_registers::spec::cxl_device_dvsec::CxlDeviceDvsecMediaType;
+use crate::pci_registers::spec::cxl_device_dvsec::CxlDeviceDvsecMemoryActiveTimeout;
+use crate::pci_registers::spec::cxl_device_dvsec::CxlDeviceDvsecMemoryClass;
+use crate::pci_registers::spec::register_locator_dvsec::CxlRegisterLocatorRegisterBir;
+use crate::pci_registers::spec::register_locator_dvsec::CxlRegisterLocatorRegisterBlockIdentifier;
+use crate::spec::CXL_COMPONENT_REGISTERS_SIZE_BYTES;
+
+const CXL_TEST_DEVICE_ID: u16 = 0xc102;
+const MICROSOFT_VENDOR_ID: u16 = 0x1414;
+const CXL_MEMORY_SUBCLASS: u8 = 0x02;
+const CXL_MEMORY_PROG_IF: u8 = 0x10;
+const HDM_SIZE_GRANULARITY_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_HDM_SIZE_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
+/// A test CXL Type-3 endpoint with one BAR containing component registers.
+#[derive(InspectMut)]
+pub struct CxlTestDevice {
+    cfg_space: ConfigSpaceType0Emulator,
+    #[inspect(skip)]
+    component_registers: CxlComponentRegisters,
+    #[inspect(skip)]
+    hdm_decoder_cap_offset: u16,
+    #[inspect(skip)]
+    hdm_io_region: Box<dyn ControlMmioIntercept>,
+    #[inspect(skip)]
+    hdm_active_len_bytes: u64,
+    #[inspect(skip)]
+    hdm_memory: Vec<u8>,
+}
+
+/// Errors when constructing a test CXL device.
+#[derive(Debug, Error)]
+pub enum CxlTestDeviceCreateError {
+    /// HDM size must be non-zero and 256MiB-aligned.
+    #[error("invalid HDM size {0:#x}; expected non-zero and 256MiB aligned")]
+    InvalidHdmSize(u64),
+    /// HDM size cannot fit into host addressable memory in this process.
+    #[error("HDM size {0:#x} is too large for host allocation")]
+    HdmSizeTooLarge(u64),
+    /// HDM size exceeds the test-device safety bound.
+    #[error("HDM size {actual:#x} exceeds test-device limit {max:#x}; reduce --cxl-test mem:<len>")]
+    HdmSizeExceedsLimit { actual: u64, max: u64 },
+    /// HDM backing allocation failed.
+    #[error("failed to allocate HDM backing memory of size {0:#x}")]
+    HdmAllocationFailed(u64),
+    /// Failed to configure CXL device DVSEC memory ranges.
+    #[error("failed to configure CXL Device DVSEC memory")]
+    InvalidDeviceDvsecConfig,
+    /// Failed to configure CXL register locator DVSEC.
+    #[error("failed to configure CXL Register Locator DVSEC")]
+    InvalidRegisterLocatorConfig,
+    /// Failed to configure CXL HDM Decoder capability.
+    #[error("failed to configure CXL HDM Decoder capability")]
+    InvalidHdmDecoderConfig,
+}
+
+impl CxlTestDevice {
+    /// Creates a new test CXL Type-3 endpoint with a BAR0 component-register aperture.
+    pub fn new(
+        register_mmio: &mut dyn RegisterMmioIntercept,
+        hdm_size_bytes: u64,
+    ) -> Result<Self, CxlTestDeviceCreateError> {
+        if hdm_size_bytes == 0 || !hdm_size_bytes.is_multiple_of(HDM_SIZE_GRANULARITY_BYTES) {
+            return Err(CxlTestDeviceCreateError::InvalidHdmSize(hdm_size_bytes));
+        }
+
+        if hdm_size_bytes > MAX_HDM_SIZE_BYTES {
+            return Err(CxlTestDeviceCreateError::HdmSizeExceedsLimit {
+                actual: hdm_size_bytes,
+                max: MAX_HDM_SIZE_BYTES,
+            });
+        }
+
+        let hdm_len = usize::try_from(hdm_size_bytes)
+            .map_err(|_| CxlTestDeviceCreateError::HdmSizeTooLarge(hdm_size_bytes))?;
+
+        // Use fallible reservation to avoid aborting the process on huge allocations.
+        let mut hdm_memory = Vec::new();
+        hdm_memory
+            .try_reserve_exact(hdm_len)
+            .map_err(|_| CxlTestDeviceCreateError::HdmAllocationFailed(hdm_size_bytes))?;
+        hdm_memory.resize(hdm_len, 0);
+
+        let hdm_io_region = register_mmio.new_io_region("cxl-test-device-hdm", hdm_size_bytes);
+
+        let mut component_registers = CxlComponentRegisters::new();
+        let mut hdm_decoder_cap = CxlHdmDecoderCapability::new()
+            .map_err(|_| CxlTestDeviceCreateError::InvalidHdmDecoderConfig)?;
+        hdm_decoder_cap
+            .with_decoder_slot(
+                CxlHdmDecoderInterleaveGranularity::Bytes256,
+                CxlHdmDecoderInterleaveWays::Way1,
+            )
+            .map_err(|_| CxlTestDeviceCreateError::InvalidHdmDecoderConfig)?;
+        if !component_registers.add_register(Box::new(hdm_decoder_cap)) {
+            return Err(CxlTestDeviceCreateError::InvalidHdmDecoderConfig);
+        }
+        let Some(hdm_decoder_cap_offset) =
+            component_registers.capability_offset(CXL_HDM_DECODER_CAPABILITY_ID)
+        else {
+            return Err(CxlTestDeviceCreateError::InvalidHdmDecoderConfig);
+        };
+
+        let bars = DeviceBars::new().bar0(
+            CXL_COMPONENT_REGISTERS_SIZE_BYTES,
+            BarMemoryKind::Intercept(
+                register_mmio
+                    .new_io_region("cxl-test-device-bar0", CXL_COMPONENT_REGISTERS_SIZE_BYTES),
+            ),
+        );
+
+        let mut cxl_device_dvsec = CxlDeviceDevsecExtendedCapability::new(None, None);
+        cxl_device_dvsec = cxl_device_dvsec
+            .with_cxl_memory(
+                hdm_size_bytes,
+                None,
+                CxlDeviceDvsecMediaType::VolatileMemory,
+                CxlDeviceDvsecMemoryClass::Memory,
+                CxlDeviceDvsecDesiredInterleave::NoInterleave,
+                CxlDeviceDvsecMemoryActiveTimeout::Seconds1,
+            )
+            .map_err(|_| CxlTestDeviceCreateError::InvalidDeviceDvsecConfig)?;
+
+        let flex_bus_dvsec = CxlFlexBusPortDvsecExtendedCapability::new()
+            .with_mem_capable(true)
+            .with_cache_capable(true);
+
+        // TODO(cxl): This test endpoint is not a Linux-complete Type-3 memdev yet.
+        // It only advertises RBI_COMPONENT in Register Locator DVSEC and does not
+        // expose an RBI_MEMDEV block with Device Status / Primary Mailbox / Memdev
+        // capabilities, so Linux cxl_pci may bind but cannot complete full memdev bring-up.
+        let register_locator_dvsec = CxlRegisterLocatorDvsecExtendedCapability::new()
+            .with_register_block(
+                CxlRegisterLocatorRegisterBir::BAR_10H,
+                CxlRegisterLocatorRegisterBlockIdentifier::COMPONENT_REGISTERS,
+                0,
+            )
+            .map_err(|_| CxlTestDeviceCreateError::InvalidRegisterLocatorConfig)?;
+
+        let cfg_space = ConfigSpaceType0Emulator::new(
+            HardwareIds {
+                vendor_id: MICROSOFT_VENDOR_ID,
+                device_id: CXL_TEST_DEVICE_ID,
+                revision_id: 0,
+                prog_if: ProgrammingInterface::from(CXL_MEMORY_PROG_IF),
+                sub_class: Subclass::from(CXL_MEMORY_SUBCLASS),
+                base_class: ClassCode::MEMORY_CONTROLLER,
+                type0_sub_vendor_id: 0,
+                type0_sub_system_id: 0,
+            },
+            vec![Box::new(PciExpressCapability::new(
+                DevicePortType::Endpoint,
+                None,
+            ))],
+            vec![
+                Box::new(cxl_device_dvsec),
+                Box::new(flex_bus_dvsec),
+                Box::new(register_locator_dvsec),
+            ],
+            bars,
+        );
+
+        Ok(Self {
+            cfg_space,
+            component_registers,
+            hdm_decoder_cap_offset,
+            hdm_io_region,
+            hdm_active_len_bytes: 0,
+            hdm_memory,
+        })
+    }
+
+    fn read_component_u32(&self, offset: u16) -> Option<u32> {
+        let mut buf = [0u8; 4];
+        if !matches!(
+            self.component_registers.read(offset, &mut buf),
+            IoResult::Ok
+        ) {
+            return None;
+        }
+
+        Some(u32::from_le_bytes(buf))
+    }
+
+    fn refresh_hdm_mapping_from_decoder_state(&mut self) {
+        debug!("refreshing HDM mapping from decoder state");
+        let Some(global_control_bits) = self.read_component_u32(
+            self.hdm_decoder_cap_offset + CXL_HDM_DECODER_GLOBAL_CONTROL_OFFSET,
+        ) else {
+            debug!("HDM mapping refresh: missing global control, unmapping HDM range");
+            self.hdm_io_region.unmap();
+            self.hdm_active_len_bytes = 0;
+            return;
+        };
+
+        let global_control = CxlHdmDecoderGlobalControlRegister::from_bits(global_control_bits);
+        debug!(
+            global_control_bits,
+            hdm_decoder_enable = global_control.hdm_decoder_enable(),
+            poison_on_decode_error_enable = global_control.poison_on_decode_error_enable(),
+            "HDM mapping refresh: decoded global control"
+        );
+        if !global_control.hdm_decoder_enable() {
+            debug!("HDM mapping refresh: decoder disabled, unmapping HDM range");
+            self.hdm_io_region.unmap();
+            self.hdm_active_len_bytes = 0;
+            return;
+        }
+
+        let decoder0 = self.hdm_decoder_cap_offset + CXL_HDM_DECODER_BASE_OFFSET;
+        let Some(base_low_bits) =
+            self.read_component_u32(decoder0 + CxlHdmDecoderRegisterOffset::BASE_LOW)
+        else {
+            debug!("HDM mapping refresh: missing BASE_LOW, unmapping HDM range");
+            self.hdm_io_region.unmap();
+            self.hdm_active_len_bytes = 0;
+            return;
+        };
+        let Some(base_high) =
+            self.read_component_u32(decoder0 + CxlHdmDecoderRegisterOffset::BASE_HIGH)
+        else {
+            debug!("HDM mapping refresh: missing BASE_HIGH, unmapping HDM range");
+            self.hdm_io_region.unmap();
+            self.hdm_active_len_bytes = 0;
+            return;
+        };
+        let Some(size_low_bits) =
+            self.read_component_u32(decoder0 + CxlHdmDecoderRegisterOffset::SIZE_LOW)
+        else {
+            debug!("HDM mapping refresh: missing SIZE_LOW, unmapping HDM range");
+            self.hdm_io_region.unmap();
+            self.hdm_active_len_bytes = 0;
+            return;
+        };
+        let Some(size_high) =
+            self.read_component_u32(decoder0 + CxlHdmDecoderRegisterOffset::SIZE_HIGH)
+        else {
+            debug!("HDM mapping refresh: missing SIZE_HIGH, unmapping HDM range");
+            self.hdm_io_region.unmap();
+            self.hdm_active_len_bytes = 0;
+            return;
+        };
+        let Some(control_bits) =
+            self.read_component_u32(decoder0 + CxlHdmDecoderRegisterOffset::CONTROL)
+        else {
+            debug!("HDM mapping refresh: missing CONTROL, unmapping HDM range");
+            self.hdm_io_region.unmap();
+            self.hdm_active_len_bytes = 0;
+            return;
+        };
+
+        let base_low = CxlHdmDecoderBaseLowRegister::from_bits(base_low_bits);
+        let size_low = CxlHdmDecoderSizeLowRegister::from_bits(size_low_bits);
+        let control = CxlHdmDecoderControlRegister::from_bits(control_bits);
+        debug!(
+            base_low_bits,
+            base_high,
+            size_low_bits,
+            size_high,
+            control_bits,
+            committed = control.committed(),
+            commit = control.commit(),
+            lock_on_commit = control.lock_on_commit(),
+            "HDM mapping refresh: decoder register snapshot"
+        );
+
+        if !control.committed() {
+            debug!("HDM mapping refresh: decoder not committed, unmapping HDM range");
+            self.hdm_io_region.unmap();
+            self.hdm_active_len_bytes = 0;
+            return;
+        }
+
+        let base = (u64::from(base_high) << 32) | (u64::from(base_low.memory_base_low()) << 28);
+        let size = (u64::from(size_high) << 32) | (u64::from(size_low.memory_size_low()) << 28);
+        debug!(
+            base,
+            size, "HDM mapping refresh: computed decoder base/size"
+        );
+
+        if size == 0 || size > self.hdm_io_region.len() {
+            debug!(
+                size,
+                max_size = self.hdm_io_region.len(),
+                "HDM mapping refresh: invalid decoder size for backing memory, unmapping HDM range"
+            );
+            self.hdm_io_region.unmap();
+            self.hdm_active_len_bytes = 0;
+            return;
+        }
+
+        self.hdm_io_region.map(base);
+        self.hdm_active_len_bytes = size;
+        debug!(base, size, "HDM mapping refresh: mapped HDM MMIO region");
+    }
+
+    fn hdm_memory_offset(&self, addr: u64, access_len: usize) -> Option<usize> {
+        if self.hdm_active_len_bytes == 0 {
+            return None;
+        }
+
+        let access_len = u64::try_from(access_len).ok()?;
+        let offset = self.hdm_io_region.offset_of(addr)?;
+        let end = offset.checked_add(access_len)?;
+        if end > self.hdm_active_len_bytes {
+            return None;
+        }
+
+        usize::try_from(offset).ok()
+    }
+
+    fn read_hdm_memory(&self, addr: u64, data: &mut [u8]) -> IoResult {
+        let Some(offset) = self.hdm_memory_offset(addr, data.len()) else {
+            return IoResult::Err(InvalidRegister);
+        };
+
+        let end = offset + data.len();
+        data.copy_from_slice(&self.hdm_memory[offset..end]);
+        IoResult::Ok
+    }
+
+    fn write_hdm_memory(&mut self, addr: u64, data: &[u8]) -> IoResult {
+        let Some(offset) = self.hdm_memory_offset(addr, data.len()) else {
+            return IoResult::Err(InvalidRegister);
+        };
+
+        let end = offset + data.len();
+        self.hdm_memory[offset..end].copy_from_slice(data);
+        IoResult::Ok
+    }
+
+    fn read_component_registers(&self, offset: u64, data: &mut [u8]) -> IoResult {
+        let Ok(offset) = u16::try_from(offset) else {
+            data.fill(0);
+            return IoResult::Ok;
+        };
+
+        match self.component_registers.read(offset, data) {
+            IoResult::Err(InvalidRegister) => {
+                data.fill(0);
+                IoResult::Ok
+            }
+            res => res,
+        }
+    }
+
+    fn write_component_registers(&mut self, offset: u64, data: &[u8]) -> IoResult {
+        let Ok(offset) = u16::try_from(offset) else {
+            return IoResult::Ok;
+        };
+
+        match self.component_registers.write(offset, data) {
+            IoResult::Err(InvalidRegister) => IoResult::Ok,
+            res => {
+                debug!(
+                    offset,
+                    write_len = data.len(),
+                    "component register write accepted; refreshing HDM mapping"
+                );
+                self.refresh_hdm_mapping_from_decoder_state();
+                res
+            }
+        }
+    }
+}
+
+impl ChangeDeviceState for CxlTestDevice {
+    fn start(&mut self) {}
+
+    async fn stop(&mut self) {}
+
+    async fn reset(&mut self) {
+        self.cfg_space.reset();
+        self.component_registers.reset();
+        self.refresh_hdm_mapping_from_decoder_state();
+        self.hdm_memory.fill(0);
+    }
+}
+
+impl ChipsetDevice for CxlTestDevice {
+    fn supports_mmio(&mut self) -> Option<&mut dyn MmioIntercept> {
+        Some(self)
+    }
+
+    fn supports_pci(&mut self) -> Option<&mut dyn PciConfigSpace> {
+        Some(self)
+    }
+}
+
+impl MmioIntercept for CxlTestDevice {
+    fn mmio_read(&mut self, addr: u64, data: &mut [u8]) -> IoResult {
+        match self.cfg_space.find_bar(addr) {
+            Some((0, offset)) => self.read_component_registers(offset, data),
+            _ => self.read_hdm_memory(addr, data),
+        }
+    }
+
+    fn mmio_write(&mut self, addr: u64, data: &[u8]) -> IoResult {
+        match self.cfg_space.find_bar(addr) {
+            Some((0, offset)) => self.write_component_registers(offset, data),
+            _ => self.write_hdm_memory(addr, data),
+        }
+    }
+}
+
+impl PciConfigSpace for CxlTestDevice {
+    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
+        self.cfg_space.read_u32(offset, value)
+    }
+
+    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
+        self.cfg_space.write_u32(offset, value)
+    }
+}
+
+impl SaveRestore for CxlTestDevice {
+    type SavedState = SavedStateNotSupported;
+
+    fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+        Err(SaveError::NotSupported)
+    }
+
+    fn restore(&mut self, state: Self::SavedState) -> Result<(), RestoreError> {
+        match state {}
+    }
+}
+
+/// Resource handle for the CXL Type-3 test endpoint.
+#[derive(MeshPayload)]
+pub struct CxlTestDeviceHandle {
+    /// HDM size in bytes. Must be non-zero and 256MiB-aligned.
+    pub hdm_size_bytes: u64,
+}
+
+impl ResourceId<PciDeviceHandleKind> for CxlTestDeviceHandle {
+    const ID: &'static str = "cxl_test";
+}
+
+/// Resource resolver for [`CxlTestDeviceHandle`].
+pub mod resolver {
+    use super::CxlTestDevice;
+    use super::CxlTestDeviceCreateError;
+    use super::CxlTestDeviceHandle;
+    use super::ResolvePciDeviceHandleParams;
+    use super::ResolvedPciDevice;
+    use super::*;
+
+    /// Resolver for CXL test devices.
+    pub struct CxlTestDeviceResolver;
+
+    declare_static_resolver!(
+        CxlTestDeviceResolver,
+        (PciDeviceHandleKind, CxlTestDeviceHandle)
+    );
+
+    /// Error returned by [`CxlTestDeviceResolver`].
+    #[derive(Debug, Error)]
+    pub enum Error {
+        /// CXL test device creation failed.
+        #[error(transparent)]
+        Create(#[from] CxlTestDeviceCreateError),
+    }
+
+    impl ResolveResource<PciDeviceHandleKind, CxlTestDeviceHandle> for CxlTestDeviceResolver {
+        type Output = ResolvedPciDevice;
+        type Error = Error;
+
+        fn resolve(
+            &self,
+            resource: CxlTestDeviceHandle,
+            input: ResolvePciDeviceHandleParams<'_>,
+        ) -> Result<Self::Output, Self::Error> {
+            let device = CxlTestDevice::new(input.register_mmio, resource.hdm_size_bytes)?;
+            Ok(device.into())
+        }
+    }
+}

--- a/vm/devices/cxl/src/test/mod.rs
+++ b/vm/devices/cxl/src/test/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Test CXL endpoint implementations.
+
+mod cxl_test_device;
+
+pub use cxl_test_device::CxlTestDevice;
+pub use cxl_test_device::CxlTestDeviceHandle;
+pub use cxl_test_device::resolver;

--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -1208,11 +1208,26 @@ impl ConfigSpaceType1Emulator {
         capabilities: Vec<Box<dyn PciCapability>>,
         extended_capabilities: Vec<Box<dyn PciExtendedCapability>>,
     ) -> Self {
-        let common = ConfigSpaceCommonHeaderEmulator::new(
+        Self::new_with_bars(
             hardware_ids,
             capabilities,
             extended_capabilities,
             DeviceBars::new(),
+        )
+    }
+
+    /// Create a new [`ConfigSpaceType1Emulator`] with caller-specified BARs.
+    pub fn new_with_bars(
+        hardware_ids: HardwareIds,
+        capabilities: Vec<Box<dyn PciCapability>>,
+        extended_capabilities: Vec<Box<dyn PciExtendedCapability>>,
+        bars: DeviceBars,
+    ) -> Self {
+        let common = ConfigSpaceCommonHeaderEmulator::new(
+            hardware_ids,
+            capabilities,
+            extended_capabilities,
+            bars,
         );
 
         Self {
@@ -1444,6 +1459,16 @@ impl ConfigSpaceType1Emulator {
     /// Get the list of PCI capabilities (mutable).
     pub fn capabilities_mut(&mut self) -> &mut [Box<dyn PciCapability>] {
         self.common.capabilities_mut()
+    }
+
+    /// Finds a BAR + offset by address.
+    pub fn find_bar(&self, address: u64) -> Option<(u8, u64)> {
+        self.common.find_bar(address)
+    }
+
+    /// Gets the active base address for a specific BAR index, if mapped.
+    pub fn bar_address(&self, bar: u8) -> Option<u64> {
+        self.common.bar_address(bar)
     }
 }
 

--- a/vm/devices/pci/pci_core/src/spec.rs
+++ b/vm/devices/pci/pci_core/src/spec.rs
@@ -454,6 +454,7 @@ pub mod caps {
             ARI   = 0x0E,
             SRIOV = 0x10,
             REBAR = 0x15,
+            DVSEC = 0x23,
         }
     }
 
@@ -1167,6 +1168,64 @@ pub mod caps {
             pub direct_translated_p2p_enable: bool,
             #[bits(9)]
             _reserved: u16,
+        }
+    }
+
+    /// Designated Vendor-Specific Extended Capability (DVSEC)
+    #[expect(missing_docs)] // primarily enums/structs with self-explanatory variants
+    pub mod dvsec {
+        use bitfield_struct::bitfield;
+        use inspect::Inspect;
+        use zerocopy::FromBytes;
+        use zerocopy::Immutable;
+        use zerocopy::IntoBytes;
+        use zerocopy::KnownLayout;
+
+        open_enum::open_enum! {
+            /// Offsets into the DVSEC Extended Capability structure.
+            ///
+            /// | Offset    | Bits 31-16               | Bits 15-0               |
+            /// |-----------|--------------------------|-------------------------|
+            /// | Ext + 0x0 | Next Cap Ptr + Version   | Extended Capability ID  |
+            /// | Ext + 0x4 | DVSEC Length + Revision  | DVSEC Vendor ID         |
+            /// | Ext + 0x8 | Reserved                 | DVSEC ID                |
+            pub enum DvsecExtendedCapabilityHeader: u16 {
+                HEADER = 0x00,
+                DVSEC_HEADER1 = 0x04,
+                DVSEC_HEADER2 = 0x08,
+            }
+        }
+
+        /// DVSEC Header 1 register.
+        ///
+        /// Software should qualify the DVSEC Vendor ID before interpreting the
+        /// DVSEC Revision field.
+        ///
+        /// | Bits 31-20   | Bits 19-16      | Bits 15-0        |
+        /// |--------------|-----------------|------------------|
+        /// | DVSEC Length | DVSEC Revision  | DVSEC Vendor ID  |
+        #[bitfield(u32)]
+        #[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
+        pub struct DvsecHeader1 {
+            pub dvsec_vendor_id: u16,
+            #[bits(4)]
+            pub dvsec_revision: u8,
+            #[bits(12)]
+            pub dvsec_length: u16,
+        }
+
+        /// DVSEC Header 2 register.
+        ///
+        /// Software should qualify the DVSEC Vendor ID before interpreting the
+        /// DVSEC ID field.
+        ///
+        /// | Bits 15-0 |
+        /// |-----------|
+        /// | DVSEC ID  |
+        #[bitfield(u16)]
+        #[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
+        pub struct DvsecHeader2 {
+            pub dvsec_id: u16,
         }
     }
 }

--- a/vm/devices/pci/pcie/Cargo.toml
+++ b/vm/devices/pci/pcie/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 [dependencies]
 anyhow.workspace = true
 chipset_device.workspace = true
+cxl_spec.workspace = true
 inspect.workspace = true
 memory_range.workspace = true
 mesh.workspace = true

--- a/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
+++ b/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
@@ -133,6 +133,7 @@ impl FuzzRootComplex {
             &mut register_mmio,
             START_BUS,
             END_BUS,
+            None,
             ecam_range,
             port_defs,
             msi_conn.target(),

--- a/vm/devices/pci/pcie/src/lib.rs
+++ b/vm/devices/pci/pcie/src/lib.rs
@@ -8,6 +8,9 @@
 pub mod its;
 pub(crate) mod port;
 pub use port::PciePortSettings;
+pub use port::PortBarDefinition;
+pub use port::PortBarSubregionDefinition;
+pub use port::PortBarSubregionKind;
 pub mod root;
 pub mod switch;
 

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -4,22 +4,53 @@
 //! Common PCIe port implementation shared between different port types.
 
 use anyhow::bail;
+use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
+use chipset_device::mmio::RegisterMmioIntercept;
+use cxl_spec::CxlComponentRegisters;
+use cxl_spec::CxlFlexBusPortDvsecExtendedCapability;
+use cxl_spec::CxlPortDvsecExtendedCapability;
+use cxl_spec::CxlRegisterLocatorDvsecExtendedCapability;
+use cxl_spec::pci_registers::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecCapability;
+use cxl_spec::pci_registers::spec::register_locator_dvsec::CxlRegisterLocatorRegisterBir;
+use cxl_spec::pci_registers::spec::register_locator_dvsec::CxlRegisterLocatorRegisterBlockIdentifier;
+use cxl_spec::spec::CXL_COMPONENT_REGISTERS_SIZE_BYTES;
 use inspect::Inspect;
 use pci_bus::GenericPciBusDevice;
 use pci_core::bus_range::AssignedBusRange;
+use pci_core::capabilities::extended::PciExtendedCapability;
 use pci_core::capabilities::extended::acs::AcsExtendedCapability;
 use pci_core::capabilities::msi_cap::MsiCapability;
 use pci_core::capabilities::pci_express::PciExpressCapability;
+use pci_core::cfg_space_emu::BarMemoryKind;
 use pci_core::cfg_space_emu::ConfigSpaceType1Emulator;
+use pci_core::cfg_space_emu::DeviceBars;
 use pci_core::msi::MsiTarget;
 use pci_core::spec::caps::pci_express::DevicePortType;
 use pci_core::spec::hwid::HardwareIds;
 use std::sync::Arc;
+use vmcore::save_restore::RestoreError;
+use vmcore::save_restore::SaveError;
+use vmcore::save_restore::SaveRestore;
 
 const ACS_CAPABILITY_IMPLEMENTED_MASK: u16 = 0x00df;
 const ACS_CAPABILITY_ALLOWED_ROOT_OR_DSP_MASK: u16 = 0x00ff;
 const ACS_CAPABILITY_ALLOWED_USP_MASK: u16 = 0x0000;
+
+type CxlComponentRegistersSavedState = <CxlComponentRegisters as SaveRestore>::SavedState;
+const CXL_COMPONENT_ALLOWED_ACCESS_SIZES: [usize; 2] = [4, 8];
+
+fn validate_cxl_component_register_access(offset: u64, len: usize) -> Result<(), IoError> {
+    if !CXL_COMPONENT_ALLOWED_ACCESS_SIZES.contains(&len) {
+        return Err(IoError::InvalidAccessSize);
+    }
+
+    if !offset.is_multiple_of(len as u64) {
+        return Err(IoError::UnalignedAccess);
+    }
+
+    Ok(())
+}
 
 /// Express-level settings for a PCIe port.
 ///
@@ -30,8 +61,140 @@ pub struct PciePortSettings {
     /// ACS capability bits to advertise on this port. `0` means the ACS
     /// extended capability is not present.
     pub acs_capabilities_supported: u16,
+
+    /// Flex Bus Port capability bits used to advertise CXL support on ports.
+    ///
+    /// CXL DVSECs are added only when this is `Some` and either `cache_capable`
+    /// or `mem_capable` is set.
+    pub cxl_flex_bus_port_capability: Option<CxlFlexBusPortDvsecCapability>,
 }
 
+/// Generic PCIe port BAR definition.
+#[derive(Clone)]
+pub struct PortBarDefinition {
+    /// BAR index (Type-1 headers currently support BAR0/BAR1 only).
+    pub index: u8,
+    /// Total BAR size in bytes.
+    pub size_bytes: u64,
+    /// BAR subregions used to dispatch MMIO accesses.
+    pub subregions: Vec<PortBarSubregionDefinition>,
+}
+
+/// Generic PCIe port BAR subregion definition.
+#[derive(Clone)]
+pub struct PortBarSubregionDefinition {
+    /// Subregion semantic kind.
+    pub kind: PortBarSubregionKind,
+    /// Subregion offset within BAR aperture.
+    pub offset: u64,
+    /// Subregion length in bytes.
+    pub size_bytes: u64,
+}
+
+/// Generic PCIe port BAR subregion kind.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum PortBarSubregionKind {
+    /// CXL component register space.
+    CxlComponentRegisters,
+    /// MSI-X table subregion.
+    MsiXTable,
+    /// MSI-X pending bit array subregion.
+    MsiXPba,
+}
+
+pub(crate) fn build_cxl_register_locator_extended_capability(
+    register_bir: CxlRegisterLocatorRegisterBir,
+    register_block_offset: u64,
+) -> Option<Box<dyn PciExtendedCapability>> {
+    // Build the single-block CXL Register Locator DVSEC and drop invalid layouts.
+    let locator = CxlRegisterLocatorDvsecExtendedCapability::new()
+        .with_register_block(
+            register_bir,
+            CxlRegisterLocatorRegisterBlockIdentifier::COMPONENT_REGISTERS,
+            register_block_offset,
+        )
+        .ok()?;
+
+    Some(Box::new(locator))
+}
+
+/// Maps a Type-1 BAR index to the corresponding CXL Register Locator BIR enum.
+///
+/// Returns `None` for unsupported BAR numbers.
+fn register_bir_from_bar_index(index: u8) -> Option<CxlRegisterLocatorRegisterBir> {
+    match index {
+        0 => Some(CxlRegisterLocatorRegisterBir::BAR_10H),
+        1 => Some(CxlRegisterLocatorRegisterBir::BAR_14H),
+        2 => Some(CxlRegisterLocatorRegisterBir::BAR_18H),
+        3 => Some(CxlRegisterLocatorRegisterBir::BAR_1CH),
+        4 => Some(CxlRegisterLocatorRegisterBir::BAR_20H),
+        5 => Some(CxlRegisterLocatorRegisterBir::BAR_24H),
+        _ => None,
+    }
+}
+
+/// Extracts CXL Register Locator settings from the configured BAR layout.
+///
+/// The locator is only emitted when a CXL component-register subregion exists and
+/// the BAR index can be represented in CXL BIR encoding.
+fn cxl_register_locator_from_bar(
+    bar: Option<&PortBarDefinition>,
+) -> Option<(CxlRegisterLocatorRegisterBir, u64)> {
+    let bar_cfg = bar?;
+    let component_subregion = bar_cfg
+        .subregions
+        .iter()
+        .find(|region| region.kind == PortBarSubregionKind::CxlComponentRegisters)?;
+
+    let Some(register_bir) = register_bir_from_bar_index(bar_cfg.index) else {
+        tracelimit::warn_ratelimited!(
+            bar_index = bar_cfg.index,
+            "unsupported BAR index for CXL Register Locator"
+        );
+        return None;
+    };
+
+    Some((register_bir, component_subregion.offset))
+}
+
+fn has_cxl_component_register_subregion(bar: Option<&PortBarDefinition>) -> bool {
+    bar.is_some_and(|bar_cfg| {
+        bar_cfg
+            .subregions
+            .iter()
+            .any(|region| region.kind == PortBarSubregionKind::CxlComponentRegisters)
+    })
+}
+
+fn drop_cxl_component_register_subregions(bar: &mut Option<PortBarDefinition>) {
+    if let Some(bar_cfg) = bar {
+        bar_cfg
+            .subregions
+            .retain(|region| region.kind != PortBarSubregionKind::CxlComponentRegisters);
+
+        if bar_cfg.subregions.is_empty() {
+            *bar = None;
+        }
+    }
+}
+
+fn default_bar_from_settings(settings: &PciePortSettings) -> Option<PortBarDefinition> {
+    let cxl_requested = settings
+        .cxl_flex_bus_port_capability
+        .is_some_and(|capability| capability.cache_capable() || capability.mem_capable());
+
+    cxl_requested.then_some(PortBarDefinition {
+        index: 0,
+        size_bytes: CXL_COMPONENT_REGISTERS_SIZE_BYTES,
+        subregions: vec![PortBarSubregionDefinition {
+            kind: PortBarSubregionKind::CxlComponentRegisters,
+            offset: 0,
+            size_bytes: CXL_COMPONENT_REGISTERS_SIZE_BYTES,
+        }],
+    })
+}
+
+/// Filters requested ACS bits by both implementation support and port-type policy.
 pub(crate) fn filter_acs_capabilities_for_bridge(
     port_type: &DevicePortType,
     requested: u16,
@@ -62,6 +225,14 @@ pub struct PcieDownstreamPort {
     /// The connected device, if any.
     #[inspect(skip)]
     pub link: Option<(Arc<str>, Box<dyn GenericPciBusDevice>)>,
+
+    /// Optional BAR layout for this port.
+    #[inspect(skip)]
+    bar: Option<PortBarDefinition>,
+
+    /// Optional CXL component-register backing for CXL BAR subregion emulation.
+    #[inspect(skip)]
+    cxl_component_registers: Option<CxlComponentRegisters>,
 }
 
 impl PcieDownstreamPort {
@@ -83,8 +254,85 @@ impl PcieDownstreamPort {
         hotplug_slot_number: Option<u32>,
         msi_target: &MsiTarget,
         settings: PciePortSettings,
+        register_mmio: Option<&mut dyn RegisterMmioIntercept>,
+        mut bar: Option<PortBarDefinition>,
     ) -> Self {
         let port_name = name.into();
+        let mut bars = DeviceBars::new();
+        let mut cxl_component_registers = None;
+        let mut cxl_locator_capability = None;
+        if bar.is_none() {
+            bar = default_bar_from_settings(&settings);
+        }
+
+        // CXL DVSECs are exposed only when the port advertises cache/mem capability.
+        let mut cxl_enabled = settings
+            .cxl_flex_bus_port_capability
+            .is_some_and(|capability| capability.cache_capable() || capability.mem_capable());
+
+        let requested_cxl_component_subregion = has_cxl_component_register_subregion(bar.as_ref());
+
+        if cxl_enabled && requested_cxl_component_subregion {
+            if let Some((register_bir, register_block_offset)) =
+                cxl_register_locator_from_bar(bar.as_ref())
+            {
+                if let Some(locator_capability) = build_cxl_register_locator_extended_capability(
+                    register_bir,
+                    register_block_offset,
+                ) {
+                    cxl_locator_capability = Some(locator_capability);
+                    cxl_component_registers = Some(CxlComponentRegisters::new());
+                } else {
+                    tracelimit::warn_ratelimited!(
+                        offset = register_block_offset,
+                        "invalid CXL Register Locator settings; disabling CXL BAR subregion"
+                    );
+                    drop_cxl_component_register_subregions(&mut bar);
+                    cxl_enabled = false;
+                }
+            } else {
+                tracelimit::warn_ratelimited!(
+                    "invalid CXL Register Locator BAR configuration; disabling CXL BAR subregion"
+                );
+                drop_cxl_component_register_subregions(&mut bar);
+                cxl_enabled = false;
+            }
+        }
+
+        // Materialize BAR intercept plumbing only when the caller provides BAR metadata.
+        if let Some(bar_cfg) = &bar {
+            if bar_cfg.index != 0 {
+                tracelimit::warn_ratelimited!(
+                    bar_index = bar_cfg.index,
+                    "ignoring unsupported BAR index; only BAR0 is supported"
+                );
+                bar = None;
+            } else if let Some(register_mmio) = register_mmio {
+                let region_name = format!("{}-bar{}", port_name, bar_cfg.index);
+                bars = bars.bar0(
+                    bar_cfg.size_bytes,
+                    BarMemoryKind::Intercept(
+                        register_mmio.new_io_region(&region_name, bar_cfg.size_bytes),
+                    ),
+                );
+            } else {
+                tracelimit::warn_ratelimited!(
+                    "ignoring BAR configuration because MMIO register context is missing"
+                );
+                bar = None;
+            }
+        }
+
+        // If CXL component-register emulation was requested but BAR MMIO interception could
+        // not be materialized, disable CXL DVSECs so config space matches emulation behavior.
+        if cxl_enabled && requested_cxl_component_subregion && bar.is_none() {
+            tracelimit::warn_ratelimited!(
+                "dropping CXL DVSECs because BAR MMIO interception is unavailable"
+            );
+            cxl_enabled = false;
+            cxl_locator_capability = None;
+            cxl_component_registers = None;
+        }
 
         let (hotplug, slot_number) = match hotplug_slot_number {
             Some(slot) => (true, Some(slot)),
@@ -103,15 +351,45 @@ impl PcieDownstreamPort {
         };
 
         let extended_capabilities = if acs_supported != 0 {
-            vec![Box::new(AcsExtendedCapability::with_capabilities(acs_supported)) as _]
+            vec![
+                Box::new(AcsExtendedCapability::with_capabilities(acs_supported))
+                    as Box<dyn PciExtendedCapability>,
+            ]
         } else {
             vec![]
         };
 
-        let cfg_space = ConfigSpaceType1Emulator::new(
+        let mut extended_capabilities = extended_capabilities;
+
+        if cxl_enabled {
+            // CXL Spec mandates that a CXL root port or downstream switch port must have CXL Port DVSEC
+            // and CXL Flex Bus Port DVSEC.
+            extended_capabilities.push(Box::new(CxlPortDvsecExtendedCapability::new()));
+            let mut flex_bus_dvsec = CxlFlexBusPortDvsecExtendedCapability::new();
+            if let Some(capability) = settings.cxl_flex_bus_port_capability {
+                flex_bus_dvsec = flex_bus_dvsec
+                    .with_cache_capable(capability.cache_capable())
+                    .with_mem_capable(capability.mem_capable())
+                    .with_optional_capabilities(
+                        capability.cache_capable(),
+                        capability.cxl_68b_flit_and_vh_capable(),
+                        capability.cxl_multi_logical_device_capable(),
+                        capability.cxl_latency_optimized_256b_flit_capable(),
+                        capability.cxl_pbr_flit_capable(),
+                    );
+            }
+            extended_capabilities.push(Box::new(flex_bus_dvsec));
+
+            if let Some(locator_capability) = cxl_locator_capability {
+                extended_capabilities.push(locator_capability);
+            }
+        }
+
+        let cfg_space = ConfigSpaceType1Emulator::new_with_bars(
             hardware_ids,
             vec![Box::new(pcie_cap), Box::new(msi_capability)],
             extended_capabilities,
+            bars,
         )
         .with_multi_function_bit(multi_function);
 
@@ -119,6 +397,218 @@ impl PcieDownstreamPort {
             name: port_name,
             cfg_space,
             link: None,
+            bar,
+            cxl_component_registers,
+        }
+    }
+
+    /// Resolves a guest physical address to a BAR index + BAR-relative offset.
+    pub(crate) fn find_bar(&self, addr: u64) -> Option<(u8, u64)> {
+        self.cfg_space.find_bar(addr)
+    }
+
+    /// Saves optional per-port CXL component-register state.
+    ///
+    /// Ports without CXL component-register backing return `None`.
+    pub(crate) fn save_cxl_component_registers_state(
+        &mut self,
+    ) -> Result<Option<CxlComponentRegistersSavedState>, SaveError> {
+        self.cxl_component_registers
+            .as_mut()
+            .map(|regs| regs.save())
+            .transpose()
+    }
+
+    /// Restores optional per-port CXL component-register state.
+    ///
+    /// State presence must match the current port topology, otherwise restore fails
+    /// with an invalid-saved-state error.
+    pub(crate) fn restore_cxl_component_registers_state(
+        &mut self,
+        state: Option<CxlComponentRegistersSavedState>,
+    ) -> Result<(), RestoreError> {
+        match (&mut self.cxl_component_registers, state) {
+            (Some(current), Some(saved)) => current.restore(saved)?,
+            (None, None) => {}
+            (Some(_), None) => {
+                return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
+                    "missing CXL component-register state"
+                )));
+            }
+            (None, Some(_)) => {
+                return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
+                    "unexpected CXL component-register state"
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Handles BAR reads for this port using subregion semantics.
+    ///
+    /// CXL component-register accesses are redirected into `CxlComponentRegisters`;
+    /// unsupported or out-of-window accesses are handled as reserved reads.
+    pub(crate) fn bar_mmio_read(&mut self, bar: u8, bar_offset: u64, data: &mut [u8]) -> IoResult {
+        if bar != 0 {
+            tracelimit::warn_ratelimited!(bar, "unsupported port BAR read");
+            data.fill(0xff);
+            return IoResult::Ok;
+        }
+
+        let Some(bar_cfg) = &self.bar else {
+            tracelimit::warn_ratelimited!(bar, "BAR read without BAR configuration");
+            data.fill(0xff);
+            return IoResult::Ok;
+        };
+
+        let access_end = match bar_offset.checked_add(data.len() as u64) {
+            Some(end) => end,
+            None => {
+                data.fill(0xff);
+                return IoResult::Ok;
+            }
+        };
+
+        let Some(subregion) = bar_cfg.subregions.iter().find(|subregion| {
+            let Some(subregion_end) = subregion.offset.checked_add(subregion.size_bytes) else {
+                return false;
+            };
+
+            bar_offset >= subregion.offset && access_end <= subregion_end
+        }) else {
+            tracelimit::warn_ratelimited!(
+                offset = bar_offset,
+                size = data.len(),
+                "BAR read outside configured subregions"
+            );
+            data.fill(0);
+            return IoResult::Ok;
+        };
+
+        match subregion.kind {
+            PortBarSubregionKind::CxlComponentRegisters => {
+                let Some(component_registers) = self.cxl_component_registers.as_ref() else {
+                    tracelimit::warn_ratelimited!(
+                        "CXL component register BAR read without component-register backing"
+                    );
+                    data.fill(0);
+                    return IoResult::Ok;
+                };
+
+                let Some(relative_offset) = bar_offset.checked_sub(subregion.offset) else {
+                    data.fill(0);
+                    return IoResult::Ok;
+                };
+
+                if let Err(err) =
+                    validate_cxl_component_register_access(relative_offset, data.len())
+                {
+                    return IoResult::Err(err);
+                }
+
+                let Ok(relative_offset) = u16::try_from(relative_offset) else {
+                    data.fill(0);
+                    return IoResult::Ok;
+                };
+
+                match component_registers.read(relative_offset, data) {
+                    IoResult::Err(IoError::InvalidRegister) => {
+                        data.fill(0);
+                        IoResult::Ok
+                    }
+                    res => res,
+                }
+            }
+            PortBarSubregionKind::MsiXTable | PortBarSubregionKind::MsiXPba => {
+                // MSI-X BAR subregions are not emulated by this port yet.
+                tracelimit::warn_ratelimited!(
+                    "read BAR subregion of kind {:?}, offset 0x{:x}, size 0x{:x}",
+                    subregion.kind,
+                    subregion.offset,
+                    subregion.size_bytes
+                );
+                data.fill(0);
+                IoResult::Ok
+            }
+        }
+    }
+
+    /// Handles BAR writes for this port using subregion semantics.
+    ///
+    /// CXL component-register accesses are redirected into `CxlComponentRegisters`;
+    /// unsupported or out-of-window accesses are treated as handled writes.
+    pub(crate) fn bar_mmio_write(&mut self, bar: u8, bar_offset: u64, data: &[u8]) -> IoResult {
+        if bar != 0 {
+            tracelimit::warn_ratelimited!(bar, "unsupported port BAR write");
+            return IoResult::Ok;
+        }
+
+        let Some(bar_cfg) = &self.bar else {
+            tracelimit::warn_ratelimited!(bar, "BAR write without BAR configuration");
+            return IoResult::Ok;
+        };
+
+        let access_end = match bar_offset.checked_add(data.len() as u64) {
+            Some(end) => end,
+            None => {
+                return IoResult::Ok;
+            }
+        };
+
+        let Some(subregion) = bar_cfg.subregions.iter().find(|subregion| {
+            let Some(subregion_end) = subregion.offset.checked_add(subregion.size_bytes) else {
+                return false;
+            };
+
+            bar_offset >= subregion.offset && access_end <= subregion_end
+        }) else {
+            tracelimit::warn_ratelimited!(
+                offset = bar_offset,
+                size = data.len(),
+                "BAR write outside configured subregions"
+            );
+            return IoResult::Ok;
+        };
+
+        match subregion.kind {
+            PortBarSubregionKind::CxlComponentRegisters => {
+                let Some(component_registers) = self.cxl_component_registers.as_mut() else {
+                    tracelimit::warn_ratelimited!(
+                        "CXL component register BAR write without component-register backing"
+                    );
+                    return IoResult::Ok;
+                };
+
+                let Some(relative_offset) = bar_offset.checked_sub(subregion.offset) else {
+                    return IoResult::Ok;
+                };
+
+                if let Err(err) =
+                    validate_cxl_component_register_access(relative_offset, data.len())
+                {
+                    return IoResult::Err(err);
+                }
+
+                let Ok(relative_offset) = u16::try_from(relative_offset) else {
+                    return IoResult::Ok;
+                };
+
+                match component_registers.write(relative_offset, data) {
+                    IoResult::Err(IoError::InvalidRegister) => IoResult::Ok,
+                    res => res,
+                }
+            }
+            PortBarSubregionKind::MsiXTable | PortBarSubregionKind::MsiXPba => {
+                // MSI-X BAR subregions are not emulated by this port yet.
+                tracelimit::warn_ratelimited!(
+                    "write BAR subregion of kind {:?}, offset 0x{:x}, size 0x{:x}",
+                    subregion.kind,
+                    subregion.offset,
+                    subregion.size_bytes
+                );
+                IoResult::Ok
+            }
         }
     }
 
@@ -338,11 +828,55 @@ impl PcieDownstreamPort {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_helpers::TestPcieMmioRegistration;
     use chipset_device::io::IoResult;
+    use cxl_spec::pci_registers::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecCapability;
     use parking_lot::Mutex;
     use pci_bus::GenericPciBusDevice;
     use pci_core::spec::hwid::HardwareIds;
     use std::sync::Arc;
+
+    fn make_cxl_bar_port() -> PcieDownstreamPort {
+        use pci_core::spec::hwid::{ClassCode, ProgrammingInterface, Subclass};
+
+        let hardware_ids = HardwareIds {
+            vendor_id: 0x1234,
+            device_id: 0x5678,
+            revision_id: 0,
+            prog_if: ProgrammingInterface::NONE,
+            sub_class: Subclass::BRIDGE_PCI_TO_PCI,
+            base_class: ClassCode::BRIDGE,
+            type0_sub_vendor_id: 0,
+            type0_sub_system_id: 0,
+        };
+
+        let mut mmio = TestPcieMmioRegistration {};
+        let msi_target = MsiTarget::disconnected();
+        PcieDownstreamPort::new(
+            "cxl-bar-port",
+            hardware_ids,
+            DevicePortType::RootPort,
+            false,
+            None,
+            &msi_target,
+            PciePortSettings {
+                acs_capabilities_supported: 0,
+                cxl_flex_bus_port_capability: Some(
+                    CxlFlexBusPortDvsecCapability::new().with_mem_capable(true),
+                ),
+            },
+            Some(&mut mmio),
+            Some(PortBarDefinition {
+                index: 0,
+                size_bytes: 0x1000,
+                subregions: vec![PortBarSubregionDefinition {
+                    kind: PortBarSubregionKind::CxlComponentRegisters,
+                    offset: 0,
+                    size_bytes: 0x1000,
+                }],
+            }),
+        )
+    }
 
     // Mock device for testing
     struct MockDevice;
@@ -437,6 +971,8 @@ mod tests {
             Some(1), // Enable hotplug with slot number 1
             msi_conn.target(),
             PciePortSettings::default(),
+            None,
+            None,
         );
 
         // Initially, presence detect state should be 0
@@ -489,6 +1025,8 @@ mod tests {
             None, // No hotplug
             msi_conn.target(),
             PciePortSettings::default(),
+            None,
+            None,
         );
 
         // Add a device to the port (should not panic even without hotplug support)
@@ -524,6 +1062,8 @@ mod tests {
             None,
             &msi_target,
             PciePortSettings::default(),
+            None,
+            None,
         );
 
         port.cfg_space
@@ -580,6 +1120,8 @@ mod tests {
             None,
             msi_conn.target(),
             PciePortSettings::default(),
+            None,
+            None,
         );
 
         port.cfg_space
@@ -639,6 +1181,8 @@ mod tests {
             None,
             msi_conn.target(),
             PciePortSettings::default(),
+            None,
+            None,
         );
 
         // Program bridge bus numbers (Type1 register at offset 0x18).
@@ -703,7 +1247,10 @@ mod tests {
             &msi_target,
             PciePortSettings {
                 acs_capabilities_supported: 0x005f,
+                ..Default::default()
             },
+            None,
+            None,
         );
         let mut value = 0u32;
         with_acs.cfg_space.read_u32(0x100, &mut value).unwrap();
@@ -717,8 +1264,98 @@ mod tests {
             None,
             &msi_target,
             PciePortSettings::default(),
+            None,
+            None,
         );
         without_acs.cfg_space.read_u32(0x100, &mut value).unwrap();
         assert_eq!(value, 0xffff_ffff);
+    }
+
+    #[test]
+    fn test_invalid_cxl_component_register_locator_disables_cxl_exposure() {
+        use cxl_spec::pci_registers::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecCapability;
+        use pci_core::spec::hwid::{ClassCode, ProgrammingInterface, Subclass};
+
+        let hardware_ids = HardwareIds {
+            vendor_id: 0x1234,
+            device_id: 0x5678,
+            revision_id: 0,
+            prog_if: ProgrammingInterface::NONE,
+            sub_class: Subclass::BRIDGE_PCI_TO_PCI,
+            base_class: ClassCode::BRIDGE,
+            type0_sub_vendor_id: 0,
+            type0_sub_system_id: 0,
+        };
+
+        let msi_target = MsiTarget::disconnected();
+        let port = PcieDownstreamPort::new(
+            "test-port",
+            hardware_ids,
+            DevicePortType::RootPort,
+            false,
+            None,
+            &msi_target,
+            PciePortSettings {
+                acs_capabilities_supported: 0,
+                cxl_flex_bus_port_capability: Some(
+                    CxlFlexBusPortDvsecCapability::new().with_mem_capable(true),
+                ),
+            },
+            None,
+            Some(PortBarDefinition {
+                index: 0,
+                size_bytes: 0x1000,
+                subregions: vec![PortBarSubregionDefinition {
+                    kind: PortBarSubregionKind::CxlComponentRegisters,
+                    offset: 0,
+                    size_bytes: 0x1000,
+                }],
+            }),
+        );
+
+        let mut value = 0u32;
+        port.cfg_space.read_u32(0x100, &mut value).unwrap();
+        assert_eq!(
+            value, 0xffff_ffff,
+            "CXL DVSECs should be absent when CXL component-register BAR backing is invalid"
+        );
+        assert!(
+            port.cxl_component_registers.is_none(),
+            "component-register backing should not be allocated"
+        );
+    }
+
+    #[test]
+    fn test_cxl_component_register_bar_rejects_1_or_2_byte_reads() {
+        let mut port = make_cxl_bar_port();
+
+        let mut read1 = [0u8; 1];
+        assert!(matches!(
+            port.bar_mmio_read(0, 0, &mut read1),
+            IoResult::Err(IoError::InvalidAccessSize)
+        ));
+
+        let mut read2 = [0u8; 2];
+        assert!(matches!(
+            port.bar_mmio_read(0, 0, &mut read2),
+            IoResult::Err(IoError::InvalidAccessSize)
+        ));
+    }
+
+    #[test]
+    fn test_cxl_component_register_bar_rejects_1_or_2_byte_writes() {
+        let mut port = make_cxl_bar_port();
+
+        let write1 = [0u8; 1];
+        assert!(matches!(
+            port.bar_mmio_write(0, 0, &write1),
+            IoResult::Err(IoError::InvalidAccessSize)
+        ));
+
+        let write2 = [0u8; 2];
+        assert!(matches!(
+            port.bar_mmio_write(0, 0, &write2),
+            IoResult::Err(IoError::InvalidAccessSize)
+        ));
     }
 }

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -20,6 +20,7 @@ use chipset_device::io::IoResult;
 use chipset_device::mmio::ControlMmioIntercept;
 use chipset_device::mmio::MmioIntercept;
 use chipset_device::mmio::RegisterMmioIntercept;
+use cxl_spec::CxlComponentRegisters;
 use inspect::Inspect;
 use inspect::InspectMut;
 use memory_range::MemoryRange;
@@ -45,6 +46,10 @@ pub struct GenericPcieRootComplex {
     end_bus: u8,
     /// Intercept control for the ECAM MMIO region.
     ecam: Box<dyn ControlMmioIntercept>,
+    /// Intercept control for the CHBCR MMIO region, when present.
+    chbcr: Option<Box<dyn ControlMmioIntercept>>,
+    /// CXL Component Registers backing CHBCR accesses in CXL mode.
+    cxl_component_registers: Option<CxlComponentRegisters>,
     /// Map of root ports attached to the root complex, indexed by combined device and function numbers.
     #[inspect(with = "|x| inspect::iter_by_key(x).map_value(|(_, v)| v)")]
     ports: HashMap<u8, (Arc<str>, RootPort)>,
@@ -121,6 +126,7 @@ impl GenericPcieRootComplex {
         register_mmio: &mut dyn RegisterMmioIntercept,
         start_bus: u8,
         end_bus: u8,
+        chbcr_range: Option<MemoryRange>,
         ecam_range: MemoryRange,
         ports: Vec<GenericPcieRootPortDefinition>,
         msi_target: &MsiTarget,
@@ -132,6 +138,24 @@ impl GenericPcieRootComplex {
 
         let mut ecam = register_mmio.new_io_region("ecam", ecam_range.len());
         ecam.map(ecam_range.start());
+
+        // Presence of CHBCR range indicates CXL mode, which needs a component-register
+        // backing object even if no capability payload blocks are registered yet.
+        let cxl_component_registers = chbcr_range.as_ref().map(|_| CxlComponentRegisters::new());
+
+        let chbcr = chbcr_range.map(|range| {
+            tracing::info!(
+                root_bus_start = start_bus,
+                root_bus_end = end_bus,
+                start = range.start(),
+                end = range.end(),
+                len = range.len(),
+                "pcie root complex CHBCR range"
+            );
+            let mut region = register_mmio.new_io_region("chbcr", range.len());
+            region.map(range.start());
+            region
+        });
 
         let port_map: HashMap<u8, (Arc<str>, RootPort)> = ports
             .into_iter()
@@ -147,6 +171,7 @@ impl GenericPcieRootComplex {
                 // Derive a per-port MSI target with this port's devfn.
                 let port_msi_target = msi_target.with_devfn(device_number);
                 let root_port = RootPort::new(
+                    register_mmio,
                     definition.name.clone(),
                     hotplug_slot_number,
                     &port_msi_target,
@@ -160,7 +185,43 @@ impl GenericPcieRootComplex {
             start_bus,
             end_bus,
             ecam,
+            chbcr,
+            cxl_component_registers,
             ports: port_map,
+        }
+    }
+
+    /// Reads CHBCR bytes from the CXL component-register backing object.
+    ///
+    /// `offset` is relative to the start of the CHBCR MMIO range.
+    fn read_chbcr_component_registers(&self, offset: u16, data: &mut [u8]) -> IoResult {
+        let Some(component_regs) = &self.cxl_component_registers else {
+            data.fill(0);
+            return IoResult::Ok;
+        };
+
+        match component_regs.read(offset, data) {
+            IoResult::Err(IoError::InvalidRegister) => {
+                // Treat unmapped CHBCR offsets as reserved MMIO reads.
+                data.fill(0);
+                IoResult::Ok
+            }
+            res => res,
+        }
+    }
+
+    /// Writes CHBCR bytes into the CXL component-register backing object.
+    ///
+    /// `offset` is relative to the start of the CHBCR MMIO range.
+    fn write_chbcr_component_registers(&mut self, offset: u16, data: &[u8]) -> IoResult {
+        let Some(component_regs) = &mut self.cxl_component_registers else {
+            return IoResult::Ok;
+        };
+
+        match component_regs.write(offset, data) {
+            // Treat unmapped CHBCR offsets as handled MMIO writes.
+            IoResult::Err(IoError::InvalidRegister) => IoResult::Ok,
+            res => res,
         }
     }
 
@@ -276,6 +337,55 @@ impl GenericPcieRootComplex {
 
         DecodedEcamAccess::UnexpectedIntercept
     }
+
+    fn mmio_read_non_ecam(&mut self, addr: u64, data: &mut [u8]) -> Option<IoResult> {
+        if let Some(chbcr) = &self.chbcr {
+            if let Some(offset) = chbcr.offset_of(addr) {
+                let Some(offset) = u16::try_from(offset).ok() else {
+                    data.fill(0);
+                    return Some(IoResult::Ok);
+                };
+                return Some(self.read_chbcr_component_registers(offset, data));
+            }
+        }
+
+        for (_, port) in self.ports.values_mut() {
+            if let Some((bar, offset)) = port.port.find_bar(addr) {
+                if let Err(err) =
+                    validate_aligned_access(addr, data.len(), &BAR_ALLOWED_ACCESS_SIZES)
+                {
+                    return Some(IoResult::Err(err));
+                }
+                return Some(port.port.bar_mmio_read(bar, offset, data));
+            }
+        }
+
+        None
+    }
+
+    fn mmio_write_non_ecam(&mut self, addr: u64, data: &[u8]) -> Option<IoResult> {
+        if let Some(chbcr) = &self.chbcr {
+            if let Some(offset) = chbcr.offset_of(addr) {
+                let Some(offset) = u16::try_from(offset).ok() else {
+                    return Some(IoResult::Err(IoError::InvalidRegister));
+                };
+                return Some(self.write_chbcr_component_registers(offset, data));
+            }
+        }
+
+        for (_, port) in self.ports.values_mut() {
+            if let Some((bar, offset)) = port.port.find_bar(addr) {
+                if let Err(err) =
+                    validate_aligned_access(addr, data.len(), &BAR_ALLOWED_ACCESS_SIZES)
+                {
+                    return Some(IoResult::Err(err));
+                }
+                return Some(port.port.bar_mmio_write(bar, offset, data));
+            }
+        }
+
+        None
+    }
 }
 
 fn ecam_size_from_bus_numbers(start_bus: u8, end_bus: u8) -> u64 {
@@ -302,19 +412,23 @@ impl ChipsetDevice for GenericPcieRootComplex {
     }
 }
 
-macro_rules! validate_ecam_intercept {
-    ($address:ident, $data:ident) => {
-        if !matches!($data.len(), 1 | 2 | 4) {
-            return IoResult::Err(IoError::InvalidAccessSize);
-        }
+const ECAM_ALLOWED_ACCESS_SIZES: [usize; 3] = [1, 2, 4];
+const BAR_ALLOWED_ACCESS_SIZES: [usize; 4] = [1, 2, 4, 8];
 
-        if !((($data.len() == 4) && ($address & 3 == 0))
-            || (($data.len() == 2) && ($address & 1 == 0))
-            || ($data.len() == 1))
-        {
-            return IoResult::Err(IoError::UnalignedAccess);
-        }
-    };
+fn validate_aligned_access(
+    address: u64,
+    len: usize,
+    allowed_sizes: &[usize],
+) -> Result<(), IoError> {
+    if !allowed_sizes.contains(&len) {
+        return Err(IoError::InvalidAccessSize);
+    }
+
+    if !address.is_multiple_of(len as u64) {
+        return Err(IoError::UnalignedAccess);
+    }
+
+    Ok(())
 }
 
 macro_rules! check_result {
@@ -330,7 +444,13 @@ macro_rules! check_result {
 
 impl MmioIntercept for GenericPcieRootComplex {
     fn mmio_read(&mut self, addr: u64, data: &mut [u8]) -> IoResult {
-        validate_ecam_intercept!(addr, data);
+        if let Some(result) = self.mmio_read_non_ecam(addr, data) {
+            return result;
+        }
+
+        if let Err(err) = validate_aligned_access(addr, data.len(), &ECAM_ALLOWED_ACCESS_SIZES) {
+            return IoResult::Err(err);
+        }
 
         // N.B. Emulators internally only support 4-byte aligned accesses to
         // 4-byte registers, but the guest can use 1-, 2-, or 4 byte memory
@@ -370,7 +490,13 @@ impl MmioIntercept for GenericPcieRootComplex {
     }
 
     fn mmio_write(&mut self, addr: u64, data: &[u8]) -> IoResult {
-        validate_ecam_intercept!(addr, data);
+        if let Some(result) = self.mmio_write_non_ecam(addr, data) {
+            return result;
+        }
+
+        if let Err(err) = validate_aligned_access(addr, data.len(), &ECAM_ALLOWED_ACCESS_SIZES) {
+            return IoResult::Err(err);
+        }
 
         // N.B. Emulators internally only support 4-byte aligned accesses to
         // 4-byte registers, but the guest can use 1-, 2-, or 4-byte memory
@@ -440,12 +566,14 @@ impl RootPort {
     /// * `msi_target` - MSI target for interrupt delivery
     /// * `settings` - Express-level port settings (ACS, etc.)
     pub fn new(
+        register_mmio: &mut dyn RegisterMmioIntercept,
         name: impl Into<Arc<str>>,
         hotplug_slot_number: Option<u32>,
         msi_target: &MsiTarget,
         settings: PciePortSettings,
     ) -> Self {
         let name_str = name.into();
+
         let hardware_ids = HardwareIds {
             vendor_id: VENDOR_ID,
             device_id: ROOT_PORT_DEVICE_ID,
@@ -465,6 +593,8 @@ impl RootPort {
             hotplug_slot_number,
             msi_target,
             settings,
+            Some(register_mmio),
+            None,
         );
 
         Self { port }
@@ -539,11 +669,13 @@ mod save_restore {
 
     mod state {
         use super::ConfigSpaceType1Emulator;
+        use super::CxlComponentRegisters;
         use super::SaveRestore;
         use mesh::payload::Protobuf;
         use vmcore::save_restore::SavedStateRoot;
 
         type RootPortCfgSpaceSavedState = <ConfigSpaceType1Emulator as SaveRestore>::SavedState;
+        type CxlComponentRegistersSavedState = <CxlComponentRegisters as SaveRestore>::SavedState;
 
         /// Saved state for a single root port.
         #[derive(Protobuf)]
@@ -555,6 +687,9 @@ mod save_restore {
             /// The root port Type 1 configuration space state.
             #[mesh(2)]
             pub cfg_space: RootPortCfgSpaceSavedState,
+            /// Optional CXL component-register state for this port.
+            #[mesh(3)]
+            pub cxl_component_registers: Option<CxlComponentRegistersSavedState>,
         }
 
         /// Saved state for the GenericPcieRootComplex.
@@ -570,6 +705,9 @@ mod save_restore {
             /// Saved state for each root port.
             #[mesh(3)]
             pub ports: Vec<PortSavedState>,
+            /// Optional CXL component-register state for CHBCR-backed root complexes.
+            #[mesh(4)]
+            pub cxl_component_registers: Option<CxlComponentRegistersSavedState>,
         }
     }
 
@@ -583,6 +721,7 @@ mod save_restore {
                 ports.push(state::PortSavedState {
                     port_number,
                     cfg_space: root_port.port.cfg_space.save()?,
+                    cxl_component_registers: root_port.port.save_cxl_component_registers_state()?,
                 });
             }
             ports.sort_by_key(|p| p.port_number);
@@ -591,6 +730,11 @@ mod save_restore {
                 start_bus: self.start_bus,
                 end_bus: self.end_bus,
                 ports,
+                cxl_component_registers: self
+                    .cxl_component_registers
+                    .as_mut()
+                    .map(|regs| regs.save())
+                    .transpose()?,
             })
         }
 
@@ -599,6 +743,7 @@ mod save_restore {
                 start_bus,
                 end_bus,
                 ports,
+                cxl_component_registers,
             } = state;
 
             // Validate that bus numbers match
@@ -634,10 +779,28 @@ mod save_restore {
 
                 if let Some((_, root_port)) = self.ports.get_mut(&port_state.port_number) {
                     root_port.port.cfg_space.restore(port_state.cfg_space)?;
+                    root_port.port.restore_cxl_component_registers_state(
+                        port_state.cxl_component_registers,
+                    )?;
                 } else {
                     return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
                         "root port {} not found",
                         port_state.port_number
+                    )));
+                }
+            }
+
+            match (&mut self.cxl_component_registers, cxl_component_registers) {
+                (Some(current), Some(saved)) => current.restore(saved)?,
+                (None, None) => {}
+                (Some(_), None) => {
+                    return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
+                        "CXL mode mismatch: current root complex has CHBCR registers but saved state does not"
+                    )));
+                }
+                (None, Some(_)) => {
+                    return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
+                        "CXL mode mismatch: saved state has CHBCR registers but current root complex does not"
                     )));
                 }
             }
@@ -651,6 +814,8 @@ mod save_restore {
 mod tests {
     use super::*;
     use crate::test_helpers::*;
+    use cxl_spec::CxlComponentRegisterType;
+    use cxl_spec::component_registers::test_helper::TestCxlComponentRegisterBlock;
     use pal_async::async_test;
 
     fn instantiate_root_complex(
@@ -675,6 +840,41 @@ mod tests {
             &mut register_mmio,
             start_bus,
             end_bus,
+            None,
+            ecam,
+            port_defs,
+            msi_conn.target(),
+        )
+    }
+
+    fn instantiate_root_complex_with_chbcr(
+        start_bus: u8,
+        end_bus: u8,
+        port_count: u8,
+        chbcr_start: u64,
+    ) -> GenericPcieRootComplex {
+        let port_defs = (0..port_count)
+            .map(|i| GenericPcieRootPortDefinition {
+                name: format!("test-port-{}", i).into(),
+                hotplug: false,
+                settings: PciePortSettings::default(),
+            })
+            .collect();
+
+        let mut register_mmio = TestPcieMmioRegistration {};
+        let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(start_bus, end_bus));
+        let chbcr = MemoryRange::new(
+            chbcr_start..(chbcr_start + cxl_spec::spec::CXL_COMPONENT_REGISTERS_SIZE_BYTES),
+        );
+        let rc_bus_range = AssignedBusRange::new();
+        rc_bus_range.set_bus_range(start_bus, end_bus);
+        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+
+        GenericPcieRootComplex::new(
+            &mut register_mmio,
+            start_bus,
+            end_bus,
+            Some(chbcr),
             ecam,
             port_defs,
             msi_conn.target(),
@@ -878,6 +1078,94 @@ mod tests {
         assert_eq!(value_32, 0xDEAD_BEEF);
     }
 
+    #[test]
+    fn test_chbcr_reads_cxl_component_header_in_cxl_mode() {
+        let chbcr_start = 0x2000_0000;
+        let mut rc = instantiate_root_complex_with_chbcr(0, 0, 1, chbcr_start);
+
+        // CHBCR + 0x1000 maps to cache/mem page 0 header dword.
+        let mut header: u32 = 0;
+        rc.mmio_read(chbcr_start + 0x1000, header.as_mut_bytes())
+            .unwrap();
+        assert_eq!(header, 0x0011_0001);
+    }
+
+    #[test]
+    fn test_chbcr_read_write_redirects_to_component_registers() {
+        let chbcr_start = 0x3000_0000;
+        let mut rc = instantiate_root_complex_with_chbcr(0, 0, 1, chbcr_start);
+
+        // Install one payload register block into the component-register space.
+        assert!(
+            rc.cxl_component_registers
+                .as_mut()
+                .expect("CXL mode must allocate component registers")
+                .add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                    CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                    16,
+                )))
+        );
+
+        let value = 0x1122_3344u32;
+        rc.mmio_write(chbcr_start + 0x1008, value.as_bytes())
+            .unwrap();
+
+        let mut read_back: u32 = 0;
+        rc.mmio_read(chbcr_start + 0x1008, read_back.as_mut_bytes())
+            .unwrap();
+        assert_eq!(read_back, value);
+    }
+
+    #[test]
+    fn test_chbcr_8byte_read_write_redirects_to_component_registers() {
+        let chbcr_start = 0x3001_0000;
+        let mut rc = instantiate_root_complex_with_chbcr(0, 0, 1, chbcr_start);
+
+        // Install one payload register block into the component-register space.
+        assert!(
+            rc.cxl_component_registers
+                .as_mut()
+                .expect("CXL mode must allocate component registers")
+                .add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                    CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                    16,
+                )))
+        );
+
+        let value = 0x1122_3344_5566_7788u64;
+        rc.mmio_write(chbcr_start + 0x1008, value.as_bytes())
+            .unwrap();
+
+        let mut read_back: u64 = 0;
+        rc.mmio_read(chbcr_start + 0x1008, read_back.as_mut_bytes())
+            .unwrap();
+        assert_eq!(read_back, value);
+    }
+
+    #[test]
+    fn test_chbcr_unmapped_read_is_handled() {
+        let chbcr_start = 0x3002_0000;
+        let mut rc = instantiate_root_complex_with_chbcr(0, 0, 1, chbcr_start);
+
+        // This offset is not synthesized/populated and should still be
+        // treated as a handled CHBCR MMIO read.
+        let mut value: u64 = 0;
+        rc.mmio_read(chbcr_start + 0x800, value.as_mut_bytes())
+            .unwrap();
+        assert_eq!(value, 0);
+    }
+
+    #[test]
+    fn test_chbcr_unmapped_write_is_handled() {
+        let chbcr_start = 0x3003_0000;
+        let mut rc = instantiate_root_complex_with_chbcr(0, 0, 1, chbcr_start);
+
+        // Unmapped CHBCR writes should be ignored but treated as handled.
+        let value = 0x0123_4567_89ab_cdefu64;
+        rc.mmio_write(chbcr_start + 0x800, value.as_bytes())
+            .unwrap();
+    }
+
     #[async_test]
     async fn test_reset() {
         const COMMAND_REG: u64 = 0x4;
@@ -926,8 +1214,10 @@ mod tests {
     fn test_root_port_hotplug_options() {
         // Test with hotplug disabled (None)
         let root_port_no_hotplug = {
+            let mut register_mmio = TestPcieMmioRegistration {};
             let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
             RootPort::new(
+                &mut register_mmio,
                 "test-port-no-hotplug",
                 None,
                 c.target(),
@@ -947,8 +1237,10 @@ mod tests {
 
         // Test with hotplug enabled (Some(slot_number))
         let root_port_with_hotplug = {
+            let mut register_mmio = TestPcieMmioRegistration {};
             let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
             RootPort::new(
+                &mut register_mmio,
                 "test-port-hotplug",
                 Some(5),
                 c.target(),
@@ -969,8 +1261,15 @@ mod tests {
     #[test]
     fn test_root_port_invalid_bus_range_handling() {
         let mut root_port = {
+            let mut register_mmio = TestPcieMmioRegistration {};
             let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-            RootPort::new("test-port", None, c.target(), PciePortSettings::default())
+            RootPort::new(
+                &mut register_mmio,
+                "test-port",
+                None,
+                c.target(),
+                PciePortSettings::default(),
+            )
         };
 
         // Don't configure bus numbers, so the range should be 0..=0 (invalid)
@@ -1125,6 +1424,48 @@ mod tests {
         // Restore should fail because port counts don't match
         let result = rc2.restore(saved_state);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_save_restore_with_cxl_component_registers() {
+        use vmcore::save_restore::SaveRestore;
+
+        let chbcr_start = 0x3004_0000;
+        let mut rc = instantiate_root_complex_with_chbcr(0, 0, 1, chbcr_start);
+
+        assert!(
+            rc.cxl_component_registers
+                .as_mut()
+                .expect("CXL mode must allocate component registers")
+                .add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                    CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                    16,
+                )))
+        );
+
+        let programmed = 0x3344_5566u32;
+        rc.mmio_write(chbcr_start + 0x1008, programmed.as_bytes())
+            .unwrap();
+
+        let saved_state = rc.save().expect("save should succeed");
+
+        let mut rc2 = instantiate_root_complex_with_chbcr(0, 0, 1, chbcr_start);
+        assert!(
+            rc2.cxl_component_registers
+                .as_mut()
+                .expect("CXL mode must allocate component registers")
+                .add_register(Box::new(TestCxlComponentRegisterBlock::new(
+                    CxlComponentRegisterType::CXL_CACHE_MEM_REGISTER,
+                    16,
+                )))
+        );
+
+        rc2.restore(saved_state).expect("restore should succeed");
+
+        let mut read_back: u32 = 0;
+        rc2.mmio_read(chbcr_start + 0x1008, read_back.as_mut_bytes())
+            .unwrap();
+        assert_eq!(read_back, programmed);
     }
 
     #[test]

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -124,6 +124,8 @@ impl DownstreamSwitchPort {
             hotplug_slot_number,
             msi_target,
             settings,
+            None,
+            None,
         );
 
         Self { port }
@@ -414,10 +416,13 @@ impl GenericPcieSwitch {
 }
 
 impl ChangeDeviceState for GenericPcieSwitch {
+    /// No-op start hook: switch state is fully modeled in config-space state.
     fn start(&mut self) {}
 
+    /// No-op stop hook: no background tasks or external resources to drain.
     async fn stop(&mut self) {}
 
+    /// Resets upstream and downstream bridge config-space state to power-on defaults.
     async fn reset(&mut self) {
         // Reset the upstream port configuration space
         self.upstream_port.cfg_space.reset();
@@ -430,17 +435,20 @@ impl ChangeDeviceState for GenericPcieSwitch {
 }
 
 impl ChipsetDevice for GenericPcieSwitch {
+    /// Exposes this switch as a PCI config-space device to the chipset bus.
     fn supports_pci(&mut self) -> Option<&mut dyn PciConfigSpace> {
         Some(self)
     }
 }
 
 impl PciConfigSpace for GenericPcieSwitch {
+    /// Reads the switch's own upstream-port config space (Type 0 view).
     fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
         // Forward to the upstream port's configuration space (the switch presents as the upstream port)
         self.upstream_port.cfg_space.read_u32(offset, value)
     }
 
+    /// Writes the switch's own upstream-port config space (Type 0 view).
     fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
         // Forward to the upstream port's configuration space (the switch presents as the upstream port)
         self.upstream_port.cfg_space.write_u32(offset, value)
@@ -454,6 +462,7 @@ impl PciConfigSpace for GenericPcieSwitch {
         offset: u16,
         value: &mut u32,
     ) -> IoResult {
+        // Try switch-internal routing first (downstream ports and their descendants).
         if let Some(result) = self.route_cfg_read(target_bus, function, offset, value) {
             return result;
         }
@@ -480,6 +489,7 @@ impl PciConfigSpace for GenericPcieSwitch {
         offset: u16,
         value: u32,
     ) -> IoResult {
+        // Try switch-internal routing first (downstream ports and their descendants).
         if let Some(result) = self.route_cfg_write(target_bus, function, offset, value) {
             return result;
         }
@@ -512,10 +522,12 @@ mod save_restore {
     mod state {
         use super::ConfigSpaceType1Emulator;
         use super::SaveRestore;
+        use cxl_spec::CxlComponentRegisters;
         use mesh::payload::Protobuf;
         use vmcore::save_restore::SavedStateRoot;
 
         type SwitchPortCfgSpaceSavedState = <ConfigSpaceType1Emulator as SaveRestore>::SavedState;
+        type CxlComponentRegistersSavedState = <CxlComponentRegisters as SaveRestore>::SavedState;
 
         /// Saved state for one switch port config space.
         #[derive(Protobuf)]
@@ -524,9 +536,12 @@ mod save_restore {
             /// Logical downstream port number.
             #[mesh(1)]
             pub port_number: u8,
-            /// The port's Type 1 configuration space state.
+            /// The downstream port Type 1 configuration space state.
             #[mesh(2)]
             pub cfg_space: SwitchPortCfgSpaceSavedState,
+            /// Optional CXL component-register state for this downstream port.
+            #[mesh(3)]
+            pub cxl_component_registers: Option<CxlComponentRegistersSavedState>,
         }
 
         /// Saved state for the GenericPcieSwitch.
@@ -553,12 +568,15 @@ mod save_restore {
             let upstream_cfg_space = self.upstream_port.cfg_space.save()?;
 
             // Save all downstream ports and sort by port number for stable ordering.
+            // Sorting keeps serialization deterministic without encoding ordering as state.
             let mut downstream_ports = Vec::with_capacity(self.downstream_ports.len());
             for (&port_number, (_, downstream_port)) in self.downstream_ports.iter_mut() {
-                let cfg_space = downstream_port.port.cfg_space.save()?;
                 downstream_ports.push(state::DownstreamPortSavedState {
                     port_number,
-                    cfg_space,
+                    cfg_space: downstream_port.port.cfg_space.save()?,
+                    cxl_component_registers: downstream_port
+                        .port
+                        .save_cxl_component_registers_state()?,
                 });
             }
             downstream_ports.sort_by_key(|p| p.port_number);
@@ -575,7 +593,7 @@ mod save_restore {
                 downstream_ports,
             } = state;
 
-            // Validate that the number of downstream ports matches
+            // Reject snapshots from a different topology shape.
             if downstream_ports.len() != self.downstream_ports.len() {
                 return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
                     "downstream port count mismatch: saved {}, current {}",
@@ -589,8 +607,9 @@ mod save_restore {
 
             let mut seen_ports = HashSet::with_capacity(downstream_ports.len());
 
-            // Restore all downstream ports by explicit port number.
+            // Restore all downstream ports by explicit port number rather than vector order.
             for port_state in downstream_ports {
+                // Duplicate entries indicate corrupted or malformed saved state.
                 if !seen_ports.insert(port_state.port_number) {
                     return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
                         "duplicate downstream port {} in saved state",
@@ -605,6 +624,9 @@ mod save_restore {
                         .port
                         .cfg_space
                         .restore(port_state.cfg_space)?;
+                    downstream_port.port.restore_cxl_component_registers_state(
+                        port_state.cxl_component_registers,
+                    )?;
                 } else {
                     return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
                         "downstream port {} not found",
@@ -1478,6 +1500,8 @@ mod tests {
             None,
             msi_conn.target(),
             PciePortSettings::default(),
+            None,
+            None,
         );
 
         // Configure the root port's bus range: secondary=1, subordinate=10
@@ -1530,6 +1554,7 @@ mod tests {
             hotplug: false,
             dsp_settings: PciePortSettings {
                 acs_capabilities_supported: 0x0001,
+                ..Default::default()
             },
             msi_target: MsiTarget::disconnected(),
         });

--- a/vm/vmcore/vm_topology/Cargo.toml
+++ b/vm/vmcore/vm_topology/Cargo.toml
@@ -13,6 +13,7 @@ mesh = ["dep:mesh_protobuf", "memory_range/mesh"]
 
 [dependencies]
 aarch64defs.workspace = true
+cxl_spec.workspace = true
 memory_range.workspace = true
 inspect = { workspace = true, optional = true }
 mesh_protobuf = { workspace = true, optional = true }

--- a/vm/vmcore/vm_topology/src/cxl.rs
+++ b/vm/vmcore/vm_topology/src/cxl.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! CXL topology types.
+
+/// CFMWS window restrictions bitfield.
+///
+/// Re-exported from `cxl_spec` so existing `vm_topology::cxl` users remain
+/// source-compatible.
+pub use cxl_spec::CfmwsWindowRestrictions;

--- a/vm/vmcore/vm_topology/src/lib.rs
+++ b/vm/vmcore/vm_topology/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![forbid(unsafe_code)]
 
+pub mod cxl;
 pub mod layout;
 pub mod memory;
 pub mod pcie;

--- a/vm/vmcore/vm_topology/src/pcie.rs
+++ b/vm/vmcore/vm_topology/src/pcie.rs
@@ -3,7 +3,18 @@
 
 //! PCI Express topology types.
 
+use crate::cxl::CfmwsWindowRestrictions;
 use memory_range::MemoryRange;
+
+/// CXL-specific host bridge metadata.
+pub struct PcieHostBridgeCxlInfo {
+    /// Memory range reserved for the CHBCR aperture.
+    pub chbcr_range: MemoryRange,
+    /// Memory range reserved for the HDM decoder.
+    pub hdm_range: MemoryRange,
+    /// CFMWS HDM window restrictions.
+    pub hdm_window_restrictions: CfmwsWindowRestrictions,
+}
 
 /// A description of a PCI Express Root Complex, as visible to the CPU.
 pub struct PcieHostBridge {
@@ -21,4 +32,6 @@ pub struct PcieHostBridge {
     pub low_mmio: MemoryRange,
     /// Memory range used for high MMIO.
     pub high_mmio: MemoryRange,
+    /// CXL metadata when this host bridge supports CXL.
+    pub cxl: Option<PcieHostBridgeCxlInfo>,
 }

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -4,6 +4,7 @@
 //! Construct ACPI tables for a concrete VM topology
 
 // TODO: continue to remove these hardcoded deps
+use acpi::cedt::Cedt;
 use acpi::dsdt;
 use acpi::ssdt::Ssdt;
 use acpi_spec::madt::InterruptPolarity;
@@ -13,6 +14,7 @@ use chipset::ioapic;
 use chipset::psp;
 use inspect::Inspect;
 use std::collections::BTreeMap;
+use thiserror::Error;
 use vm_topology::memory::MemoryLayout;
 use vm_topology::pcie::PcieHostBridge;
 use vm_topology::processor::ArchTopology;
@@ -85,6 +87,81 @@ pub const OEM_INFO: acpi::builder::OemInfo = acpi::builder::OemInfo {
     creator_id: *b"MSHV",
     creator_revision: 0,
 };
+
+/// Errors that can occur while building PCIe SSDT/CEDT payloads.
+#[derive(Debug, Error)]
+pub enum PcieAcpiBuildError {
+    #[error("invalid CXL host-bridge CEDT entry for uid {uid}")]
+    CedtHostBridge {
+        uid: u32,
+        #[source]
+        source: acpi::cedt::CedtHostBridgeError,
+    },
+    #[error("failed to serialize CEDT ACPI table")]
+    CedtSerialize(#[source] acpi::cedt::CedtSerializeError),
+}
+
+/// Serialized PCIe-related ACPI tables.
+pub struct BuiltPcieAcpiTables {
+    /// SSDT bytes containing PCI host-bridge namespace objects.
+    pub ssdt: Vec<u8>,
+    /// Optional CEDT bytes when at least one valid CXL host bridge is present.
+    pub cedt: Option<Vec<u8>>,
+}
+
+/// Build PCIe SSDT/CEDT payloads from host-bridge topology.
+pub fn build_pcie_acpi_tables(
+    pcie_host_bridges: &[PcieHostBridge],
+) -> Result<BuiltPcieAcpiTables, PcieAcpiBuildError> {
+    let mut ssdt = Ssdt::new();
+    let mut cedt = Cedt::new();
+    let mut has_cedt_entries = false;
+
+    for bridge in pcie_host_bridges {
+        ssdt.add_pcie(
+            bridge.index,
+            bridge.segment,
+            bridge.start_bus,
+            bridge.end_bus,
+            bridge.ecam_range,
+            bridge.low_mmio,
+            bridge.high_mmio,
+            bridge.cxl.is_some(),
+        );
+
+        if let Some(cxl) = &bridge.cxl {
+            if let Err(source) = cedt.add_cxl_host_bridge(
+                bridge.index,
+                cxl.hdm_range,
+                cxl.chbcr_range,
+                cxl.hdm_window_restrictions.bits(),
+            ) {
+                return Err(PcieAcpiBuildError::CedtHostBridge {
+                    uid: bridge.index,
+                    source,
+                });
+            } else {
+                has_cedt_entries = true;
+            }
+        }
+    }
+
+    let cedt = if has_cedt_entries {
+        match cedt.to_bytes() {
+            Ok(table) => Some(table),
+            Err(source) => {
+                return Err(PcieAcpiBuildError::CedtSerialize(source));
+            }
+        }
+    } else {
+        None
+    };
+
+    Ok(BuiltPcieAcpiTables {
+        ssdt: ssdt.to_bytes(),
+        cedt,
+    })
+}
 
 pub trait AcpiTopology: ArchTopology + Inspect + Sized {
     fn extend_srat(topology: &ProcessorTopology<Self>, srat: &mut Vec<u8>);
@@ -751,19 +828,12 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
                 self.with_iort(|t| b.append(t));
             }
 
-            let mut ssdt = Ssdt::new();
-            for bridge in self.pcie_host_bridges {
-                ssdt.add_pcie(
-                    bridge.index,
-                    bridge.segment,
-                    bridge.start_bus,
-                    bridge.end_bus,
-                    bridge.ecam_range,
-                    bridge.low_mmio,
-                    bridge.high_mmio,
-                );
+            let pcie_tables = build_pcie_acpi_tables(self.pcie_host_bridges)
+                .expect("PCIe ACPI table build should not fail");
+            b.append_raw(&pcie_tables.ssdt);
+            if let Some(cedt) = pcie_tables.cedt {
+                b.append_raw(&cedt);
             }
-            b.append_raw(&ssdt.to_bytes());
         }
 
         if self.cache_topology.is_some() {
@@ -938,6 +1008,7 @@ mod test {
                 ecam_range: MemoryRange::new(0..256 * 256 * 4096),
                 low_mmio: MemoryRange::new(0..0),
                 high_mmio: MemoryRange::new(0..0),
+                cxl: None,
             },
             PcieHostBridge {
                 index: 1,
@@ -947,6 +1018,7 @@ mod test {
                 ecam_range: MemoryRange::new(5 * GB..5 * GB + 32 * 256 * 4096),
                 low_mmio: MemoryRange::new(0..0),
                 high_mmio: MemoryRange::new(0..0),
+                cxl: None,
             },
         ];
 
@@ -1041,6 +1113,7 @@ mod test {
                 ecam_range: MemoryRange::new(0..256 * 256 * 4096),
                 low_mmio: MemoryRange::new(0xdc000000..0xe0000000),
                 high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
+                cxl: None,
             },
             PcieHostBridge {
                 index: 7,
@@ -1050,6 +1123,7 @@ mod test {
                 ecam_range: MemoryRange::new(5 * GB..5 * GB + 32 * 256 * 4096),
                 low_mmio: MemoryRange::new(0xe0000000..0xe4000000),
                 high_mmio: MemoryRange::new(0x1040000000..0x1080000000),
+                cxl: None,
             },
         ];
         let builder = new_aarch64_builder(&mem, &topology, &pcie_host_bridges);
@@ -1108,6 +1182,7 @@ mod test {
             ecam_range: MemoryRange::new(0..256 * 256 * 4096),
             low_mmio: MemoryRange::new(0xdc000000..0xe0000000),
             high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
+            cxl: None,
         }];
         let builder = new_builder(&mem, &topology, &pcie_host_bridges);
         assert!(builder.build_iort().is_none());
@@ -1137,11 +1212,36 @@ mod test {
             ecam_range: MemoryRange::new(0..256 * 256 * 4096),
             low_mmio: MemoryRange::new(0xdc000000..0xe0000000),
             high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
+            cxl: None,
         }];
         let builder = new_aarch64_builder(&mem, &topology, &pcie_host_bridges);
 
         let tables = builder.build_acpi_tables(0x100000, |_, _| {});
         assert!(contains_signature(&tables.tables, b"MCFG"));
         assert!(contains_signature(&tables.tables, b"IORT"));
+    }
+
+    #[test]
+    fn test_acpi_tables_include_cedt_when_cxl_bridge_present() {
+        let mem = new_mem();
+        let topology = TopologyBuilder::new_x86().build(1).unwrap();
+        let pcie_host_bridges = vec![PcieHostBridge {
+            index: 0,
+            segment: 0,
+            start_bus: 0,
+            end_bus: 255,
+            ecam_range: MemoryRange::new(0..256 * 256 * 4096),
+            low_mmio: MemoryRange::new(0xdc000000..0xe0000000),
+            high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
+            cxl: Some(vm_topology::pcie::PcieHostBridgeCxlInfo {
+                chbcr_range: MemoryRange::new(0x1040000000..0x1040010000),
+                hdm_range: MemoryRange::new(0x1000000000..0x1040000000),
+                hdm_window_restrictions: Default::default(),
+            }),
+        }];
+        let builder = new_builder(&mem, &topology, &pcie_host_bridges);
+
+        let tables = builder.build_acpi_tables(0x100000, |_, _| {});
+        assert!(contains_signature(&tables.tables, b"CEDT"));
     }
 }


### PR DESCRIPTION
This change emulates CXL for the root bus and root port. Also add a test CXL device.

```
        Capabilities: [10c v1] Designated Vendor-Specific: Vendor=1e98 ID=0003 Rev=0 Len=40: CXL
                CXLPortSta:     PMComplete-
                CXLPortCtl:     UnmaskSBR- UnmaskLinkDisable- AltMem- AltBME- ViralEnable-
                AlternateBus:   00-00
                AlternateBus:   0000-0000
        Capabilities: [134 v1] Designated Vendor-Specific: Vendor=1e98 ID=0007 Rev=3 Len=32: CXL
                FBCap:  Cache+ IO+ Mem+ 68BFlit- MltLogDev- 256BFlit- PBRFlit-
                FBCtl:  Cache- IO+ Mem- SynHdrByp- DrftBuf- 68BFlit- MltLogDev- RCD- Retimer1- Retimer2- 256BFlit- PBRFlit-
                FBSta:  Cache- IO- Mem- SynHdrByp- DrftBuf- 68BFlit- MltLogDev- 256BFlit- PBRFlit-
                FBModTS:        Received FB Data: 000000
                FBCap2: NOPHint-
                FBCtl2: NOPHint-
                FBSta2: NOPHintInfo: 0
        Capabilities: [154 v1] Designated Vendor-Specific: Vendor=1e98 ID=0008 Rev=0 Len=20: CXL
                Block1: BIR: bar0, ID: component registers, offset: 0000000000000000
```

Linux is able to fully recognize our devices:
```
root@ubuntu:~# dmesg -T | grep -Ei "cxl|acpi0016|cedt|chbs|cfmws"
[Mon May 18 06:50:17 2026] ACPI: CEDT 0x000000003FFD4000 00006C (v02 MSFTVM CEDT01   00000001 MSFT 01000000)
[Mon May 18 06:50:17 2026] ACPI: Reserving CEDT table memory at [mem 0x3ffd4000-0x3ffd406b]
[Mon May 18 06:50:19 2026] acpi ACPI0016:00: _OSC: OS supports [ExtendedConfig ASPM ClockPM Segments MSI EDR HPX-Type3]
[Mon May 18 06:50:19 2026] acpi ACPI0016:00: _OSC: OS supports [CXL11PortRegAccess CXL20PortDevRegAccess CXLProtocolErrorReporting CXLNativeHot]
[Mon May 18 06:50:19 2026] acpi ACPI0016:00: _OSC: OS now controls [PCIeHotplug SHPCHotplug PME AER PCIeCapability LTR DPC]
[Mon May 18 06:50:19 2026] acpi ACPI0016:00: _OSC: OS now controls [CXLMemErrorReporting]
[Mon May 18 06:50:30 2026] cxl_pci 0000:01:00.0: enabling device (0000 -> 0002)
```