### PR TITLE
openvmm_core: add SPI layout allocator

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -500,12 +500,24 @@ impl ExtractTopologyConfig for ProcessorTopology<Aarch64Topology> {
 }
 
 #[cfg(guest_arch = "aarch64")]
+struct Aarch64TopologyResult {
+    processor_topology: ProcessorTopology<Aarch64Topology>,
+    #[expect(dead_code)] // consumed by SMMU device wiring
+    spi_layout: super::spi_layout::ResolvedSpiLayout,
+}
+
+#[cfg(guest_arch = "aarch64")]
 fn build_aarch64_topology(
     config: &ProcessorTopologyConfig,
     platform_info: &virt::PlatformInfo,
-    gic_msi: vm_topology::processor::aarch64::GicMsiController,
-) -> anyhow::Result<ProcessorTopology<Aarch64Topology>> {
+) -> anyhow::Result<Aarch64TopologyResult> {
+    use openvmm_defs::config::GicMsiConfig;
     use vm_topology::processor::aarch64::Aarch64PlatformConfig;
+    use vm_topology::processor::aarch64::GicItsInfo;
+    use vm_topology::processor::aarch64::GicMsiController;
+    use vm_topology::processor::aarch64::GicV2mInfo;
+
+    const DEFAULT_GIC_V2M_SPI_COUNT: u32 = 64;
 
     let arch = match &config.arch {
         None => Default::default(),
@@ -582,6 +594,43 @@ fn build_aarch64_topology(
         }
     };
 
+    // Resolve ITS vs v2m and determine v2m SPI count.
+    let is_gicv2 = matches!(gic_version, GicVersion::V2 { .. });
+    let v2m_spi_count = match &arch.gic_msi {
+        GicMsiConfig::Auto if platform_info.supports_its && !is_gicv2 => None,
+        GicMsiConfig::Auto => Some(DEFAULT_GIC_V2M_SPI_COUNT),
+        GicMsiConfig::Its => {
+            if is_gicv2 {
+                anyhow::bail!("ITS is incompatible with GICv2");
+            }
+            if !platform_info.supports_its {
+                anyhow::bail!("ITS requested but the hypervisor does not support it");
+            }
+            None
+        }
+        GicMsiConfig::V2m { spi_count } => Some(spi_count.unwrap_or(DEFAULT_GIC_V2M_SPI_COUNT)),
+    };
+
+    // Resolve SPI layout — all SPI allocations in one deterministic pass.
+    let spi_layout = super::spi_layout::resolve_spi_layout(&super::spi_layout::SpiLayoutInput {
+        v2m_spi_count,
+    })?;
+
+    // Build the GIC MSI controller from resolved SPIs.
+    let gic_msi = if let Some(count) = v2m_spi_count {
+        GicMsiController::V2m(GicV2mInfo {
+            frame_base: openvmm_defs::config::DEFAULT_GIC_V2M_MSI_FRAME_BASE,
+            spi_base: spi_layout
+                .v2m_spi_base
+                .expect("v2m base must be allocated when v2m_spi_count is Some"),
+            spi_count: count,
+        })
+    } else {
+        GicMsiController::Its(GicItsInfo {
+            its_base: openvmm_defs::config::DEFAULT_GIC_ITS_BASE,
+        })
+    };
+
     let platform = Aarch64PlatformConfig {
         gic_distributor_base,
         gic_version,
@@ -600,7 +649,10 @@ fn build_aarch64_topology(
     } else {
         builder.vps_per_socket(config.proc_count);
     }
-    Ok(builder.build(config.proc_count)?)
+    Ok(Aarch64TopologyResult {
+        processor_topology: builder.build(config.proc_count)?,
+        spi_layout,
+    })
 }
 
 /// A VM that has been loaded and can be run.
@@ -823,57 +875,8 @@ impl InitializedVm {
 
         #[cfg(guest_arch = "aarch64")]
         let processor_topology = {
-            use openvmm_defs::config::GicMsiConfig;
-            use vm_topology::processor::aarch64::GicItsInfo;
-            use vm_topology::processor::aarch64::GicMsiController;
-            use vm_topology::processor::aarch64::GicV2mInfo;
-
-            // Resolve ITS vs v2m and determine v2m SPI count.
-            let arch_config = match &cfg.processor_topology.arch {
-                Some(ArchTopologyConfig::Aarch64(a)) => a,
-                _ => &Aarch64TopologyConfig::default(),
-            };
-            let is_gicv2 = match &arch_config.gic_config {
-                Some(GicConfig::V2(_)) => true,
-                _ => !platform_info.supports_gic_v3,
-            };
-            let v2m_spi_count = match &arch_config.gic_msi {
-                GicMsiConfig::Auto if platform_info.supports_its && !is_gicv2 => None,
-                GicMsiConfig::Auto => Some(openvmm_defs::config::DEFAULT_GIC_V2M_SPI_COUNT),
-                GicMsiConfig::Its => {
-                    if is_gicv2 {
-                        anyhow::bail!("ITS is incompatible with GICv2");
-                    }
-                    if !platform_info.supports_its {
-                        anyhow::bail!("ITS requested but the hypervisor does not support it");
-                    }
-                    None
-                }
-                GicMsiConfig::V2m { spi_count } => Some(*spi_count),
-            };
-
-            // Resolve SPI layout — all SPI allocations in one deterministic pass.
-            let spi_layout =
-                super::spi_layout::resolve_spi_layout(&super::spi_layout::SpiLayoutInput {
-                    v2m_spi_count,
-                })?;
-
-            // Build the GIC MSI controller from resolved SPIs.
-            let gic_msi = if let Some(count) = v2m_spi_count {
-                GicMsiController::V2m(GicV2mInfo {
-                    frame_base: openvmm_defs::config::DEFAULT_GIC_V2M_MSI_FRAME_BASE,
-                    spi_base: spi_layout
-                        .v2m_spi_base
-                        .expect("v2m base must be allocated when v2m_spi_count is Some"),
-                    spi_count: count,
-                })
-            } else {
-                GicMsiController::Its(GicItsInfo {
-                    its_base: openvmm_defs::config::DEFAULT_GIC_ITS_BASE,
-                })
-            };
-
-            build_aarch64_topology(&cfg.processor_topology, &platform_info, gic_msi)?
+            let result = build_aarch64_topology(&cfg.processor_topology, &platform_info)?;
+            result.processor_topology
         };
         #[cfg(not(guest_arch = "aarch64"))]
         let processor_topology = build_x86_topology(&cfg.processor_topology)?;

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -34,7 +34,6 @@ use ide_resources::IdeDeviceConfig;
 use igvm::IgvmFile;
 use input_core::InputData;
 use input_core::MultiplexedInputHandle;
-use inspect::Inspect;
 use local_clock::LocalClockDelta;
 use membacking::GuestMemoryBuilder;
 use membacking::GuestMemoryManager;
@@ -113,7 +112,6 @@ use vm_resource::kind::VirtioDeviceHandle;
 use vm_resource::kind::VmbusDeviceHandleKind;
 use vm_topology::memory::MemoryLayout;
 use vm_topology::pcie::PcieHostBridge;
-use vm_topology::processor::ArchTopology;
 use vm_topology::processor::ProcessorTopology;
 use vm_topology::processor::TopologyBuilder;
 use vm_topology::processor::aarch64::Aarch64Topology;
@@ -414,13 +412,6 @@ pub(crate) struct InitializedVm {
     driver_source: VmTaskDriverSource,
 }
 
-trait BuildTopology<T: ArchTopology + Inspect> {
-    fn to_topology(
-        &self,
-        platform_info: &virt::PlatformInfo,
-    ) -> anyhow::Result<ProcessorTopology<T>>;
-}
-
 trait ExtractTopologyConfig {
     fn to_config(&self) -> ProcessorTopologyConfig;
 }
@@ -446,38 +437,35 @@ impl ExtractTopologyConfig for ProcessorTopology<X86Topology> {
 }
 
 #[cfg(guest_arch = "x86_64")]
-impl BuildTopology<X86Topology> for ProcessorTopologyConfig {
-    fn to_topology(
-        &self,
-        _platform_info: &virt::PlatformInfo,
-    ) -> anyhow::Result<ProcessorTopology<X86Topology>> {
-        use vm_topology::processor::x86::X2ApicState;
+fn build_x86_topology(
+    config: &ProcessorTopologyConfig,
+) -> anyhow::Result<ProcessorTopology<X86Topology>> {
+    use vm_topology::processor::x86::X2ApicState;
 
-        let arch = match &self.arch {
-            None => Default::default(),
-            Some(ArchTopologyConfig::X86(arch)) => arch.clone(),
-            _ => anyhow::bail!("invalid architecture config"),
-        };
-        let mut builder = TopologyBuilder::from_host_topology()?;
-        builder.apic_id_offset(arch.apic_id_offset);
-        if let Some(smt) = self.enable_smt {
-            builder.smt_enabled(smt);
-        }
-        if let Some(count) = self.vps_per_socket {
-            builder.vps_per_socket(count);
-        }
-        let x2apic = match arch.x2apic {
-            X2ApicConfig::Auto => {
-                // FUTURE: query the hypervisor for a recommendation.
-                X2ApicState::Supported
-            }
-            X2ApicConfig::Supported => X2ApicState::Supported,
-            X2ApicConfig::Unsupported => X2ApicState::Unsupported,
-            X2ApicConfig::Enabled => X2ApicState::Enabled,
-        };
-        builder.x2apic(x2apic);
-        Ok(builder.build(self.proc_count)?)
+    let arch = match &config.arch {
+        None => Default::default(),
+        Some(ArchTopologyConfig::X86(arch)) => arch.clone(),
+        _ => anyhow::bail!("invalid architecture config"),
+    };
+    let mut builder = TopologyBuilder::from_host_topology()?;
+    builder.apic_id_offset(arch.apic_id_offset);
+    if let Some(smt) = config.enable_smt {
+        builder.smt_enabled(smt);
     }
+    if let Some(count) = config.vps_per_socket {
+        builder.vps_per_socket(count);
+    }
+    let x2apic = match arch.x2apic {
+        X2ApicConfig::Auto => {
+            // FUTURE: query the hypervisor for a recommendation.
+            X2ApicState::Supported
+        }
+        X2ApicConfig::Supported => X2ApicState::Supported,
+        X2ApicConfig::Unsupported => X2ApicState::Unsupported,
+        X2ApicConfig::Enabled => X2ApicState::Enabled,
+    };
+    builder.x2apic(x2apic);
+    Ok(builder.build(config.proc_count)?)
 }
 
 impl ExtractTopologyConfig for ProcessorTopology<Aarch64Topology> {
@@ -512,140 +500,107 @@ impl ExtractTopologyConfig for ProcessorTopology<Aarch64Topology> {
 }
 
 #[cfg(guest_arch = "aarch64")]
-impl BuildTopology<Aarch64Topology> for ProcessorTopologyConfig {
-    fn to_topology(
-        &self,
-        platform_info: &virt::PlatformInfo,
-    ) -> anyhow::Result<ProcessorTopology<Aarch64Topology>> {
-        use vm_topology::processor::aarch64::Aarch64PlatformConfig;
-        use vm_topology::processor::aarch64::GicItsInfo;
-        use vm_topology::processor::aarch64::GicMsiController;
-        use vm_topology::processor::aarch64::GicV2mInfo;
+fn build_aarch64_topology(
+    config: &ProcessorTopologyConfig,
+    platform_info: &virt::PlatformInfo,
+    gic_msi: vm_topology::processor::aarch64::GicMsiController,
+) -> anyhow::Result<ProcessorTopology<Aarch64Topology>> {
+    use vm_topology::processor::aarch64::Aarch64PlatformConfig;
 
-        let arch = match &self.arch {
-            None => Default::default(),
-            Some(ArchTopologyConfig::Aarch64(arch)) => arch.clone(),
-            _ => anyhow::bail!("invalid architecture config"),
-        };
+    let arch = match &config.arch {
+        None => Default::default(),
+        Some(ArchTopologyConfig::Aarch64(arch)) => arch.clone(),
+        _ => anyhow::bail!("invalid architecture config"),
+    };
 
-        let pmu_gsiv = match arch.pmu_gsiv {
-            PmuGsivConfig::Disabled => None,
-            PmuGsivConfig::Gsiv(gsiv) => Some(gsiv),
-            PmuGsivConfig::Platform => platform_info.platform_gsiv,
-        };
+    let pmu_gsiv = match arch.pmu_gsiv {
+        PmuGsivConfig::Disabled => None,
+        PmuGsivConfig::Gsiv(gsiv) => Some(gsiv),
+        PmuGsivConfig::Platform => platform_info.platform_gsiv,
+    };
 
-        // TODO: When this value is supported on all platforms, we should change
-        // the arch config to not be an option. For now, warn since the ARM VBSA
-        // expects this to be available.
-        if pmu_gsiv.is_none() {
-            tracing::warn!("PMU GSIV is not set");
+    // TODO: When this value is supported on all platforms, we should change
+    // the arch config to not be an option. For now, warn since the ARM VBSA
+    // expects this to be available.
+    if pmu_gsiv.is_none() {
+        tracing::warn!("PMU GSIV is not set");
+    }
+
+    let (gic_distributor_base, gic_version) = match &arch.gic_config {
+        Some(GicConfig::V3(config)) => {
+            let dist = config
+                .as_ref()
+                .map(|c| c.gic_distributor_base)
+                .unwrap_or(openvmm_defs::config::DEFAULT_GIC_DISTRIBUTOR_BASE);
+            let redist = config
+                .as_ref()
+                .map(|c| c.gic_redistributors_base)
+                .unwrap_or(openvmm_defs::config::DEFAULT_GIC_REDISTRIBUTORS_BASE);
+            (
+                dist,
+                GicVersion::V3 {
+                    redistributors_base: redist,
+                },
+            )
         }
-
-        let (gic_distributor_base, gic_version) = match &arch.gic_config {
-            Some(GicConfig::V3(config)) => {
-                let dist = config
-                    .as_ref()
-                    .map(|c| c.gic_distributor_base)
-                    .unwrap_or(openvmm_defs::config::DEFAULT_GIC_DISTRIBUTOR_BASE);
-                let redist = config
-                    .as_ref()
-                    .map(|c| c.gic_redistributors_base)
-                    .unwrap_or(openvmm_defs::config::DEFAULT_GIC_REDISTRIBUTORS_BASE);
+        Some(GicConfig::V2(config)) => {
+            let dist = config
+                .as_ref()
+                .map(|c| c.gic_distributor_base)
+                .unwrap_or(openvmm_defs::config::DEFAULT_GIC_DISTRIBUTOR_BASE);
+            let cpu_if = config
+                .as_ref()
+                .map(|c| c.cpu_interface_base)
+                .unwrap_or(openvmm_defs::config::DEFAULT_GIC_REDISTRIBUTORS_BASE);
+            (
+                dist,
+                GicVersion::V2 {
+                    cpu_interface_base: cpu_if,
+                },
+            )
+        }
+        None => {
+            // No explicit GIC config — use the hypervisor's detected version
+            // with default addresses.
+            let dist = openvmm_defs::config::DEFAULT_GIC_DISTRIBUTOR_BASE;
+            let second = openvmm_defs::config::DEFAULT_GIC_REDISTRIBUTORS_BASE;
+            if platform_info.supports_gic_v3 {
                 (
                     dist,
                     GicVersion::V3 {
-                        redistributors_base: redist,
+                        redistributors_base: second,
                     },
                 )
-            }
-            Some(GicConfig::V2(config)) => {
-                let dist = config
-                    .as_ref()
-                    .map(|c| c.gic_distributor_base)
-                    .unwrap_or(openvmm_defs::config::DEFAULT_GIC_DISTRIBUTOR_BASE);
-                let cpu_if = config
-                    .as_ref()
-                    .map(|c| c.cpu_interface_base)
-                    .unwrap_or(openvmm_defs::config::DEFAULT_GIC_REDISTRIBUTORS_BASE);
+            } else {
                 (
                     dist,
                     GicVersion::V2 {
-                        cpu_interface_base: cpu_if,
+                        cpu_interface_base: second,
                     },
                 )
             }
-            None => {
-                // No explicit GIC config — use the hypervisor's detected version
-                // with default addresses.
-                let dist = openvmm_defs::config::DEFAULT_GIC_DISTRIBUTOR_BASE;
-                let second = openvmm_defs::config::DEFAULT_GIC_REDISTRIBUTORS_BASE;
-                if platform_info.supports_gic_v3 {
-                    (
-                        dist,
-                        GicVersion::V3 {
-                            redistributors_base: second,
-                        },
-                    )
-                } else {
-                    (
-                        dist,
-                        GicVersion::V2 {
-                            cpu_interface_base: second,
-                        },
-                    )
-                }
-            }
-        };
-
-        // Use the ITS for MSI delivery when the backend supports it
-        // (KVM with GICv3). Otherwise fall back to GICv2m (SPI-based MSIs).
-        use openvmm_defs::config::GicMsiConfig;
-        let is_gicv2 = matches!(gic_version, GicVersion::V2 { .. });
-        let use_its = match arch.gic_msi {
-            GicMsiConfig::Auto => platform_info.supports_its && !is_gicv2,
-            GicMsiConfig::Its => {
-                if is_gicv2 {
-                    anyhow::bail!("ITS is incompatible with GICv2");
-                }
-                if !platform_info.supports_its {
-                    anyhow::bail!("ITS requested but the hypervisor does not support it");
-                }
-                true
-            }
-            GicMsiConfig::V2m => false,
-        };
-        let gic_msi = if use_its {
-            GicMsiController::Its(GicItsInfo {
-                its_base: openvmm_defs::config::DEFAULT_GIC_ITS_BASE,
-            })
-        } else {
-            GicMsiController::V2m(GicV2mInfo {
-                frame_base: openvmm_defs::config::DEFAULT_GIC_V2M_MSI_FRAME_BASE,
-                spi_base: openvmm_defs::config::DEFAULT_GIC_V2M_SPI_BASE,
-                spi_count: openvmm_defs::config::DEFAULT_GIC_V2M_SPI_COUNT,
-            })
-        };
-
-        let platform = Aarch64PlatformConfig {
-            gic_distributor_base,
-            gic_version,
-            gic_msi,
-            pmu_gsiv,
-            virt_timer_ppi: openvmm_defs::config::DEFAULT_VIRT_TIMER_PPI,
-            gic_nr_irqs: openvmm_defs::config::DEFAULT_GIC_NR_IRQS,
-        };
-
-        let mut builder = TopologyBuilder::new_aarch64(platform);
-        if let Some(smt) = self.enable_smt {
-            builder.smt_enabled(smt);
         }
-        if let Some(count) = self.vps_per_socket {
-            builder.vps_per_socket(count);
-        } else {
-            builder.vps_per_socket(self.proc_count);
-        }
-        Ok(builder.build(self.proc_count)?)
+    };
+
+    let platform = Aarch64PlatformConfig {
+        gic_distributor_base,
+        gic_version,
+        gic_msi,
+        pmu_gsiv,
+        virt_timer_ppi: openvmm_defs::config::DEFAULT_VIRT_TIMER_PPI,
+        gic_nr_irqs: openvmm_defs::config::DEFAULT_GIC_NR_IRQS,
+    };
+
+    let mut builder = TopologyBuilder::new_aarch64(platform);
+    if let Some(smt) = config.enable_smt {
+        builder.smt_enabled(smt);
     }
+    if let Some(count) = config.vps_per_socket {
+        builder.vps_per_socket(count);
+    } else {
+        builder.vps_per_socket(config.proc_count);
+    }
+    Ok(builder.build(config.proc_count)?)
 }
 
 /// A VM that has been loaded and can be run.
@@ -818,6 +773,7 @@ impl InitializedVm {
     pub(crate) async fn new_with_hypervisor<P, H>(
         driver_source: VmTaskDriverSource,
         hypervisor: &mut H,
+        #[cfg_attr(not(guest_arch = "aarch64"), expect(unused_variables))]
         platform_info: virt::PlatformInfo,
         cfg: Manifest,
         shared_memory: Option<SharedMemoryBacking>,
@@ -865,7 +821,64 @@ impl InitializedVm {
             None
         };
 
-        let processor_topology = cfg.processor_topology.to_topology(&platform_info)?;
+        cfg_if! {
+            if #[cfg(guest_arch = "aarch64")] {
+                use openvmm_defs::config::GicMsiConfig;
+                use vm_topology::processor::aarch64::GicItsInfo;
+                use vm_topology::processor::aarch64::GicMsiController;
+                use vm_topology::processor::aarch64::GicV2mInfo;
+
+                // Resolve ITS vs v2m and determine v2m SPI count.
+                let arch_config = match &cfg.processor_topology.arch {
+                    Some(ArchTopologyConfig::Aarch64(a)) => a,
+                    _ => &Aarch64TopologyConfig::default(),
+                };
+                let is_gicv2 = match &arch_config.gic_config {
+                    Some(GicConfig::V2(_)) => true,
+                    _ => !platform_info.supports_gic_v3,
+                };
+                let v2m_spi_count = match &arch_config.gic_msi {
+                    GicMsiConfig::Auto if platform_info.supports_its && !is_gicv2 => None,
+                    GicMsiConfig::Auto => Some(openvmm_defs::config::DEFAULT_GIC_V2M_SPI_COUNT),
+                    GicMsiConfig::Its => {
+                        if is_gicv2 {
+                            anyhow::bail!("ITS is incompatible with GICv2");
+                        }
+                        if !platform_info.supports_its {
+                            anyhow::bail!("ITS requested but the hypervisor does not support it");
+                        }
+                        None
+                    }
+                    GicMsiConfig::V2m { spi_count } => Some(*spi_count),
+                };
+
+                // Resolve SPI layout — all SPI allocations in one deterministic pass.
+                let spi_layout = super::spi_layout::resolve_spi_layout(
+                    &super::spi_layout::SpiLayoutInput {
+                        v2m_spi_count,
+                    },
+                )?;
+
+                // Build the GIC MSI controller from resolved SPIs.
+                let gic_msi = if let Some(count) = v2m_spi_count {
+                    GicMsiController::V2m(GicV2mInfo {
+                        frame_base: openvmm_defs::config::DEFAULT_GIC_V2M_MSI_FRAME_BASE,
+                        spi_base: spi_layout.v2m_spi_base.expect("v2m base must be allocated when v2m_spi_count is Some"),
+                        spi_count: count,
+                    })
+                } else {
+                    GicMsiController::Its(GicItsInfo {
+                        its_base: openvmm_defs::config::DEFAULT_GIC_ITS_BASE,
+                    })
+                };
+
+                let processor_topology =
+                    build_aarch64_topology(&cfg.processor_topology, &platform_info, gic_msi)?;
+            } else {
+                let processor_topology =
+                    build_x86_topology(&cfg.processor_topology)?;
+            }
+        }
 
         let proto = hypervisor
             .new_partition(virt::ProtoPartitionConfig {

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -821,64 +821,62 @@ impl InitializedVm {
             None
         };
 
-        cfg_if! {
-            if #[cfg(guest_arch = "aarch64")] {
-                use openvmm_defs::config::GicMsiConfig;
-                use vm_topology::processor::aarch64::GicItsInfo;
-                use vm_topology::processor::aarch64::GicMsiController;
-                use vm_topology::processor::aarch64::GicV2mInfo;
+        #[cfg(guest_arch = "aarch64")]
+        let processor_topology = {
+            use openvmm_defs::config::GicMsiConfig;
+            use vm_topology::processor::aarch64::GicItsInfo;
+            use vm_topology::processor::aarch64::GicMsiController;
+            use vm_topology::processor::aarch64::GicV2mInfo;
 
-                // Resolve ITS vs v2m and determine v2m SPI count.
-                let arch_config = match &cfg.processor_topology.arch {
-                    Some(ArchTopologyConfig::Aarch64(a)) => a,
-                    _ => &Aarch64TopologyConfig::default(),
-                };
-                let is_gicv2 = match &arch_config.gic_config {
-                    Some(GicConfig::V2(_)) => true,
-                    _ => !platform_info.supports_gic_v3,
-                };
-                let v2m_spi_count = match &arch_config.gic_msi {
-                    GicMsiConfig::Auto if platform_info.supports_its && !is_gicv2 => None,
-                    GicMsiConfig::Auto => Some(openvmm_defs::config::DEFAULT_GIC_V2M_SPI_COUNT),
-                    GicMsiConfig::Its => {
-                        if is_gicv2 {
-                            anyhow::bail!("ITS is incompatible with GICv2");
-                        }
-                        if !platform_info.supports_its {
-                            anyhow::bail!("ITS requested but the hypervisor does not support it");
-                        }
-                        None
+            // Resolve ITS vs v2m and determine v2m SPI count.
+            let arch_config = match &cfg.processor_topology.arch {
+                Some(ArchTopologyConfig::Aarch64(a)) => a,
+                _ => &Aarch64TopologyConfig::default(),
+            };
+            let is_gicv2 = match &arch_config.gic_config {
+                Some(GicConfig::V2(_)) => true,
+                _ => !platform_info.supports_gic_v3,
+            };
+            let v2m_spi_count = match &arch_config.gic_msi {
+                GicMsiConfig::Auto if platform_info.supports_its && !is_gicv2 => None,
+                GicMsiConfig::Auto => Some(openvmm_defs::config::DEFAULT_GIC_V2M_SPI_COUNT),
+                GicMsiConfig::Its => {
+                    if is_gicv2 {
+                        anyhow::bail!("ITS is incompatible with GICv2");
                     }
-                    GicMsiConfig::V2m { spi_count } => Some(*spi_count),
-                };
+                    if !platform_info.supports_its {
+                        anyhow::bail!("ITS requested but the hypervisor does not support it");
+                    }
+                    None
+                }
+                GicMsiConfig::V2m { spi_count } => Some(*spi_count),
+            };
 
-                // Resolve SPI layout — all SPI allocations in one deterministic pass.
-                let spi_layout = super::spi_layout::resolve_spi_layout(
-                    &super::spi_layout::SpiLayoutInput {
-                        v2m_spi_count,
-                    },
-                )?;
+            // Resolve SPI layout — all SPI allocations in one deterministic pass.
+            let spi_layout =
+                super::spi_layout::resolve_spi_layout(&super::spi_layout::SpiLayoutInput {
+                    v2m_spi_count,
+                })?;
 
-                // Build the GIC MSI controller from resolved SPIs.
-                let gic_msi = if let Some(count) = v2m_spi_count {
-                    GicMsiController::V2m(GicV2mInfo {
-                        frame_base: openvmm_defs::config::DEFAULT_GIC_V2M_MSI_FRAME_BASE,
-                        spi_base: spi_layout.v2m_spi_base.expect("v2m base must be allocated when v2m_spi_count is Some"),
-                        spi_count: count,
-                    })
-                } else {
-                    GicMsiController::Its(GicItsInfo {
-                        its_base: openvmm_defs::config::DEFAULT_GIC_ITS_BASE,
-                    })
-                };
-
-                let processor_topology =
-                    build_aarch64_topology(&cfg.processor_topology, &platform_info, gic_msi)?;
+            // Build the GIC MSI controller from resolved SPIs.
+            let gic_msi = if let Some(count) = v2m_spi_count {
+                GicMsiController::V2m(GicV2mInfo {
+                    frame_base: openvmm_defs::config::DEFAULT_GIC_V2M_MSI_FRAME_BASE,
+                    spi_base: spi_layout
+                        .v2m_spi_base
+                        .expect("v2m base must be allocated when v2m_spi_count is Some"),
+                    spi_count: count,
+                })
             } else {
-                let processor_topology =
-                    build_x86_topology(&cfg.processor_topology)?;
-            }
-        }
+                GicMsiController::Its(GicItsInfo {
+                    its_base: openvmm_defs::config::DEFAULT_GIC_ITS_BASE,
+                })
+            };
+
+            build_aarch64_topology(&cfg.processor_topology, &platform_info, gic_msi)?
+        };
+        #[cfg(not(guest_arch = "aarch64"))]
+        let processor_topology = build_x86_topology(&cfg.processor_topology)?;
 
         let proto = hypervisor
             .new_partition(virt::ProtoPartitionConfig {

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -612,7 +612,9 @@ fn build_aarch64_topology(
     };
 
     // Resolve SPI layout — all SPI allocations in one deterministic pass.
+    let gic_nr_irqs = openvmm_defs::config::DEFAULT_GIC_NR_IRQS;
     let spi_layout = super::spi_layout::resolve_spi_layout(&super::spi_layout::SpiLayoutInput {
+        gic_nr_irqs,
         v2m_spi_count,
     })?;
 
@@ -637,7 +639,7 @@ fn build_aarch64_topology(
         gic_msi,
         pmu_gsiv,
         virt_timer_ppi: openvmm_defs::config::DEFAULT_VIRT_TIMER_PPI,
-        gic_nr_irqs: openvmm_defs::config::DEFAULT_GIC_NR_IRQS,
+        gic_nr_irqs,
     };
 
     let mut builder = TopologyBuilder::new_aarch64(platform);

--- a/openvmm/openvmm_core/src/worker/mod.rs
+++ b/openvmm/openvmm_core/src/worker/mod.rs
@@ -4,4 +4,5 @@
 pub mod dispatch;
 mod memory_layout;
 mod rom;
+mod spi_layout;
 pub mod vm_loaders;

--- a/openvmm/openvmm_core/src/worker/spi_layout.rs
+++ b/openvmm/openvmm_core/src/worker/spi_layout.rs
@@ -20,6 +20,8 @@
 /// Top-down GIC SPI allocator.
 struct SpiAllocator {
     range_start: u32,
+    /// One past the last allocated INTID, or `range_end + 1` when nothing
+    /// has been allocated yet.
     cursor: u32,
 }
 
@@ -27,33 +29,31 @@ impl SpiAllocator {
     fn new(range: std::ops::RangeInclusive<u32>) -> Self {
         Self {
             range_start: *range.start(),
-            cursor: *range.end(),
+            cursor: *range.end() + 1,
         }
     }
 
     /// Allocates a single SPI, returning its GIC INTID.
     #[expect(dead_code)] // used when SMMU instances are configured
     fn alloc(&mut self, tag: &str) -> anyhow::Result<u32> {
-        if self.cursor < self.range_start {
+        if self.cursor <= self.range_start {
             anyhow::bail!("SPI exhausted allocating {tag}");
         }
-        let intid = self.cursor;
         self.cursor -= 1;
-        Ok(intid)
+        Ok(self.cursor)
     }
 
     /// Allocates a contiguous block of `count` SPIs, returning the lowest
     /// GIC INTID in the block.
     fn alloc_block(&mut self, tag: &str, count: u32) -> anyhow::Result<u32> {
-        let available = self.cursor.saturating_sub(self.range_start) + 1;
-        if count == 0 || count > available {
+        let available = self.cursor - self.range_start;
+        if count > available {
             anyhow::bail!(
                 "SPI exhausted allocating {tag}: need {count}, only {available} remaining"
             );
         }
-        let base = self.cursor - count + 1;
-        self.cursor = base - 1;
-        Ok(base)
+        self.cursor -= count;
+        Ok(self.cursor)
     }
 }
 

--- a/openvmm/openvmm_core/src/worker/spi_layout.rs
+++ b/openvmm/openvmm_core/src/worker/spi_layout.rs
@@ -31,6 +31,7 @@ impl SpiAllocator {
     }
 
     /// Allocates a single SPI, returning its GIC INTID.
+    #[expect(dead_code)] // used when SMMU instances are configured
     fn alloc(&mut self, tag: &str) -> anyhow::Result<u32> {
         if self.cursor < self.range_start {
             anyhow::bail!("SPI exhausted allocating {tag}");

--- a/openvmm/openvmm_core/src/worker/spi_layout.rs
+++ b/openvmm/openvmm_core/src/worker/spi_layout.rs
@@ -12,9 +12,10 @@
 //! This is critical for hibernation — a resumed VM must get the same SPI
 //! layout as the original.
 //!
-//! SPIs are allocated top-down from INTID 1019. This maximizes distance from
-//! the guest-side vPCI MSI allocator (Hyper-V PCI driver in Linux), which
-//! allocates bottom-up starting at INTID 64.
+//! SPIs are allocated top-down from the highest SPI supported by the GIC
+//! (determined by `gic_nr_irqs`). This maximizes distance from the guest-side
+//! vPCI MSI allocator (Hyper-V PCI driver in Linux), which allocates bottom-up
+//! starting at INTID 64.
 
 /// Top-down GIC SPI allocator.
 struct SpiAllocator {
@@ -58,6 +59,9 @@ impl SpiAllocator {
 
 /// Inputs to the SPI layout resolver.
 pub(super) struct SpiLayoutInput {
+    /// Total number of GIC interrupt lines (INTIDs 0..gic_nr_irqs-1).
+    /// Determines the highest usable SPI.
+    pub gic_nr_irqs: u32,
     /// Number of SPIs to reserve for GICv2m MSI delivery. `None` when using
     /// ITS (no v2m block needed).
     pub v2m_spi_count: Option<u32>,
@@ -72,11 +76,12 @@ pub(super) struct ResolvedSpiLayout {
 /// Resolves SPI assignments for all platform devices.
 ///
 /// All allocations happen here in a single top-down pass over the SPI range
-/// `[64, 1019]`. The order of allocations determines the layout and must not
-/// change across OpenVMM versions for a given config, or hibernation will
-/// break.
+/// `[64, gic_nr_irqs-1]`. The order of allocations determines the layout and
+/// must not change across OpenVMM versions for a given config, or hibernation
+/// will break.
 pub(super) fn resolve_spi_layout(input: &SpiLayoutInput) -> anyhow::Result<ResolvedSpiLayout> {
-    let mut spi = SpiAllocator::new(64..=1019);
+    let max_intid = input.gic_nr_irqs.saturating_sub(1).min(1019);
+    let mut spi = SpiAllocator::new(64..=max_intid);
 
     // --- Allocation order (do not reorder!) ---
 
@@ -96,16 +101,18 @@ mod tests {
     #[test]
     fn v2m_allocation() {
         let result = resolve_spi_layout(&SpiLayoutInput {
+            gic_nr_irqs: 992,
             v2m_spi_count: Some(64),
         })
         .unwrap();
 
-        assert_eq!(result.v2m_spi_base, Some(956));
+        assert_eq!(result.v2m_spi_base, Some(928));
     }
 
     #[test]
     fn its_skips_v2m() {
         let result = resolve_spi_layout(&SpiLayoutInput {
+            gic_nr_irqs: 992,
             v2m_spi_count: None,
         })
         .unwrap();

--- a/openvmm/openvmm_core/src/worker/spi_layout.rs
+++ b/openvmm/openvmm_core/src/worker/spi_layout.rs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![cfg(guest_arch = "aarch64")]
+
+//! GIC SPI layout resolver for aarch64 VMs.
+//!
+//! This module determines the GIC SPI assignments for all platform devices
+//! that need dynamically allocated interrupts. It is the SPI analogue of
+//! [`super::memory_layout`]: all allocations happen in a single deterministic
+//! pass so that the assignments are a pure function of the VM configuration.
+//! This is critical for hibernation — a resumed VM must get the same SPI
+//! layout as the original.
+//!
+//! SPIs are allocated top-down from INTID 1019. This maximizes distance from
+//! the guest-side vPCI MSI allocator (Hyper-V PCI driver in Linux), which
+//! allocates bottom-up starting at INTID 64.
+
+/// Top-down GIC SPI allocator.
+struct SpiAllocator {
+    range_start: u32,
+    cursor: u32,
+}
+
+impl SpiAllocator {
+    fn new(range: std::ops::RangeInclusive<u32>) -> Self {
+        Self {
+            range_start: *range.start(),
+            cursor: *range.end(),
+        }
+    }
+
+    /// Allocates a single SPI, returning its GIC INTID.
+    fn alloc(&mut self, tag: &str) -> anyhow::Result<u32> {
+        if self.cursor < self.range_start {
+            anyhow::bail!("SPI exhausted allocating {tag}");
+        }
+        let intid = self.cursor;
+        self.cursor -= 1;
+        Ok(intid)
+    }
+
+    /// Allocates a contiguous block of `count` SPIs, returning the lowest
+    /// GIC INTID in the block.
+    fn alloc_block(&mut self, tag: &str, count: u32) -> anyhow::Result<u32> {
+        let available = self.cursor.saturating_sub(self.range_start) + 1;
+        if count == 0 || count > available {
+            anyhow::bail!(
+                "SPI exhausted allocating {tag}: need {count}, only {available} remaining"
+            );
+        }
+        let base = self.cursor - count + 1;
+        self.cursor = base - 1;
+        Ok(base)
+    }
+}
+
+/// Inputs to the SPI layout resolver.
+pub(super) struct SpiLayoutInput {
+    /// Number of SPIs to reserve for GICv2m MSI delivery. `None` when using
+    /// ITS (no v2m block needed).
+    pub v2m_spi_count: Option<u32>,
+}
+
+/// Resolved SPI assignments for all platform devices.
+pub(super) struct ResolvedSpiLayout {
+    /// GICv2m SPI base INTID. `None` when using ITS.
+    pub v2m_spi_base: Option<u32>,
+}
+
+/// Resolves SPI assignments for all platform devices.
+///
+/// All allocations happen here in a single top-down pass over the SPI range
+/// `[64, 1019]`. The order of allocations determines the layout and must not
+/// change across OpenVMM versions for a given config, or hibernation will
+/// break.
+pub(super) fn resolve_spi_layout(input: &SpiLayoutInput) -> anyhow::Result<ResolvedSpiLayout> {
+    let mut spi = SpiAllocator::new(64..=1019);
+
+    // --- Allocation order (do not reorder!) ---
+
+    // 1. GICv2m MSI block.
+    let v2m_spi_base = input
+        .v2m_spi_count
+        .map(|count| spi.alloc_block("gicv2m", count))
+        .transpose()?;
+
+    Ok(ResolvedSpiLayout { v2m_spi_base })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn v2m_allocation() {
+        let result = resolve_spi_layout(&SpiLayoutInput {
+            v2m_spi_count: Some(64),
+        })
+        .unwrap();
+
+        assert_eq!(result.v2m_spi_base, Some(956));
+    }
+
+    #[test]
+    fn its_skips_v2m() {
+        let result = resolve_spi_layout(&SpiLayoutInput {
+            v2m_spi_count: None,
+        })
+        .unwrap();
+
+        assert_eq!(result.v2m_spi_base, None);
+    }
+}

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -80,9 +80,6 @@ pub const DEFAULT_GIC_V2M_MSI_FRAME_BASE: u64 = 0xEFFE_8000;
 /// Size of the v2m MSI frame (one 4KB page is the architectural minimum).
 pub const GIC_V2M_MSI_FRAME_SIZE: u64 = 0x1000;
 
-/// Default number of SPIs reserved for PCIe MSIs when using GICv2m.
-pub const DEFAULT_GIC_V2M_SPI_COUNT: u32 = 64;
-
 /// Base address of the GICv3 ITS MMIO region. Must be 64 KiB aligned,
 /// below the v2m frame address, and not overlap other devices.
 /// The region extends from this base to base + GIC_ITS_SIZE (128 KiB).
@@ -294,8 +291,9 @@ pub enum GicMsiConfig {
     Its,
     /// Force GICv2m for MSI delivery via SPIs.
     V2m {
-        /// Number of SPIs to reserve for PCIe MSIs.
-        spi_count: u32,
+        /// Number of SPIs to reserve for PCIe MSIs. Defaults to a
+        /// platform-specific value when `None`.
+        spi_count: Option<u32>,
     },
 }
 

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -80,10 +80,7 @@ pub const DEFAULT_GIC_V2M_MSI_FRAME_BASE: u64 = 0xEFFE_8000;
 /// Size of the v2m MSI frame (one 4KB page is the architectural minimum).
 pub const GIC_V2M_MSI_FRAME_SIZE: u64 = 0x1000;
 
-/// First GIC interrupt ID reserved for PCIe MSIs via the v2m frame.
-/// Must be in the SPI range (32–1019) and not conflict with other devices.
-pub const DEFAULT_GIC_V2M_SPI_BASE: u32 = 512;
-/// Number of SPIs reserved for PCIe MSIs.
+/// Default number of SPIs reserved for PCIe MSIs when using GICv2m.
 pub const DEFAULT_GIC_V2M_SPI_COUNT: u32 = 64;
 
 /// Base address of the GICv3 ITS MMIO region. Must be 64 KiB aligned,
@@ -296,7 +293,10 @@ pub enum GicMsiConfig {
     /// Force GICv3 ITS for MSI delivery via LPIs.
     Its,
     /// Force GICv2m for MSI delivery via SPIs.
-    V2m,
+    V2m {
+        /// Number of SPIs to reserve for PCIe MSIs.
+        spi_count: u32,
+    },
 }
 
 #[derive(Debug, Protobuf, Default, Clone)]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1285,7 +1285,9 @@ async fn vm_config_from_command_line(
             gic_msi: match opt.gic_msi {
                 cli_args::GicMsiCli::Auto => openvmm_defs::config::GicMsiConfig::Auto,
                 cli_args::GicMsiCli::Its => openvmm_defs::config::GicMsiConfig::Its,
-                cli_args::GicMsiCli::V2m => openvmm_defs::config::GicMsiConfig::V2m,
+                cli_args::GicMsiCli::V2m => openvmm_defs::config::GicMsiConfig::V2m {
+                    spi_count: openvmm_defs::config::DEFAULT_GIC_V2M_SPI_COUNT,
+                },
             },
         },
     );

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1285,9 +1285,9 @@ async fn vm_config_from_command_line(
             gic_msi: match opt.gic_msi {
                 cli_args::GicMsiCli::Auto => openvmm_defs::config::GicMsiConfig::Auto,
                 cli_args::GicMsiCli::Its => openvmm_defs::config::GicMsiConfig::Its,
-                cli_args::GicMsiCli::V2m => openvmm_defs::config::GicMsiConfig::V2m {
-                    spi_count: openvmm_defs::config::DEFAULT_GIC_V2M_SPI_COUNT,
-                },
+                cli_args::GicMsiCli::V2m => {
+                    openvmm_defs::config::GicMsiConfig::V2m { spi_count: None }
+                }
             },
         },
     );


### PR DESCRIPTION
Introduce a deterministic SPI layout resolver for aarch64 VMs, analogous to the memory layout engine. All GIC SPI assignments for platform devices (GICv2m MSI block) are computed in a single top-down pass over the SPI range [64, 1019], ensuring the layout is a pure function of the VM config. This is critical for hibernation stability.

The BuildTopology trait is replaced with cfg-gated free functions, and the GicMsiConfig::V2m variant now carries an explicit spi_count field so the user can control the v2m block size. The DEFAULT_GIC_V2M_SPI_BASE constant is removed since the allocator picks the base dynamically.

This is not very interesting yet, but it will become more interesting when we add vSMMUs (which need SPIs).