### PR TITLE
crypto: Remove the rsa dep from the symcrypt backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,7 @@ dependencies = [
  "rsa",
  "sha1",
  "sha2",
+ "signature",
  "symcrypt",
  "thiserror 2.0.16",
  "wchar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -527,6 +527,7 @@ pkcs8 = "0.11.0"
 rsa = { version = "0.10.0-rc.18", default-features = false }
 sha1 = { version = "0.11.0", default-features = false }
 sha2 = { version = "0.11.0", default-features = false }
+signature = { version = "3.0.0", default-features = false }
 symcrypt = { version = "0.6.0", git = "https://github.com/microsoft/rust-symcrypt.git", branch = "release/0.6.0" }
 x509-cert = { version = "0.3.0-rc.4", default-features = false }
 

--- a/support/crypto/Cargo.toml
+++ b/support/crypto/Cargo.toml
@@ -26,7 +26,7 @@ symcrypt = [
     "dep:der",
     "dep:pkcs1",
     "dep:pkcs8",
-    "dep:rsa",
+    "dep:signature",
     "dep:x509-cert",
 ]
 
@@ -57,10 +57,11 @@ cms = { workspace = true, optional = true }
 der = { workspace = true, optional = true }
 getrandom = { workspace = true, optional = true, features = ["sys_rng"] }
 pkcs1 = { workspace = true, optional = true }
-pkcs8 = { workspace = true, optional = true }
+pkcs8 = { workspace = true, optional = true, features = ["alloc"] }
 rsa = { workspace = true, optional = true, features = ["encoding", "sha2"] }
 sha1 = { workspace = true, optional = true, features = ["oid"] }
 sha2 = { workspace = true, optional = true }
+signature = { workspace = true, optional = true, features = ["alloc"] }
 x509-cert = { workspace = true, optional = true, features = ["builder"] }
 
 anyhow.workspace = true

--- a/support/crypto/src/rsa/symcrypt.rs
+++ b/support/crypto/src/rsa/symcrypt.rs
@@ -4,15 +4,20 @@
 //! RSA implementation using SymCrypt.
 
 use super::RsaError;
+use der::Decode;
+use der::Encode;
+use der::asn1::OctetString;
+use der::asn1::UintRef;
 use symcrypt::rsa::RsaKey;
 use symcrypt::rsa::RsaKeyUsage;
+use x509_cert::spki::AlgorithmIdentifierOwned;
 
 fn err(err: symcrypt::errors::SymCryptError, op: &'static str) -> RsaError {
     RsaError(crate::BackendError::SymCrypt(err, op))
 }
 
-fn pkcs8_err(err: pkcs8::Error, op: &'static str) -> RsaError {
-    RsaError(crate::BackendError::Pkcs8Encoding(err, op))
+fn der_err(e: der::Error, op: &'static str) -> RsaError {
+    RsaError(crate::BackendError::Der(e, op))
 }
 
 #[repr(transparent)] // Needed for the transmute in as_pub.
@@ -25,25 +30,28 @@ impl RsaKeyPairInner {
         Ok(Self(rsa))
     }
 
-    pub fn from_pkcs8_der(der: &[u8]) -> Result<Self, RsaError> {
-        use pkcs8::DecodePrivateKey;
-        use rsa::traits::PrivateKeyParts;
-        use rsa::traits::PublicKeyParts;
-
-        let parsed = rsa::RsaPrivateKey::from_pkcs8_der(der)
-            .map_err(|e| pkcs8_err(e, "parsing PKCS#8 DER"))?;
-        let primes = parsed.primes();
-        if primes.len() != 2 {
+    pub fn from_pkcs8_der(der_bytes: &[u8]) -> Result<Self, RsaError> {
+        let pki = pkcs8::PrivateKeyInfoRef::from_der(der_bytes)
+            .map_err(|e| der_err(e, "parsing PKCS#8 DER"))?;
+        if pki.algorithm.oid != pkcs1::ALGORITHM_OID {
+            return Err(RsaError(crate::BackendError::Pkcs8Encoding(
+                pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid),
+                "PKCS#8 algorithm is not rsaEncryption",
+            )));
+        }
+        let key = pkcs1::RsaPrivateKey::from_der(pki.private_key.as_bytes())
+            .map_err(|e| der_err(e, "parsing PKCS#1 RSA private key"))?;
+        if key.other_prime_infos.is_some() {
             return Err(RsaError(crate::BackendError::Pkcs8Encoding(
                 pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid),
                 "multiprime RSA keys not supported",
             )));
         }
         let rsa = RsaKey::set_key_pair(
-            &parsed.n().to_be_bytes_trimmed_vartime(),
-            &parsed.e().to_be_bytes_trimmed_vartime(),
-            &primes[0].to_be_bytes_trimmed_vartime(),
-            &primes[1].to_be_bytes_trimmed_vartime(),
+            key.modulus.as_bytes(),
+            key.public_exponent.as_bytes(),
+            key.prime1.as_bytes(),
+            key.prime2.as_bytes(),
             RsaKeyUsage::SignAndEncrypt,
         )
         .map_err(|e| err(e, "setting RSA key pair"))?;
@@ -51,27 +59,40 @@ impl RsaKeyPairInner {
     }
 
     pub fn to_pkcs8_der(&self) -> Result<Vec<u8>, RsaError> {
-        use pkcs8::EncodePrivateKey;
-
         let blob = self
             .0
             .export_key_pair_blob()
             .map_err(|e| err(e, "exporting RSA key blob"))?;
-        let rsa = rsa::RsaPrivateKey::from_components(
-            rsa::BoxedUint::from_be_slice_vartime(&blob.modulus),
-            rsa::BoxedUint::from_be_slice_vartime(&blob.pub_exp),
-            rsa::BoxedUint::from_be_slice_vartime(&blob.private_exp),
-            vec![
-                rsa::BoxedUint::from_be_slice_vartime(&blob.p),
-                rsa::BoxedUint::from_be_slice_vartime(&blob.q),
-            ],
-        )
-        .unwrap();
-        Ok(rsa
-            .to_pkcs8_der()
-            .map_err(|e| pkcs8_err(e, "converting to DER"))?
-            .as_bytes()
-            .to_vec())
+
+        let pkcs1_key = pkcs1::RsaPrivateKey {
+            modulus: UintRef::new(&blob.modulus).map_err(|e| der_err(e, "encoding modulus"))?,
+            public_exponent: UintRef::new(&blob.pub_exp)
+                .map_err(|e| der_err(e, "encoding public exponent"))?,
+            private_exponent: UintRef::new(&blob.private_exp)
+                .map_err(|e| der_err(e, "encoding private exponent"))?,
+            prime1: UintRef::new(&blob.p).map_err(|e| der_err(e, "encoding prime1"))?,
+            prime2: UintRef::new(&blob.q).map_err(|e| der_err(e, "encoding prime2"))?,
+            exponent1: UintRef::new(&blob.d_p).map_err(|e| der_err(e, "encoding exponent1"))?,
+            exponent2: UintRef::new(&blob.d_q).map_err(|e| der_err(e, "encoding exponent2"))?,
+            coefficient: UintRef::new(&blob.crt_coefficient)
+                .map_err(|e| der_err(e, "encoding coefficient"))?,
+            other_prime_infos: None,
+        };
+        let pkcs1_der = pkcs1_key
+            .to_der()
+            .map_err(|e| der_err(e, "encoding PKCS#1 RSA private key"))?;
+
+        let pki = pkcs8::PrivateKeyInfoOwned {
+            algorithm: AlgorithmIdentifierOwned {
+                oid: pkcs1::ALGORITHM_OID,
+                parameters: None,
+            },
+            private_key: OctetString::new(pkcs1_der)
+                .map_err(|e| der_err(e, "wrapping PKCS#1 in OCTET STRING"))?,
+            public_key: None,
+        };
+        pki.to_der()
+            .map_err(|e| der_err(e, "encoding PKCS#8 PrivateKeyInfo"))
     }
 
     pub fn oaep_decrypt(

--- a/support/crypto/src/rsa/symcrypt.rs
+++ b/support/crypto/src/rsa/symcrypt.rs
@@ -85,7 +85,7 @@ impl RsaKeyPairInner {
         let pki = pkcs8::PrivateKeyInfoOwned {
             algorithm: AlgorithmIdentifierOwned {
                 oid: pkcs1::ALGORITHM_OID,
-                parameters: None,
+                parameters: Some(der::Any::null()),
             },
             private_key: OctetString::new(pkcs1_der)
                 .map_err(|e| der_err(e, "wrapping PKCS#1 in OCTET STRING"))?,

--- a/support/crypto/src/x509/symcrypt_rust.rs
+++ b/support/crypto/src/x509/symcrypt_rust.rs
@@ -196,7 +196,7 @@ impl X509CertificateInner {
         let spki = x509_cert::spki::SubjectPublicKeyInfoOwned {
             algorithm: x509_cert::spki::AlgorithmIdentifierOwned {
                 oid: pkcs1::ALGORITHM_OID,
-                parameters: None,
+                parameters: Some(der::Any::null()),
             },
             subject_public_key: der::asn1::BitString::from_bytes(&pkcs1_der)?,
         };
@@ -213,10 +213,7 @@ impl X509CertificateInner {
             x509_cert::builder::CertificateBuilder::new(profile, serial_number, validity, spki)?;
 
         #[cfg(symcrypt)]
-        let cert = builder.build(&symcrypt_signer::SymCryptRsaSigner {
-            key,
-            spki_der: pkcs1_der,
-        })?;
+        let cert = builder.build(&symcrypt_signer::SymCryptRsaSigner { key, pkcs1_der })?;
         #[cfg(rust)]
         let cert = builder.build(&rsa::pkcs1v15::SigningKey::<sha2::Sha256>::new(
             key.0.0.clone(),
@@ -234,7 +231,7 @@ mod symcrypt_signer {
 
     pub struct SymCryptRsaSigner<'a> {
         pub key: &'a crate::rsa::RsaKeyPair,
-        pub spki_der: Vec<u8>,
+        pub pkcs1_der: Vec<u8>,
     }
 
     #[derive(Clone)]
@@ -246,7 +243,7 @@ mod symcrypt_signer {
         type VerifyingKey = SymCryptRsaVerifyingKey;
 
         fn verifying_key(&self) -> Self::VerifyingKey {
-            SymCryptRsaVerifyingKey(self.spki_der.clone())
+            SymCryptRsaVerifyingKey(self.pkcs1_der.clone())
         }
     }
 
@@ -256,7 +253,7 @@ mod symcrypt_signer {
         ) -> x509_cert::spki::Result<x509_cert::spki::AlgorithmIdentifierOwned> {
             Ok(x509_cert::spki::AlgorithmIdentifierOwned {
                 oid: der::oid::db::rfc5912::SHA_256_WITH_RSA_ENCRYPTION,
-                parameters: None,
+                parameters: Some(der::Any::null()),
             })
         }
     }
@@ -277,7 +274,7 @@ mod symcrypt_signer {
             let spki = x509_cert::spki::SubjectPublicKeyInfoOwned {
                 algorithm: x509_cert::spki::AlgorithmIdentifierOwned {
                     oid: pkcs1::ALGORITHM_OID,
-                    parameters: None,
+                    parameters: Some(der::Any::null()),
                 },
                 subject_public_key: der::asn1::BitString::from_bytes(&self.0)?,
             };

--- a/support/crypto/src/x509/symcrypt_rust.rs
+++ b/support/crypto/src/x509/symcrypt_rust.rs
@@ -4,9 +4,12 @@
 //! X.509 certificate parsing and verification using the `x509-cert` RustCrypto crate.
 
 use super::X509Error;
+use core::str::FromStr;
 use der::Decode;
 use der::Encode;
 use x509_cert::Certificate;
+use x509_cert::builder::Builder;
+use x509_cert::name::Name;
 
 #[cfg(symcrypt)]
 fn der_err(err: der::Error, op: &'static str) -> X509Error {
@@ -154,12 +157,6 @@ impl X509CertificateInner {
         organization: &str,
         common_name: &str,
     ) -> anyhow::Result<Self> {
-        use core::str::FromStr;
-        #[cfg(symcrypt)]
-        use rsa::sha2;
-        use x509_cert::builder::Builder;
-        use x509_cert::name::Name;
-
         // Profile that produces a basic self-signed certificate with no
         // extensions and the same `Name` for both the subject and issuer.
         struct SelfSignedProfile {
@@ -199,7 +196,7 @@ impl X509CertificateInner {
         let spki = x509_cert::spki::SubjectPublicKeyInfoOwned {
             algorithm: x509_cert::spki::AlgorithmIdentifierOwned {
                 oid: pkcs1::ALGORITHM_OID,
-                parameters: Some(der::asn1::Any::null()),
+                parameters: None,
             },
             subject_public_key: der::asn1::BitString::from_bytes(&pkcs1_der)?,
         };
@@ -216,22 +213,81 @@ impl X509CertificateInner {
             x509_cert::builder::CertificateBuilder::new(profile, serial_number, validity, spki)?;
 
         #[cfg(symcrypt)]
-        let blob = key.0.0.export_key_pair_blob()?;
-        #[cfg(symcrypt)]
-        let key = rsa::RsaPrivateKey::from_components(
-            rsa::BoxedUint::from_be_slice_vartime(&blob.modulus),
-            rsa::BoxedUint::from_be_slice_vartime(&blob.pub_exp),
-            rsa::BoxedUint::from_be_slice_vartime(&blob.private_exp),
-            vec![
-                rsa::BoxedUint::from_be_slice_vartime(&blob.p),
-                rsa::BoxedUint::from_be_slice_vartime(&blob.q),
-            ],
-        )?;
+        let cert = builder.build(&symcrypt_signer::SymCryptRsaSigner {
+            key,
+            spki_der: pkcs1_der,
+        })?;
         #[cfg(rust)]
-        let key = key.0.0.clone();
-        let signer = rsa::pkcs1v15::SigningKey::<sha2::Sha256>::new(key);
-
-        let cert = builder.build(&signer)?;
+        let cert = builder.build(&rsa::pkcs1v15::SigningKey::<sha2::Sha256>::new(
+            key.0.0.clone(),
+        ))?;
         Ok(Self(cert))
+    }
+}
+
+/// Adapters that implement the `signature` and `spki` traits required by
+/// `x509_cert::builder::CertificateBuilder::build` on top of SymCrypt's
+/// PKCS#1 v1.5 signing primitive.
+#[cfg(symcrypt)]
+mod symcrypt_signer {
+    use der::Encode;
+
+    pub struct SymCryptRsaSigner<'a> {
+        pub key: &'a crate::rsa::RsaKeyPair,
+        pub spki_der: Vec<u8>,
+    }
+
+    #[derive(Clone)]
+    pub struct SymCryptRsaVerifyingKey(Vec<u8>);
+
+    pub struct SymCryptRsaSignature(Vec<u8>);
+
+    impl signature::Keypair for SymCryptRsaSigner<'_> {
+        type VerifyingKey = SymCryptRsaVerifyingKey;
+
+        fn verifying_key(&self) -> Self::VerifyingKey {
+            SymCryptRsaVerifyingKey(self.spki_der.clone())
+        }
+    }
+
+    impl x509_cert::spki::DynSignatureAlgorithmIdentifier for SymCryptRsaSigner<'_> {
+        fn signature_algorithm_identifier(
+            &self,
+        ) -> x509_cert::spki::Result<x509_cert::spki::AlgorithmIdentifierOwned> {
+            Ok(x509_cert::spki::AlgorithmIdentifierOwned {
+                oid: der::oid::db::rfc5912::SHA_256_WITH_RSA_ENCRYPTION,
+                parameters: None,
+            })
+        }
+    }
+
+    impl signature::Signer<SymCryptRsaSignature> for SymCryptRsaSigner<'_> {
+        fn try_sign(&self, msg: &[u8]) -> Result<SymCryptRsaSignature, signature::Error> {
+            self.key
+                .pkcs1_sign(msg, crate::HashAlgorithm::Sha256)
+                .map(SymCryptRsaSignature)
+                .map_err(signature::Error::from_source)
+        }
+    }
+
+    impl x509_cert::spki::EncodePublicKey for SymCryptRsaVerifyingKey {
+        fn to_public_key_der(&self) -> x509_cert::spki::Result<der::Document> {
+            // Wrap the PKCS#1 RSAPublicKey DER in a SubjectPublicKeyInfo and
+            // encode the result as a DER document.
+            let spki = x509_cert::spki::SubjectPublicKeyInfoOwned {
+                algorithm: x509_cert::spki::AlgorithmIdentifierOwned {
+                    oid: pkcs1::ALGORITHM_OID,
+                    parameters: None,
+                },
+                subject_public_key: der::asn1::BitString::from_bytes(&self.0)?,
+            };
+            Ok(der::Document::try_from(spki.to_der()?)?)
+        }
+    }
+
+    impl x509_cert::spki::SignatureBitStringEncoding for SymCryptRsaSignature {
+        fn to_bitstring(&self) -> der::Result<der::asn1::BitString> {
+            der::asn1::BitString::from_bytes(&self.0)
+        }
     }
 }


### PR DESCRIPTION
This PR makes it so that our symcrypt backend no longer relies on the RustCrypto `rsa` crate for any operations. It was previously only being used for parsing and test-related functionality, but it's safer to have it gone completely. This required writing a bunch of ugly adapter code, which is why I didn't do it originally.