### PR TITLE
inspect: adding active and inactive anonymous memory to memory inspect (#3525)

### DIFF
--- a/openhcl/underhill_core/src/inspect_proc.rs
+++ b/openhcl/underhill_core/src/inspect_proc.rs
@@ -18,6 +18,8 @@ fn inspect_meminfo(req: Request<'_>) {
         "Mapped",
         "Slab",
         "AnonPages",
+        "Active(anon)",
+        "Inactive(anon)",
         "SUnreclaim",
         "KernelStack",
         "PageTables",


### PR DESCRIPTION
Adding active and inactive anonymous memory usage will remove some of the guesswork with investigating OOMs as it will provide a more verbose breakdown of the user mode memory history from periodic memory status telemetry.

(cherry picked from commit 15f3e2912d26bcbbfdaab8c2a77da46af8fb2322)