### PR TITLE
flowey: update openvmm-deps resolver for split archives and use Linux 6.18 test kernel

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -32,7 +32,8 @@ pub const NODEJS: &str = "24.x";
 //      increases with each release from the respective branch.
 pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.3";
 pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.3";
-pub const OPENVMM_DEPS: &str = "0.3.0-33";
+pub const OPENVMM_DEPS: &str = "0.3.0-40";
+pub const OPENVMM_TEST_LINUX_KERNEL: &str = "6.18";
 pub const PROTOC: &str = "27.1";
 
 flowey_request! {

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -33,7 +33,6 @@ pub const NODEJS: &str = "24.x";
 pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.3";
 pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.3";
 pub const OPENVMM_DEPS: &str = "0.3.0-40";
-pub const OPENVMM_TEST_LINUX_KERNEL: &str = "6.18";
 pub const PROTOC: &str = "27.1";
 
 flowey_request! {

--- a/flowey/flowey_lib_hvlite/src/resolve_openvmm_deps.rs
+++ b/flowey/flowey_lib_hvlite/src/resolve_openvmm_deps.rs
@@ -2,10 +2,16 @@
 // Licensed under the MIT License.
 
 //! Download various pre-built `openvmm-deps` dependencies, or use a local path if specified.
+//!
+//! The openvmm-deps release publishes separate archives:
+//! - `openvmm-deps.{arch}.{ver}.tar.gz` — SDK tools (dbgrd, shell, sysroot, petritools)
+//! - `openvmm-test-initrd.{arch}.{ver}.tar.gz` — shared test initrd
+//! - `openvmm-test-linux-{kernel_ver}.{arch}.{ver}.tar.gz` — test kernel
 
 use crate::common::CommonArch;
 use flowey::node::prelude::*;
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 
 /// Which file to extract from the openvmm-deps archive.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -87,9 +93,6 @@ impl FlowNodeWithConfig for Node {
             return Ok(());
         }
 
-        // Which architectures have at least one dep requested?
-        let needs_arch = |arch: CommonArch| deps.keys().any(|(_, a)| *a == arch);
-
         if !local_paths.is_empty() {
             ctx.emit_rust_step("use local openvmm-deps", |ctx| {
                 let deps = deps.claim(ctx);
@@ -118,67 +121,65 @@ impl FlowNodeWithConfig for Node {
             return Ok(());
         }
 
-        let extract_tar_gz_persistent_dir = ctx.persistent_dir();
+        let version = version.expect("local requests handled above");
 
-        let download_archive = |arch: CommonArch, ctx: &mut NodeCtx<'_>| {
-            let version = version.clone().expect("local requests handled above");
-            let arch_str = match arch {
-                CommonArch::X86_64 => "x86_64",
-                CommonArch::Aarch64 => "aarch64",
-            };
-            ctx.reqv(|v| flowey_lib_common::download_gh_release::Request {
-                repo_owner: "microsoft".into(),
-                repo_name: "openvmm-deps".into(),
-                needs_auth: false,
-                tag: version.clone(),
-                file_name: format!("openvmm-deps.{arch_str}.{version}.tar.gz"),
-                path: v,
+        // Determine which architectures we need to download.
+        let needed_archs: BTreeSet<CommonArch> = deps.keys().map(|(_, arch)| *arch).collect();
+
+        let persistent_dir = ctx.persistent_dir();
+
+        // Download each unique architecture.
+        let downloads: BTreeMap<CommonArch, ReadVar<PathBuf>> = needed_archs
+            .into_iter()
+            .map(|arch| {
+                let arch_str = match arch {
+                    CommonArch::X86_64 => "x86_64",
+                    CommonArch::Aarch64 => "aarch64",
+                };
+                let file_name = format!("openvmm-deps.{arch_str}.{version}.tar.gz");
+                let path = ctx.reqv(|v| flowey_lib_common::download_gh_release::Request {
+                    repo_owner: "microsoft".into(),
+                    repo_name: "openvmm-deps".into(),
+                    needs_auth: false,
+                    tag: version.clone(),
+                    file_name,
+                    path: v,
+                });
+                (arch, path)
             })
-        };
-
-        let openvmm_deps_tar_gz_x64 =
-            needs_arch(CommonArch::X86_64).then(|| download_archive(CommonArch::X86_64, ctx));
-        let openvmm_deps_tar_gz_aarch64 =
-            needs_arch(CommonArch::Aarch64).then(|| download_archive(CommonArch::Aarch64, ctx));
+            .collect();
 
         ctx.emit_rust_step("unpack openvmm-deps archive", |ctx| {
-            let extract_tar_gz_persistent_dir = extract_tar_gz_persistent_dir.claim(ctx);
-            let openvmm_deps_tar_gz_x64 = openvmm_deps_tar_gz_x64.claim(ctx);
-            let openvmm_deps_tar_gz_aarch64 = openvmm_deps_tar_gz_aarch64.claim(ctx);
+            let persistent_dir = persistent_dir.claim(ctx);
+            let downloads: BTreeMap<_, _> = downloads
+                .into_iter()
+                .map(|(key, var)| (key, var.claim(ctx)))
+                .collect();
             let deps = deps.claim(ctx);
-            let version = version.clone().expect("local requests handled above");
+            let version = version.clone();
             move |rt| {
-                let persistent_dir = extract_tar_gz_persistent_dir.map(|d| rt.read(d));
-                let extract_dir_x64 = openvmm_deps_tar_gz_x64
-                    .map(|file| {
-                        let file = rt.read(file);
-                        flowey_lib_common::_util::extract::extract_tar_gz_if_new(
-                            rt,
-                            persistent_dir.as_deref(),
-                            &file,
-                            &version,
-                        )
-                    })
-                    .transpose()?;
-                let extract_dir_aarch64 = openvmm_deps_tar_gz_aarch64
-                    .map(|file| {
-                        let file = rt.read(file);
-                        flowey_lib_common::_util::extract::extract_tar_gz_if_new(
-                            rt,
-                            persistent_dir.as_deref(),
-                            &file,
-                            &version,
-                        )
-                    })
-                    .transpose()?;
+                let persistent_dir = persistent_dir.map(|d| rt.read(d));
 
-                let base_dir = |arch| match arch {
-                    CommonArch::X86_64 => extract_dir_x64.clone().unwrap(),
-                    CommonArch::Aarch64 => extract_dir_aarch64.clone().unwrap(),
-                };
+                // Extract each downloaded archive, keyed by architecture.
+                let extract_dirs: BTreeMap<CommonArch, PathBuf> = downloads
+                    .into_iter()
+                    .map(|(arch, var)| {
+                        let file = rt.read(var);
+                        let dir = flowey_lib_common::_util::extract::extract_tar_gz_if_new(
+                            rt,
+                            persistent_dir.as_deref(),
+                            &file,
+                            &version,
+                        )?;
+                        Ok((arch, dir))
+                    })
+                    .collect::<anyhow::Result<_>>()?;
 
                 for ((dep, arch), vars) in deps {
-                    let path = base_dir(arch).join(dep.filename());
+                    let extract_dir = extract_dirs
+                        .get(&arch)
+                        .expect("archive was downloaded for this arch");
+                    let path = extract_dir.join(dep.filename());
                     rt.write_all(vars, &path)
                 }
 

--- a/flowey/flowey_lib_hvlite/src/resolve_openvmm_test_linux_kernel.rs
+++ b/flowey/flowey_lib_hvlite/src/resolve_openvmm_test_linux_kernel.rs
@@ -21,13 +21,10 @@ use std::collections::BTreeSet;
 
 /// Which Linux test kernel version to fetch from the openvmm-deps GitHub
 /// release.
-///
-/// The `openvmm-deps` release currently only ships the 6.1 kernel; additional
-/// kernel lines (e.g. 6.6, 6.12) are intended to be added as purely additive
-/// follow-ups, both upstream and as new variants of this enum.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LinuxTestKernelVersion {
     Linux6_1,
+    Linux6_18,
 }
 
 impl LinuxTestKernelVersion {
@@ -36,6 +33,7 @@ impl LinuxTestKernelVersion {
     pub fn artifact_tag(self) -> &'static str {
         match self {
             Self::Linux6_1 => "6.1",
+            Self::Linux6_18 => "6.18",
         }
     }
 }
@@ -73,7 +71,7 @@ impl OpenvmmTestKernelFile {
 /// The default Linux test kernel version. Call sites that don't otherwise care
 /// which kernel they're using should pass this.
 pub const DEFAULT_LINUX_TEST_KERNEL_VERSION: LinuxTestKernelVersion =
-    LinuxTestKernelVersion::Linux6_1;
+    LinuxTestKernelVersion::Linux6_18;
 
 flowey_config! {
     /// Config for the resolve_openvmm_test_linux_kernel node.


### PR DESCRIPTION
## Summary
- update the openvmm-deps resolver for the split archive format introduced in openvmm-deps 0.3.0-29+
- use the Linux 6.18 test kernel as the default
- remove the prior pcie_devices known issue because openvmm-deps#68 fixes it by bumping the kernel to 6.18.33

## Details
The openvmm-deps release now publishes separate archives for:
- SDK dependencies (`openvmm-deps.<arch>.<version>.tar.gz`)
- shared test initrd (`openvmm-test-initrd.<arch>.<version>.tar.gz`)
- per-kernel test Linux artifacts (`openvmm-test-linux-<kernel>.<arch>.<version>.tar.gz`)

This PR updates flowey to resolve those split archives, keeps the tar.gz handling aligned with the new release format, and makes Linux 6.18 the default test kernel.

## Related openvmm-deps changes
- openvmm-deps#61
- openvmm-deps#62
- openvmm-deps#68
