### PR TITLE
vmm_tests: wait for SCSI "running" state during device discovery

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/utils.rs
+++ b/vmm_tests/vmm_tests/tests/tests/utils.rs
@@ -101,5 +101,28 @@ pub(crate) async fn get_device_paths(
         );
     }
 
+    // Verify each device is in the "running" SCSI state before declaring
+    // discovery successful.
+    //
+    // SCSI LUN removal in the Linux guest is asynchronous: after a LUN is
+    // removed from VTL2 settings, the kernel takes some time to actually
+    // tear down the block device. If a subsequent re-add races with an
+    // in-flight removal, the block device node can briefly exist while its
+    // SCSI device is in a transient state (e.g. "cancel" / "deleted" /
+    // "transport-offline"), causing `open(O_DIRECT)` to fail with EINVAL
+    // when the test starts IO. Reading the sysfs state lets the caller's
+    // retry loop wait for the kernel to settle.
+    for dev in &device_paths {
+        let name = dev.trim_start_matches("/dev/");
+        let state = cmd!(sh, "cat /sys/block/{name}/device/state")
+            .read()
+            .await
+            .with_context(|| format!("failed to read SCSI state for {dev}"))?;
+        let state = state.trim();
+        if state != "running" {
+            anyhow::bail!("device {dev} is not running (state={state:?})");
+        }
+    }
+
     Ok(device_paths)
 }


### PR DESCRIPTION
The storvsp dynamic add/remove tests intermittently fail mid-IO with `dd: can't open '/dev/sdX': Invalid argument`.

**Root cause:** SCSI LUN removal in the Linux guest is asynchronous. After clearing LUNs from VTL2 settings, the kernel takes time to finish tearing down each block device. If the next iteration re-adds LUNs before the previous removal completes, the block device node can briefly exist while the underlying SCSI device is in a transient state (`cancel` / `deleted` / `transport-offline`), causing `open(O_DIRECT)` to return `EINVAL` once the IO phase starts.

**Fix:** extend `get_device_paths` to read `/sys/block/<dev>/device/state` for each discovered device and require it to be `running`. Anything else returns an error, so the existing 20 × 3s retry loop in `test_storage_linux` waits for the kernel to settle before declaring discovery complete.

**Observed on:** CI run [`26106927163`](https://github.com/microsoft/openvmm/actions/runs/26106927163), test `openvmm_openhcl_linux_x64_storvsp_dynamic_add_disk` (iteration 3/3, `/dev/sdi`). Test logs: [openvmm.dev/test-results/#/runs/26106927163](https://openvmm.dev/test-results/#/runs/26106927163).