### PR TITLE
vmotherboard, pcie: add Root Complex Integrated Endpoint (RCiEP) infra

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1888,15 +1888,14 @@ impl InitializedVm {
                                 .map(build_root_port_definition)
                                 .collect();
 
-                            GenericPcieRootComplex::new(
+                            GenericPcieRootComplex::builder(
                                 &mut services.register_mmio(),
-                                rc.start_bus,
-                                rc.end_bus,
-                                chbcr_range,
+                                rc.start_bus..=rc.end_bus,
                                 ranges.ecam_range,
-                                root_port_definitions,
-                                msi_conn.target(),
                             )
+                            .root_ports(root_port_definitions, msi_conn.target())
+                            .chbcr_range(chbcr_range)
+                            .build()
                         })?;
 
                 if let Some(signal_msi) = partition.as_signal_msi(Vtl::Vtl0) {

--- a/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
+++ b/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
@@ -129,15 +129,10 @@ impl FuzzRootComplex {
             .collect();
         let msi_conn =
             pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
-        let rc = GenericPcieRootComplex::new(
-            &mut register_mmio,
-            START_BUS,
-            END_BUS,
-            None,
-            ecam_range,
-            port_defs,
-            msi_conn.target(),
-        );
+        let rc =
+            GenericPcieRootComplex::builder(&mut register_mmio, START_BUS..=END_BUS, ecam_range)
+                .root_ports(port_defs, msi_conn.target())
+                .build();
         Self { rc }
     }
 
@@ -264,7 +259,7 @@ fn do_fuzz(u: &mut Unstructured<'_>) -> arbitrary::Result<()> {
 
     let mut rc = FuzzRootComplex::new(&topology, ecam_range);
 
-    // Port keys: port 0 = device_number 0, port 1 = device_number 8 (1 << 3)
+    // Port keys: device number 0, 1, etc.
     let port0_key: u8 = 0;
 
     match topology {

--- a/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
+++ b/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
@@ -259,7 +259,7 @@ fn do_fuzz(u: &mut Unstructured<'_>) -> arbitrary::Result<()> {
 
     let mut rc = FuzzRootComplex::new(&topology, ecam_range);
 
-    // Port keys: device number 0, 1, etc.
+    // Port keys: port 0 = device_number 0, port 1 = device_number 8 (1 << 3)
     let port0_key: u8 = 0;
 
     match topology {

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -37,7 +37,6 @@ use std::sync::Arc;
 use vmcore::device_state::ChangeDeviceState;
 use zerocopy::IntoBytes;
 
-
 /// A generic PCI Express root complex emulator.
 #[derive(InspectMut)]
 pub struct GenericPcieRootComplex {
@@ -51,19 +50,14 @@ pub struct GenericPcieRootComplex {
     chbcr: Option<Box<dyn ControlMmioIntercept>>,
     /// CXL Component Registers backing CHBCR accesses in CXL mode.
     cxl_component_registers: Option<CxlComponentRegisters>,
-    /// Devices on the root complex bus, indexed by PCI device number (0-31).
-    /// Each slot can hold a root port, an RCiEP, or be empty.
-    #[inspect(iter_by_index)]
-    devices: [BusDevice; MAX_DEVICES_PER_BUS],
+    /// Devices on the root complex bus, sorted by devfn
+    /// (device << 3 | function).
+    #[inspect(skip)]
+    devices: Vec<(u8, BusDevice)>,
 }
-
-/// Maximum number of PCI devices on a single bus.
-const MAX_DEVICES_PER_BUS: usize = 32;
 
 /// A device occupying a slot on the root complex bus.
 enum BusDevice {
-    /// No device at this slot.
-    Empty,
     /// A root port providing downstream connectivity.
     RootPort { name: Arc<str>, port: Box<RootPort> },
     /// A Root Complex Integrated Endpoint (RCiEP).
@@ -73,25 +67,10 @@ enum BusDevice {
     },
 }
 
-impl Inspect for BusDevice {
-    fn inspect(&self, req: inspect::Request<'_>) {
-        match self {
-            BusDevice::Empty => {}
-            BusDevice::RootPort { port, .. } => {
-                req.respond().merge(port.as_ref());
-            }
-            BusDevice::Rciep { name, .. } => {
-                req.respond().field("name", name);
-            }
-        }
-    }
-}
-
-
 /// Information about a downstream port in a PCIe topology.
 pub struct DownstreamPortInfo {
-    /// The PCI device number (0-31) of this port on the root complex bus.
-    pub port_number: u8,
+    /// The devfn (device << 3 | function) of this port on the root complex bus.
+    pub devfn: u8,
     /// The port name.
     pub name: Arc<str>,
     /// Shared bus range, updated by the config space emulator when the
@@ -191,14 +170,14 @@ impl<'a> GenericPcieRootComplexBuilder<'a> {
             region
         });
 
-        let mut devices: [BusDevice; MAX_DEVICES_PER_BUS] =
-            std::array::from_fn(|_| BusDevice::Empty);
+        let mut devices: Vec<(u8, BusDevice)> = Vec::new();
 
         if let Some((ports, msi_target)) = root_ports {
             for (i, definition) in ports.into_iter().enumerate() {
                 let device = i + first_port_device_number as usize;
-                assert!(device < MAX_DEVICES_PER_BUS, "too many ports");
-                let devfn = (device << BDF_DEVICE_SHIFT) as u8;
+                assert!(device < 32, "too many ports");
+                let device = device as u8;
+                let devfn = device << BDF_DEVICE_SHIFT;
                 let hotplug_slot_number = if definition.hotplug {
                     Some(device as u32 + 1)
                 } else {
@@ -212,10 +191,13 @@ impl<'a> GenericPcieRootComplexBuilder<'a> {
                     &port_msi_target,
                     definition.settings,
                 );
-                devices[device] = BusDevice::RootPort {
-                    name: definition.name,
-                    port: Box::new(root_port),
-                };
+                devices.push((
+                    devfn,
+                    BusDevice::RootPort {
+                        name: definition.name,
+                        port: Box::new(root_port),
+                    },
+                ));
             }
         }
 
@@ -269,7 +251,8 @@ enum DecodedEcamAccess<'a> {
     InternalBus(&'a mut RootPort, u16),
     DownstreamPort(&'a mut RootPort, u8, u8, u16),
     /// A Root Complex Integrated Endpoint (RCiEP) on the start bus.
-    Rciep(&'a mut dyn GenericPciBusDevice, u16),
+    /// Fields: device, function, config offset.
+    Rciep(&'a mut dyn GenericPciBusDevice, u8, u16),
 }
 
 impl GenericPcieRootComplex {
@@ -330,17 +313,17 @@ impl GenericPcieRootComplex {
     }
 
     /// Attach the provided `GenericPciBusDevice` to the port identified by
-    /// PCI device number (0-31).
+    /// its devfn (device << 3 | function).
     pub fn add_pcie_device(
         &mut self,
-        port: u8,
+        port_devfn: u8,
         name: impl AsRef<str>,
         dev: Box<dyn GenericPciBusDevice>,
     ) -> Result<(), Arc<str>> {
-        let root_port = match &mut self.devices[port as usize] {
-            BusDevice::RootPort { port, .. } => port,
-            BusDevice::Rciep { name: existing, .. } => return Err(existing.clone()),
-            BusDevice::Empty => return Err(format!("device {port} is not a root port").into()),
+        let root_port = match self.devices.iter_mut().find(|(d, _)| *d == port_devfn) {
+            Some((_, BusDevice::RootPort { port, .. })) => port,
+            Some((_, BusDevice::Rciep { name: existing, .. })) => return Err(existing.clone()),
+            None => return Err(format!("devfn {port_devfn} is not a root port").into()),
         };
 
         root_port.connect_device(name, dev)
@@ -350,14 +333,13 @@ impl GenericPcieRootComplex {
     pub fn downstream_ports(&self) -> Vec<DownstreamPortInfo> {
         self.devices
             .iter()
-            .enumerate()
-            .filter_map(|(i, d)| match d {
+            .filter_map(|(devfn, d)| match d {
                 BusDevice::RootPort { name, port } => Some(DownstreamPortInfo {
-                    port_number: i as u8,
+                    devfn: *devfn,
                     name: name.clone(),
                     bus_range: port.port.bus_range(),
                 }),
-                BusDevice::Rciep { .. } | BusDevice::Empty => None,
+                BusDevice::Rciep { .. } => None,
             })
             .collect()
     }
@@ -372,9 +354,9 @@ impl GenericPcieRootComplex {
         let root_port = self
             .devices
             .iter_mut()
-            .find_map(|d| match d {
+            .find_map(|(_, d)| match d {
                 BusDevice::RootPort { name, port } if name.as_ref() == port_name => Some(port),
-                BusDevice::RootPort { .. } | BusDevice::Rciep { .. } | BusDevice::Empty => None,
+                BusDevice::RootPort { .. } | BusDevice::Rciep { .. } => None,
             })
             .ok_or_else(|| anyhow::anyhow!("port '{}' not found", port_name))?;
         root_port.port.hotplug_add_device(device_name, device)
@@ -385,35 +367,52 @@ impl GenericPcieRootComplex {
         let root_port = self
             .devices
             .iter_mut()
-            .find_map(|d| match d {
+            .find_map(|(_, d)| match d {
                 BusDevice::RootPort { name, port } if name.as_ref() == port_name => Some(port),
-                BusDevice::RootPort { .. } | BusDevice::Rciep { .. } | BusDevice::Empty => None,
+                BusDevice::RootPort { .. } | BusDevice::Rciep { .. } => None,
             })
             .ok_or_else(|| anyhow::anyhow!("port '{}' not found", port_name))?;
         root_port.port.hotplug_remove_device()
     }
 
     /// Attach a Root Complex Integrated Endpoint (RCiEP) at the given
-    /// PCI device number (0-31) on the start bus of this root complex.
+    /// devfn (device << 3 | function) on the start bus of this root complex.
     ///
     /// RCiEPs are Type 0 PCI functions that appear directly on the start
     /// bus alongside root ports (e.g., an AMD IOMMU at device 0).
     /// They do not sit behind a downstream port and have a fixed BDF.
+    ///
+    /// For a single-function RCiEP, register at function 0. Config space
+    /// accesses to other functions of the same device will be forwarded
+    /// to the function 0 device via
+    /// [`pci_cfg_read_with_routing`](GenericPciBusDevice::pci_cfg_read_with_routing),
+    /// whose default implementation returns all-1s (no device present).
+    ///
+    /// For a multi-function RCiEP, either register each function as a
+    /// separate `GenericPciBusDevice`, or register a single device at
+    /// function 0 and override `pci_cfg_read_with_routing` /
+    /// `pci_cfg_write_with_routing` to handle non-zero functions.
     pub fn add_rciep(
         &mut self,
-        device: u8,
+        devfn: u8,
         name: impl Into<Arc<str>>,
         dev: Box<dyn GenericPciBusDevice>,
     ) -> Result<(), Arc<str>> {
         let name = name.into();
-        match &self.devices[device as usize] {
-            BusDevice::Empty => {}
-            BusDevice::RootPort { name: existing, .. }
-            | BusDevice::Rciep { name: existing, .. } => {
-                return Err(existing.clone());
+        match self.devices.binary_search_by_key(&devfn, |(d, _)| *d) {
+            Ok(i) => {
+                let existing = match &self.devices[i].1 {
+                    BusDevice::RootPort { name, .. } | BusDevice::Rciep { name, .. } => {
+                        name.clone()
+                    }
+                };
+                return Err(existing);
+            }
+            Err(i) => {
+                self.devices
+                    .insert(i, (devfn, BusDevice::Rciep { name, dev }));
             }
         }
-        self.devices[device as usize] = BusDevice::Rciep { name, dev };
         Ok(())
     }
 
@@ -431,21 +430,42 @@ impl GenericPcieRootComplex {
         let cfg_offset_within_function = (ecam_offset & PAGE_OFFSET_MASK) as u16;
 
         if bus_number == self.start_bus {
-            let device = (device_function >> BDF_DEVICE_SHIFT) as usize;
             let function = device_function & 0x7;
-            match &mut self.devices[device] {
-                BusDevice::RootPort { port, .. } if function == 0 => {
+            // Look up the exact devfn first; if not found, fall back to
+            // function 0 of the same device so that multi-function
+            // endpoints can handle the access via
+            // `pci_cfg_read_with_routing`.
+            let devfn_fn0 = device_function & !7;
+            let mut idx = None;
+            for (i, (d, _)) in self.devices.iter().enumerate() {
+                if *d == device_function {
+                    idx = Some(i);
+                    break;
+                }
+                if *d == devfn_fn0 {
+                    idx = Some(i);
+                }
+                if *d > device_function {
+                    break;
+                }
+            }
+            match idx.map(|i| &mut self.devices[i].1) {
+                Some(BusDevice::RootPort { port, .. }) if function == 0 => {
                     return DecodedEcamAccess::InternalBus(port, cfg_offset_within_function);
                 }
-                BusDevice::Rciep { dev, .. } if function == 0 => {
-                    return DecodedEcamAccess::Rciep(dev.as_mut(), cfg_offset_within_function);
+                Some(BusDevice::Rciep { dev, .. }) => {
+                    return DecodedEcamAccess::Rciep(
+                        dev.as_mut(),
+                        function,
+                        cfg_offset_within_function,
+                    );
                 }
-                BusDevice::RootPort { .. } | BusDevice::Rciep { .. } | BusDevice::Empty => {
+                _ => {
                     return DecodedEcamAccess::Unroutable;
                 }
             }
         } else if bus_number > self.start_bus && bus_number <= self.end_bus {
-            for d in self.devices.iter_mut() {
+            for (_, d) in self.devices.iter_mut() {
                 if let BusDevice::RootPort { port, .. } = d {
                     if port
                         .port
@@ -479,7 +499,7 @@ impl GenericPcieRootComplex {
             }
         }
 
-        for d in self.devices.iter_mut() {
+        for (_, d) in self.devices.iter_mut() {
             if let BusDevice::RootPort { port, .. } = d {
                 if let Some((bar, offset)) = port.port.find_bar(addr) {
                     if let Err(err) =
@@ -505,7 +525,7 @@ impl GenericPcieRootComplex {
             }
         }
 
-        for d in self.devices.iter_mut() {
+        for (_, d) in self.devices.iter_mut() {
             if let BusDevice::RootPort { port, .. } = d {
                 if let Some((bar, offset)) = port.port.find_bar(addr) {
                     if let Err(err) =
@@ -534,7 +554,7 @@ impl ChangeDeviceState for GenericPcieRootComplex {
     async fn stop(&mut self) {}
 
     async fn reset(&mut self) {
-        for d in self.devices.iter_mut() {
+        for (_, d) in self.devices.iter_mut() {
             if let BusDevice::RootPort { port, .. } = d {
                 port.port.cfg_space.reset();
             }
@@ -596,6 +616,7 @@ impl MmioIntercept for GenericPcieRootComplex {
 
         let dword_aligned_addr = addr & !3;
         let mut dword_value = !0;
+        let start_bus = self.start_bus;
         match self.decode_ecam_access(dword_aligned_addr) {
             DecodedEcamAccess::UnexpectedIntercept => {
                 tracing::error!("unexpected intercept at address 0x{:16x}", addr);
@@ -606,8 +627,11 @@ impl MmioIntercept for GenericPcieRootComplex {
             DecodedEcamAccess::InternalBus(port, cfg_offset) => {
                 check_result!(port.port.cfg_space.read_u32(cfg_offset, &mut dword_value));
             }
-            DecodedEcamAccess::Rciep(dev, cfg_offset) => {
-                if let Some(result) = dev.pci_cfg_read(cfg_offset, &mut dword_value) {
+            DecodedEcamAccess::Rciep(dev, function, cfg_offset) => {
+                let bus = start_bus;
+                if let Some(result) =
+                    dev.pci_cfg_read_with_routing(bus, bus, function, cfg_offset, &mut dword_value)
+                {
                     check_result!(result);
                 }
             }
@@ -667,6 +691,7 @@ impl MmioIntercept for GenericPcieRootComplex {
             }
         };
 
+        let start_bus = self.start_bus;
         match self.decode_ecam_access(dword_aligned_addr) {
             DecodedEcamAccess::UnexpectedIntercept => {
                 tracing::error!("unexpected intercept at address 0x{:16x}", addr);
@@ -677,8 +702,11 @@ impl MmioIntercept for GenericPcieRootComplex {
             DecodedEcamAccess::InternalBus(port, cfg_offset) => {
                 check_result!(port.port.cfg_space.write_u32(cfg_offset, write_dword));
             }
-            DecodedEcamAccess::Rciep(dev, cfg_offset) => {
-                if let Some(result) = dev.pci_cfg_write(cfg_offset, write_dword) {
+            DecodedEcamAccess::Rciep(dev, function, cfg_offset) => {
+                let bus = start_bus;
+                if let Some(result) =
+                    dev.pci_cfg_write_with_routing(bus, bus, function, cfg_offset, write_dword)
+                {
                     check_result!(result);
                 }
             }
@@ -827,9 +855,9 @@ mod save_restore {
         #[derive(Protobuf)]
         #[mesh(package = "pcie.root")]
         pub struct PortSavedState {
-            /// The PCI device number (0-31) of this port.
+            /// The devfn (device << 3 | function) of this port.
             #[mesh(1)]
-            pub port_number: u8,
+            pub devfn: u8,
             /// The root port Type 1 configuration space state.
             #[mesh(2)]
             pub cfg_space: RootPortCfgSpaceSavedState,
@@ -861,12 +889,12 @@ mod save_restore {
         type SavedState = state::SavedState;
 
         fn save(&mut self) -> Result<Self::SavedState, SaveError> {
-            // Save all root ports in device-number order (already ordered by array index).
+            // Save all root ports in devfn order.
             let mut ports = Vec::new();
-            for (i, d) in self.devices.iter_mut().enumerate() {
+            for (devfn, d) in self.devices.iter_mut() {
                 if let BusDevice::RootPort { port, .. } = d {
                     ports.push(state::PortSavedState {
-                        port_number: i as u8,
+                        devfn: *devfn,
                         cfg_space: port.port.cfg_space.save()?,
                         cxl_component_registers: port.port.save_cxl_component_registers_state()?,
                     });
@@ -908,7 +936,7 @@ mod save_restore {
             let root_port_count = self
                 .devices
                 .iter()
-                .filter(|d| matches!(d, BusDevice::RootPort { .. }))
+                .filter(|(_, d)| matches!(d, BusDevice::RootPort { .. }))
                 .count();
             if ports.len() != root_port_count {
                 return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
@@ -920,26 +948,30 @@ mod save_restore {
 
             let mut seen_ports = HashSet::with_capacity(ports.len());
 
-            // Restore each saved port by explicit port number.
+            // Restore each saved port by devfn.
             for port_state in ports {
-                if !seen_ports.insert(port_state.port_number) {
+                if !seen_ports.insert(port_state.devfn) {
                     return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
-                        "duplicate root port {} in saved state",
-                        port_state.port_number
+                        "duplicate root port devfn {} in saved state",
+                        port_state.devfn
                     )));
                 }
 
-                match &mut self.devices[port_state.port_number as usize] {
-                    BusDevice::RootPort { port, .. } => {
+                match self
+                    .devices
+                    .iter_mut()
+                    .find(|(d, _)| *d == port_state.devfn)
+                {
+                    Some((_, BusDevice::RootPort { port, .. })) => {
                         port.port.cfg_space.restore(port_state.cfg_space)?;
                         port.port.restore_cxl_component_registers_state(
                             port_state.cxl_component_registers,
                         )?;
                     }
-                    BusDevice::Rciep { .. } | BusDevice::Empty => {
+                    Some((_, BusDevice::Rciep { .. })) | None => {
                         return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
-                            "root port {} not found",
-                            port_state.port_number
+                            "root port devfn {} not found",
+                            port_state.devfn
                         )));
                     }
                 }

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -52,7 +52,7 @@ pub struct GenericPcieRootComplex {
     cxl_component_registers: Option<CxlComponentRegisters>,
     /// Devices on the root complex bus, sorted by devfn
     /// (device << 3 | function).
-    #[inspect(skip)]
+    #[inspect(with = "|x| inspect::iter_by_key(x.iter().map(|(k, v)| (k, v)))")]
     devices: Vec<(u8, BusDevice)>,
 }
 
@@ -65,6 +65,19 @@ enum BusDevice {
         name: Arc<str>,
         dev: Box<dyn GenericPciBusDevice>,
     },
+}
+
+impl Inspect for BusDevice {
+    fn inspect(&self, req: inspect::Request<'_>) {
+        match self {
+            BusDevice::RootPort { port, .. } => {
+                port.as_ref().inspect(req);
+            }
+            BusDevice::Rciep { name, .. } => {
+                req.value(name.as_ref());
+            }
+        }
+    }
 }
 
 /// Information about a downstream port in a PCIe topology.
@@ -86,6 +99,49 @@ pub struct GenericPcieRootPortDefinition {
     pub hotplug: bool,
     /// Express-level port settings (ACS, etc.).
     pub settings: PciePortSettings,
+}
+
+/// A flat description of a PCIe switch without hierarchy.
+pub struct GenericSwitchDefinition {
+    /// The name of the switch.
+    pub name: Arc<str>,
+    /// Number of downstream ports.
+    pub num_downstream_ports: u8,
+    /// The parent port this switch is connected to.
+    pub parent_port: Arc<str>,
+    /// Whether hotplug is enabled for this switch.
+    pub hotplug: bool,
+    /// Express-level settings for downstream switch ports.
+    pub dsp_settings: PciePortSettings,
+}
+
+impl GenericSwitchDefinition {
+    /// Create a new switch definition.
+    pub fn new(
+        name: impl Into<Arc<str>>,
+        num_downstream_ports: u8,
+        parent_port: impl Into<Arc<str>>,
+        hotplug: bool,
+        dsp_settings: PciePortSettings,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            num_downstream_ports,
+            parent_port: parent_port.into(),
+            hotplug,
+            dsp_settings,
+        }
+    }
+}
+
+enum DecodedEcamAccess<'a> {
+    UnexpectedIntercept,
+    Unroutable,
+    InternalBus(&'a mut RootPort, u16),
+    DownstreamPort(&'a mut RootPort, u8, u8, u16),
+    /// A Root Complex Integrated Endpoint (RCiEP) on the start bus.
+    /// Fields: device, function, config offset.
+    Rciep(&'a mut dyn GenericPciBusDevice, u8, u16),
 }
 
 /// Builder for [`GenericPcieRootComplex`].
@@ -210,49 +266,6 @@ impl<'a> GenericPcieRootComplexBuilder<'a> {
             devices,
         }
     }
-}
-
-/// A flat description of a PCIe switch without hierarchy.
-pub struct GenericSwitchDefinition {
-    /// The name of the switch.
-    pub name: Arc<str>,
-    /// Number of downstream ports.
-    pub num_downstream_ports: u8,
-    /// The parent port this switch is connected to.
-    pub parent_port: Arc<str>,
-    /// Whether hotplug is enabled for this switch.
-    pub hotplug: bool,
-    /// Express-level settings for downstream switch ports.
-    pub dsp_settings: PciePortSettings,
-}
-
-impl GenericSwitchDefinition {
-    /// Create a new switch definition.
-    pub fn new(
-        name: impl Into<Arc<str>>,
-        num_downstream_ports: u8,
-        parent_port: impl Into<Arc<str>>,
-        hotplug: bool,
-        dsp_settings: PciePortSettings,
-    ) -> Self {
-        Self {
-            name: name.into(),
-            num_downstream_ports,
-            parent_port: parent_port.into(),
-            hotplug,
-            dsp_settings,
-        }
-    }
-}
-
-enum DecodedEcamAccess<'a> {
-    UnexpectedIntercept,
-    Unroutable,
-    InternalBus(&'a mut RootPort, u16),
-    DownstreamPort(&'a mut RootPort, u8, u8, u16),
-    /// A Root Complex Integrated Endpoint (RCiEP) on the start bus.
-    /// Fields: device, function, config offset.
-    Rciep(&'a mut dyn GenericPciBusDevice, u8, u16),
 }
 
 impl GenericPcieRootComplex {

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -32,10 +32,40 @@ use pci_core::spec::hwid::ClassCode;
 use pci_core::spec::hwid::HardwareIds;
 use pci_core::spec::hwid::ProgrammingInterface;
 use pci_core::spec::hwid::Subclass;
-use std::collections::HashMap;
+use std::ops::RangeInclusive;
 use std::sync::Arc;
 use vmcore::device_state::ChangeDeviceState;
 use zerocopy::IntoBytes;
+
+/// Maximum number of PCI devices on a single bus.
+const MAX_DEVICES_PER_BUS: usize = 32;
+
+/// A device occupying a slot on the root complex bus.
+enum BusDevice {
+    /// No device at this slot.
+    Empty,
+    /// A root port providing downstream connectivity.
+    RootPort { name: Arc<str>, port: Box<RootPort> },
+    /// A Root Complex Integrated Endpoint (RCiEP).
+    Rciep {
+        name: Arc<str>,
+        dev: Box<dyn GenericPciBusDevice>,
+    },
+}
+
+impl Inspect for BusDevice {
+    fn inspect(&self, req: inspect::Request<'_>) {
+        match self {
+            BusDevice::Empty => {}
+            BusDevice::RootPort { port, .. } => {
+                req.respond().merge(port.as_ref());
+            }
+            BusDevice::Rciep { name, .. } => {
+                req.respond().field("name", name);
+            }
+        }
+    }
+}
 
 /// A generic PCI Express root complex emulator.
 #[derive(InspectMut)]
@@ -50,14 +80,15 @@ pub struct GenericPcieRootComplex {
     chbcr: Option<Box<dyn ControlMmioIntercept>>,
     /// CXL Component Registers backing CHBCR accesses in CXL mode.
     cxl_component_registers: Option<CxlComponentRegisters>,
-    /// Map of root ports attached to the root complex, indexed by combined device and function numbers.
-    #[inspect(with = "|x| inspect::iter_by_key(x).map_value(|(_, v)| v)")]
-    ports: HashMap<u8, (Arc<str>, RootPort)>,
+    /// Devices on the root complex bus, indexed by PCI device number (0-31).
+    /// Each slot can hold a root port, an RCiEP, or be empty.
+    #[inspect(iter_by_index)]
+    devices: [BusDevice; MAX_DEVICES_PER_BUS],
 }
 
 /// Information about a downstream port in a PCIe topology.
 pub struct DownstreamPortInfo {
-    /// The port number (device/function index).
+    /// The PCI device number (0-31) of this port on the root complex bus.
     pub port_number: u8,
     /// The port name.
     pub name: Arc<str>,
@@ -74,6 +105,127 @@ pub struct GenericPcieRootPortDefinition {
     pub hotplug: bool,
     /// Express-level port settings (ACS, etc.).
     pub settings: PciePortSettings,
+}
+
+/// Builder for [`GenericPcieRootComplex`].
+///
+/// Obtain via [`GenericPcieRootComplex::builder`], configure optional
+/// settings, then call [`build`](GenericPcieRootComplexBuilder::build).
+pub struct GenericPcieRootComplexBuilder<'a> {
+    register_mmio: &'a mut dyn RegisterMmioIntercept,
+    bus_range: RangeInclusive<u8>,
+    ecam_range: MemoryRange,
+    root_ports: Option<(Vec<GenericPcieRootPortDefinition>, &'a MsiTarget)>,
+    first_port_device_number: u8,
+    chbcr_range: Option<MemoryRange>,
+}
+
+impl<'a> GenericPcieRootComplexBuilder<'a> {
+    /// Add root ports to the complex.
+    ///
+    /// `msi_target` is the MSI target for all root ports; the caller is
+    /// responsible for creating the `MsiConnection` and connecting it to
+    /// the platform's interrupt controller.
+    pub fn root_ports(
+        mut self,
+        ports: Vec<GenericPcieRootPortDefinition>,
+        msi_target: &'a MsiTarget,
+    ) -> Self {
+        self.root_ports = Some((ports, msi_target));
+        self
+    }
+
+    /// Set the first PCI device number to assign to root ports (default 0).
+    ///
+    /// Root ports are placed at consecutive device numbers starting from
+    /// this value. Use a non-zero value to reserve lower device numbers
+    /// for RCiEPs (e.g., an IOMMU at device 0).
+    pub fn first_port_device_number(mut self, device: u8) -> Self {
+        self.first_port_device_number = device;
+        self
+    }
+
+    /// Set the CHBCR (Component Register BAR) MMIO range for CXL mode.
+    ///
+    /// When set, CXL component registers are allocated and a CHBCR MMIO
+    /// region is mapped.
+    pub fn chbcr_range(mut self, range: Option<MemoryRange>) -> Self {
+        self.chbcr_range = range;
+        self
+    }
+
+    /// Build the root complex.
+    pub fn build(self) -> GenericPcieRootComplex {
+        let Self {
+            register_mmio,
+            bus_range,
+            ecam_range,
+            root_ports,
+            first_port_device_number,
+            chbcr_range,
+        } = self;
+
+        let start_bus = *bus_range.start();
+        let end_bus = *bus_range.end();
+
+        let mut ecam = register_mmio.new_io_region("ecam", ecam_range.len());
+        ecam.map(ecam_range.start());
+
+        // Presence of CHBCR range indicates CXL mode, which needs a component-register
+        // backing object even if no capability payload blocks are registered yet.
+        let cxl_component_registers = chbcr_range.as_ref().map(|_| CxlComponentRegisters::new());
+
+        let chbcr = chbcr_range.map(|range| {
+            tracing::info!(
+                root_bus_start = start_bus,
+                root_bus_end = end_bus,
+                start = range.start(),
+                end = range.end(),
+                len = range.len(),
+                "pcie root complex CHBCR range"
+            );
+            let mut region = register_mmio.new_io_region("chbcr", range.len());
+            region.map(range.start());
+            region
+        });
+
+        let mut devices: [BusDevice; MAX_DEVICES_PER_BUS] =
+            std::array::from_fn(|_| BusDevice::Empty);
+
+        if let Some((ports, msi_target)) = root_ports {
+            for (i, definition) in ports.into_iter().enumerate() {
+                let device = i + first_port_device_number as usize;
+                assert!(device < MAX_DEVICES_PER_BUS, "too many ports");
+                let devfn = (device << BDF_DEVICE_SHIFT) as u8;
+                let hotplug_slot_number = if definition.hotplug {
+                    Some(device as u32 + 1)
+                } else {
+                    None
+                };
+                let port_msi_target = msi_target.with_devfn(devfn);
+                let root_port = RootPort::new(
+                    register_mmio,
+                    definition.name.clone(),
+                    hotplug_slot_number,
+                    &port_msi_target,
+                    definition.settings,
+                );
+                devices[device] = BusDevice::RootPort {
+                    name: definition.name,
+                    port: Box::new(root_port),
+                };
+            }
+        }
+
+        GenericPcieRootComplex {
+            start_bus,
+            end_bus,
+            ecam,
+            chbcr,
+            cxl_component_registers,
+            devices,
+        }
+    }
 }
 
 /// A flat description of a PCIe switch without hierarchy.
@@ -114,80 +266,30 @@ enum DecodedEcamAccess<'a> {
     Unroutable,
     InternalBus(&'a mut RootPort, u16),
     DownstreamPort(&'a mut RootPort, u8, u8, u16),
+    /// A Root Complex Integrated Endpoint (RCiEP) on the start bus.
+    Rciep(&'a mut dyn GenericPciBusDevice, u16),
 }
 
 impl GenericPcieRootComplex {
-    /// Constructs a new `GenericPcieRootComplex` emulator.
-    ///
-    /// `msi_target` is the MSI target for all root ports in this complex.
-    /// The caller is responsible for creating the `MsiConnection` and
-    /// connecting it to the platform's interrupt controller.
-    pub fn new(
-        register_mmio: &mut dyn RegisterMmioIntercept,
-        start_bus: u8,
-        end_bus: u8,
-        chbcr_range: Option<MemoryRange>,
+    /// Returns a builder for constructing a new `GenericPcieRootComplex`.
+    pub fn builder<'a>(
+        register_mmio: &'a mut dyn RegisterMmioIntercept,
+        bus_range: RangeInclusive<u8>,
         ecam_range: MemoryRange,
-        ports: Vec<GenericPcieRootPortDefinition>,
-        msi_target: &MsiTarget,
-    ) -> Self {
+    ) -> GenericPcieRootComplexBuilder<'a> {
         assert_eq!(
-            ecam_size_from_bus_numbers(start_bus, end_bus),
-            ecam_range.len()
+            ecam_size_from_bus_numbers(*bus_range.start(), *bus_range.end()),
+            ecam_range.len(),
+            "ECAM range size does not match bus range"
         );
 
-        let mut ecam = register_mmio.new_io_region("ecam", ecam_range.len());
-        ecam.map(ecam_range.start());
-
-        // Presence of CHBCR range indicates CXL mode, which needs a component-register
-        // backing object even if no capability payload blocks are registered yet.
-        let cxl_component_registers = chbcr_range.as_ref().map(|_| CxlComponentRegisters::new());
-
-        let chbcr = chbcr_range.map(|range| {
-            tracing::info!(
-                root_bus_start = start_bus,
-                root_bus_end = end_bus,
-                start = range.start(),
-                end = range.end(),
-                len = range.len(),
-                "pcie root complex CHBCR range"
-            );
-            let mut region = register_mmio.new_io_region("chbcr", range.len());
-            region.map(range.start());
-            region
-        });
-
-        let port_map: HashMap<u8, (Arc<str>, RootPort)> = ports
-            .into_iter()
-            .enumerate()
-            .map(|(i, definition)| {
-                let device_number: u8 = (i << BDF_DEVICE_SHIFT).try_into().expect("too many ports");
-                // Use the device number as the slot number for hotpluggable ports
-                let hotplug_slot_number = if definition.hotplug {
-                    Some((device_number as u32) + 1)
-                } else {
-                    None
-                };
-                // Derive a per-port MSI target with this port's devfn.
-                let port_msi_target = msi_target.with_devfn(device_number);
-                let root_port = RootPort::new(
-                    register_mmio,
-                    definition.name.clone(),
-                    hotplug_slot_number,
-                    &port_msi_target,
-                    definition.settings,
-                );
-                (device_number, (definition.name, root_port))
-            })
-            .collect();
-
-        Self {
-            start_bus,
-            end_bus,
-            ecam,
-            chbcr,
-            cxl_component_registers,
-            ports: port_map,
+        GenericPcieRootComplexBuilder {
+            register_mmio,
+            bus_range,
+            ecam_range,
+            root_ports: None,
+            first_port_device_number: 0,
+            chbcr_range: None,
         }
     }
 
@@ -225,43 +327,35 @@ impl GenericPcieRootComplex {
         }
     }
 
-    /// Attach the provided `GenericPciBusDevice` to the port identified.
+    /// Attach the provided `GenericPciBusDevice` to the port identified by
+    /// PCI device number (0-31).
     pub fn add_pcie_device(
         &mut self,
         port: u8,
         name: impl AsRef<str>,
         dev: Box<dyn GenericPciBusDevice>,
     ) -> Result<(), Arc<str>> {
-        let (_port_name, root_port) = self.ports.get_mut(&port).ok_or_else(|| -> Arc<str> {
-            tracing::error!(
-                "GenericPcieRootComplex: port {:#x} not found for device '{}'",
-                port,
-                name.as_ref()
-            );
-            format!("Port {:#x} not found", port).into()
-        })?;
+        let root_port = match &mut self.devices[port as usize] {
+            BusDevice::RootPort { port, .. } => port,
+            BusDevice::Rciep { name: existing, .. } => return Err(existing.clone()),
+            BusDevice::Empty => return Err(format!("device {port} is not a root port").into()),
+        };
 
-        match root_port.connect_device(name, dev) {
-            Ok(()) => Ok(()),
-            Err(existing_device) => {
-                tracing::warn!(
-                    "GenericPcieRootComplex: failed to connect device to port {:#x}, existing device: '{}'",
-                    port,
-                    existing_device
-                );
-                Err(existing_device)
-            }
-        }
+        root_port.connect_device(name, dev)
     }
 
     /// Enumerate the downstream ports of the root complex.
     pub fn downstream_ports(&self) -> Vec<DownstreamPortInfo> {
-        self.ports
+        self.devices
             .iter()
-            .map(|(port, (name, rp))| DownstreamPortInfo {
-                port_number: *port,
-                name: name.clone(),
-                bus_range: rp.port.bus_range(),
+            .enumerate()
+            .filter_map(|(i, d)| match d {
+                BusDevice::RootPort { name, port } => Some(DownstreamPortInfo {
+                    port_number: i as u8,
+                    name: name.clone(),
+                    bus_range: port.port.bus_range(),
+                }),
+                BusDevice::Rciep { .. } | BusDevice::Empty => None,
             })
             .collect()
     }
@@ -273,27 +367,52 @@ impl GenericPcieRootComplex {
         device_name: &str,
         device: Box<dyn GenericPciBusDevice>,
     ) -> anyhow::Result<()> {
-        let (_, (_, root_port)) = self
-            .ports
+        let root_port = self
+            .devices
             .iter_mut()
-            .find(|(_, (name, _))| name.as_ref() == port_name)
+            .find_map(|d| match d {
+                BusDevice::RootPort { name, port } if name.as_ref() == port_name => Some(port),
+                BusDevice::RootPort { .. } | BusDevice::Rciep { .. } | BusDevice::Empty => None,
+            })
             .ok_or_else(|| anyhow::anyhow!("port '{}' not found", port_name))?;
         root_port.port.hotplug_add_device(device_name, device)
     }
 
     /// Hot-remove the device from a named port.
     pub fn hotplug_remove_device(&mut self, port_name: &str) -> anyhow::Result<()> {
-        let (_, (_, root_port)) = self
-            .ports
+        let root_port = self
+            .devices
             .iter_mut()
-            .find(|(_, (name, _))| name.as_ref() == port_name)
+            .find_map(|d| match d {
+                BusDevice::RootPort { name, port } if name.as_ref() == port_name => Some(port),
+                BusDevice::RootPort { .. } | BusDevice::Rciep { .. } | BusDevice::Empty => None,
+            })
             .ok_or_else(|| anyhow::anyhow!("port '{}' not found", port_name))?;
         root_port.port.hotplug_remove_device()
     }
 
-    /// Returns the size of the ECAM MMIO region this root complex is emulating.
-    pub fn ecam_size(&self) -> u64 {
-        ecam_size_from_bus_numbers(self.start_bus, self.end_bus)
+    /// Attach a Root Complex Integrated Endpoint (RCiEP) at the given
+    /// PCI device number (0-31) on the start bus of this root complex.
+    ///
+    /// RCiEPs are Type 0 PCI functions that appear directly on the start
+    /// bus alongside root ports (e.g., an AMD IOMMU at device 0).
+    /// They do not sit behind a downstream port and have a fixed BDF.
+    pub fn add_rciep(
+        &mut self,
+        device: u8,
+        name: impl Into<Arc<str>>,
+        dev: Box<dyn GenericPciBusDevice>,
+    ) -> Result<(), Arc<str>> {
+        let name = name.into();
+        match &self.devices[device as usize] {
+            BusDevice::Empty => {}
+            BusDevice::RootPort { name: existing, .. }
+            | BusDevice::Rciep { name: existing, .. } => {
+                return Err(existing.clone());
+            }
+        }
+        self.devices[device as usize] = BusDevice::Rciep { name, dev };
+        Ok(())
     }
 
     fn decode_ecam_access<'a>(&'a mut self, addr: u64) -> DecodedEcamAccess<'a> {
@@ -310,26 +429,35 @@ impl GenericPcieRootComplex {
         let cfg_offset_within_function = (ecam_offset & PAGE_OFFSET_MASK) as u16;
 
         if bus_number == self.start_bus {
-            match self.ports.get_mut(&device_function) {
-                Some((_, port)) => {
+            let device = (device_function >> BDF_DEVICE_SHIFT) as usize;
+            let function = device_function & 0x7;
+            match &mut self.devices[device] {
+                BusDevice::RootPort { port, .. } if function == 0 => {
                     return DecodedEcamAccess::InternalBus(port, cfg_offset_within_function);
                 }
-                None => return DecodedEcamAccess::Unroutable,
+                BusDevice::Rciep { dev, .. } if function == 0 => {
+                    return DecodedEcamAccess::Rciep(dev.as_mut(), cfg_offset_within_function);
+                }
+                BusDevice::RootPort { .. } | BusDevice::Rciep { .. } | BusDevice::Empty => {
+                    return DecodedEcamAccess::Unroutable;
+                }
             }
         } else if bus_number > self.start_bus && bus_number <= self.end_bus {
-            for (_, port) in self.ports.values_mut() {
-                if port
-                    .port
-                    .cfg_space
-                    .assigned_bus_range()
-                    .contains(&bus_number)
-                {
-                    return DecodedEcamAccess::DownstreamPort(
-                        port,
-                        bus_number,
-                        device_function,
-                        cfg_offset_within_function,
-                    );
+            for d in self.devices.iter_mut() {
+                if let BusDevice::RootPort { port, .. } = d {
+                    if port
+                        .port
+                        .cfg_space
+                        .assigned_bus_range()
+                        .contains(&bus_number)
+                    {
+                        return DecodedEcamAccess::DownstreamPort(
+                            port,
+                            bus_number,
+                            device_function,
+                            cfg_offset_within_function,
+                        );
+                    }
                 }
             }
             return DecodedEcamAccess::Unroutable;
@@ -349,14 +477,16 @@ impl GenericPcieRootComplex {
             }
         }
 
-        for (_, port) in self.ports.values_mut() {
-            if let Some((bar, offset)) = port.port.find_bar(addr) {
-                if let Err(err) =
-                    validate_aligned_access(addr, data.len(), &BAR_ALLOWED_ACCESS_SIZES)
-                {
-                    return Some(IoResult::Err(err));
+        for d in self.devices.iter_mut() {
+            if let BusDevice::RootPort { port, .. } = d {
+                if let Some((bar, offset)) = port.port.find_bar(addr) {
+                    if let Err(err) =
+                        validate_aligned_access(addr, data.len(), &BAR_ALLOWED_ACCESS_SIZES)
+                    {
+                        return Some(IoResult::Err(err));
+                    }
+                    return Some(port.port.bar_mmio_read(bar, offset, data));
                 }
-                return Some(port.port.bar_mmio_read(bar, offset, data));
             }
         }
 
@@ -373,14 +503,16 @@ impl GenericPcieRootComplex {
             }
         }
 
-        for (_, port) in self.ports.values_mut() {
-            if let Some((bar, offset)) = port.port.find_bar(addr) {
-                if let Err(err) =
-                    validate_aligned_access(addr, data.len(), &BAR_ALLOWED_ACCESS_SIZES)
-                {
-                    return Some(IoResult::Err(err));
+        for d in self.devices.iter_mut() {
+            if let BusDevice::RootPort { port, .. } = d {
+                if let Some((bar, offset)) = port.port.find_bar(addr) {
+                    if let Err(err) =
+                        validate_aligned_access(addr, data.len(), &BAR_ALLOWED_ACCESS_SIZES)
+                    {
+                        return Some(IoResult::Err(err));
+                    }
+                    return Some(port.port.bar_mmio_write(bar, offset, data));
                 }
-                return Some(port.port.bar_mmio_write(bar, offset, data));
             }
         }
 
@@ -400,8 +532,10 @@ impl ChangeDeviceState for GenericPcieRootComplex {
     async fn stop(&mut self) {}
 
     async fn reset(&mut self) {
-        for (_, (_, port)) in self.ports.iter_mut() {
-            port.port.cfg_space.reset();
+        for d in self.devices.iter_mut() {
+            if let BusDevice::RootPort { port, .. } = d {
+                port.port.cfg_space.reset();
+            }
         }
     }
 }
@@ -470,6 +604,11 @@ impl MmioIntercept for GenericPcieRootComplex {
             DecodedEcamAccess::InternalBus(port, cfg_offset) => {
                 check_result!(port.port.cfg_space.read_u32(cfg_offset, &mut dword_value));
             }
+            DecodedEcamAccess::Rciep(dev, cfg_offset) => {
+                if let Some(result) = dev.pci_cfg_read(cfg_offset, &mut dword_value) {
+                    check_result!(result);
+                }
+            }
             DecodedEcamAccess::DownstreamPort(port, bus_number, function, cfg_offset) => {
                 check_result!(port.forward_cfg_read(
                     &bus_number,
@@ -535,6 +674,11 @@ impl MmioIntercept for GenericPcieRootComplex {
             }
             DecodedEcamAccess::InternalBus(port, cfg_offset) => {
                 check_result!(port.port.cfg_space.write_u32(cfg_offset, write_dword));
+            }
+            DecodedEcamAccess::Rciep(dev, cfg_offset) => {
+                if let Some(result) = dev.pci_cfg_write(cfg_offset, write_dword) {
+                    check_result!(result);
+                }
             }
             DecodedEcamAccess::DownstreamPort(port, bus_number, function, cfg_offset) => {
                 check_result!(port.forward_cfg_write(
@@ -681,7 +825,7 @@ mod save_restore {
         #[derive(Protobuf)]
         #[mesh(package = "pcie.root")]
         pub struct PortSavedState {
-            /// The port number (device_function index in the ports HashMap).
+            /// The PCI device number (0-31) of this port.
             #[mesh(1)]
             pub port_number: u8,
             /// The root port Type 1 configuration space state.
@@ -715,16 +859,17 @@ mod save_restore {
         type SavedState = state::SavedState;
 
         fn save(&mut self) -> Result<Self::SavedState, SaveError> {
-            // Save all root ports and sort by port number for stable ordering.
-            let mut ports = Vec::with_capacity(self.ports.len());
-            for (&port_number, (_, root_port)) in self.ports.iter_mut() {
-                ports.push(state::PortSavedState {
-                    port_number,
-                    cfg_space: root_port.port.cfg_space.save()?,
-                    cxl_component_registers: root_port.port.save_cxl_component_registers_state()?,
-                });
+            // Save all root ports in device-number order (already ordered by array index).
+            let mut ports = Vec::new();
+            for (i, d) in self.devices.iter_mut().enumerate() {
+                if let BusDevice::RootPort { port, .. } = d {
+                    ports.push(state::PortSavedState {
+                        port_number: i as u8,
+                        cfg_space: port.port.cfg_space.save()?,
+                        cxl_component_registers: port.port.save_cxl_component_registers_state()?,
+                    });
+                }
             }
-            ports.sort_by_key(|p| p.port_number);
 
             Ok(state::SavedState {
                 start_bus: self.start_bus,
@@ -758,11 +903,16 @@ mod save_restore {
             }
 
             // Validate port count matches
-            if ports.len() != self.ports.len() {
+            let root_port_count = self
+                .devices
+                .iter()
+                .filter(|d| matches!(d, BusDevice::RootPort { .. }))
+                .count();
+            if ports.len() != root_port_count {
                 return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
                     "root port count mismatch: saved {}, current {}",
                     ports.len(),
-                    self.ports.len()
+                    root_port_count
                 )));
             }
 
@@ -777,16 +927,19 @@ mod save_restore {
                     )));
                 }
 
-                if let Some((_, root_port)) = self.ports.get_mut(&port_state.port_number) {
-                    root_port.port.cfg_space.restore(port_state.cfg_space)?;
-                    root_port.port.restore_cxl_component_registers_state(
-                        port_state.cxl_component_registers,
-                    )?;
-                } else {
-                    return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
-                        "root port {} not found",
-                        port_state.port_number
-                    )));
+                match &mut self.devices[port_state.port_number as usize] {
+                    BusDevice::RootPort { port, .. } => {
+                        port.port.cfg_space.restore(port_state.cfg_space)?;
+                        port.port.restore_cxl_component_registers_state(
+                            port_state.cxl_component_registers,
+                        )?;
+                    }
+                    BusDevice::Rciep { .. } | BusDevice::Empty => {
+                        return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
+                            "root port {} not found",
+                            port_state.port_number
+                        )));
+                    }
                 }
             }
 
@@ -836,15 +989,9 @@ mod tests {
         let rc_bus_range = AssignedBusRange::new();
         rc_bus_range.set_bus_range(start_bus, end_bus);
         let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
-        GenericPcieRootComplex::new(
-            &mut register_mmio,
-            start_bus,
-            end_bus,
-            None,
-            ecam,
-            port_defs,
-            msi_conn.target(),
-        )
+        GenericPcieRootComplex::builder(&mut register_mmio, start_bus..=end_bus, ecam)
+            .root_ports(port_defs, msi_conn.target())
+            .build()
     }
 
     fn instantiate_root_complex_with_chbcr(
@@ -870,15 +1017,10 @@ mod tests {
         rc_bus_range.set_bus_range(start_bus, end_bus);
         let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
 
-        GenericPcieRootComplex::new(
-            &mut register_mmio,
-            start_bus,
-            end_bus,
-            Some(chbcr),
-            ecam,
-            port_defs,
-            msi_conn.target(),
-        )
+        GenericPcieRootComplex::builder(&mut register_mmio, start_bus..=end_bus, ecam)
+            .root_ports(port_defs, msi_conn.target())
+            .chbcr_range(Some(chbcr))
+            .build()
     }
 
     #[test]
@@ -930,17 +1072,17 @@ mod tests {
     #[test]
     fn test_ecam_size() {
         // Single bus
-        assert_eq!(instantiate_root_complex(0, 0, 0).ecam_size(), 0x10_0000);
-        assert_eq!(instantiate_root_complex(32, 32, 0).ecam_size(), 0x10_0000);
-        assert_eq!(instantiate_root_complex(255, 255, 0).ecam_size(), 0x10_0000);
+        assert_eq!(ecam_size_from_bus_numbers(0, 0), 0x10_0000);
+        assert_eq!(ecam_size_from_bus_numbers(32, 32), 0x10_0000);
+        assert_eq!(ecam_size_from_bus_numbers(255, 255), 0x10_0000);
 
         // Two bus
-        assert_eq!(instantiate_root_complex(0, 1, 0).ecam_size(), 0x20_0000);
-        assert_eq!(instantiate_root_complex(32, 33, 0).ecam_size(), 0x20_0000);
-        assert_eq!(instantiate_root_complex(254, 255, 0).ecam_size(), 0x20_0000);
+        assert_eq!(ecam_size_from_bus_numbers(0, 1), 0x20_0000);
+        assert_eq!(ecam_size_from_bus_numbers(32, 33), 0x20_0000);
+        assert_eq!(ecam_size_from_bus_numbers(254, 255), 0x20_0000);
 
         // Everything
-        assert_eq!(instantiate_root_complex(0, 255, 0).ecam_size(), 0x1000_0000);
+        assert_eq!(ecam_size_from_bus_numbers(0, 255), 0x1000_0000);
     }
 
     #[test]
@@ -1000,12 +1142,8 @@ mod tests {
 
         rc.add_pcie_device(0, "ep1", Box::new(endpoint1)).unwrap();
 
-        match rc.add_pcie_device(0, "ep2", Box::new(endpoint2)) {
-            Ok(()) => panic!("should have failed"),
-            Err(name) => {
-                assert_eq!(name, "ep1".into());
-            }
-        }
+        rc.add_pcie_device(0, "ep2", Box::new(endpoint2))
+            .expect_err("should fail: port already occupied");
     }
 
     #[test]

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -37,6 +37,26 @@ use std::sync::Arc;
 use vmcore::device_state::ChangeDeviceState;
 use zerocopy::IntoBytes;
 
+
+/// A generic PCI Express root complex emulator.
+#[derive(InspectMut)]
+pub struct GenericPcieRootComplex {
+    /// The lowest valid bus number under the root complex.
+    start_bus: u8,
+    /// The highest valid bus number under the root complex.
+    end_bus: u8,
+    /// Intercept control for the ECAM MMIO region.
+    ecam: Box<dyn ControlMmioIntercept>,
+    /// Intercept control for the CHBCR MMIO region, when present.
+    chbcr: Option<Box<dyn ControlMmioIntercept>>,
+    /// CXL Component Registers backing CHBCR accesses in CXL mode.
+    cxl_component_registers: Option<CxlComponentRegisters>,
+    /// Devices on the root complex bus, indexed by PCI device number (0-31).
+    /// Each slot can hold a root port, an RCiEP, or be empty.
+    #[inspect(iter_by_index)]
+    devices: [BusDevice; MAX_DEVICES_PER_BUS],
+}
+
 /// Maximum number of PCI devices on a single bus.
 const MAX_DEVICES_PER_BUS: usize = 32;
 
@@ -67,24 +87,6 @@ impl Inspect for BusDevice {
     }
 }
 
-/// A generic PCI Express root complex emulator.
-#[derive(InspectMut)]
-pub struct GenericPcieRootComplex {
-    /// The lowest valid bus number under the root complex.
-    start_bus: u8,
-    /// The highest valid bus number under the root complex.
-    end_bus: u8,
-    /// Intercept control for the ECAM MMIO region.
-    ecam: Box<dyn ControlMmioIntercept>,
-    /// Intercept control for the CHBCR MMIO region, when present.
-    chbcr: Option<Box<dyn ControlMmioIntercept>>,
-    /// CXL Component Registers backing CHBCR accesses in CXL mode.
-    cxl_component_registers: Option<CxlComponentRegisters>,
-    /// Devices on the root complex bus, indexed by PCI device number (0-31).
-    /// Each slot can hold a root port, an RCiEP, or be empty.
-    #[inspect(iter_by_index)]
-    devices: [BusDevice; MAX_DEVICES_PER_BUS],
-}
 
 /// Information about a downstream port in a PCIe topology.
 pub struct DownstreamPortInfo {

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -1680,4 +1680,126 @@ mod tests {
         rc.mmio_write(SUBORDINATE_BUS_NUM_REG, &[30]).unwrap();
         assert_eq!(bus_range.bus_range(), (20, 30));
     }
+
+    #[test]
+    fn test_rciep_ecam_read_write() {
+        // Create a root complex with root ports starting at device 1,
+        // leaving device 0 free for an RCiEP.
+        let mut register_mmio = TestPcieMmioRegistration {};
+        let start_bus: u8 = 0;
+        let end_bus: u8 = 0;
+        let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(start_bus, end_bus));
+        let rc_bus_range = AssignedBusRange::new();
+        rc_bus_range.set_bus_range(start_bus, end_bus);
+        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let port_defs = vec![GenericPcieRootPortDefinition {
+            name: "port-0".into(),
+            hotplug: false,
+            settings: PciePortSettings::default(),
+        }];
+        let mut rc = GenericPcieRootComplex::builder(&mut register_mmio, start_bus..=end_bus, ecam)
+            .root_ports(port_defs, msi_conn.target())
+            .first_port_device_number(1)
+            .build();
+
+        // Attach an RCiEP at device 0 function 0 (devfn 0).
+        let rciep = TestPcieEndpoint::new(
+            |offset, value| {
+                if offset == 0 {
+                    *value = 0xDEAD_BEEF;
+                }
+                Some(IoResult::Ok)
+            },
+            |_, _| Some(IoResult::Ok),
+        );
+        rc.add_rciep(0, "rciep-0", Box::new(rciep)).unwrap();
+
+        // ECAM read at device 0, function 0 should hit the RCiEP.
+        let mut vendor_device: u32 = 0;
+        rc.mmio_read(0, vendor_device.as_mut_bytes()).unwrap();
+        assert_eq!(vendor_device, 0xDEAD_BEEF);
+
+        // ECAM write at device 0, function 0 should route to the RCiEP
+        // (the test endpoint accepts all writes).
+        rc.mmio_write(0, &0x1234_5678u32.to_le_bytes()).unwrap();
+
+        // Root port at device 1 should still be accessible.
+        let mut root_port_vendor: u32 = 0;
+        // device 1, function 0 → devfn 8 → offset 8 * 4096
+        rc.mmio_read(8 * 4096, root_port_vendor.as_mut_bytes())
+            .unwrap();
+        assert_eq!(root_port_vendor, 0xC030_1414);
+
+        // An unoccupied device slot should return all-1s.
+        let mut empty: u32 = 0;
+        // device 2, function 0 → devfn 16 → offset 16 * 4096
+        rc.mmio_read(16 * 4096, empty.as_mut_bytes()).unwrap();
+        assert_eq!(empty, 0xFFFF_FFFF);
+    }
+
+    #[test]
+    fn test_rciep_function0_fallback() {
+        // Test that a config read to function 1 of an RCiEP device falls
+        // back to the function-0 device via pci_cfg_read_with_routing,
+        // which by default returns all-1s for non-zero functions.
+        let mut register_mmio = TestPcieMmioRegistration {};
+        let start_bus: u8 = 0;
+        let end_bus: u8 = 0;
+        let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(start_bus, end_bus));
+        let mut rc =
+            GenericPcieRootComplex::builder(&mut register_mmio, start_bus..=end_bus, ecam).build();
+
+        let rciep = TestPcieEndpoint::new(
+            |offset, value| {
+                if offset == 0 {
+                    *value = 0xCAFE_F00D;
+                }
+                Some(IoResult::Ok)
+            },
+            |_, _| Some(IoResult::Ok),
+        );
+        rc.add_rciep(0, "rciep-0", Box::new(rciep)).unwrap();
+
+        // Function 0 should return the device's vendor/device ID.
+        let mut val: u32 = 0;
+        rc.mmio_read(0, val.as_mut_bytes()).unwrap();
+        assert_eq!(val, 0xCAFE_F00D);
+
+        // Function 1 (devfn 1) falls back to the function-0 device's
+        // pci_cfg_read_with_routing, which returns all-1s by default.
+        let mut val_fn1: u32 = 0;
+        // devfn 1 → offset 1 * 4096
+        rc.mmio_read(4096, val_fn1.as_mut_bytes()).unwrap();
+        assert_eq!(val_fn1, 0xFFFF_FFFF);
+    }
+
+    #[test]
+    fn test_rciep_collision_with_root_port() {
+        // Verify that adding an RCiEP at a devfn already occupied by a
+        // root port returns an error with the port's name.
+        let mut rc = instantiate_root_complex(0, 0, 1);
+
+        let rciep = TestPcieEndpoint::new(|_, _| Some(IoResult::Ok), |_, _| Some(IoResult::Ok));
+        // Root port 0 sits at devfn 0; adding an RCiEP there should fail.
+        let err = rc
+            .add_rciep(0, "rciep-collision", Box::new(rciep))
+            .expect_err("should fail: devfn occupied by root port");
+        assert_eq!(err.as_ref(), "test-port-0");
+    }
+
+    #[test]
+    fn test_rciep_collision_with_rciep() {
+        // Verify that adding two RCiEPs at the same devfn returns an error.
+        let mut register_mmio = TestPcieMmioRegistration {};
+        let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(0, 0));
+        let mut rc = GenericPcieRootComplex::builder(&mut register_mmio, 0..=0u8, ecam).build();
+
+        let rciep1 = TestPcieEndpoint::new(|_, _| Some(IoResult::Ok), |_, _| Some(IoResult::Ok));
+        let rciep2 = TestPcieEndpoint::new(|_, _| Some(IoResult::Ok), |_, _| Some(IoResult::Ok));
+        rc.add_rciep(0, "rciep-first", Box::new(rciep1)).unwrap();
+        let err = rc
+            .add_rciep(0, "rciep-second", Box::new(rciep2))
+            .expect_err("should fail: devfn already has an RCiEP");
+        assert_eq!(err.as_ref(), "rciep-first");
+    }
 }

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -395,16 +395,13 @@ impl GenericPcieRootComplex {
     /// bus alongside root ports (e.g., an AMD IOMMU at device 0).
     /// They do not sit behind a downstream port and have a fixed BDF.
     ///
-    /// For a single-function RCiEP, register at function 0. Config space
+    /// Most RCiEPs should be registered at function 0. Config space
     /// accesses to other functions of the same device will be forwarded
     /// to the function 0 device via
     /// [`pci_cfg_read_with_routing`](GenericPciBusDevice::pci_cfg_read_with_routing),
     /// whose default implementation returns all-1s (no device present).
-    ///
-    /// For a multi-function RCiEP, either register each function as a
-    /// separate `GenericPciBusDevice`, or register a single device at
-    /// function 0 and override `pci_cfg_read_with_routing` /
-    /// `pci_cfg_write_with_routing` to handle non-zero functions.
+    /// A multi-function RCiEP should override `pci_cfg_read_with_routing`
+    /// and `pci_cfg_write_with_routing` to handle non-zero functions.
     pub fn add_rciep(
         &mut self,
         devfn: u8,

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -1323,7 +1323,7 @@ mod tests {
         }
 
         // Verify the downstream port bus range is set
-        if let Some((_, downstream_port)) = switch.downstream_ports.get(0) {
+        if let Some((_, downstream_port)) = switch.downstream_ports.first() {
             let bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(*bus_range.start(), 10);
             assert_eq!(*bus_range.end(), 20);
@@ -1343,7 +1343,7 @@ mod tests {
         let mut switch2 = GenericPcieSwitch::new(definition2);
 
         // Verify the new switch has default bus range on downstream port before restore
-        if let Some((_, downstream_port)) = switch2.downstream_ports.get(0) {
+        if let Some((_, downstream_port)) = switch2.downstream_ports.first() {
             let default_bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(default_bus_range, 0..=0);
         }
@@ -1354,7 +1354,7 @@ mod tests {
             .expect("restore should succeed");
 
         // Verify the downstream port bus range is restored
-        if let Some((_, downstream_port)) = switch2.downstream_ports.get(0) {
+        if let Some((_, downstream_port)) = switch2.downstream_ports.first() {
             let restored_bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(*restored_bus_range.start(), 10);
             assert_eq!(*restored_bus_range.end(), 20);

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -15,7 +15,7 @@ use crate::UPSTREAM_SWITCH_PORT_DEVICE_ID;
 use crate::VENDOR_ID;
 use crate::port::PcieDownstreamPort;
 use crate::port::PciePortSettings;
-use anyhow::{Context, bail};
+use anyhow::Context;
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoResult;
 use chipset_device::pci::PciConfigSpace;
@@ -30,7 +30,6 @@ use pci_core::spec::hwid::ClassCode;
 use pci_core::spec::hwid::HardwareIds;
 use pci_core::spec::hwid::ProgrammingInterface;
 use pci_core::spec::hwid::Subclass;
-use std::collections::HashMap;
 use std::sync::Arc;
 use vmcore::device_state::ChangeDeviceState;
 
@@ -172,9 +171,9 @@ pub struct GenericPcieSwitch {
     name: Arc<str>,
     /// The upstream switch port that connects to the parent.
     upstream_port: UpstreamSwitchPort,
-    /// Map of downstream switch ports, indexed by port number.
-    #[inspect(with = "|x| inspect::iter_by_key(x).map_value(|(_, v)| v)")]
-    downstream_ports: HashMap<u8, (Arc<str>, DownstreamSwitchPort)>,
+    /// Downstream switch ports indexed by devfn.
+    #[inspect(skip)]
+    downstream_ports: Vec<(Arc<str>, DownstreamSwitchPort)>,
 }
 
 impl GenericPcieSwitch {
@@ -193,9 +192,10 @@ impl GenericPcieSwitch {
             .msi_target
             .with_bus_range(upstream_port.cfg_space().bus_range(), 0);
 
-        let downstream_ports = (0..definition.downstream_port_count)
+        let downstream_ports: Vec<(Arc<str>, DownstreamSwitchPort)> = (0..definition
+            .downstream_port_count)
             .map(|i| {
-                let port_name = format!("{}-downstream-{}", definition.name, i);
+                let port_name: Arc<str> = format!("{}-downstream-{}", definition.name, i).into();
                 // Use the port index as the slot number for hotpluggable ports
                 let hotplug_slot_number = if definition.hotplug {
                     Some((i as u32) + 1)
@@ -210,7 +210,7 @@ impl GenericPcieSwitch {
                     &port_msi_target,
                     definition.dsp_settings.clone(),
                 );
-                (i, (port_name.into(), port))
+                (port_name, port)
             })
             .collect();
 
@@ -235,8 +235,9 @@ impl GenericPcieSwitch {
     pub fn downstream_ports(&self) -> Vec<crate::root::DownstreamPortInfo> {
         self.downstream_ports
             .iter()
-            .map(|(port, (name, dsp))| crate::root::DownstreamPortInfo {
-                port_number: *port,
+            .enumerate()
+            .map(|(i, (name, dsp))| crate::root::DownstreamPortInfo {
+                devfn: i as u8,
                 name: name.clone(),
                 bus_range: dsp.port.bus_range(),
             })
@@ -312,12 +313,8 @@ impl GenericPcieSwitch {
         cfg_offset: u16,
         value: &mut u32,
     ) -> Option<IoResult> {
-        if let Some((_, downstream_port)) = self.downstream_ports.get_mut(&function) {
-            Some(downstream_port.port.cfg_space.read_u32(cfg_offset, value))
-        } else {
-            // No downstream switch port found for this device function
-            None
-        }
+        let (_, downstream_port) = self.downstream_ports.get_mut(function as usize)?;
+        Some(downstream_port.port.cfg_space.read_u32(cfg_offset, value))
     }
 
     /// Handle direct configuration space write to downstream switch ports.
@@ -327,12 +324,8 @@ impl GenericPcieSwitch {
         cfg_offset: u16,
         value: u32,
     ) -> Option<IoResult> {
-        if let Some((_, downstream_port)) = self.downstream_ports.get_mut(&function) {
-            Some(downstream_port.port.cfg_space.write_u32(cfg_offset, value))
-        } else {
-            // No downstream switch port found for this device function
-            None
-        }
+        let (_, downstream_port) = self.downstream_ports.get_mut(function as usize)?;
+        Some(downstream_port.port.cfg_space.write_u32(cfg_offset, value))
     }
 
     /// Route configuration space read to downstream ports for further forwarding.
@@ -343,7 +336,7 @@ impl GenericPcieSwitch {
         cfg_offset: u16,
         value: &mut u32,
     ) -> Option<IoResult> {
-        for (_, downstream_port) in self.downstream_ports.values_mut() {
+        for (_, downstream_port) in self.downstream_ports.iter_mut() {
             let downstream_bus_range = downstream_port.cfg_space().assigned_bus_range();
 
             // Skip downstream ports with invalid/uninitialized bus configuration
@@ -372,7 +365,7 @@ impl GenericPcieSwitch {
         cfg_offset: u16,
         value: u32,
     ) -> Option<IoResult> {
-        for (_, downstream_port) in self.downstream_ports.values_mut() {
+        for (_, downstream_port) in self.downstream_ports.iter_mut() {
             let downstream_bus_range = downstream_port.cfg_space().assigned_bus_range();
 
             // Skip downstream ports with invalid/uninitialized bus configuration
@@ -396,22 +389,19 @@ impl GenericPcieSwitch {
     /// Attach the provided `GenericPciBusDevice` to the port identified.
     pub fn add_pcie_device(
         &mut self,
-        port: u8,
+        port_devfn: u8,
         name: &str,
         dev: Box<dyn GenericPciBusDevice>,
     ) -> anyhow::Result<()> {
-        // Find the specific downstream port that matches the port number
-        if let Some((port_name, downstream_port)) = self.downstream_ports.get_mut(&port) {
-            // Found the matching port, try to connect to it using the port's name
-            downstream_port
-                .port
-                .add_pcie_device(port_name.as_ref(), name, dev)
-                .context("failed to add PCIe device to downstream port")?;
-            Ok(())
-        } else {
-            // No downstream port found with matching port number
-            bail!("port {} not found", port);
-        }
+        let (port_name, downstream_port) = self
+            .downstream_ports
+            .get_mut(port_devfn as usize)
+            .ok_or_else(|| anyhow::anyhow!("port devfn {} not found", port_devfn))?;
+        downstream_port
+            .port
+            .add_pcie_device(port_name.as_ref(), name, dev)
+            .context("failed to add PCIe device to downstream port")?;
+        Ok(())
     }
 }
 
@@ -428,7 +418,7 @@ impl ChangeDeviceState for GenericPcieSwitch {
         self.upstream_port.cfg_space.reset();
 
         // Reset all downstream port configuration spaces
-        for (_, downstream_port) in self.downstream_ports.values_mut() {
+        for (_, downstream_port) in self.downstream_ports.iter_mut() {
             downstream_port.port.cfg_space.reset();
         }
     }
@@ -533,9 +523,9 @@ mod save_restore {
         #[derive(Protobuf)]
         #[mesh(package = "pcie.switch")]
         pub struct DownstreamPortSavedState {
-            /// Logical downstream port number.
+            /// The devfn of this downstream port.
             #[mesh(1)]
-            pub port_number: u8,
+            pub devfn: u8,
             /// The downstream port Type 1 configuration space state.
             #[mesh(2)]
             pub cfg_space: SwitchPortCfgSpaceSavedState,
@@ -553,7 +543,7 @@ mod save_restore {
             pub upstream_cfg_space: SwitchPortCfgSpaceSavedState,
             /// Saved state for downstream ports.
             ///
-            /// `port_number` identifies the target port for each entry.
+            /// `devfn` identifies the target port for each entry.
             /// The vector ordering is not part of the saved-state contract.
             #[mesh(2)]
             pub downstream_ports: Vec<DownstreamPortSavedState>,
@@ -567,19 +557,17 @@ mod save_restore {
             // Save the upstream port configuration space
             let upstream_cfg_space = self.upstream_port.cfg_space.save()?;
 
-            // Save all downstream ports and sort by port number for stable ordering.
-            // Sorting keeps serialization deterministic without encoding ordering as state.
+            // Save all downstream ports (already sorted by devfn in the Vec).
             let mut downstream_ports = Vec::with_capacity(self.downstream_ports.len());
-            for (&port_number, (_, downstream_port)) in self.downstream_ports.iter_mut() {
+            for (i, (_, downstream_port)) in self.downstream_ports.iter_mut().enumerate() {
                 downstream_ports.push(state::DownstreamPortSavedState {
-                    port_number,
+                    devfn: i as u8,
                     cfg_space: downstream_port.port.cfg_space.save()?,
                     cxl_component_registers: downstream_port
                         .port
                         .save_cxl_component_registers_state()?,
                 });
             }
-            downstream_ports.sort_by_key(|p| p.port_number);
 
             Ok(state::SavedState {
                 upstream_cfg_space,
@@ -607,18 +595,18 @@ mod save_restore {
 
             let mut seen_ports = HashSet::with_capacity(downstream_ports.len());
 
-            // Restore all downstream ports by explicit port number rather than vector order.
+            // Restore all downstream ports by devfn index.
             for port_state in downstream_ports {
                 // Duplicate entries indicate corrupted or malformed saved state.
-                if !seen_ports.insert(port_state.port_number) {
+                if !seen_ports.insert(port_state.devfn) {
                     return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
-                        "duplicate downstream port {} in saved state",
-                        port_state.port_number
+                        "duplicate downstream port devfn {} in saved state",
+                        port_state.devfn
                     )));
                 }
 
                 if let Some((_, downstream_port)) =
-                    self.downstream_ports.get_mut(&port_state.port_number)
+                    self.downstream_ports.get_mut(port_state.devfn as usize)
                 {
                     downstream_port
                         .port
@@ -629,8 +617,8 @@ mod save_restore {
                     )?;
                 } else {
                     return Err(RestoreError::InvalidSavedState(anyhow::anyhow!(
-                        "downstream port {} not found",
-                        port_state.port_number
+                        "downstream port devfn {} not found",
+                        port_state.devfn
                     )));
                 }
             }
@@ -802,8 +790,7 @@ mod tests {
         assert!(port_names.contains("test-switch-downstream-2"));
 
         // Verify port numbers
-        let port_numbers: std::collections::HashSet<_> =
-            ports.iter().map(|p| p.port_number).collect();
+        let port_numbers: std::collections::HashSet<_> = ports.iter().map(|p| p.devfn).collect();
         assert!(port_numbers.contains(&0));
         assert!(port_numbers.contains(&1));
         assert!(port_numbers.contains(&2));
@@ -1079,8 +1066,10 @@ mod tests {
 
         // Verify each downstream port has the multi-function bit set
         for p in multi_port_switch.downstream_ports() {
-            let port_num = p.port_number;
-            if let Some((_, downstream_port)) = multi_port_switch.downstream_ports.get(&port_num) {
+            let port_num = p.devfn;
+            if let Some((_, downstream_port)) =
+                multi_port_switch.downstream_ports.get(port_num as usize)
+            {
                 let mut header_type_value: u32 = 0;
                 downstream_port
                     .cfg_space()
@@ -1120,8 +1109,10 @@ mod tests {
 
         // Verify the single downstream port does NOT have the multi-function bit set
         for p in single_port_switch.downstream_ports() {
-            let port_num = p.port_number;
-            if let Some((_, downstream_port)) = single_port_switch.downstream_ports.get(&port_num) {
+            let port_num = p.devfn;
+            if let Some((_, downstream_port)) =
+                single_port_switch.downstream_ports.get(port_num as usize)
+            {
                 let mut header_type_value: u32 = 0;
                 downstream_port
                     .cfg_space()
@@ -1317,7 +1308,7 @@ mod tests {
 
         // Configure bus numbers on one of the downstream ports
         // First, we need to get access to the downstream port and configure it
-        if let Some((_, downstream_port)) = switch.downstream_ports.get_mut(&0) {
+        if let Some((_, downstream_port)) = switch.downstream_ports.get_mut(0) {
             let secondary_bus = 10u8;
             let subordinate_bus = 20u8;
             let primary_bus = 5u8;
@@ -1332,7 +1323,7 @@ mod tests {
         }
 
         // Verify the downstream port bus range is set
-        if let Some((_, downstream_port)) = switch.downstream_ports.get(&0) {
+        if let Some((_, downstream_port)) = switch.downstream_ports.get(0) {
             let bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(*bus_range.start(), 10);
             assert_eq!(*bus_range.end(), 20);
@@ -1352,7 +1343,7 @@ mod tests {
         let mut switch2 = GenericPcieSwitch::new(definition2);
 
         // Verify the new switch has default bus range on downstream port before restore
-        if let Some((_, downstream_port)) = switch2.downstream_ports.get(&0) {
+        if let Some((_, downstream_port)) = switch2.downstream_ports.get(0) {
             let default_bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(default_bus_range, 0..=0);
         }
@@ -1363,7 +1354,7 @@ mod tests {
             .expect("restore should succeed");
 
         // Verify the downstream port bus range is restored
-        if let Some((_, downstream_port)) = switch2.downstream_ports.get(&0) {
+        if let Some((_, downstream_port)) = switch2.downstream_ports.get(0) {
             let restored_bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(*restored_bus_range.start(), 10);
             assert_eq!(*restored_bus_range.end(), 20);
@@ -1391,7 +1382,7 @@ mod tests {
             .unwrap();
 
         // Downstream port 1 bus range.
-        if let Some((_, downstream_port)) = switch.downstream_ports.get_mut(&1) {
+        if let Some((_, downstream_port)) = switch.downstream_ports.get_mut(1) {
             downstream_port
                 .port
                 .cfg_space
@@ -1418,7 +1409,7 @@ mod tests {
         assert_eq!(*upstream_bus_range.start(), 0x12);
         assert_eq!(*upstream_bus_range.end(), 0x14);
 
-        if let Some((_, downstream_port)) = switch2.downstream_ports.get(&1) {
+        if let Some((_, downstream_port)) = switch2.downstream_ports.get(1) {
             let downstream_bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(*downstream_bus_range.start(), 0x1f);
             assert_eq!(*downstream_bus_range.end(), 0x20);
@@ -1569,7 +1560,7 @@ mod tests {
         assert_eq!(upstream_header, 0xffff_ffff);
 
         let mut switch = switch;
-        let (_, (_, downstream_port)) = switch
+        let (_, downstream_port) = switch
             .downstream_ports
             .iter_mut()
             .next()

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -172,7 +172,7 @@ pub struct GenericPcieSwitch {
     /// The upstream switch port that connects to the parent.
     upstream_port: UpstreamSwitchPort,
     /// Downstream switch ports indexed by devfn.
-    #[inspect(skip)]
+    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(|(_, v)| v)")]
     downstream_ports: Vec<(Arc<str>, DownstreamSwitchPort)>,
 }
 

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -823,12 +823,16 @@ mod weak_mutex_pci {
     impl RegisterWeakMutexPcie for Arc<CloseableMutex<pcie::root::GenericPcieRootComplex>> {
         fn add_pcie_device(
             &mut self,
-            port: u8,
+            port_devfn: u8,
             name: Arc<str>,
             dev: Weak<CloseableMutex<dyn ChipsetDevice>>,
         ) -> Result<(), PcieConflict> {
             self.lock()
-                .add_pcie_device(port, name.clone(), Box::new(WeakMutexPciDeviceWrapper(dev)))
+                .add_pcie_device(
+                    port_devfn,
+                    name.clone(),
+                    Box::new(WeakMutexPciDeviceWrapper(dev)),
+                )
                 .map_err(|existing_dev_name| PcieConflict {
                     reason: PcieConflictReason::ExistingDev(existing_dev_name),
                     conflict_dev: name,
@@ -841,13 +845,13 @@ mod weak_mutex_pci {
 
         fn add_rciep(
             &mut self,
-            device: u8,
+            devfn: u8,
             name: Arc<str>,
             dev: Weak<CloseableMutex<dyn ChipsetDevice>>,
         ) -> Result<(), PcieConflict> {
             self.lock()
                 .add_rciep(
-                    device,
+                    devfn,
                     name.clone(),
                     Box::new(WeakMutexPciDeviceWrapper(dev)),
                 )
@@ -862,12 +866,12 @@ mod weak_mutex_pci {
     impl RegisterWeakMutexPcie for Arc<CloseableMutex<pcie::switch::GenericPcieSwitch>> {
         fn add_pcie_device(
             &mut self,
-            port: u8,
+            port_devfn: u8,
             name: Arc<str>,
             dev: Weak<CloseableMutex<dyn ChipsetDevice>>,
         ) -> Result<(), PcieConflict> {
             self.lock()
-                .add_pcie_device(port, &name, Box::new(WeakMutexPciDeviceWrapper(dev)))
+                .add_pcie_device(port_devfn, &name, Box::new(WeakMutexPciDeviceWrapper(dev)))
                 .map_err(|err| PcieConflict {
                     reason: PcieConflictReason::ExistingDev(err.to_string().into()),
                     conflict_dev: name,

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -838,6 +838,24 @@ mod weak_mutex_pci {
         fn downstream_ports(&self) -> Vec<pcie::root::DownstreamPortInfo> {
             self.lock().downstream_ports()
         }
+
+        fn add_rciep(
+            &mut self,
+            device: u8,
+            name: Arc<str>,
+            dev: Weak<CloseableMutex<dyn ChipsetDevice>>,
+        ) -> Result<(), PcieConflict> {
+            self.lock()
+                .add_rciep(
+                    device,
+                    name.clone(),
+                    Box::new(WeakMutexPciDeviceWrapper(dev)),
+                )
+                .map_err(|existing_dev_name| PcieConflict {
+                    reason: PcieConflictReason::ExistingDev(existing_dev_name),
+                    conflict_dev: name,
+                })
+        }
     }
 
     // wiring to enable using the PCIe switch alongside the Arc+CloseableMutex device infra

--- a/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/device.rs
+++ b/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/device.rs
@@ -139,14 +139,9 @@ where
     ///
     /// RCiEPs are Type 0 PCI functions that sit directly on the start bus
     /// alongside root ports, without a downstream port above them (e.g., an
-    /// AMD IOMMU). The device occupies function 0 of the given PCI device
-    /// number (0-31).
-    pub fn on_pcie_root_complex(
-        mut self,
-        enumerator_id: BusIdPcieEnumerator,
-        device: u8,
-    ) -> Self {
-        self.pcie_rciep = Some((enumerator_id, device));
+    /// AMD IOMMU). `devfn` is `device << 3 | function`.
+    pub fn on_pcie_root_complex(mut self, enumerator_id: BusIdPcieEnumerator, devfn: u8) -> Self {
+        self.pcie_rciep = Some((enumerator_id, devfn));
         self
     }
 
@@ -200,9 +195,9 @@ where
 
                 if let Some(bus_id_port) = self.pcie_port {
                     self.services.register_static_pcie(bus_id_port);
-                } else if let Some((enumerator_id, device)) = self.pcie_rciep {
+                } else if let Some((enumerator_id, devfn)) = self.pcie_rciep {
                     self.services
-                        .register_static_pcie_rciep(enumerator_id, device);
+                        .register_static_pcie_rciep(enumerator_id, devfn);
                 } else {
                     // static pci registration
                     let bdf = match (self.pci_addr, dev.suggested_bdf()) {

--- a/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/device.rs
+++ b/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/device.rs
@@ -7,6 +7,7 @@
 use super::services::ArcMutexChipsetServices;
 use crate::BusIdPci;
 use crate::BusIdPcieDownstreamPort;
+use crate::BusIdPcieEnumerator;
 use crate::VmmChipsetDevice;
 use arc_cyclic_builder::ArcCyclicBuilder;
 use arc_cyclic_builder::ArcCyclicBuilderExt;
@@ -75,6 +76,7 @@ pub struct ArcMutexChipsetDeviceBuilder<'a, 'b, T> {
     pci_addr: Option<(u8, u8, u8)>,
     pci_bus_id: Option<BusIdPci>,
     pcie_port: Option<BusIdPcieDownstreamPort>,
+    pcie_rciep: Option<(BusIdPcieEnumerator, u8)>,
     external_pci: bool,
 }
 
@@ -102,6 +104,7 @@ where
             pci_addr: None,
             pci_bus_id: None,
             pcie_port: None,
+            pcie_rciep: None,
             external_pci: false,
         }
     }
@@ -128,6 +131,22 @@ where
     /// For PCIe devices: place the device on the specified downstream port
     pub fn on_pcie_port(mut self, id: BusIdPcieDownstreamPort) -> Self {
         self.pcie_port = Some(id);
+        self
+    }
+
+    /// For PCIe devices: place the device as a Root Complex Integrated
+    /// Endpoint (RCiEP) on the start bus of the specified root complex.
+    ///
+    /// RCiEPs are Type 0 PCI functions that sit directly on the start bus
+    /// alongside root ports, without a downstream port above them (e.g., an
+    /// AMD IOMMU). The device occupies function 0 of the given PCI device
+    /// number (0-31).
+    pub fn on_pcie_root_complex(
+        mut self,
+        enumerator_id: BusIdPcieEnumerator,
+        device: u8,
+    ) -> Self {
+        self.pcie_rciep = Some((enumerator_id, device));
         self
     }
 
@@ -167,15 +186,23 @@ where
 
         if !self.external_pci {
             if let Some(dev) = typed_dev.supports_pci() {
-                if self.pci_bus_id.is_some() && self.pcie_port.is_some() {
+                let bus_options = [
+                    self.pci_bus_id.is_some(),
+                    self.pcie_port.is_some(),
+                    self.pcie_rciep.is_some(),
+                ];
+                if bus_options.iter().filter(|&&v| v).count() > 1 {
                     panic!(
-                        "wiring error: invoked both `on_pci_bus` and `on_pcie_port` for `{}`",
+                        "wiring error: invoked multiple bus placement methods for `{}`",
                         self.dev_name
                     );
                 }
 
                 if let Some(bus_id_port) = self.pcie_port {
                     self.services.register_static_pcie(bus_id_port);
+                } else if let Some((enumerator_id, device)) = self.pcie_rciep {
+                    self.services
+                        .register_static_pcie_rciep(enumerator_id, device);
                 } else {
                     // static pci registration
                     let bdf = match (self.pci_addr, dev.suggested_bdf()) {

--- a/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/pci.rs
+++ b/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/pci.rs
@@ -77,11 +77,11 @@ impl BusResolverWeakMutexPci {
 /// is able to route accesses to `Weak<CloseableMutex<dyn ChipsetDevice>>`
 /// devices via downstream ports.
 pub trait RegisterWeakMutexPcie: Send {
-    /// Try to add a PCIe device to the enumerator at the specified port,
+    /// Try to add a PCIe device to the enumerator at the specified port devfn,
     /// reporting any conflicts.
     fn add_pcie_device(
         &mut self,
-        port: u8,
+        port_devfn: u8,
         name: Arc<str>,
         device: Weak<CloseableMutex<dyn ChipsetDevice>>,
     ) -> Result<(), PcieConflict>;
@@ -90,13 +90,13 @@ pub trait RegisterWeakMutexPcie: Send {
     fn downstream_ports(&self) -> Vec<pcie::root::DownstreamPortInfo>;
 
     /// Try to add a Root Complex Integrated Endpoint (RCiEP) at the given
-    /// PCI device number (0-31) on the start bus of the root complex.
+    /// devfn (device << 3 | function) on the start bus of the root complex.
     ///
     /// Not all enumerators support RCiEPs — only root complexes do.
     /// The default implementation returns an error.
     fn add_rciep(
         &mut self,
-        _device: u8,
+        _devfn: u8,
         name: Arc<str>,
         _device_handle: Weak<CloseableMutex<dyn ChipsetDevice>>,
     ) -> Result<(), PcieConflict> {
@@ -115,7 +115,7 @@ pub struct WeakMutexPcieDeviceEntry {
 
 pub struct WeakMutexPcieRciepEntry {
     pub bus_id_enumerator: BusIdPcieEnumerator,
-    pub device: u8,
+    pub devfn: u8,
     pub name: Arc<str>,
     pub dev: Weak<CloseableMutex<dyn ChipsetDevice>>,
 }
@@ -138,7 +138,7 @@ impl BusResolverWeakMutexPcie {
             dev,
         } in self.devices
         {
-            let (port_number, bus_id_enumerator) = match self.ports.get(&bus_id_port) {
+            let (devfn, bus_id_enumerator) = match self.ports.get(&bus_id_port) {
                 Some(v) => v,
                 None => {
                     errs.push(PcieConflict {
@@ -160,7 +160,7 @@ impl BusResolverWeakMutexPcie {
                 }
             };
 
-            match enumerator.add_pcie_device(*port_number, name, dev) {
+            match enumerator.add_pcie_device(*devfn, name, dev) {
                 Ok(()) => {}
                 Err(conflict) => {
                     errs.push(conflict);
@@ -171,7 +171,7 @@ impl BusResolverWeakMutexPcie {
 
         for WeakMutexPcieRciepEntry {
             bus_id_enumerator,
-            device,
+            devfn,
             name,
             dev,
         } in self.rcieps
@@ -187,7 +187,7 @@ impl BusResolverWeakMutexPcie {
                 }
             };
 
-            match enumerator.add_rciep(device, name, dev) {
+            match enumerator.add_rciep(devfn, name, dev) {
                 Ok(()) => {}
                 Err(conflict) => {
                     errs.push(conflict);

--- a/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/pci.rs
+++ b/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/pci.rs
@@ -88,10 +88,34 @@ pub trait RegisterWeakMutexPcie: Send {
 
     /// Enumerate the downstream ports.
     fn downstream_ports(&self) -> Vec<pcie::root::DownstreamPortInfo>;
+
+    /// Try to add a Root Complex Integrated Endpoint (RCiEP) at the given
+    /// device/function on the start bus of the root complex.
+    ///
+    /// Not all enumerators support RCiEPs — only root complexes do.
+    /// The default implementation returns an error.
+    fn add_rciep(
+        &mut self,
+        _device: u8,
+        name: Arc<str>,
+        _device_handle: Weak<CloseableMutex<dyn ChipsetDevice>>,
+    ) -> Result<(), PcieConflict> {
+        Err(PcieConflict {
+            conflict_dev: name,
+            reason: PcieConflictReason::RciepNotSupported,
+        })
+    }
 }
 
 pub struct WeakMutexPcieDeviceEntry {
     pub bus_id_port: BusIdPcieDownstreamPort,
+    pub name: Arc<str>,
+    pub dev: Weak<CloseableMutex<dyn ChipsetDevice>>,
+}
+
+pub struct WeakMutexPcieRciepEntry {
+    pub bus_id_enumerator: BusIdPcieEnumerator,
+    pub device: u8,
     pub name: Arc<str>,
     pub dev: Weak<CloseableMutex<dyn ChipsetDevice>>,
 }
@@ -101,6 +125,7 @@ pub struct BusResolverWeakMutexPcie {
     pub enumerators: HashMap<BusIdPcieEnumerator, Box<dyn RegisterWeakMutexPcie>>,
     pub ports: HashMap<BusIdPcieDownstreamPort, (u8, BusIdPcieEnumerator)>,
     pub devices: Vec<WeakMutexPcieDeviceEntry>,
+    pub rcieps: Vec<WeakMutexPcieRciepEntry>,
 }
 
 impl BusResolverWeakMutexPcie {
@@ -136,6 +161,33 @@ impl BusResolverWeakMutexPcie {
             };
 
             match enumerator.add_pcie_device(*port_number, name, dev) {
+                Ok(()) => {}
+                Err(conflict) => {
+                    errs.push(conflict);
+                    continue;
+                }
+            };
+        }
+
+        for WeakMutexPcieRciepEntry {
+            bus_id_enumerator,
+            device,
+            name,
+            dev,
+        } in self.rcieps
+        {
+            let enumerator = match self.enumerators.get_mut(&bus_id_enumerator) {
+                Some(enumerator) => enumerator,
+                None => {
+                    errs.push(PcieConflict {
+                        conflict_dev: name.clone(),
+                        reason: PcieConflictReason::MissingEnumerator,
+                    });
+                    continue;
+                }
+            };
+
+            match enumerator.add_rciep(device, name, dev) {
                 Ok(()) => {}
                 Err(conflict) => {
                     errs.push(conflict);

--- a/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/pci.rs
+++ b/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/pci.rs
@@ -90,7 +90,7 @@ pub trait RegisterWeakMutexPcie: Send {
     fn downstream_ports(&self) -> Vec<pcie::root::DownstreamPortInfo>;
 
     /// Try to add a Root Complex Integrated Endpoint (RCiEP) at the given
-    /// device/function on the start bus of the root complex.
+    /// PCI device number (0-31) on the start bus of the root complex.
     ///
     /// Not all enumerators support RCiEPs — only root complexes do.
     /// The default implementation returns an error.

--- a/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/services.rs
+++ b/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/services.rs
@@ -204,14 +204,10 @@ impl<'a, 'b> ArcMutexChipsetServices<'a, 'b> {
         );
     }
 
-    pub fn register_static_pcie_rciep(
-        &mut self,
-        enumerator_id: BusIdPcieEnumerator,
-        device: u8,
-    ) {
+    pub fn register_static_pcie_rciep(&mut self, enumerator_id: BusIdPcieEnumerator, devfn: u8) {
         self.builder.register_weak_mutex_pcie_rciep(
             enumerator_id,
-            device,
+            devfn,
             self.dev_name.clone(),
             self.dev.clone(),
         );

--- a/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/services.rs
+++ b/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/services.rs
@@ -8,6 +8,7 @@ use super::device::ArcMutexChipsetServicesFinalize;
 use super::state_unit::ArcMutexChipsetDeviceUnit;
 use crate::BusIdPci;
 use crate::BusIdPcieDownstreamPort;
+use crate::BusIdPcieEnumerator;
 use crate::ChipsetBuilder;
 use crate::VmmChipsetDevice;
 use crate::chipset::io_ranges::IoRanges;
@@ -198,6 +199,19 @@ impl<'a, 'b> ArcMutexChipsetServices<'a, 'b> {
     pub fn register_static_pcie(&mut self, bus_id: BusIdPcieDownstreamPort) {
         self.builder.register_weak_mutex_pcie_device(
             bus_id,
+            self.dev_name.clone(),
+            self.dev.clone(),
+        );
+    }
+
+    pub fn register_static_pcie_rciep(
+        &mut self,
+        enumerator_id: BusIdPcieEnumerator,
+        device: u8,
+    ) {
+        self.builder.register_weak_mutex_pcie_rciep(
+            enumerator_id,
+            device,
             self.dev_name.clone(),
             self.dev.clone(),
         );

--- a/vmm_core/vmotherboard/src/chipset/builder/mod.rs
+++ b/vmm_core/vmotherboard/src/chipset/builder/mod.rs
@@ -228,7 +228,7 @@ impl<'a> ChipsetBuilder<'a> {
         for port_info in downstream_ports {
             let existing = inner.bus_resolver.pcie.ports.insert(
                 BusId::new(&port_info.name),
-                (port_info.port_number, bus_id.clone()),
+                (port_info.devfn, bus_id.clone()),
             );
             assert!(
                 existing.is_none(),
@@ -259,7 +259,7 @@ impl<'a> ChipsetBuilder<'a> {
     pub(crate) fn register_weak_mutex_pcie_rciep(
         &self,
         bus_id_enumerator: BusIdPcieEnumerator,
-        device: u8,
+        devfn: u8,
         name: Arc<str>,
         dev: Weak<CloseableMutex<dyn ChipsetDevice>>,
     ) {
@@ -270,7 +270,7 @@ impl<'a> ChipsetBuilder<'a> {
             .rcieps
             .push(WeakMutexPcieRciepEntry {
                 bus_id_enumerator,
-                device,
+                devfn,
                 name,
                 dev,
             });

--- a/vmm_core/vmotherboard/src/chipset/builder/mod.rs
+++ b/vmm_core/vmotherboard/src/chipset/builder/mod.rs
@@ -15,6 +15,7 @@ use super::backing::arc_mutex::pci::RegisterWeakMutexPci;
 use super::backing::arc_mutex::pci::RegisterWeakMutexPcie;
 use super::backing::arc_mutex::pci::WeakMutexPciEntry;
 use super::backing::arc_mutex::pci::WeakMutexPcieDeviceEntry;
+use super::backing::arc_mutex::pci::WeakMutexPcieRciepEntry;
 use super::backing::arc_mutex::services::ArcMutexChipsetServices;
 use super::backing::arc_mutex::state_unit::ArcMutexChipsetDeviceUnit;
 use crate::BusId;
@@ -250,6 +251,26 @@ impl<'a> ChipsetBuilder<'a> {
             .devices
             .push(WeakMutexPcieDeviceEntry {
                 bus_id_port,
+                name,
+                dev,
+            });
+    }
+
+    pub(crate) fn register_weak_mutex_pcie_rciep(
+        &self,
+        bus_id_enumerator: BusIdPcieEnumerator,
+        device: u8,
+        name: Arc<str>,
+        dev: Weak<CloseableMutex<dyn ChipsetDevice>>,
+    ) {
+        self.inner
+            .lock()
+            .bus_resolver
+            .pcie
+            .rcieps
+            .push(WeakMutexPcieRciepEntry {
+                bus_id_enumerator,
+                device,
                 name,
                 dev,
             });

--- a/vmm_core/vmotherboard/src/chipset/mod.rs
+++ b/vmm_core/vmotherboard/src/chipset/mod.rs
@@ -324,6 +324,7 @@ pub enum PcieConflictReason {
     ExistingDev(Arc<str>),
     MissingDownstreamPort,
     MissingEnumerator,
+    RciepNotSupported,
 }
 
 #[derive(Debug)]
@@ -353,6 +354,13 @@ impl std::fmt::Display for PcieConflict {
                 write!(
                     fmt,
                     "cannot attach {}, no valid pcie enumerator",
+                    self.conflict_dev
+                )
+            }
+            PcieConflictReason::RciepNotSupported => {
+                write!(
+                    fmt,
+                    "cannot attach {} as RCiEP, enumerator does not support RCiEPs",
                     self.conflict_dev
                 )
             }


### PR DESCRIPTION
Some PCIe devices — most notably an AMD IOMMU — live on the start bus of a root complex as Type 0 PCI functions alongside (not behind) root ports. The existing PCIe switch infra only knew how to attach devices behind downstream ports, so there was no way to wire up an RCiEP.

Teach the generic root complex (GenericPcieRootComplex) to hold RCiEPs indexed by PCI device number (0-31), and route ECAM accesses on the start bus that don't hit a root port through to a registered RCiEP at function 0. Also add a builder API with a `first_port_device_number` option so callers can reserve low device numbers on the start bus for RCiEPs (e.g., put the IOMMU at device 0 and start root ports at device 1).

No callers yet — that comes in a follow-up. This change is purely additive infrastructure.