### PR TITLE
virt_kvm: strip PSFD CPUID when KVM won't allow SPEC_CTRL MSR

### DIFF
--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -306,6 +306,7 @@ impl ProtoPartition for KvmProtoPartition<'_> {
         let mut cpuid = self.cpuid.into_leaves();
         cpuid.extend(config.cpuid);
         cpuid.extend(topology_leaves);
+        fixup_spec_ctrl_cpuid(&mut cpuid);
         let cpuid = CpuidLeafSet::new(cpuid);
 
         let bsp_apic_id = self.config.processor_topology.vp_arch(VpIndex::BSP).apic_id;
@@ -484,6 +485,49 @@ impl ProtoPartition for KvmProtoPartition<'_> {
         }
 
         Ok((partition, vps))
+    }
+}
+
+/// Work around a KVM bug where PSFD is advertised in guest CPUID but the
+/// SPEC_CTRL MSR (0x48) is not accessible.
+///
+/// KVM's `guest_has_spec_ctrl_msr()` determines whether a guest may access
+/// MSR 0x48 by checking CPUID 7.0.EDX bit 26 (SPEC_CTRL), and
+/// 0x80000008.EBX bits 14 (AMD_IBRS), 15 (AMD_STIBP), and 24 (AMD_SSBD).
+/// However, KVM also passes through AMD PSFD (0x80000008.EBX bit 28) in
+/// CPUID without including it in that check. PSFD is architecturally
+/// controlled via bit 7 of MSR 0x48, so a guest that sees PSFD and infers
+/// SPEC_CTRL MSR support (as Hyper-V does) will #GP when writing the MSR.
+///
+/// Strip PSFD from the guest CPUID when none of the bits that KVM uses to
+/// gate MSR 0x48 access are present.
+fn fixup_spec_ctrl_cpuid(cpuid: &mut Vec<CpuidLeaf>) {
+    use x86defs::cpuid::ExtendedAddressSpaceSizesEbx;
+    use x86defs::cpuid::ExtendedFeatureSubleaf0Edx;
+
+    let temp_cpuid = CpuidLeafSet::new(cpuid.clone());
+    let leaf7 = temp_cpuid.result(CpuidFunction::ExtendedFeatures.0, 0, &[0; 4]);
+    let leaf80000008 = temp_cpuid.result(
+        CpuidFunction::ExtendedAddressSpaceSizes.0,
+        0,
+        &[0; 4],
+    );
+
+    let edx = ExtendedFeatureSubleaf0Edx::from(leaf7[3]);
+    let ebx = ExtendedAddressSpaceSizesEbx::from(leaf80000008[1]);
+
+    // Mirror KVM's guest_has_spec_ctrl_msr() check.
+    let has_spec_ctrl_msr = edx.ibrs() || ebx.ibrs() || ebx.stibp() || ebx.ssbd();
+
+    if !has_spec_ctrl_msr && ebx.psfd() {
+        let psfd_mask = ExtendedAddressSpaceSizesEbx::new().with_psfd(true);
+        cpuid.push(
+            CpuidLeaf::new(
+                CpuidFunction::ExtendedAddressSpaceSizes.0,
+                [0, 0, 0, 0],
+            )
+            .masked([0, u32::from(psfd_mask), 0, 0]),
+        );
     }
 }
 

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -303,10 +303,16 @@ impl ProtoPartition for KvmProtoPartition<'_> {
         )
         .map_err(KvmError::TopologyCpuid)?;
 
+        // Work around a KVM bug where PSFD is advertised in guest CPUID
+        // but the SPEC_CTRL MSR is not accessible. Check the KVM-reported
+        // CPUID (before user overrides) since that determines what KVM
+        // will allow.
+        let psfd_fixup = strip_psfd_leaf(&self.cpuid);
+
         let mut cpuid = self.cpuid.into_leaves();
         cpuid.extend(config.cpuid);
         cpuid.extend(topology_leaves);
-        fixup_spec_ctrl_cpuid(&mut cpuid);
+        cpuid.extend(psfd_fixup);
         let cpuid = CpuidLeafSet::new(cpuid);
 
         let bsp_apic_id = self.config.processor_topology.vp_arch(VpIndex::BSP).apic_id;
@@ -488,46 +494,38 @@ impl ProtoPartition for KvmProtoPartition<'_> {
     }
 }
 
-/// Work around a KVM bug where PSFD is advertised in guest CPUID but the
-/// SPEC_CTRL MSR (0x48) is not accessible.
+/// KVM's `guest_has_spec_ctrl_msr()` decides whether a guest may access
+/// the SPEC_CTRL MSR by checking for IBRS, STIBP, and SSBD in CPUID.
+/// However, KVM also passes through AMD PSFD without including it in that
+/// check. PSFD is architecturally controlled via the SPEC_CTRL MSR, so a
+/// guest that sees PSFD and infers SPEC_CTRL MSR support (as Hyper-V
+/// does) will #GP when writing the MSR.
 ///
-/// KVM's `guest_has_spec_ctrl_msr()` determines whether a guest may access
-/// MSR 0x48 by checking CPUID 7.0.EDX bit 26 (SPEC_CTRL), and
-/// 0x80000008.EBX bits 14 (AMD_IBRS), 15 (AMD_STIBP), and 24 (AMD_SSBD).
-/// However, KVM also passes through AMD PSFD (0x80000008.EBX bit 28) in
-/// CPUID without including it in that check. PSFD is architecturally
-/// controlled via bit 7 of MSR 0x48, so a guest that sees PSFD and infers
-/// SPEC_CTRL MSR support (as Hyper-V does) will #GP when writing the MSR.
-///
-/// Strip PSFD from the guest CPUID when none of the bits that KVM uses to
-/// gate MSR 0x48 access are present.
-fn fixup_spec_ctrl_cpuid(cpuid: &mut Vec<CpuidLeaf>) {
+/// Returns a leaf that strips PSFD when it should not be advertised.
+fn strip_psfd_leaf(cpuid: &CpuidLeafSet) -> Option<CpuidLeaf> {
     use x86defs::cpuid::ExtendedAddressSpaceSizesEbx;
     use x86defs::cpuid::ExtendedFeatureSubleaf0Edx;
 
-    let temp_cpuid = CpuidLeafSet::new(cpuid.clone());
-    let leaf7 = temp_cpuid.result(CpuidFunction::ExtendedFeatures.0, 0, &[0; 4]);
-    let leaf80000008 = temp_cpuid.result(
-        CpuidFunction::ExtendedAddressSpaceSizes.0,
-        0,
-        &[0; 4],
-    );
+    let leaf7 = cpuid.result(CpuidFunction::ExtendedFeatures.0, 0, &[0; 4]);
+    let leaf80000008 = cpuid.result(CpuidFunction::ExtendedAddressSpaceSizes.0, 0, &[0; 4]);
 
     let edx = ExtendedFeatureSubleaf0Edx::from(leaf7[3]);
     let ebx = ExtendedAddressSpaceSizesEbx::from(leaf80000008[1]);
 
     // Mirror KVM's guest_has_spec_ctrl_msr() check.
     let has_spec_ctrl_msr = edx.ibrs() || ebx.ibrs() || ebx.stibp() || ebx.ssbd();
-
     if !has_spec_ctrl_msr && ebx.psfd() {
         let psfd_mask = ExtendedAddressSpaceSizesEbx::new().with_psfd(true);
-        cpuid.push(
-            CpuidLeaf::new(
-                CpuidFunction::ExtendedAddressSpaceSizes.0,
-                [0, 0, 0, 0],
-            )
-            .masked([0, u32::from(psfd_mask), 0, 0]),
-        );
+        Some(
+            CpuidLeaf::new(CpuidFunction::ExtendedAddressSpaceSizes.0, [0, 0, 0, 0]).masked([
+                0,
+                u32::from(psfd_mask),
+                0,
+                0,
+            ]),
+        )
+    } else {
+        None
     }
 }
 


### PR DESCRIPTION
KVM has a bug where it advertises AMD PSFD (Predictive Store Forwarding Disable) in guest CPUID via leaf 0x80000008.EBX bit 28, but its `guest_has_spec_ctrl_msr()` function does not include PSFD when deciding whether to allow guest access to MSR 0x48 (IA32_SPEC_CTRL). PSFD is architecturally controlled via bit 7 of that MSR, so advertising PSFD implies the MSR should be accessible.

This causes a problem for nested Hyper-V guests. The Hyper-V hypervisor includes PSFD (which it calls MDD) in its `HV_PARTITION_PROCESSOR_FEATURES0_MASK_SPEC_CTRL` mask, so seeing PSFD alone is enough to set `ValFeatureSet.SpecCtrlMsr = true`. On initialization, it writes zero to MSR 0x48 to clear speculation controls. KVM rejects this write because none of the four CPUID bits it checks (CPUID 7.0.EDX IBRS, 0x80000008.EBX IBRS/STIBP/SSBD) are set, and so it injects a #GP that crashes the nested hypervisor.

This is only visible on AMD hosts where Hyper-V strips IBRS/STIBP/SSBD from the guest CPUID but leaves PSFD, which is the case when running KVM inside a Hyper-V VM with nested virtualization.

The fix detects this inconsistency during partition construction: if PSFD is set in the guest CPUID but none of the bits that KVM uses to gate MSR 0x48 access are present, strip PSFD.