### PR TITLE
petri: fix host capabilities discovery

### DIFF
--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -1812,6 +1812,7 @@ pub async fn run_get_vm_host() -> anyhow::Result<HyperVGetVmHost> {
             .pipeline()
             .cmdlet("ConvertTo-Json")
             .arg("Depth", 3)
+            .arg("WarningAction", "Ignore")
             .flag("Compress")
             .finish()
             .build(),


### PR DESCRIPTION
After switching to `pwsh`, the parsing of `Get-VMHost` started failing on systems with Hyper-V NICs. This was because the recursion depth of the output JSON exceeded the specified depth of 3, which with `pwsh` results in a warning printed to STDOUT (but no warning with `powershell`). This does not happen in CI because our test machines do not have Hyper-V NICs, so the depth is no more than 3 anyway. The error is suppressed, so we don't get any logs and just see that all tests are ignored if you request only SNP tests. In a follow up PR, I will try to refactor petri to surface this error. For now, just suppress the warning message.