### PR TITLE
kernel: update kernel version to 6.12.52.12 (madvise fix)

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -28,8 +28,8 @@ pub const NODEJS: &str = "18.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.52.7";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.52.7";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.52.12";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.52.12";
 pub const OPENVMM_DEPS: &str = "0.1.0-20250403.3";
 pub const PROTOC: &str = "27.1";
 


### PR DESCRIPTION
This change updates the OpenHCL kernel to the latest version which contains this patch: https://github.com/microsoft/OHCL-Linux-Kernel/pull/133

Huge props to @dpaliulis-msft for debugging this!