### PR TITLE
openvmm: add Windows version resource (.rc) to openvmm.exe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5268,6 +5268,7 @@ dependencies = [
 name = "openvmm"
 version = "0.0.0"
 dependencies = [
+ "embed-resource",
  "openvmm_entry",
  "openvmm_resources",
 ]

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -644,6 +644,7 @@ impl IntoPipeline for CheckinGatesCli {
                                 [].into()
                             },
                         },
+                        version: None,
                         openvmm,
                     }
                 })
@@ -803,6 +804,7 @@ impl IntoPipeline for CheckinGatesCli {
                             features: [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::Tpm]
                                 .into(),
                         },
+                        version: None,
                         openvmm,
                     }
                 })
@@ -871,6 +873,7 @@ impl IntoPipeline for CheckinGatesCli {
                             features: [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::Tpm]
                                 .into(),
                         },
+                        version: None,
                         openvmm,
                     }
                 })

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -314,6 +314,7 @@ impl SimpleFlowNode for Node {
                         [].into()
                     },
                 },
+                version: None,
                 openvmm: v,
             });
             if copy_extras {

--- a/flowey/flowey_lib_hvlite/src/build_openvmm.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openvmm.rs
@@ -90,7 +90,7 @@ impl FlowNode for Node {
         {
             // Set the OPENVMM_* env vars for version information (if provided).
             let extra_env = version.map(|version| {
-                ctx.emit_rust_stepv("set openvmm version env vars", |ctx| {
+                ctx.emit_minor_rust_stepv("set openvmm version env vars", |ctx| {
                     let version = version.claim(ctx);
                     |rt| {
                         let mut env = BTreeMap::new();
@@ -99,7 +99,7 @@ impl FlowNode for Node {
                         env.insert("OPENVMM_MINOR".into(), minor.to_string());
                         env.insert("OPENVMM_PATCH".into(), patch.to_string());
                         env.insert("OPENVMM_REVISION".into(), revision.to_string());
-                        Ok(env)
+                        env
                     }
                 })
             });

--- a/flowey/flowey_lib_hvlite/src/build_openvmm.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openvmm.rs
@@ -7,6 +7,7 @@ use crate::common::CommonProfile;
 use crate::common::CommonTriple;
 use flowey::node::prelude::*;
 use flowey_lib_common::run_cargo_build::CargoFeatureSet;
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -45,6 +46,7 @@ impl Artifact for OpenvmmOutput {}
 flowey_request! {
     pub struct Request {
         pub params: OpenvmmBuildParams,
+        pub version: Option<ReadVar<(u16, u16, u16, u16)>>,
         pub openvmm: WriteVar<OpenvmmOutput>,
     }
 }
@@ -82,9 +84,26 @@ impl FlowNode for Node {
                     target,
                     features,
                 },
+            version,
             openvmm: openvmm_bin,
         } in requests
         {
+            // Set the OPENVMM_* env vars for version information (if provided).
+            let extra_env = version.map(|version| {
+                ctx.emit_rust_stepv("set openvmm version env vars", |ctx| {
+                    let version = version.claim(ctx);
+                    |rt| {
+                        let mut env = BTreeMap::new();
+                        let (major, minor, patch, revision) = rt.read(version);
+                        env.insert("OPENVMM_MAJOR".into(), major.to_string());
+                        env.insert("OPENVMM_MINOR".into(), minor.to_string());
+                        env.insert("OPENVMM_PATCH".into(), patch.to_string());
+                        env.insert("OPENVMM_REVISION".into(), revision.to_string());
+                        Ok(env)
+                    }
+                })
+            });
+
             let output = ctx.reqv(|v| crate::run_cargo_build::Request {
                 crate_name: "openvmm".into(),
                 out_name: "openvmm".into(),
@@ -105,7 +124,7 @@ impl FlowNode for Node {
                 ),
                 target: target.as_triple(),
                 no_split_dbg_info: false,
-                extra_env: None,
+                extra_env,
                 pre_build_deps: pre_build_deps.clone(),
                 output: v,
             });

--- a/openvmm/openvmm/Cargo.toml
+++ b/openvmm/openvmm/Cargo.toml
@@ -44,5 +44,8 @@ unstable_whp = ["openvmm_entry/unstable_whp", "openvmm_resources/unstable_whp"]
 openvmm_entry.workspace = true
 openvmm_resources.workspace = true
 
+[build-dependencies]
+embed-resource.workspace = true
+
 [lints]
 workspace = true

--- a/openvmm/openvmm/build.rs
+++ b/openvmm/openvmm/build.rs
@@ -10,5 +10,38 @@ fn main() {
     if std::env::var_os("CARGO_CFG_WINDOWS").is_some() {
         println!("cargo:rustc-link-lib=onecore_apiset");
         println!("cargo:rustc-link-lib=onecoreuap_apiset");
+
+        // Embed version/resource info into the EXE.
+        println!("cargo:rerun-if-changed=resources.rc");
+        println!("cargo:rerun-if-env-changed=OPENVMM_MAJOR");
+        println!("cargo:rerun-if-env-changed=OPENVMM_MINOR");
+        println!("cargo:rerun-if-env-changed=OPENVMM_PATCH");
+        println!("cargo:rerun-if-env-changed=OPENVMM_REVISION");
+
+        let parse_u16 = |s: String| s.parse::<u16>().unwrap_or(0);
+        let major = std::env::var("OPENVMM_MAJOR").map(parse_u16).unwrap_or(0);
+        let minor = std::env::var("OPENVMM_MINOR").map(parse_u16).unwrap_or(0);
+        let patch = std::env::var("OPENVMM_PATCH").map(parse_u16).unwrap_or(0);
+        let revision = std::env::var("OPENVMM_REVISION")
+            .map(parse_u16)
+            .unwrap_or(0);
+
+        let macros = [
+            (
+                "OPENVMM_VERSION",
+                format!("{major},{minor},{patch},{revision}"),
+            ),
+            (
+                "OPENVMM_VERSION_STR",
+                format!(r#""{major}.{minor}.{patch}.{revision}""#),
+            ),
+        ];
+
+        embed_resource::compile(
+            "resources.rc",
+            macros.iter().map(|(k, v)| format!("{k}={v}")),
+        )
+        .manifest_required()
+        .expect("Failed to embed resources");
     }
 }

--- a/openvmm/openvmm/resources.rc
+++ b/openvmm/openvmm/resources.rc
@@ -1,0 +1,31 @@
+// Windows Version Resource for openvmm.exe
+// Values are provided via build.rs using the following macros:
+// - OPENVMM_VERSION (e.g., 1,2,3,4)
+// - OPENVMM_VERSION_STR (e.g., "1.2.3.4")
+
+1 VERSIONINFO
+FILEVERSION    OPENVMM_VERSION
+PRODUCTVERSION OPENVMM_VERSION
+FILEOS 0x10004
+FILETYPE 0x1
+{
+BLOCK "StringFileInfo"
+{
+	BLOCK "040904B0"
+	{
+		VALUE "CompanyName", "Microsoft Corporation"
+		VALUE "FileDescription", "OpenVMM Virtual Machine Monitor"
+		VALUE "FileVersion", OPENVMM_VERSION_STR
+		VALUE "InternalName", "openvmm.exe"
+		VALUE "LegalCopyright", "(C) Microsoft Corporation. All rights reserved."
+		VALUE "OriginalFilename", "openvmm.exe"
+		VALUE "ProductName", "OpenVMM"
+		VALUE "ProductVersion", OPENVMM_VERSION_STR
+	}
+}
+
+BLOCK "VarFileInfo"
+{
+	VALUE "Translation", 0x0409 0x04B0
+}
+}


### PR DESCRIPTION
Add a VERSIONINFO resource to the openvmm binary so that Windows displays proper version metadata in file properties. The version is injected via environment variables (OPENVMM_MAJOR/MINOR/PATCH/REVISION) at build time, defaulting to 0.0.0.0 when not set.

The `build_openvmm` flowey node now accepts an optional `version` parameter that sets the environment variables for the build script.