### PR TITLE
crypto: Beginnings of pkcs7 symcrypt support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,6 +804,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
+name = "cms"
+version = "0.3.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986e7713348fbe5322df18082d73a0ad53a2946dbb7a02452cf3622b83b91e7c"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1052,7 @@ name = "crypto"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "cms",
  "der",
  "getrandom 0.4.2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -512,6 +512,7 @@ flate2 = "1.1"
 
 # --- Cryptography & secure computing ---
 constant_time_eq = "0.5"
+cms = { version = "0.3.0-pre.2", default-features = false }
 der = "0.8"
 getrandom = "0.4"
 ms-tpm-20-ref = { version = "0.1", git = "https://github.com/microsoft/ms-tpm-20-ref-rs.git", branch = "main" }

--- a/support/crypto/Cargo.toml
+++ b/support/crypto/Cargo.toml
@@ -22,6 +22,7 @@ symcrypt = [
     "dep:symcrypt",
     "symcrypt/sha1",
     # The Symcrypt backend uses RustCrypto crates for de/serialization only.
+    "dep:cms",
     "dep:der",
     "dep:pkcs1",
     "dep:pkcs8",
@@ -33,6 +34,7 @@ symcrypt = [
 # Note that some of these crates have known security issues.
 # This backend should not be used in production scenarios.
 rust = [
+    "dep:cms",
     "dep:der",
     "dep:getrandom",
     "dep:pkcs1",
@@ -49,6 +51,7 @@ openssl = { workspace = true, optional = true }
 
 symcrypt = { workspace = true, optional = true }
 
+cms = { workspace = true, optional = true }
 der = { workspace = true, optional = true }
 getrandom = { workspace = true, optional = true, features = ["sys_rng"] }
 pkcs1 = { workspace = true, optional = true }

--- a/support/crypto/src/pkcs7/mod.rs
+++ b/support/crypto/src/pkcs7/mod.rs
@@ -3,7 +3,13 @@
 
 //! PKCS#7 signed data verification.
 
-#![cfg(any(openssl, all(native, windows), all(native, target_os = "macos")))]
+#![cfg(any(
+    openssl,
+    all(native, windows),
+    all(native, target_os = "macos"),
+    rust,
+    symcrypt
+))]
 
 #[cfg(openssl)]
 mod ossl;
@@ -20,6 +26,11 @@ mod mac;
 #[cfg(all(native, target_os = "macos"))]
 use mac as sys;
 
+#[cfg(any(rust, symcrypt))]
+mod symcrypt_rust;
+#[cfg(any(rust, symcrypt))]
+use symcrypt_rust as sys;
+
 use thiserror::Error;
 
 /// A parsed PKCS#7 signedData object.
@@ -29,9 +40,16 @@ pub struct Pkcs7SignedData(sys::Pkcs7SignedDataInner);
 pub struct Pkcs7CertStore(sys::Pkcs7CertStoreInner);
 
 /// An error for PKCS#7 operations.
+#[cfg(not(rust))]
 #[derive(Clone, Debug, Error)]
 #[error("PKCS#7 error")]
 pub struct Pkcs7Error(#[source] super::BackendError);
+
+/// An error for PKCS#7 operations.
+#[cfg(rust)]
+#[derive(Clone, Debug, Error)]
+#[error("PKCS#7 error during {1}")]
+pub struct Pkcs7Error(#[source] der::Error, &'static str);
 
 impl Pkcs7CertStore {
     /// Creates a new empty certificate store.
@@ -39,9 +57,31 @@ impl Pkcs7CertStore {
         sys::Pkcs7CertStoreInner::new().map(Self)
     }
 
+    /// Adds an X509 certificate to the store.
+    #[cfg(any(openssl, rust, symcrypt))]
+    pub fn add_cert(&mut self, cert: &super::x509::X509Certificate) -> Result<(), Pkcs7Error> {
+        self.0.add_cert(cert)
+    }
+
     /// Adds a DER-encoded X509 certificate to the store.
+    // TODO: Remove this method and make every backend support add_cert.
     pub fn add_cert_der(&mut self, data: &[u8]) -> Result<(), Pkcs7Error> {
-        self.0.add_cert_der(data)
+        #[cfg(any(openssl, symcrypt))]
+        {
+            self.0.add_cert(
+                &crate::x509::X509Certificate::from_der(data).map_err(|e| Pkcs7Error(e.0))?,
+            )
+        }
+        #[cfg(rust)]
+        {
+            self.0.add_cert(
+                &crate::x509::X509Certificate::from_der(data).map_err(|e| Pkcs7Error(e.0, e.1))?,
+            )
+        }
+        #[cfg(not(any(openssl, rust, symcrypt)))]
+        {
+            self.0.add_cert_der(data)
+        }
     }
 }
 
@@ -52,19 +92,19 @@ impl Pkcs7SignedData {
     }
 
     /// Encode this PKCS#7 object as DER bytes.
-    #[cfg(openssl)]
+    #[cfg(any(openssl, rust, symcrypt))]
     pub fn to_der(&self) -> Result<Vec<u8>, Pkcs7Error> {
         self.0.to_der()
     }
 
-    /// Creates a PKCS#7 signed-data object by signing `data` with the given
-    /// certificate and key pair.
-    #[cfg(openssl)]
+    /// Creates a detached PKCS#7 signed-data object by signing `data` with the
+    /// given certificate and key pair.
+    #[cfg(any(openssl, rust, symcrypt))]
     pub fn sign(
         cert: &super::x509::X509Certificate,
         key_pair: &super::rsa::RsaKeyPair,
         data: &[u8],
-    ) -> Result<Self, Pkcs7Error> {
+    ) -> Result<Self, crate::rsa::RsaError> {
         sys::Pkcs7SignedDataInner::sign(cert, key_pair, data).map(Self)
     }
 
@@ -98,6 +138,7 @@ impl Pkcs7SignedData {
     /// 3. **Any key-usage / extended-key-usage is accepted.** UEFI signature
     ///    list certs are not marked with the usages that a general-purpose
     ///    PKI verifier expects for the default purpose.
+    #[cfg(not(any(rust, symcrypt)))]
     pub fn verify(
         self,
         store: Pkcs7CertStore,
@@ -115,5 +156,164 @@ impl Pkcs7SignedData {
         // may be other subtle differences as well.
         assert!(uefi_mode, "only uefi_mode is currently supported");
         self.0.verify(store.0, signed_content, uefi_mode)
+    }
+}
+
+#[cfg(all(test, openssl))]
+mod tests {
+    use super::*;
+
+    /// The detached content used by the cross-backend verification tests.
+    const SIGNED_CONTENT: &[u8] = b"openvmm pkcs7 cross-backend test data";
+
+    /// Build a self-signed cert + detached PKCS#7 signature over
+    /// `SIGNED_CONTENT`. Used to generate fresh fixtures inside each test
+    /// rather than reading them from disk.
+    fn make_fixture() -> (crate::x509::X509Certificate, Pkcs7SignedData) {
+        let key = crate::rsa::RsaKeyPair::generate(2048).unwrap();
+        let cert = crate::x509::X509Certificate::build_self_signed(
+            &key,
+            "US",
+            "WA",
+            "Redmond",
+            "OpenVMM Test",
+            "pkcs7.test.openvmm",
+        )
+        .unwrap();
+        let p7 = Pkcs7SignedData::sign(&cert, &key, SIGNED_CONTENT).unwrap();
+        (cert, p7)
+    }
+
+    /// Garbage input must not panic and must surface as an `Err`. This
+    /// guards against unchecked DER parsing across backends.
+    #[test]
+    fn from_der_rejects_garbage() {
+        assert!(Pkcs7SignedData::from_der(&[]).is_err());
+        assert!(Pkcs7SignedData::from_der(&[0xff, 0x00, 0x01, 0x02]).is_err());
+    }
+
+    /// A PKCS#7 detached signature must verify against the issuing cert
+    /// in a UEFI-mode store across all supported backends. This is the
+    /// main cross-backend coverage for the verify path.
+    #[test]
+    fn verify_with_trusted_cert_succeeds() {
+        let (cert, p7) = make_fixture();
+        let mut store = Pkcs7CertStore::new().unwrap();
+        store.add_cert(&cert).unwrap();
+        assert!(p7.verify(store, SIGNED_CONTENT, true).unwrap());
+    }
+
+    /// Helper: verification failures may surface as either `Ok(false)`
+    /// or `Err(_)` depending on the backend, per the documented
+    /// contract on `Pkcs7SignedData::verify`. Both are acceptable; the
+    /// only forbidden outcome is `Ok(true)`.
+    fn assert_verify_rejected(result: Result<bool, Pkcs7Error>) {
+        match result {
+            Ok(false) | Err(_) => {}
+            Ok(true) => panic!("verify unexpectedly succeeded"),
+        }
+    }
+
+    /// Verifying with content that does not match the signed digest
+    /// must not succeed. This is the contract that
+    /// `authenticate_variable` in the UEFI nvram service relies on.
+    #[test]
+    fn verify_rejects_tampered_content() {
+        let (cert, p7) = make_fixture();
+        let mut store = Pkcs7CertStore::new().unwrap();
+        store.add_cert(&cert).unwrap();
+        let mut tampered = SIGNED_CONTENT.to_vec();
+        tampered[0] ^= 0xff;
+        assert_verify_rejected(p7.verify(store, &tampered, true));
+    }
+
+    /// A truncated detached content must not verify.
+    #[test]
+    fn verify_rejects_truncated_content() {
+        let (cert, p7) = make_fixture();
+        let mut store = Pkcs7CertStore::new().unwrap();
+        store.add_cert(&cert).unwrap();
+        let truncated = &SIGNED_CONTENT[..SIGNED_CONTENT.len() - 1];
+        assert_verify_rejected(p7.verify(store, truncated, true));
+    }
+
+    /// An empty trust store must cause verification to fail (no trust
+    /// anchor available).
+    #[test]
+    fn verify_with_empty_store_fails() {
+        let (_cert, p7) = make_fixture();
+        let store = Pkcs7CertStore::new().unwrap();
+        assert_verify_rejected(p7.verify(store, SIGNED_CONTENT, true));
+    }
+
+    /// A store populated only with an unrelated cert must cause
+    /// verification to fail.
+    #[test]
+    fn verify_with_unrelated_cert_fails() {
+        let (_cert, p7) = make_fixture();
+        let key = crate::rsa::RsaKeyPair::generate(2048).unwrap();
+        let other = crate::x509::X509Certificate::build_self_signed(
+            &key,
+            "US",
+            "WA",
+            "Redmond",
+            "Other",
+            "other.test.openvmm",
+        )
+        .unwrap();
+        let mut store = Pkcs7CertStore::new().unwrap();
+        store.add_cert(&other).unwrap();
+        assert_verify_rejected(p7.verify(store, SIGNED_CONTENT, true));
+    }
+
+    /// Full sign + verify roundtrip using freshly generated keys.
+    #[test]
+    fn sign_verify_roundtrip() {
+        let key = crate::rsa::RsaKeyPair::generate(2048).unwrap();
+        let cert = crate::x509::X509Certificate::build_self_signed(
+            &key,
+            "US",
+            "WA",
+            "Redmond",
+            "Roundtrip",
+            "roundtrip.test.openvmm",
+        )
+        .unwrap();
+        let content = b"hello pkcs7 roundtrip";
+        let p7 = Pkcs7SignedData::sign(&cert, &key, content).unwrap();
+        let mut store = Pkcs7CertStore::new().unwrap();
+        store.add_cert(&cert).unwrap();
+        assert!(p7.verify(store, content, true).unwrap());
+    }
+
+    /// Cross-check: a freshly produced signature must fail verification
+    /// against a different cert's store.
+    #[test]
+    fn sign_verify_rejects_wrong_store() {
+        let signer_key = crate::rsa::RsaKeyPair::generate(2048).unwrap();
+        let signer_cert = crate::x509::X509Certificate::build_self_signed(
+            &signer_key,
+            "US",
+            "WA",
+            "Redmond",
+            "Signer",
+            "signer.test.openvmm",
+        )
+        .unwrap();
+        let other_key = crate::rsa::RsaKeyPair::generate(2048).unwrap();
+        let other_cert = crate::x509::X509Certificate::build_self_signed(
+            &other_key,
+            "US",
+            "WA",
+            "Redmond",
+            "Other",
+            "other.test.openvmm",
+        )
+        .unwrap();
+        let content = b"wrong-store content";
+        let p7 = Pkcs7SignedData::sign(&signer_cert, &signer_key, content).unwrap();
+        let mut store = Pkcs7CertStore::new().unwrap();
+        store.add_cert(&other_cert).unwrap();
+        assert_verify_rejected(p7.verify(store, content, true));
     }
 }

--- a/support/crypto/src/pkcs7/ossl.rs
+++ b/support/crypto/src/pkcs7/ossl.rs
@@ -58,7 +58,7 @@ impl Pkcs7SignedDataInner {
             // - DETACHED: do not embed the content; the verifier supplies it.
             // - BINARY: do not perform text/CRLF canonicalization.
             // - NOATTR: omit signedAttrs; the signature covers the raw
-            //   encapsulated content directly per RFC 5652 §5.4.``
+            //   encapsulated content directly per RFC 5652 §5.4.
             openssl::pkcs7::Pkcs7Flags::DETACHED
                 | openssl::pkcs7::Pkcs7Flags::BINARY
                 | openssl::pkcs7::Pkcs7Flags::NOATTR,

--- a/support/crypto/src/pkcs7/ossl.rs
+++ b/support/crypto/src/pkcs7/ossl.rs
@@ -20,11 +20,9 @@ impl Pkcs7CertStoreInner {
         Ok(Self(builder))
     }
 
-    pub fn add_cert_der(&mut self, data: &[u8]) -> Result<(), Pkcs7Error> {
-        let cert = openssl::x509::X509::from_der(data)
-            .map_err(|e| err(e, "decoding x509 certificate from DER"))?;
+    pub fn add_cert(&mut self, cert: &crate::x509::X509Certificate) -> Result<(), Pkcs7Error> {
         self.0
-            .add_cert(cert)
+            .add_cert(cert.0.0.clone())
             .map_err(|e| err(e, "adding certificate to store"))
     }
 }
@@ -46,17 +44,26 @@ impl Pkcs7SignedDataInner {
         cert: &crate::x509::X509Certificate,
         key_pair: &crate::rsa::RsaKeyPair,
         data: &[u8],
-    ) -> Result<Self, Pkcs7Error> {
-        let certs =
-            openssl::stack::Stack::new().map_err(|e| err(e, "creating empty certificate stack"))?;
+    ) -> Result<Self, crate::rsa::RsaError> {
+        fn rsa_err(err: openssl::error::ErrorStack, op: &'static str) -> crate::rsa::RsaError {
+            crate::rsa::RsaError(crate::BackendError(err, op))
+        }
+        let certs = openssl::stack::Stack::new()
+            .map_err(|e| rsa_err(e, "creating empty certificate stack"))?;
         let pkcs7 = openssl::pkcs7::Pkcs7::sign(
             &cert.0.0,
             &key_pair.0.0,
             &certs,
             data,
-            openssl::pkcs7::Pkcs7Flags::empty(),
+            // - DETACHED: do not embed the content; the verifier supplies it.
+            // - BINARY: do not perform text/CRLF canonicalization.
+            // - NOATTR: omit signedAttrs; the signature covers the raw
+            //   encapsulated content directly per RFC 5652 §5.4.``
+            openssl::pkcs7::Pkcs7Flags::DETACHED
+                | openssl::pkcs7::Pkcs7Flags::BINARY
+                | openssl::pkcs7::Pkcs7Flags::NOATTR,
         )
-        .map_err(|e| err(e, "pkcs7 signing"))?;
+        .map_err(|e| rsa_err(e, "pkcs7 signing"))?;
         Ok(Self(pkcs7))
     }
 

--- a/support/crypto/src/pkcs7/symcrypt_rust.rs
+++ b/support/crypto/src/pkcs7/symcrypt_rust.rs
@@ -59,6 +59,15 @@ impl Pkcs7CertStoreInner {
 impl Pkcs7SignedDataInner {
     pub fn from_der(data: &[u8]) -> Result<Self, Pkcs7Error> {
         let ci = ContentInfo::from_der(data).map_err(|e| err(e, "parsing PKCS#7 ContentInfo"))?;
+        if ci.content_type != ID_SIGNED_DATA {
+            return Err(err(
+                der::ErrorKind::OidUnknown {
+                    oid: ci.content_type,
+                }
+                .to_error(),
+                "unrecognized content type OID",
+            ));
+        }
         let signed_data = ci
             .content
             .decode_as::<SignedData>()

--- a/support/crypto/src/pkcs7/symcrypt_rust.rs
+++ b/support/crypto/src/pkcs7/symcrypt_rust.rs
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Pure-Rust PKCS#7 (CMS SignedData) verification backend.
+//!
+//! Shared by the `rust` and `symcrypt` features. Uses the RustCrypto
+//! `cms`/`x509-cert`/`der` stack for parsing and structural traversal,
+//! delegates RSA signature verification to this crate's `rsa` module
+//! (which uses `symcrypt` or `rsa` depending on the active feature).
+
+use super::*;
+use cms::cert::CertificateChoices;
+use cms::cert::IssuerAndSerialNumber;
+use cms::content_info::CmsVersion;
+use cms::content_info::ContentInfo;
+use cms::signed_data::CertificateSet;
+use cms::signed_data::EncapsulatedContentInfo;
+use cms::signed_data::SignedData;
+use cms::signed_data::SignerIdentifier;
+use cms::signed_data::SignerInfo;
+use cms::signed_data::SignerInfos;
+use der::AnyRef;
+use der::Decode;
+use der::Encode;
+use der::asn1::OctetString;
+use der::asn1::SetOfVec;
+use der::oid::db::rfc5911::ID_DATA;
+use der::oid::db::rfc5911::ID_SIGNED_DATA;
+use der::oid::db::rfc5912::ID_SHA_256;
+use der::oid::db::rfc5912::SHA_256_WITH_RSA_ENCRYPTION;
+use x509_cert::Certificate;
+use x509_cert::spki::AlgorithmIdentifierOwned;
+
+#[cfg(symcrypt)]
+fn err(err: der::Error, op: &'static str) -> Pkcs7Error {
+    Pkcs7Error(crate::BackendError::Der(err, op))
+}
+
+#[cfg(rust)]
+fn err(err: der::Error, op: &'static str) -> Pkcs7Error {
+    Pkcs7Error(err, op)
+}
+
+pub struct Pkcs7SignedDataInner(SignedData);
+
+pub struct Pkcs7CertStoreInner(Vec<Certificate>);
+
+impl Pkcs7CertStoreInner {
+    pub fn new() -> Result<Self, Pkcs7Error> {
+        Ok(Self(Vec::new()))
+    }
+
+    pub fn add_cert(&mut self, cert: &crate::x509::X509Certificate) -> Result<(), Pkcs7Error> {
+        self.0.push(cert.0.0.clone());
+        Ok(())
+    }
+}
+
+impl Pkcs7SignedDataInner {
+    pub fn from_der(data: &[u8]) -> Result<Self, Pkcs7Error> {
+        let ci = ContentInfo::from_der(data).map_err(|e| err(e, "parsing PKCS#7 ContentInfo"))?;
+        let signed_data = ci
+            .content
+            .decode_as::<SignedData>()
+            .map_err(|e| err(e, "decoding PKCS#7 SignedData"))?;
+        Ok(Self(signed_data))
+    }
+
+    pub fn to_der(&self) -> Result<Vec<u8>, Pkcs7Error> {
+        let sd_der = self
+            .0
+            .to_der()
+            .map_err(|e| err(e, "encoding PKCS#7 SignedData"))?;
+        let content = AnyRef::try_from(sd_der.as_slice())
+            .map_err(|e| err(e, "wrapping SignedData in Any"))?;
+        let ci = ContentInfo {
+            content_type: ID_SIGNED_DATA,
+            content: content.into(),
+        };
+        ci.to_der()
+            .map_err(|e| err(e, "encoding PKCS#7 ContentInfo"))
+    }
+
+    pub fn sign(
+        cert: &crate::x509::X509Certificate,
+        key_pair: &crate::rsa::RsaKeyPair,
+        data: &[u8],
+    ) -> Result<Self, crate::rsa::RsaError> {
+        // Produce a detached PKCS#1 v1.5 SHA-256 signature over `data`. We
+        // omit signed attributes, so the signature covers the content
+        // directly per RFC 5652 §5.4.
+        let signature = key_pair.pkcs1_sign(data, crate::rsa::HashAlgorithm::Sha256)?;
+
+        let digest_alg = AlgorithmIdentifierOwned {
+            oid: ID_SHA_256,
+            parameters: None,
+        };
+        let signature_algorithm = AlgorithmIdentifierOwned {
+            oid: SHA_256_WITH_RSA_ENCRYPTION,
+            parameters: None,
+        };
+
+        let sid = SignerIdentifier::IssuerAndSerialNumber(IssuerAndSerialNumber {
+            issuer: cert.0.0.tbs_certificate().issuer().clone(),
+            serial_number: cert.0.0.tbs_certificate().serial_number().clone(),
+        });
+
+        let signer = SignerInfo {
+            version: CmsVersion::V1,
+            sid,
+            digest_alg: digest_alg.clone(),
+            signed_attrs: None,
+            signature_algorithm,
+            signature: OctetString::new(signature).unwrap(),
+            unsigned_attrs: None,
+        };
+
+        let mut digest_algorithms = SetOfVec::new();
+        digest_algorithms.insert(digest_alg).unwrap();
+
+        let mut certs = SetOfVec::new();
+        certs
+            .insert(CertificateChoices::Certificate(cert.0.0.clone()))
+            .unwrap();
+
+        let mut signer_infos = SetOfVec::new();
+        signer_infos.insert(signer).unwrap();
+
+        let signed_data = SignedData {
+            version: CmsVersion::V1,
+            digest_algorithms,
+            encap_content_info: EncapsulatedContentInfo {
+                econtent_type: ID_DATA,
+                econtent: None,
+            },
+            certificates: Some(CertificateSet(certs)),
+            crls: None,
+            signer_infos: SignerInfos(signer_infos),
+        };
+
+        Ok(Self(signed_data))
+    }
+}

--- a/support/crypto/src/x509/mod.rs
+++ b/support/crypto/src/x509/mod.rs
@@ -21,13 +21,13 @@ use thiserror::Error;
 #[cfg(not(rust))]
 #[derive(Debug, Error)]
 #[error("X.509 error")]
-pub struct X509Error(#[source] super::BackendError);
+pub struct X509Error(#[source] pub(crate) super::BackendError);
 
 /// An error for X.509 operations.
 #[cfg(rust)]
 #[derive(Debug, Error)]
 #[error("X.509 error during {1}")]
-pub struct X509Error(#[source] der::Error, &'static str);
+pub struct X509Error(#[source] pub(crate) der::Error, pub(crate) &'static str);
 
 /// An X.509 certificate.
 pub struct X509Certificate(pub(crate) sys::X509CertificateInner);

--- a/support/crypto/src/x509/symcrypt_rust.rs
+++ b/support/crypto/src/x509/symcrypt_rust.rs
@@ -6,8 +6,6 @@
 use super::X509Error;
 use der::Decode;
 use der::Encode;
-#[cfg(symcrypt)]
-use rsa::sha2;
 use x509_cert::Certificate;
 
 #[cfg(symcrypt)]
@@ -35,7 +33,7 @@ fn rsa_der_err(err: der::Error, op: &'static str) -> crate::rsa::RsaError {
     crate::rsa::RsaError(rsa::Error::Pkcs1(pkcs1::Error::Asn1(err)), op)
 }
 
-pub struct X509CertificateInner(Certificate);
+pub struct X509CertificateInner(pub(crate) Certificate);
 
 impl X509CertificateInner {
     pub fn from_der(data: &[u8]) -> Result<Self, X509Error> {
@@ -74,11 +72,10 @@ impl X509CertificateInner {
         &self,
         issuer_public_key: &crate::rsa::RsaPublicKey,
     ) -> Result<bool, crate::rsa::RsaError> {
-        use rsa::pkcs1v15::RsaSignatureAssociatedOid;
-
         let oid = self.0.signature_algorithm().oid;
         let hash = match oid {
-            sha2::Sha256::OID => crate::rsa::HashAlgorithm::Sha256,
+            der::oid::db::rfc5912::SHA_256_WITH_RSA_ENCRYPTION => crate::rsa::HashAlgorithm::Sha256,
+            der::oid::db::rfc5912::SHA_1_WITH_RSA_ENCRYPTION => crate::rsa::HashAlgorithm::Sha1,
             _ => {
                 return Err(rsa_der_err(
                     der::ErrorKind::OidUnknown { oid }.to_error(),
@@ -179,6 +176,8 @@ impl X509CertificateInner {
         common_name: &str,
     ) -> anyhow::Result<Self> {
         use core::str::FromStr;
+        #[cfg(symcrypt)]
+        use rsa::sha2;
         use x509_cert::builder::Builder;
         use x509_cert::name::Name;
 


### PR DESCRIPTION
Pkcs7 is by far the most complicated bit of crypto that we have to support. OpenSSL provides a lot of nice simple helper functions for us, but the RustCrypto crates don't yet (https://github.com/RustCrypto/formats/issues/1204). This PR gets things started, and includes the simpler, defensible bits, while punting on verification for the moment. This is intended to be a WIP state, not the eventual final product.