### PR TITLE
petri: include internal halt reason in error

### DIFF
--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -15,7 +15,7 @@ use crate::ModifyFn;
 use crate::NoPetriVmInspector;
 use crate::OpenHclServicingFlags;
 use crate::OpenvmmLogConfig;
-use crate::PetriHaltReason;
+use crate::PetriHaltReasonDetail;
 use crate::PetriVmConfig;
 use crate::PetriVmResources;
 use crate::PetriVmRuntime;
@@ -478,7 +478,7 @@ impl PetriVmRuntime for HyperVPetriRuntime {
         self.vm.remove().await
     }
 
-    async fn wait_for_halt(&mut self, allow_reset: bool) -> anyhow::Result<PetriHaltReason> {
+    async fn wait_for_halt(&mut self, allow_reset: bool) -> anyhow::Result<PetriHaltReasonDetail> {
         self.vm.wait_for_halt(allow_reset).await
     }
 

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -1451,6 +1451,92 @@ pub async fn run_get_winevent(
 const HYPERV_WORKER_TABLE: &str = "Microsoft-Windows-Hyper-V-Worker-Admin";
 const HYPERV_VMMS_TABLE: &str = "Microsoft-Windows-Hyper-V-VMMS-Admin";
 
+macro_rules! define_winevents {
+    (
+        $($collection_name:ident(
+            $(
+                $(#[doc = $doc:literal])*
+                $vis:vis const $name:ident: u32 = $id:literal;
+            )*
+        )),*
+    ) => {
+        $($(
+            $(#[doc = $doc])*
+            $vis const $name: u32 = $id;
+        )*)*
+
+        /// Get the name of a Windows event ID
+        pub fn winevent_name(id: u32) -> Option<&'static str> {
+            match id {
+                $($(
+                    $name => Some(stringify!($name)),
+                )*)*
+                _ => None
+            }
+        }
+
+        $(
+            const $collection_name: &[u32] = &[
+                $($name,)*
+            ];
+        )*
+    };
+}
+
+define_winevents!(
+    BOOT_EVENT_IDS(
+        /// The vm successfully booted an operating system.
+        pub const MSVM_BOOT_RESULTS_SUCCESS: u32 = 18601;
+        /// The vm successfully booted an operating system, but at least one boot source failed secure boot validation.
+        pub const MSVM_BOOT_RESULTS_SUCCESS_SECURE_BOOT_FAILURES: u32 = 18602;
+        /// The vm failed to boot an operating system.
+        pub const MSVM_BOOT_RESULTS_FAILURE: u32 = 18603;
+        /// The vm failed to boot an operating system. At least one boot source failed secure boot validation.
+        pub const MSVM_BOOT_RESULTS_FAILURE_SECURE_BOOT_FAILURES: u32 = 18604;
+        /// The vm failed to boot an operating system. No bootable devices are configured.
+        pub const MSVM_BOOT_RESULTS_FAILURE_NO_DEVICES: u32 = 18605;
+        /// The vm is attempting to boot an operating system. (PCAT only)
+        pub const MSVM_BOOT_RESULTS_ATTEMPT: u32 = 18606;
+    ),
+    HALT_EVENT_IDS(
+        /// The vm was turned off.
+        pub const MSVM_HOST_STOP_SUCCESS: u32 = 18502;
+        /// The vm was shut down using the Shutdown Integration Component.
+        pub const MSVM_HOST_SHUTDOWN_SUCCESS: u32 = 18504;
+        /// The vm was shut down by the guest operating system.
+        pub const MSVM_GUEST_SHUTDOWN_SUCCESS: u32 = 18508;
+        /// The vm was shut down using the Shutdown Integration Component.
+        pub const MSVM_HOST_RESET_SUCCESS: u32 = 18512;
+        /// The vm was shut down by the guest operating system.
+        pub const MSVM_GUEST_RESET_SUCCESS: u32 = 18514;
+        /// The vm was shut down for a reset initiated by the guest operating system.
+        pub const MSVM_STOP_FOR_GUEST_RESET_SUCCESS: u32 = 18515;
+        /// The vm was turned off as it could not recover from a critical error.
+        pub const MSVM_STOP_CRITICAL_SUCCESS: u32 = 18528;
+        /// The vm was reset because the guest operating system requested an operation
+        /// that is not supported by Hyper-V or an unrecoverable error occurred.
+        /// This caused a triple fault.
+        pub const MSVM_TRIPLE_FAULT_GENERAL_ERROR: u32 = 18539;
+        /// The vm was reset because the guest operating system requested an operation
+        /// that is not supported by Hyper-V. This request caused a triple fault.
+        pub const MSVM_TRIPLE_FAULT_UNSUPPORTED_FEATURE_ERROR: u32 = 18540;
+        /// The vm was reset because an unrecoverable error occurred while accessing a
+        /// virtual processor register which caused a triple fault.
+        pub const MSVM_TRIPLE_FAULT_INVALID_VP_REGISTER_ERROR: u32 = 18550;
+        /// The vm was reset because an unrecoverable error occurred on a virtual
+        /// processor that caused a triple fault.
+        pub const MSVM_TRIPLE_FAULT_UNRECOVERABLE_EXCEPTION_ERROR: u32 = 18560;
+        /// The vm was hibernated successfully.
+        pub const MSVM_GUEST_HIBERNATE_SUCCESS: u32 = 18608;
+        /// The vm has quit unexpectedly (the worker process terminated).
+        pub const MSVM_VMMS_VM_TERMINATE_ERROR: u32 = 14070;
+        /// The vm has encountered a fatal error. The guest operating system reported that it failed.
+        pub const MSVM_GUEST_CRASH_REPORT: u32 = 18590;
+        /// The vm failed in the management VTL before starting guest VTL0.
+        pub const MSVM_START_VTL0_REQUEST_ERROR: u32 = 18620;
+    )
+);
+
 /// Get Hyper-V event logs for a VM
 pub async fn hyperv_event_logs(
     vmid: Option<&Guid>,
@@ -1466,28 +1552,6 @@ pub async fn hyperv_event_logs(
     .await
 }
 
-/// The vm successfully booted an operating system.
-pub const MSVM_BOOT_RESULTS_SUCCESS: u32 = 18601;
-/// The vm successfully booted an operating system, but at least one boot source failed secure boot validation.
-pub const MSVM_BOOT_RESULTS_SUCCESS_SECURE_BOOT_FAILURES: u32 = 18602;
-/// The vm failed to boot an operating system.
-pub const MSVM_BOOT_RESULTS_FAILURE: u32 = 18603;
-/// The vm failed to boot an operating system. At least one boot source failed secure boot validation.
-pub const MSVM_BOOT_RESULTS_FAILURE_SECURE_BOOT_FAILURES: u32 = 18604;
-/// The vm failed to boot an operating system. No bootable devices are configured.
-pub const MSVM_BOOT_RESULTS_FAILURE_NO_DEVICES: u32 = 18605;
-/// The vm is attempting to boot an operating system. (PCAT only)
-pub const MSVM_BOOT_RESULTS_ATTEMPT: u32 = 18606;
-
-const BOOT_EVENT_IDS: [u32; 6] = [
-    MSVM_BOOT_RESULTS_SUCCESS,
-    MSVM_BOOT_RESULTS_SUCCESS_SECURE_BOOT_FAILURES,
-    MSVM_BOOT_RESULTS_FAILURE,
-    MSVM_BOOT_RESULTS_FAILURE_SECURE_BOOT_FAILURES,
-    MSVM_BOOT_RESULTS_FAILURE_NO_DEVICES,
-    MSVM_BOOT_RESULTS_ATTEMPT,
-];
-
 /// Get Hyper-V boot event logs for a VM
 pub async fn hyperv_boot_events(
     vmid: &Guid,
@@ -1498,58 +1562,10 @@ pub async fn hyperv_boot_events(
         &[HYPERV_WORKER_TABLE],
         Some(start_time),
         Some(&vmid),
-        &BOOT_EVENT_IDS,
+        BOOT_EVENT_IDS,
     )
     .await
 }
-
-/// The vm was turned off.
-pub const MSVM_HOST_STOP_SUCCESS: u32 = 18502;
-/// The vm was shut down using the Shutdown Integration Component.
-pub const MSVM_HOST_SHUTDOWN_SUCCESS: u32 = 18504;
-/// The vm was shut down by the guest operating system.
-pub const MSVM_GUEST_SHUTDOWN_SUCCESS: u32 = 18508;
-/// The vm was shut down using the Shutdown Integration Component.
-pub const MSVM_HOST_RESET_SUCCESS: u32 = 18512;
-/// The vm was shut down by the guest operating system.
-pub const MSVM_GUEST_RESET_SUCCESS: u32 = 18514;
-/// The vm was shut down for a reset initiated by the guest operating system.
-pub const MSVM_STOP_FOR_GUEST_RESET_SUCCESS: u32 = 18515;
-/// The vm was turned off as it could not recover from a critical error.
-pub const MSVM_STOP_CRITICAL_SUCCESS: u32 = 18528;
-/// The vm was reset because the guest operating system requested an operation
-/// that is not supported by Hyper-V or an unrecoverable error occurred.
-/// This caused a triple fault.
-pub const MSVM_TRIPLE_FAULT_GENERAL_ERROR: u32 = 18539;
-/// The vm was reset because the guest operating system requested an operation
-/// that is not supported by Hyper-V. This request caused a triple fault.
-pub const MSVM_TRIPLE_FAULT_UNSUPPORTED_FEATURE_ERROR: u32 = 18540;
-/// The vm was reset because an unrecoverable error occurred while accessing a
-/// virtual processor register which caused a triple fault.
-pub const MSVM_TRIPLE_FAULT_INVALID_VP_REGISTER_ERROR: u32 = 18550;
-/// The vm was reset because an unrecoverable error occurred on a virtual
-/// processor that caused a triple fault.
-pub const MSVM_TRIPLE_FAULT_UNRECOVERABLE_EXCEPTION_ERROR: u32 = 18560;
-/// The vm was hibernated successfully.
-pub const MSVM_GUEST_HIBERNATE_SUCCESS: u32 = 18608;
-/// The vm has quit unexpectedly (the worker process terminated).
-pub const MSVM_VMMS_VM_TERMINATE_ERROR: u32 = 14070;
-
-const HALT_EVENT_IDS: [u32; 13] = [
-    MSVM_HOST_STOP_SUCCESS,
-    MSVM_HOST_SHUTDOWN_SUCCESS,
-    MSVM_GUEST_SHUTDOWN_SUCCESS,
-    MSVM_HOST_RESET_SUCCESS,
-    MSVM_GUEST_RESET_SUCCESS,
-    MSVM_STOP_FOR_GUEST_RESET_SUCCESS,
-    MSVM_STOP_CRITICAL_SUCCESS,
-    MSVM_TRIPLE_FAULT_GENERAL_ERROR,
-    MSVM_TRIPLE_FAULT_UNSUPPORTED_FEATURE_ERROR,
-    MSVM_TRIPLE_FAULT_INVALID_VP_REGISTER_ERROR,
-    MSVM_TRIPLE_FAULT_UNRECOVERABLE_EXCEPTION_ERROR,
-    MSVM_GUEST_HIBERNATE_SUCCESS,
-    MSVM_VMMS_VM_TERMINATE_ERROR,
-];
 
 /// Get Hyper-V halt event logs for a VM
 pub async fn hyperv_halt_events(
@@ -1561,7 +1577,7 @@ pub async fn hyperv_halt_events(
         &[HYPERV_WORKER_TABLE, HYPERV_VMMS_TABLE],
         Some(start_time),
         Some(&vmid),
-        &HALT_EVENT_IDS,
+        HALT_EVENT_IDS,
     )
     .await
 }

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -9,6 +9,7 @@ use super::powershell;
 use crate::CommandError;
 use crate::OpenHclServicingFlags;
 use crate::PetriHaltReason;
+use crate::PetriHaltReasonDetail;
 use crate::PetriLogFile;
 use crate::PetriLogSource;
 use crate::PetriVmFramebufferAccess;
@@ -372,13 +373,16 @@ impl HyperVVM {
     }
 
     /// Wait for the VM to stop
-    pub async fn wait_for_halt(&mut self, _allow_reset: bool) -> anyhow::Result<PetriHaltReason> {
+    pub async fn wait_for_halt(
+        &mut self,
+        _allow_reset: bool,
+    ) -> anyhow::Result<PetriHaltReasonDetail> {
         // Allow CVMs some time for the VM to be off after reset.
         const CVM_ALLOWED_OFF_TIME: Duration = Duration::from_secs(15);
 
         let (halt_reason, timestamp) = self.wait_for_off_or_internal(Self::halt_event).await?;
 
-        if halt_reason == PetriHaltReason::Reset {
+        if halt_reason.reason == PetriHaltReason::Reset {
             // add 1ms to avoid getting the same event again
             self.last_start_time = Some(timestamp.checked_add(Duration::from_millis(1))?);
 
@@ -409,19 +413,25 @@ impl HyperVVM {
         Ok(halt_reason)
     }
 
-    async fn halt_event(&self) -> anyhow::Result<Option<(PetriHaltReason, Timestamp)>> {
+    async fn halt_event(&self) -> anyhow::Result<Option<(PetriHaltReasonDetail, Timestamp)>> {
         let events = powershell::hyperv_halt_events(
             &self.vmid,
             self.last_start_time.as_ref().unwrap_or(&self.create_time),
         )
         .await?;
 
-        if events.len() > 1 {
-            anyhow::bail!("Got more than one halt event");
-        }
-        let event = events.first();
+        let detail = events
+            .iter()
+            .map(|e| {
+                powershell::winevent_name(e.id)
+                    .map(|n| n.to_string())
+                    .unwrap_or(e.id.to_string())
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
 
-        event
+        let reasons = events
+            .into_iter()
             .map(|e| {
                 Ok((
                     match e.id {
@@ -439,13 +449,24 @@ impl HyperVVM {
                             PetriHaltReason::TripleFault
                         }
                         powershell::MSVM_STOP_CRITICAL_SUCCESS
-                        | powershell::MSVM_VMMS_VM_TERMINATE_ERROR => PetriHaltReason::Other,
+                        | powershell::MSVM_VMMS_VM_TERMINATE_ERROR
+                        | powershell::MSVM_GUEST_CRASH_REPORT
+                        | powershell::MSVM_START_VTL0_REQUEST_ERROR => PetriHaltReason::Other,
                         id => anyhow::bail!("Unexpected event id: {id}"),
                     },
                     e.time_created,
                 ))
             })
-            .transpose()
+            .collect::<anyhow::Result<Vec<(PetriHaltReason, Timestamp)>>>()?;
+
+        Ok(if reasons.len() > 1 {
+            Some((
+                PetriHaltReason::Other.with_detail(detail),
+                reasons.last().unwrap().1,
+            ))
+        } else {
+            reasons.first().map(|r| (r.0.with_detail(detail), r.1))
+        })
     }
 
     /// Wait for the VM shutdown ic

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -1579,7 +1579,7 @@ impl<T: PetriVmmBackend> PetriVm<T> {
     }
 
     /// Wait for the VM to halt, returning the reason for the halt.
-    pub async fn wait_for_halt(&mut self) -> anyhow::Result<PetriHaltReason> {
+    pub async fn wait_for_halt(&mut self) -> anyhow::Result<PetriHaltReasonDetail> {
         tracing::info!("Waiting for VM to halt...");
         let halt_reason = self.runtime.wait_for_halt(false).await?;
         tracing::info!("VM halted: {halt_reason:?}. Cancelling watchdogs...");
@@ -1590,7 +1590,7 @@ impl<T: PetriVmmBackend> PetriVm<T> {
     /// Wait for the VM to cleanly shutdown.
     pub async fn wait_for_clean_shutdown(&mut self) -> anyhow::Result<()> {
         let halt_reason = self.wait_for_halt().await?;
-        if halt_reason != PetriHaltReason::PowerOff {
+        if halt_reason.reason != PetriHaltReason::PowerOff {
             anyhow::bail!("Expected PowerOff, got {halt_reason:?}");
         }
         tracing::info!("VM was cleanly powered off and torn down.");
@@ -1599,7 +1599,7 @@ impl<T: PetriVmmBackend> PetriVm<T> {
 
     /// Wait for the VM to halt, returning the reason for the halt,
     /// and tear down the VM.
-    pub async fn wait_for_teardown(mut self) -> anyhow::Result<PetriHaltReason> {
+    pub async fn wait_for_teardown(mut self) -> anyhow::Result<PetriHaltReasonDetail> {
         let halt_reason = self.wait_for_halt().await?;
         self.teardown().await?;
         Ok(halt_reason)
@@ -1627,7 +1627,7 @@ impl<T: PetriVmmBackend> PetriVm<T> {
     async fn wait_for_reset_core(&mut self) -> anyhow::Result<()> {
         tracing::info!("Waiting for VM to reset...");
         let halt_reason = self.runtime.wait_for_halt(true).await?;
-        if halt_reason != PetriHaltReason::Reset {
+        if halt_reason.reason != PetriHaltReason::Reset {
             anyhow::bail!("Expected reset, got {halt_reason:?}");
         }
         tracing::info!("VM reset.");
@@ -1967,7 +1967,7 @@ pub trait PetriVmRuntime: Send + Sync + 'static {
     async fn teardown(self) -> anyhow::Result<()>;
     /// Wait for the VM to halt, returning the reason for the halt. The VM
     /// should automatically restart the VM on reset if `allow_reset` is true.
-    async fn wait_for_halt(&mut self, allow_reset: bool) -> anyhow::Result<PetriHaltReason>;
+    async fn wait_for_halt(&mut self, allow_reset: bool) -> anyhow::Result<PetriHaltReasonDetail>;
     /// Wait for a connection from a pipette agent
     async fn wait_for_agent(&mut self, set_high_vtl: bool) -> anyhow::Result<PipetteClient>;
     /// Get an OpenHCL diagnostics handler for the VM
@@ -3130,6 +3130,25 @@ pub enum PetriHaltReason {
     TripleFault,
     /// The vm halted for some other reason
     Other,
+}
+
+impl PetriHaltReason {
+    /// Construct a halt reason with detailed debug info
+    pub fn with_detail(self, detail: String) -> PetriHaltReasonDetail {
+        PetriHaltReasonDetail {
+            reason: self,
+            detail,
+        }
+    }
+}
+
+/// The reason that the VM halted, with optional addition debug details
+#[derive(Debug, Clone)]
+pub struct PetriHaltReasonDetail {
+    /// The reason for the halt
+    pub reason: PetriHaltReason,
+    /// More details about the halt
+    pub detail: String,
 }
 
 fn append_cmdline(cmd: &mut Option<String>, add_cmd: impl AsRef<str>) {

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -6,6 +6,7 @@
 use super::PetriVmResourcesOpenVmm;
 use crate::OpenHclServicingFlags;
 use crate::PetriHaltReason;
+use crate::PetriHaltReasonDetail;
 use crate::PetriVmFramebufferAccess;
 use crate::PetriVmInspector;
 use crate::PetriVmRuntime;
@@ -68,7 +69,7 @@ impl PetriVmRuntime for PetriVmOpenVmm {
         Ok(())
     }
 
-    async fn wait_for_halt(&mut self, allow_reset: bool) -> anyhow::Result<PetriHaltReason> {
+    async fn wait_for_halt(&mut self, allow_reset: bool) -> anyhow::Result<PetriHaltReasonDetail> {
         let halt_reason = if let Some(already) = self.halt.already_received.take() {
             already.map_err(anyhow::Error::from)
         } else {
@@ -81,7 +82,7 @@ impl PetriVmRuntime for PetriVmOpenVmm {
 
         tracing::info!(?halt_reason, "Got halt reason");
 
-        let halt_reason = match halt_reason {
+        let reason = match halt_reason {
             HaltReason::PowerOff => PetriHaltReason::PowerOff,
             HaltReason::Reset => PetriHaltReason::Reset,
             HaltReason::Hibernate => PetriHaltReason::Hibernate,
@@ -89,11 +90,14 @@ impl PetriVmRuntime for PetriVmOpenVmm {
             _ => PetriHaltReason::Other,
         };
 
-        if allow_reset && halt_reason == PetriHaltReason::Reset {
+        if allow_reset && reason == PetriHaltReason::Reset {
             self.reset().await?
         }
 
-        Ok(halt_reason)
+        Ok(PetriHaltReasonDetail {
+            reason,
+            detail: format!("{halt_reason:?}"),
+        })
     }
 
     async fn wait_for_agent(&mut self, set_high_vtl: bool) -> anyhow::Result<PipetteClient> {

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -553,11 +553,16 @@ async fn guest_test_uefi<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyho
     // No boot event check, UEFI watchdog gets fired before ExitBootServices
     let halt_reason = vm.wait_for_teardown().await?;
     tracing::debug!("vm halt reason: {halt_reason:?}");
+    let check_reason = |expected| {
+        if halt_reason.reason != expected {
+            anyhow::bail!("Expected {expected:?}, got {halt_reason:?}");
+        }
+        Ok(())
+    };
     match arch {
-        MachineArch::X86_64 => assert!(matches!(halt_reason, PetriHaltReason::TripleFault)),
-        MachineArch::Aarch64 => assert!(matches!(halt_reason, PetriHaltReason::Reset)),
+        MachineArch::X86_64 => check_reason(PetriHaltReason::TripleFault),
+        MachineArch::Aarch64 => check_reason(PetriHaltReason::Reset),
     }
-    Ok(())
 }
 
 /// Test that unauthenticated deletion of PK and KEK is rejected by the firmware.

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
@@ -762,33 +762,20 @@ async fn skip_hw_unseal<T, U: PetriVmmBackend>(
     //
     // Both outcomes confirm the expected behavior: the VM cannot boot after
     // hardware unsealing is skipped.
-    match vm.wait_for_halt().await {
-        Ok(PetriHaltReason::Reset) => {
+    let halt_reason = vm.wait_for_halt().await?;
+    match halt_reason.reason {
+        PetriHaltReason::Reset => {
             tracing::info!("Got reset event; waiting for second boot termination...");
-            // The VM termination after second boot failure may not produce
-            // a recognized Hyper-V halt event (e.g., event 18620 from
-            // Hyper-V-Chipset is not in the standard halt event filter).
-            // Ignore the error — the VM going off IS the expected outcome.
-            match vm.wait_for_teardown().await {
-                Ok(halt_reason) => {
-                    tracing::info!("Second boot halt reason: {halt_reason:?}");
-                }
-                Err(e) => {
-                    tracing::info!("Second boot terminated as expected: {e:#}");
-                }
+            let second_halt_reason = vm.wait_for_teardown().await?;
+            if !matches!(second_halt_reason.reason, PetriHaltReason::Other) {
+                anyhow::bail!("Unexpected second boot halt reason: {second_halt_reason:?}")
             }
         }
-        Ok(other) => {
-            let error = anyhow::anyhow!("Expected Reset or VM start failure, got {other:?}");
-            vm.teardown().await?;
-            return Err(error);
-        }
-        Err(e) => {
-            // The VM failed to restart within the allowed time, which is
-            // the expected behavior when underhill cannot unlock VMGS.
-            tracing::info!("VM failed to restart as expected: {e:#}");
+        PetriHaltReason::Other => {
+            tracing::info!("VM failed to restart as expected: {halt_reason:?}");
             vm.teardown().await?;
         }
+        _ => anyhow::bail!("Unexpected halt reason: {halt_reason:?}"),
     }
 
     Ok(())


### PR DESCRIPTION
Include the internal, backend-specific halt reason in petri error messages for easier debugging. This is done by propagating a string along with the enum for the halt reason.

For Hyper-V, this change also adds a macro the generates a function to get the name of a Windows event from its ID and adds a two more events to the list.