### PR TITLE
Handle SNP VMMCALL vm exit

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1195,21 +1195,21 @@ impl UhProcessor<'_, SnpBacked> {
 
                                 let input_control: u64 = shared_memory
                                     .read_plain(
-                                        overlay_base + x86defs::snp::GHCB_PAGE_RCX_OFFSET as u64,
+                                        overlay_base + std::mem::offset_of!(SevVmsa, rcx) as u64,
                                     )
                                     .map_err(SnpGhcbError::GhcbPageAccess)?;
                                 let input_gpa: u64 = shared_memory
                                     .read_plain(
-                                        overlay_base + x86defs::snp::GHCB_PAGE_RDX_OFFSET as u64,
+                                        overlay_base + std::mem::offset_of!(SevVmsa, rdx) as u64,
                                     )
                                     .map_err(SnpGhcbError::GhcbPageAccess)?;
                                 let output_gpa: u64 = shared_memory
                                     .read_plain(
-                                        overlay_base + x86defs::snp::GHCB_PAGE_R8_OFFSET as u64,
+                                        overlay_base + std::mem::offset_of!(SevVmsa, r8) as u64,
                                     )
                                     .map_err(SnpGhcbError::GhcbPageAccess)?;
 
-                                let guest_memory = &self.partition.gm[intercepted_vtl];
+                                let guest_memory = &self.shared.cvm.shared_memory;
                                 let mut handler = GhcbEnlightenedHypercall {
                                     handler: UhHypercallHandler {
                                         vp: self,
@@ -1227,7 +1227,7 @@ impl UhProcessor<'_, SnpBacked> {
 
                                 shared_memory
                                     .write_at(
-                                        overlay_base + x86defs::snp::GHCB_PAGE_RAX_OFFSET as u64,
+                                        overlay_base + std::mem::offset_of!(SevVmsa, rax) as u64,
                                         handler.result.as_bytes(),
                                     )
                                     .map_err(SnpGhcbError::GhcbPageAccess)?;

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1186,16 +1186,66 @@ impl UhProcessor<'_, SnpBacked> {
                             )
                             .map_err(SnpGhcbError::GhcbPageAccess)?;
                     }
+                    x86defs::snp::GhcbUsage::BASE => {
+                        match SevExitCode(sw_exit_code) {
+                            // The hypervisor could not handle VMMCALL and forwarded the GHCB message
+                            SevExitCode::VMMCALL => {
+                                let shared_memory = &self.shared.cvm.shared_memory;
+                                let overlay_base = ghcb_overlay * HV_PAGE_SIZE;
+
+                                let input_control: u64 = shared_memory
+                                    .read_plain(
+                                        overlay_base + x86defs::snp::GHCB_PAGE_RCX_OFFSET as u64,
+                                    )
+                                    .map_err(SnpGhcbError::GhcbPageAccess)?;
+                                let input_gpa: u64 = shared_memory
+                                    .read_plain(
+                                        overlay_base + x86defs::snp::GHCB_PAGE_RDX_OFFSET as u64,
+                                    )
+                                    .map_err(SnpGhcbError::GhcbPageAccess)?;
+                                let output_gpa: u64 = shared_memory
+                                    .read_plain(
+                                        overlay_base + x86defs::snp::GHCB_PAGE_R8_OFFSET as u64,
+                                    )
+                                    .map_err(SnpGhcbError::GhcbPageAccess)?;
+
+                                let guest_memory = &self.partition.gm[intercepted_vtl];
+                                let mut handler = GhcbEnlightenedHypercall {
+                                    handler: UhHypercallHandler {
+                                        vp: self,
+                                        trusted: false,
+                                        intercepted_vtl,
+                                    },
+                                    control: input_control,
+                                    output_gpa,
+                                    input_gpa,
+                                    result: 0,
+                                };
+
+                                UhHypercallHandler::UNTRUSTED_DISPATCHER
+                                    .dispatch(guest_memory, &mut handler);
+
+                                shared_memory
+                                    .write_at(
+                                        overlay_base + x86defs::snp::GHCB_PAGE_RAX_OFFSET as u64,
+                                        handler.result.as_bytes(),
+                                    )
+                                    .map_err(SnpGhcbError::GhcbPageAccess)?;
+                            }
+                            _ => {
+                                let exit_code = SevExitCode(sw_exit_code);
+                                unimplemented!("unhandled GHCB BASE sw_exit_code {exit_code:?}");
+                            }
+                        }
+                    }
                     usage => unimplemented!(
-                        r#"
-                        Invalid ghcb message.
-                        usage {usage:?}
-                        flags {flags:?}
-                        ghcb_msr {ghcb_msr:?}
-                        sw_exit_code {sw_exit_code:?}
-                        sw_exit_info1 {sw_exit_info1:?}
-                        sw_exit_info2 {sw_exit_info2:?}
-                    "#
+                        "Invalid ghcb message.\n\
+                         usage {usage:?}\n\
+                         flags {flags:?}\n\
+                         ghcb_msr {ghcb_msr:?}\n\
+                         sw_exit_code {sw_exit_code:?}\n\
+                         sw_exit_info1 {sw_exit_info1:?}\n\
+                         sw_exit_info2 {sw_exit_info2:?}"
                     ),
                 }
             }

--- a/vm/x86/x86defs/src/snp.rs
+++ b/vm/x86/x86defs/src/snp.rs
@@ -693,10 +693,6 @@ pub struct GhcbHypercallParameters {
 
 pub const GHCB_PAGE_HYPERCALL_PARAMETERS_OFFSET: usize = 4072;
 pub const GHCB_PAGE_HYPERCALL_OUTPUT_OFFSET: usize = 4080;
-pub const GHCB_PAGE_RAX_OFFSET: usize = core::mem::offset_of!(SevVmsa, rax);
-pub const GHCB_PAGE_RCX_OFFSET: usize = core::mem::offset_of!(SevVmsa, rcx);
-pub const GHCB_PAGE_RDX_OFFSET: usize = core::mem::offset_of!(SevVmsa, rdx);
-pub const GHCB_PAGE_R8_OFFSET: usize = core::mem::offset_of!(SevVmsa, r8);
 
 // Exit Codes.
 open_enum::open_enum! {

--- a/vm/x86/x86defs/src/snp.rs
+++ b/vm/x86/x86defs/src/snp.rs
@@ -693,6 +693,10 @@ pub struct GhcbHypercallParameters {
 
 pub const GHCB_PAGE_HYPERCALL_PARAMETERS_OFFSET: usize = 4072;
 pub const GHCB_PAGE_HYPERCALL_OUTPUT_OFFSET: usize = 4080;
+pub const GHCB_PAGE_RAX_OFFSET: usize = core::mem::offset_of!(SevVmsa, rax);
+pub const GHCB_PAGE_RCX_OFFSET: usize = core::mem::offset_of!(SevVmsa, rcx);
+pub const GHCB_PAGE_RDX_OFFSET: usize = core::mem::offset_of!(SevVmsa, rdx);
+pub const GHCB_PAGE_R8_OFFSET: usize = core::mem::offset_of!(SevVmsa, r8);
 
 // Exit Codes.
 open_enum::open_enum! {


### PR DESCRIPTION
The hypervisor will forward VMMCALL GHCB messages to VTL2 if it is not able to handle the message. Minivmbus uses this path when it is not able to use the fast hypercall path. This change adds handling for the VMMCALL GHCB messages used by minivmbus.  