### PR TITLE
WIP: crypto: Add a native feature flag

### DIFF
--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -66,7 +66,7 @@ pcie_remote_resources.workspace = true
 
 clap_dyn_complete.workspace = true
 console_relay.workspace = true
-crypto = { workspace = true, optional = true }
+crypto = { workspace = true, features = ["native"] }
 guid.workspace = true
 inspect.workspace = true
 inspect_proto.workspace = true
@@ -122,5 +122,5 @@ build_rs_guest_arch.workspace = true
 workspace = true
 
 [package.metadata.xtask.unused-deps]
-# keep the crypto dep so we can specify the vendored feature
+# keep the crypto dep so we can specify the vendored and backend features
 ignored = ["crypto"]

--- a/support/crypto/Cargo.toml
+++ b/support/crypto/Cargo.toml
@@ -12,6 +12,9 @@ rust-version.workspace = true
 # If the chosen backend is not natively available and can't be vendored, this will trigger a compile error.
 vendored = ["openssl?/vendored"]
 
+# Use a native backend, or OpenSSL on Linux.
+native = []
+
 # Use OpenSSL instead of any native backend.
 openssl = ["dep:openssl", "dep:openssl_kdf"]
 

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -4,6 +4,7 @@
 #![expect(missing_docs)]
 
 fn main() {
+    println!("cargo::rerun-if-env-changed=CARGO_FEATURE_NATIVE");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_OPENSSL");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_RUST");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_SYMCRYPT");
@@ -15,14 +16,15 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(rust)");
     println!("cargo::rustc-check-cfg=cfg(symcrypt)");
 
+    let native = std::env::var_os("CARGO_FEATURE_NATIVE").is_some();
     let openssl = std::env::var_os("CARGO_FEATURE_OPENSSL").is_some();
     let rust = std::env::var_os("CARGO_FEATURE_RUST").is_some();
     let symcrypt = std::env::var_os("CARGO_FEATURE_SYMCRYPT").is_some();
     let vendored = std::env::var_os("CARGO_FEATURE_VENDORED").is_some();
     let linux = std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "linux";
 
-    let all_features = openssl && rust && symcrypt && vendored;
-    let backend_count = openssl as u8 + rust as u8 + symcrypt as u8;
+    let all_features = native && openssl && rust && symcrypt && vendored;
+    let backend_count = native as u8 + openssl as u8 + rust as u8 + symcrypt as u8;
 
     // If we see multiple backends enabled that's an error. However if we see every
     // backend, and vendoring, enabled, it's likely we're in an --all-features session.
@@ -30,7 +32,9 @@ fn main() {
     // platform defaults.
     if backend_count > 1 && !all_features {
         panic!("Multiple crypto backends enabled, but only one can be selected");
-    } else if backend_count == 0 || all_features {
+    } else if backend_count == 0 {
+        panic!("No crypto backend enabled, but one must be selected");
+    } else if native || all_features {
         // Default to openssl on linux, the dependencies are also marked
         // non-optional and there is no native backend available
         if linux {

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -31,7 +31,17 @@ fn main() {
     // Since this is a common rust-analyzer configuration, allow it and fall back to
     // platform defaults.
     if backend_count > 1 && !all_features {
-        panic!("Multiple crypto backends enabled, but only one can be selected");
+        let enabled = [
+            ("native", native),
+            ("openssl", openssl),
+            ("rust", rust),
+            ("symcrypt", symcrypt),
+        ]
+        .iter()
+        .filter_map(|(n, e)| e.then_some(*n))
+        .collect::<Vec<_>>()
+        .join(", ");
+        panic!("Multiple crypto backends enabled, but only one can be selected: {enabled}");
     } else if backend_count == 0 {
         panic!("No crypto backend enabled, but one must be selected");
     } else if native || all_features {

--- a/vm/devices/firmware/firmware_uefi/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/Cargo.toml
@@ -24,7 +24,8 @@ vmcore.workspace = true
 
 async-trait.workspace = true
 bitfield-struct.workspace = true
-crypto.workspace = true
+# TODO: Should probably be the rust backend
+crypto = { workspace = true, features = ["native"] }
 der = { workspace = true, features = ["derive", "alloc", "oid"] }
 getrandom.workspace = true
 guid.workspace = true

--- a/vm/vmgs/vmgs_lib/Cargo.toml
+++ b/vm/vmgs/vmgs_lib/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-crypto = { workspace = true, features = ["vendored"] }
+crypto = { workspace = true, features = ["native", "vendored"] }
 disk_backend.workspace = true
 disk_vhd1.workspace = true
 futures.workspace = true

--- a/vm/vmgs/vmgstool/Cargo.toml
+++ b/vm/vmgs/vmgstool/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 [features]
 default = []
 
-encryption = ["vmgs/encryption", "crypto/vendored"]
+encryption = ["vmgs/encryption", "crypto/vendored", "crypto/native"]
 
 test_helpers = ["vmgs/test_helpers", "getrandom", "dep:resource_dll_parser"]
 


### PR DESCRIPTION
Binaries who care about having specifically the native backend need a way to ensure a different backend isn't being silently chosen instead.