### PR TITLE
kernel: update kernel version to 6.18.0.3 (madvise fix)

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -30,8 +30,8 @@ pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.2";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.2";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.3";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.3";
 pub const OPENVMM_DEPS: &str = "0.3.0-29";
 pub const PROTOC: &str = "27.1";
 


### PR DESCRIPTION
This change updates the OpenHCL kernel to the latest version which contains this patch: https://github.com/microsoft/OHCL-Linux-Kernel/pull/136

Huge props to @dpaliulis-msft for debugging this!