### PR TITLE
Remove the unstable_whp feature

### DIFF
--- a/Guide/src/dev_guide/getting_started/cross_compile.md
+++ b/Guide/src/dev_guide/getting_started/cross_compile.md
@@ -219,10 +219,6 @@ if [[ $1 == "build" || $1 == "run" ]]; then
 
     echo
 
-    if [[ $5 == "unstable" ]]; then
-        build_args+=" --features unstable_whp"
-    fi
-
     echo "Building openvmm..."
     (
         set -x

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -484,7 +484,6 @@ impl IntoPipeline for CheckinGatesCli {
                             platform: CommonPlatform::LinuxMusl,
                         },
                         profile: CommonProfile::from_release(release),
-                        unstable_whp: false,
                         tmk_vmm,
                     }
                 });
@@ -636,13 +635,7 @@ impl IntoPipeline for CheckinGatesCli {
                             },
                             profile: CommonProfile::from_release(release),
                             // FIXME: this relies on openvmm default features
-                            // Our ARM test runners need the latest WHP changes
-                            features: if matches!(arch, CommonArch::Aarch64) {
-                                [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::UnstableWhp]
-                                    .into()
-                            } else {
-                                [].into()
-                            },
+                            features: [].into(),
                         },
                         version: None,
                         openvmm,
@@ -654,7 +647,6 @@ impl IntoPipeline for CheckinGatesCli {
                             arch,
                             platform: CommonPlatform::WindowsMsvc,
                         },
-                        unstable_whp: true, // The ARM64 CI runner supports the unstable WHP interface
                         profile: CommonProfile::from_release(release),
                         tmk_vmm,
                     }

--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
@@ -60,9 +60,6 @@ pub struct VmmTestsRunCli {
     #[clap(long)]
     install_missing_deps: bool,
 
-    /// Use unstable WHP interfaces
-    #[clap(long)]
-    unstable_whp: bool,
     /// Release build instead of debug build
     #[clap(long)]
     release: bool,
@@ -152,7 +149,6 @@ impl IntoPipeline for VmmTestsRunCli {
             filter,
             verbose,
             install_missing_deps,
-            unstable_whp,
             release,
             build_only,
             copy_extras,
@@ -332,7 +328,6 @@ impl IntoPipeline for VmmTestsRunCli {
                     target,
                     test_content_dir,
                     selections: selections_from_resolved(filter, resolved, target_os),
-                    unstable_whp,
                     release,
                     build_only,
                     copy_extras,

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -82,8 +82,6 @@ flowey_request! {
 
         pub selections: VmmTestSelections,
 
-        /// Use unstable WHP interfaces
-        pub unstable_whp: bool,
         /// Release build instead of debug build
         pub release: bool,
 
@@ -145,7 +143,6 @@ impl SimpleFlowNode for Node {
             target,
             test_content_dir,
             selections,
-            unstable_whp,
             release,
             build_only,
             copy_extras,
@@ -308,11 +305,7 @@ impl SimpleFlowNode for Node {
                     target: target.clone(),
                     profile: CommonProfile::from_release(release),
                     // FIXME: this relies on openvmm default features
-                    features: if unstable_whp {
-                        [crate::build_openvmm::OpenvmmFeature::UnstableWhp].into()
-                    } else {
-                        [].into()
-                    },
+                    features: [].into(),
                 },
                 version: None,
                 openvmm: v,
@@ -485,7 +478,6 @@ impl SimpleFlowNode for Node {
                     arch,
                     platform: CommonPlatform::WindowsMsvc,
                 },
-                unstable_whp,
                 profile: CommonProfile::from_release(release),
                 tmk_vmm: v,
             });
@@ -509,7 +501,6 @@ impl SimpleFlowNode for Node {
                     arch,
                     platform: CommonPlatform::LinuxMusl,
                 },
-                unstable_whp,
                 profile: CommonProfile::from_release(release),
                 tmk_vmm: v,
             });

--- a/flowey/flowey_lib_hvlite/src/build_openvmm.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openvmm.rs
@@ -14,7 +14,6 @@ use std::collections::BTreeSet;
 pub enum OpenvmmFeature {
     Gdb,
     Tpm,
-    UnstableWhp,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -116,7 +115,6 @@ impl FlowNode for Node {
                             match f {
                                 OpenvmmFeature::Gdb => "gdb",
                                 OpenvmmFeature::Tpm => "tpm",
-                                OpenvmmFeature::UnstableWhp => "unstable_whp",
                             }
                             .into()
                         })

--- a/flowey/flowey_lib_hvlite/src/build_tmk_vmm.rs
+++ b/flowey/flowey_lib_hvlite/src/build_tmk_vmm.rs
@@ -31,7 +31,6 @@ flowey_request! {
     pub struct Request {
         pub profile: CommonProfile,
         pub target: CommonTriple,
-        pub unstable_whp: bool,
         pub tmk_vmm: WriteVar<TmkVmmOutput>,
     }
 }
@@ -53,28 +52,19 @@ impl FlowNode for Node {
                 let Request {
                     target,
                     profile,
-                    unstable_whp,
                     tmk_vmm,
                 } = r;
-                m.entry((target, profile, unstable_whp))
-                    .or_default()
-                    .push(tmk_vmm);
+                m.entry((target, profile)).or_default().push(tmk_vmm);
                 m
             });
 
-        for ((target, profile, unstable_whp), tmk_vmm) in requests {
-            let features = if unstable_whp && target == CommonTriple::AARCH64_WINDOWS_MSVC {
-                ["unstable_whp".to_owned()].into()
-            } else {
-                Default::default()
-            };
-
+        for ((target, profile), tmk_vmm) in requests {
             let output = ctx.reqv(|v| crate::run_cargo_build::Request {
                 crate_name: "tmk_vmm".into(),
                 out_name: "tmk_vmm".into(),
                 crate_type: flowey_lib_common::run_cargo_build::CargoCrateType::Bin,
                 profile: profile.into(),
-                features,
+                features: Default::default(),
                 target: target.as_triple(),
                 no_split_dbg_info: false,
                 extra_env: None,

--- a/openvmm/openvmm/Cargo.toml
+++ b/openvmm/openvmm/Cargo.toml
@@ -35,11 +35,6 @@ disk_blob = ["openvmm_resources/disk_blob"]
 disk_crypt = ["openvmm_resources/disk_crypt"]
 disklayer_sqlite = ["openvmm_resources/disklayer_sqlite"]
 
-# build openvmm to support the latest insider build of windows on arm
-# rather than latest release build
-# TODO: remove once whp on arm is stabilized
-unstable_whp = ["openvmm_entry/unstable_whp", "openvmm_resources/unstable_whp"]
-
 [dependencies]
 openvmm_entry.workspace = true
 openvmm_resources.workspace = true

--- a/openvmm/openvmm_core/Cargo.toml
+++ b/openvmm/openvmm_core/Cargo.toml
@@ -9,8 +9,6 @@ rust-version.workspace = true
 [features]
 gdb = ["vmm_core/gdb"]
 
-unstable_whp = ["virt_whp/unstable_whp"]
-
 [dependencies]
 hypervisor_resources.workspace = true
 openvmm_defs.workspace = true

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -11,8 +11,6 @@ default = ["ttrpc", "grpc"]
 
 vendored_crypto = ["crypto/vendored"]
 
-unstable_whp = ["virt_whp/unstable_whp", "whp/unstable_whp"]
-
 grpc = ["mesh_rpc/grpc"]
 ttrpc = []
 

--- a/openvmm/openvmm_resources/Cargo.toml
+++ b/openvmm/openvmm_resources/Cargo.toml
@@ -25,8 +25,6 @@ virt_whp = ["openvmm_core/virt_whp", "openvmm_hypervisors/virt_whp"]
 # Enable building with macOS hypervisor framework support.
 virt_hvf = ["openvmm_hypervisors/virt_hvf"]
 
-unstable_whp = ["openvmm_core/unstable_whp"]
-
 [dependencies]
 mesh_worker.workspace = true
 openvmm_hypervisors.workspace = true

--- a/tmk/tmk_vmm/Cargo.toml
+++ b/tmk/tmk_vmm/Cargo.toml
@@ -6,9 +6,6 @@ name = "tmk_vmm"
 edition.workspace = true
 rust-version.workspace = true
 
-[features]
-unstable_whp = ["virt_whp/unstable_whp"]
-
 [dependencies]
 tmk_protocol.workspace = true
 

--- a/vm/whp/Cargo.toml
+++ b/vm/whp/Cargo.toml
@@ -6,9 +6,6 @@ name = "whp"
 edition.workspace = true
 rust-version.workspace = true
 
-[features]
-unstable_whp = []
-
 [target.'cfg(windows)'.dependencies]
 guid.workspace = true
 pal.workspace = true

--- a/vm/whp/src/abi.rs
+++ b/vm/whp/src/abi.rs
@@ -284,7 +284,7 @@ pub struct WHV_RUN_VP_EXIT_CONTEXT {
     pub Reserved: u32,
     #[cfg(target_arch = "x86_64")]
     pub VpContext: WHV_VP_EXIT_CONTEXT,
-    #[cfg(all(target_arch = "aarch64", feature = "unstable_whp"))]
+    #[cfg(target_arch = "aarch64")]
     pub Reserved1: u64,
     pub u: WHV_RUN_VP_EXIT_CONTEXT_u,
 }

--- a/vmm_core/virt_whp/Cargo.toml
+++ b/vmm_core/virt_whp/Cargo.toml
@@ -6,9 +6,6 @@ name = "virt_whp"
 edition.workspace = true
 rust-version.workspace = true
 
-[features]
-unstable_whp = ["whp/unstable_whp"]
-
 [target.'cfg(windows)'.dependencies]
 chipset_device.workspace = true
 hv1_emulator.workspace = true

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1424,12 +1424,7 @@ impl VtlPartition {
 
                     #[cfg(guest_arch = "aarch64")]
                     {
-                        features.bank0 |= F::AccessVpRegs | F::SyncContext;
-                    }
-
-                    #[cfg(guest_arch = "aarch64")]
-                    {
-                        features.bank0 |= F::TbFlushHypercalls;
+                        features.bank0 |= F::AccessVpRegs | F::SyncContext | F::TbFlushHypercalls;
                     }
 
                     if vtl == Vtl::Vtl0 {

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -663,14 +663,7 @@ impl virt::BindProcessor for WhpProcessorBinder {
                 }
             }
 
-            #[cfg(all(guest_arch = "aarch64", not(feature = "unstable_whp")))]
-            {
-                let _ = vp_info;
-                let _ = vtlp;
-                let _ = vtl;
-            }
-
-            #[cfg(all(guest_arch = "aarch64", feature = "unstable_whp"))]
+            #[cfg(guest_arch = "aarch64")]
             {
                 let _ = vtlp;
                 vp.vp
@@ -1335,7 +1328,7 @@ impl VtlPartition {
             }
         }
 
-        #[cfg(all(guest_arch = "aarch64", feature = "unstable_whp"))]
+        #[cfg(guest_arch = "aarch64")]
         {
             let gic_params = whp::abi::WHV_ARM64_IC_PARAMETERS {
                 EmulationMode: whp::abi::WHV_ARM64_IC_EMULATION_MODE::GicV3,
@@ -1434,7 +1427,7 @@ impl VtlPartition {
                         features.bank0 |= F::AccessVpRegs | F::SyncContext;
                     }
 
-                    #[cfg(all(guest_arch = "aarch64", feature = "unstable_whp"))]
+                    #[cfg(guest_arch = "aarch64")]
                     {
                         features.bank0 |= F::TbFlushHypercalls;
                     }


### PR DESCRIPTION
The WHP aarch64 support is no longer unstable—it is the only supported configuration. Remove the unstable_whp cargo feature and all associated cfg guards, making the previously-gated behavior unconditional.

This removes the feature from six Cargo.toml files (whp, virt_whp, openvmm, openvmm_entry, openvmm_resources, openvmm_core, tmk_vmm), simplifies cfg guards in whp's abi.rs and virt_whp's lib.rs, removes the UnstableWhp variant from the flowey build system, drops the --unstable-whp CLI flag from vmm-tests-run, and removes the related shell script logic from the cross-compilation guide.