### PR TITLE
crypto: AI generated audit feedback

### DIFF
--- a/support/crypto/src/kbkdf/mod.rs
+++ b/support/crypto/src/kbkdf/mod.rs
@@ -36,10 +36,10 @@ pub struct KbkdfError(#[source] super::BackendError);
 pub fn kbkdf_hmac_sha256(
     key: &[u8],
     context: &[u8],
-    salt: &[u8],
+    label: &[u8],
     output_len: usize,
 ) -> Result<Vec<u8>, KbkdfError> {
-    sys::kbkdf_hmac_sha256(key, context, salt, output_len)
+    sys::kbkdf_hmac_sha256(key, context, label, output_len)
 }
 
 #[cfg(test)]

--- a/support/crypto/src/kbkdf/ossl.rs
+++ b/support/crypto/src/kbkdf/ossl.rs
@@ -7,12 +7,12 @@ use openssl_kdf::kdf::Kbkdf;
 pub fn kbkdf_hmac_sha256(
     key: &[u8],
     context: &[u8],
-    salt: &[u8],
+    label: &[u8],
     output_len: usize,
 ) -> Result<Vec<u8>, KbkdfError> {
     let mut kdf = Kbkdf::new(
         openssl::hash::MessageDigest::sha256(),
-        salt.to_vec(),
+        label.to_vec(),
         key.to_vec(),
     );
     kdf.set_context(context.to_vec());

--- a/support/crypto/src/kbkdf/symcrypt.rs
+++ b/support/crypto/src/kbkdf/symcrypt.rs
@@ -10,13 +10,13 @@ use symcrypt::sp800_108::sp800_108_counter_mode;
 pub fn kbkdf_hmac_sha256(
     key: &[u8],
     context: &[u8],
-    salt: &[u8],
+    label: &[u8],
     output_len: usize,
 ) -> Result<Vec<u8>, KbkdfError> {
     sp800_108_counter_mode(
         HmacAlgorithm::HmacSha256,
         key,
-        salt,
+        label,
         context,
         output_len as u64,
     )

--- a/support/crypto/src/rsa/mod.rs
+++ b/support/crypto/src/rsa/mod.rs
@@ -23,12 +23,14 @@ pub(crate) use symcrypt as sys;
 use thiserror::Error;
 
 /// An error for RSA operations.
+// TODO: Make this clone once RustCrypto rsa::errors::Error is cloneable
 #[cfg(not(rust))]
 #[derive(Debug, Error)]
 #[error("RSA error")]
 pub struct RsaError(#[source] pub(crate) super::BackendError);
 
 /// An error for RSA operations.
+// TODO: Make this clone once RustCrypto rsa::errors::Error is cloneable
 #[cfg(rust)]
 #[derive(Debug, Error)]
 #[error("RSA error during {1}")]

--- a/support/crypto/src/x509/mod.rs
+++ b/support/crypto/src/x509/mod.rs
@@ -55,6 +55,11 @@ impl X509Certificate {
     }
 
     /// Check if this certificate (acting as issuer) issued `subject`.
+    ///
+    /// This performs only deterministic structural comparisons - it does not
+    /// cryptographically verify the issuer's signature on `subject`. Callers
+    /// that need to establish a trust relationship must additionally call
+    /// [`X509Certificate::verify`] with the issuer's public key.
     pub fn issued(&self, subject: &X509Certificate) -> Result<bool, X509Error> {
         self.0.issued(&subject.0)
     }

--- a/support/crypto/src/xts_aes_256/mod.rs
+++ b/support/crypto/src/xts_aes_256/mod.rs
@@ -52,7 +52,10 @@ pub struct XtsAes256EncCtx<'a>(sys::XtsAes256EncCtxInner<'a>);
 
 impl XtsAes256EncCtx<'_> {
     /// Encrypts `data` using the provided `tweak`.
-    pub fn cipher(&mut self, tweak: u128, data: &mut [u8]) -> Result<(), XtsAes256Error> {
+    // BCrypt only supports 64-bit tweaks, internally padding out the high 8
+    // bytes with zeroes (Why?). This is fine for our purposes but it's a
+    // bit annoying. We restrict all backends to 64-bit tweaks for consistency.
+    pub fn cipher(&mut self, tweak: u64, data: &mut [u8]) -> Result<(), XtsAes256Error> {
         self.0.cipher(tweak, data)
     }
 }
@@ -62,7 +65,10 @@ pub struct XtsAes256DecCtx<'a>(sys::XtsAes256DecCtxInner<'a>);
 
 impl XtsAes256DecCtx<'_> {
     /// Decrypts `data` using the provided `tweak`.
-    pub fn cipher(&mut self, tweak: u128, data: &mut [u8]) -> Result<(), XtsAes256Error> {
+    // BCrypt only supports 64-bit tweaks, internally padding out the high 8
+    // bytes with zeroes (Why?). This is fine for our purposes but it's a
+    // bit annoying. We restrict all backends to 64-bit tweaks for consistency.
+    pub fn cipher(&mut self, tweak: u64, data: &mut [u8]) -> Result<(), XtsAes256Error> {
         self.0.cipher(tweak, data)
     }
 }
@@ -80,7 +86,7 @@ mod tests {
              3141592653589793238462643383279502884197169399375105820974944592",
         )
         .unwrap();
-        let tweak: u128 = 0;
+        let tweak = 0;
         let plain = hex::decode("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
             .unwrap();
         let expected_ciphertext =

--- a/support/crypto/src/xts_aes_256/ossl.rs
+++ b/support/crypto/src/xts_aes_256/ossl.rs
@@ -54,8 +54,8 @@ impl XtsAes256Inner {
 }
 
 impl XtsAes256EncCtxInner<'_> {
-    pub fn cipher(&mut self, tweak: u128, data: &mut [u8]) -> Result<(), XtsAes256Error> {
-        let iv = tweak.to_le_bytes();
+    pub fn cipher(&mut self, tweak: u64, data: &mut [u8]) -> Result<(), XtsAes256Error> {
+        let iv = (tweak as u128).to_le_bytes();
         self.ctx
             .encrypt_init(None, None, Some(&iv))
             .map_err(|e| err(e, "encryption"))?;
@@ -67,8 +67,8 @@ impl XtsAes256EncCtxInner<'_> {
 }
 
 impl XtsAes256DecCtxInner<'_> {
-    pub fn cipher(&mut self, tweak: u128, data: &mut [u8]) -> Result<(), XtsAes256Error> {
-        let iv = tweak.to_le_bytes();
+    pub fn cipher(&mut self, tweak: u64, data: &mut [u8]) -> Result<(), XtsAes256Error> {
+        let iv = (tweak as u128).to_le_bytes();
         self.ctx
             .decrypt_init(None, None, Some(&iv))
             .map_err(|e| err(e, "decryption"))?;

--- a/support/crypto/src/xts_aes_256/win.rs
+++ b/support/crypto/src/xts_aes_256/win.rs
@@ -6,7 +6,6 @@
 use super::*;
 use crate::win::*;
 use std::sync::LazyLock;
-use windows::Win32::Foundation::E_INVALIDARG;
 use windows::Win32::Security::Cryptography::BCRYPT_ALG_HANDLE;
 use windows::Win32::Security::Cryptography::BCRYPT_HANDLE;
 use windows::Win32::Security::Cryptography::BCRYPT_KEY_HANDLE;
@@ -86,13 +85,8 @@ impl XtsAes256Inner {
 }
 
 impl XtsAes256EncCtxInner<'_> {
-    pub fn cipher(&mut self, tweak: u128, data: &mut [u8]) -> Result<(), XtsAes256Error> {
-        // BCrypt only supports 64-bit tweaks, internally padding out the high 8
-        // bytes with zeroes. (Why?) This is fine for our purposes but it's a
-        // bit annoying.
-        let mut iv = u64::try_from(tweak)
-            .map_err(|_| XtsAes256Error(crate::BackendError(E_INVALIDARG.into(), "convert tweak")))?
-            .to_le_bytes();
+    pub fn cipher(&mut self, tweak: u64, data: &mut [u8]) -> Result<(), XtsAes256Error> {
+        let mut iv = tweak.to_le_bytes();
 
         // TODO: fix windows crate to allow aliased input and output, as
         // allowed by the API.
@@ -119,13 +113,8 @@ impl XtsAes256EncCtxInner<'_> {
 }
 
 impl XtsAes256DecCtxInner<'_> {
-    pub fn cipher(&mut self, tweak: u128, data: &mut [u8]) -> Result<(), XtsAes256Error> {
-        // BCrypt only supports 64-bit tweaks, internally padding out the high 8
-        // bytes with zeroes. (Why?) This is fine for our purposes but it's a
-        // bit annoying.
-        let mut iv = u64::try_from(tweak)
-            .map_err(|_| XtsAes256Error(crate::BackendError(E_INVALIDARG.into(), "convert tweak")))?
-            .to_le_bytes();
+    pub fn cipher(&mut self, tweak: u64, data: &mut [u8]) -> Result<(), XtsAes256Error> {
+        let mut iv = tweak.to_le_bytes();
 
         // TODO: fix windows crate to allow aliased input and output, as
         // allowed by the API.

--- a/vm/devices/storage/disk_crypt/src/lib.rs
+++ b/vm/devices/storage/disk_crypt/src/lib.rs
@@ -111,7 +111,7 @@ impl DiskIo for CryptDisk {
         let mut writer = buffers.writer();
         for i in 0..buffers.len() >> self.inner.sector_shift() {
             reader.read(&mut buf)?;
-            ctx.cipher((sector + i as u64).into(), &mut buf)
+            ctx.cipher(sector + i as u64, &mut buf)
                 .map_err(crypto_error)?;
             writer.write(&buf)?;
         }
@@ -143,7 +143,7 @@ impl DiskIo for CryptDisk {
         while offset < buffers.len() {
             let this_buf = &mut buf[offset..][..sector_size];
             reader.read(this_buf)?;
-            ctx.cipher(tweak.into(), this_buf).map_err(crypto_error)?;
+            ctx.cipher(tweak, this_buf).map_err(crypto_error)?;
             offset += sector_size;
             tweak += 1;
         }


### PR DESCRIPTION
Some small cleanups:

- Rename kbkdf 'salt' to 'label' to match the algorithm's official definition
- Add some comments
- Set xts_aes_256's tweak size to u64 everywhere to match the bcrypt restriction, so we don't accidentally depend on a larger tweak in the future