### PR TITLE
petri: Harden linux direct serial command end sentinel check

### DIFF
--- a/petri/src/linux_direct_serial_agent.rs
+++ b/petri/src/linux_direct_serial_agent.rs
@@ -59,8 +59,12 @@ impl LinuxDirectSerialAgent {
             let n = self.read.read(&mut buf).await?;
             tracing::debug!(buf = ?&buf[..n], "read serial bytes from guest");
             output.extend_from_slice(&buf[..n]);
-            if output.ends_with(COMMAND_END_SIGNAL.as_bytes()) {
-                output.truncate(output.len() - COMMAND_END_SIGNAL.len());
+            if let Some(pos) = output
+                .windows(COMMAND_END_SIGNAL.len())
+                .rev()
+                .position(|window| window == COMMAND_END_SIGNAL.as_bytes())
+            {
+                output.truncate(pos);
                 break;
             }
         }

--- a/petri/src/linux_direct_serial_agent.rs
+++ b/petri/src/linux_direct_serial_agent.rs
@@ -40,7 +40,7 @@ impl LinuxDirectSerialAgent {
     pub(crate) async fn run_command(&mut self, command: &str) -> anyhow::Result<String> {
         self.init_busybox_if_necessary().await?;
         let bytes = self.run_command_core(command).await?;
-        Ok(String::from_utf8_lossy(&bytes).into_owned())
+        Ok(String::from_utf8_lossy(bytes.trim_ascii()).into_owned())
     }
 
     async fn run_command_core(&mut self, command: &str) -> anyhow::Result<Vec<u8>> {
@@ -49,10 +49,7 @@ impl LinuxDirectSerialAgent {
         // Instead we send this special text sequence to signal the end of the command, since it's unlikely
         // that a normal command will ever output it.
         const COMMAND_END_SIGNAL: &str = "== Petri Command Complete ==";
-        let command =
-            format!("({command}) > /dev/ttyS1\nprintf '{COMMAND_END_SIGNAL}\\n' > /dev/ttyS1\n");
-
-        const COMMAND_END_SIGNAL_READ: &str = "== Petri Command Complete ==\n";
+        let command = format!("({command}) > /dev/ttyS1\necho {COMMAND_END_SIGNAL} > /dev/ttyS1\n");
 
         self.write.write_all(command.as_bytes()).await?;
 
@@ -62,8 +59,8 @@ impl LinuxDirectSerialAgent {
             let n = self.read.read(&mut buf).await?;
             tracing::debug!(buf = ?&buf[..n], "read serial bytes from guest");
             output.extend_from_slice(&buf[..n]);
-            if output.ends_with(COMMAND_END_SIGNAL_READ.as_bytes()) {
-                output.truncate(output.len() - COMMAND_END_SIGNAL_READ.len());
+            if output.ends_with(COMMAND_END_SIGNAL.as_bytes()) {
+                output.truncate(output.len() - COMMAND_END_SIGNAL.len());
                 break;
             }
         }

--- a/petri/src/linux_direct_serial_agent.rs
+++ b/petri/src/linux_direct_serial_agent.rs
@@ -49,10 +49,10 @@ impl LinuxDirectSerialAgent {
         // Instead we send this special text sequence to signal the end of the command, since it's unlikely
         // that a normal command will ever output it.
         const COMMAND_END_SIGNAL: &str = "== Petri Command Complete ==";
-        let command = format!("({command}) > /dev/ttyS1\necho {COMMAND_END_SIGNAL} > /dev/ttyS1\n");
+        let command =
+            format!("({command}) > /dev/ttyS1\nprintf '{COMMAND_END_SIGNAL}\\n' > /dev/ttyS1\n");
 
-        // When reading the output there will be a trailing newline.
-        const COMMAND_END_SIGNAL_READ: &str = "== Petri Command Complete ==\r\n";
+        const COMMAND_END_SIGNAL_READ: &str = "== Petri Command Complete ==\n";
 
         self.write.write_all(command.as_bytes()).await?;
 


### PR DESCRIPTION
I've seen a few cases of test flakiness on linux direct where it seems like the trailing newline characters that are part of our command end sentinel aren't making it across the wire, leading to the test hanging forever. So instead, don't look for them at all, just look for the sentinel value. If these newlines end up sitting in the serial buffer they'll just get read at the beginning of the next command, which now will trim them away. In the best case this will fix the problem, in the worst case it should be equivalent, so let's give it a shot.