### PR TITLE
petri: use pwsh

### DIFF
--- a/petri/src/vm/hyperv/hyperv.psm1
+++ b/petri/src/vm/hyperv/hyperv.psm1
@@ -537,7 +537,15 @@ function Convert-ImcData
         [string] $ImcHive
     )
 
-    $imcHiveData = Get-Content -Encoding Byte $ImcHive
+    if ($PSVersionTable.PSVersion.Major -gt 5)
+    {
+        $imcHiveData = Get-Content -AsByteStream -Raw $ImcHive
+    }
+    else
+    {
+        $imcHiveData = Get-Content -Encoding Byte $ImcHive
+    }
+
     $length = [System.BitConverter]::GetBytes([int32]$imcHiveData.Length + 4)
     if ([System.BitConverter]::IsLittleEndian)
     {

--- a/support/powershell_builder/src/lib.rs
+++ b/support/powershell_builder/src/lib.rs
@@ -21,8 +21,10 @@ pub struct PowerShellBuilder(Command);
 impl PowerShellBuilder {
     /// Create a new PowerShell command
     pub fn new() -> Self {
-        PowerShellCmdletBuilder(Command::new("powershell.exe"))
+        // TODO: fall back to powershell.exe if pwsh.exe does not exist
+        PowerShellCmdletBuilder(Command::new("pwsh.exe"))
             .flag("NoProfile")
+            .flag("Command")
             .finish()
     }
 

--- a/support/powershell_builder/src/lib.rs
+++ b/support/powershell_builder/src/lib.rs
@@ -14,15 +14,39 @@ use std::ffi::OsString;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::OnceLock;
 
 /// A PowerShell script builder
 pub struct PowerShellBuilder(Command);
 
 impl PowerShellBuilder {
+    // use pwsh if it exists, otherwise powershell. cache the result
+    fn get_program() -> &'static str {
+        const PWSH: &str = "pwsh.exe";
+        const POWERSHELL: &str = "powershell.exe";
+        static PROGRAM: OnceLock<&'static str> = OnceLock::new();
+        PROGRAM.get_or_init(|| {
+            if Self::new_inner(PWSH)
+                .cmdlet("exit")
+                .finish()
+                .build()
+                .status()
+                .is_ok_and(|r| r.success())
+            {
+                PWSH
+            } else {
+                POWERSHELL
+            }
+        })
+    }
+
     /// Create a new PowerShell command
     pub fn new() -> Self {
-        // TODO: fall back to powershell.exe if pwsh.exe does not exist
-        PowerShellCmdletBuilder(Command::new("pwsh.exe"))
+        Self::new_inner(Self::get_program())
+    }
+
+    fn new_inner(program: &'static str) -> Self {
+        PowerShellCmdletBuilder(Command::new(program))
             .flag("NoProfile")
             .flag("Command")
             .finish()


### PR DESCRIPTION
Use pwsh if it is available to try to mitigate powershell access violation errors. Includes some small tweaks to make this work.