### PR TITLE
ci: revert to older windows runner image

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1386,7 +1386,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3480,7 +3480,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3748,7 +3748,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3930,7 +3930,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4472,7 +4472,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6517,7 +6517,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6732,7 +6732,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7034,7 +7034,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7253,7 +7253,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -1263,7 +1263,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3249,7 +3249,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3518,7 +3518,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3702,7 +3702,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4246,7 +4246,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6070,7 +6070,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6287,7 +6287,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6591,7 +6591,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6812,7 +6812,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1654,7 +1654,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3248,7 +3248,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3824,7 +3824,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4093,7 +4093,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4637,7 +4637,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6528,7 +6528,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6745,7 +6745,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7049,7 +7049,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7270,7 +7270,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -819,7 +819,7 @@ jobs:
   displayName: clippy [x64-windows], unit tests [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals HvLite-CI-Win-Ge-Image-256GB
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -2455,7 +2455,7 @@ jobs:
   displayName: build artifacts (for VMM tests) [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals HvLite-CI-Win-Ge-Image-256GB
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -2734,7 +2734,7 @@ jobs:
   displayName: build artifacts (not for VMM tests) [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals HvLite-CI-Win-Ge-Image-256GB
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -2935,7 +2935,7 @@ jobs:
   displayName: build artifacts (for VMM tests) [aarch64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals HvLite-CI-Win-Ge-Image-256GB
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -3209,7 +3209,7 @@ jobs:
   displayName: build artifacts (not for VMM tests) [aarch64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals HvLite-CI-Win-Ge-Image-256GB
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -3697,7 +3697,7 @@ jobs:
   displayName: build artifacts (shared VMM tests) [windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals HvLite-CI-Win-Ge-Image-256GB
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -4099,7 +4099,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-amd]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals HvLite-CI-Win-Ge-Image-256GB
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -4372,7 +4372,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-intel-mi-secure]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals HvLite-CI-Win-Ge-Image-256GB
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -4645,7 +4645,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-intel]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals HvLite-CI-Win-Ge-Image-256GB
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -4918,7 +4918,7 @@ jobs:
   displayName: xtask fmt (windows)
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals HvLite-CI-Win-Ge-Image-256GB
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1470,7 +1470,8 @@ impl IntoPipeline for CheckinGatesCli {
                 label: "x64-windows-amd",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_amd_x86,
-                nextest_filter_expr: standard_filter.clone(),
+                // TODO: remove servicing exclusion once we return to using updated runners
+                nextest_filter_expr: format!("{standard_filter} & !test(servicing)"),
                 test_artifacts: standard_x64_test_artifacts.clone(),
                 needs_prep_run: false,
                 hugetlb_2mb_overcommit_pages: None,

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -9,7 +9,8 @@ pub const AMD_POOL_1ES: &str = "openvmm-gh-amd-westus3";
 pub const INTEL_POOL_1ES: &str = "openvmm-gh-intel-westus3";
 pub const ARM_POOL_1ES: &str = "openvmm-gh-arm-westus2";
 
-pub const WINDOWS_IMAGE_AMD64: &str = "win-amd64";
+// temporarily revert to the older image to mitigate powershell issues.
+pub const WINDOWS_IMAGE_AMD64: &str = "HvLite-CI-Win-Ge-Image-256GB";
 pub const WINDOWS_IMAGE_ARM64: &str = "win-arm64";
 pub const LINUX_IMAGE_AMD64: &str = "ubuntu2404-amd64";
 pub const LINUX_IMAGE_ARM64: &str = "ubuntu2404-arm64";

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -10,6 +10,7 @@ pub const INTEL_POOL_1ES: &str = "openvmm-gh-intel-westus3";
 pub const ARM_POOL_1ES: &str = "openvmm-gh-arm-westus2";
 
 // temporarily revert to the older image to mitigate powershell issues.
+// TODO: return to using updated runner image
 pub const WINDOWS_IMAGE_AMD64: &str = "HvLite-CI-Win-Ge-Image-256GB";
 pub const WINDOWS_IMAGE_ARM64: &str = "win-arm64";
 pub const LINUX_IMAGE_AMD64: &str = "ubuntu2404-amd64";

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -58,8 +58,6 @@ pub enum HyperVGuestStateIsolationType {
     Tdx = 3,
     /// OpenHCL but no isolation
     OpenHCL = 16,
-    /// No HCL and no isolation
-    Disabled = -1,
 }
 
 impl TryFrom<i32> for HyperVGuestStateIsolationType {
@@ -67,7 +65,6 @@ impl TryFrom<i32> for HyperVGuestStateIsolationType {
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
-            -1 => Ok(HyperVGuestStateIsolationType::Disabled),
             0 => Ok(HyperVGuestStateIsolationType::TrustedLaunch),
             1 => Ok(HyperVGuestStateIsolationType::Vbs),
             2 => Ok(HyperVGuestStateIsolationType::Snp),
@@ -81,7 +78,6 @@ impl TryFrom<i32> for HyperVGuestStateIsolationType {
 impl ps::AsVal for HyperVGuestStateIsolationType {
     fn as_val(&self) -> impl '_ + AsRef<OsStr> {
         match self {
-            HyperVGuestStateIsolationType::Disabled => "-1",
             HyperVGuestStateIsolationType::TrustedLaunch => "0",
             HyperVGuestStateIsolationType::Vbs => "1",
             HyperVGuestStateIsolationType::Snp => "2",
@@ -99,8 +95,7 @@ impl HyperVGuestStateIsolationType {
             | HyperVGuestStateIsolationType::Snp
             | HyperVGuestStateIsolationType::Tdx => true,
             HyperVGuestStateIsolationType::TrustedLaunch
-            | HyperVGuestStateIsolationType::OpenHCL
-            | HyperVGuestStateIsolationType::Disabled => false,
+            | HyperVGuestStateIsolationType::OpenHCL => false,
         }
     }
 }
@@ -479,6 +474,13 @@ impl HyperVNewCustomVMArgs {
                 Some(IsolationType::Vbs) => Some(HyperVGuestStateIsolationType::Vbs),
                 Some(IsolationType::Snp) => Some(HyperVGuestStateIsolationType::Snp),
                 Some(IsolationType::Tdx) => Some(HyperVGuestStateIsolationType::Tdx),
+                // Workaround for running (UEFI only) OpenHCL tests on hosts
+                // that do not support OpenHCL isolation type
+                // TODO: query host for supported isolation types and only do
+                // this when necessary in `make_compatible`
+                None if properties.is_openhcl && !properties.is_pcat => {
+                    Some(HyperVGuestStateIsolationType::TrustedLaunch)
+                }
                 None if properties.is_openhcl => Some(HyperVGuestStateIsolationType::OpenHCL),
                 None => None,
             },
@@ -587,10 +589,7 @@ impl HyperVNewCustomVMArgs {
 pub async fn run_new_customvm(ps_mod: &Path, args: HyperVNewCustomVMArgs) -> anyhow::Result<Guid> {
     let (guest_state_isolation_enabled, guest_state_isolation_type) = args
         .guest_state_isolation_type
-        .and_then(|isolation_type| match isolation_type {
-            HyperVGuestStateIsolationType::Disabled => None,
-            isolation_type => Some((true, isolation_type)),
-        })
+        .map(|isolation_type| (true, isolation_type))
         .unzip();
 
     let secure_boot_template_id = args.secure_boot_template.map(|t| match t {


### PR DESCRIPTION
In an attempt to mitigate the powershell access violation errors, revert to the old CI image.