### PR TITLE
sparse_mmap, membacking: add NUMA-aware memory allocation and mapping

### DIFF
--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -218,6 +218,8 @@ pub struct MappingParams {
     /// that external consumers (vhost-user backends, etc.) can share the
     /// backing memory.
     pub dma_target: bool,
+    /// Host NUMA node for this mapping. `None` means OS default placement.
+    pub numa_node: Option<u32>,
 }
 
 struct Mappers {
@@ -440,6 +442,7 @@ mod tests {
                 file_offset: 0,
                 writable: true,
                 dma_target: true,
+                numa_node: None,
             })
             .await;
 
@@ -450,6 +453,7 @@ mod tests {
                 file_offset: 0,
                 writable: true,
                 dma_target: false,
+                numa_node: None,
             })
             .await;
 
@@ -481,6 +485,7 @@ mod tests {
                 file_offset: 0,
                 writable: true,
                 dma_target: false,
+                numa_node: None,
             })
             .await;
 

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -204,9 +204,7 @@ impl MapperTask {
                 let _ = numa_node;
             }
             _ => {
-                if numa_node.is_some() {
-                    tracing::warn!(%range, "NUMA not supported on this platform, using default placement");
-                }
+                assert!(numa_node.is_none(), "NUMA not supported on this platform; should have been rejected at build time");
             }
         }
 
@@ -379,11 +377,7 @@ impl VaMapper {
                 Ok(())
             }
             _ => {
-                if numa_node.is_some() {
-                    return Err(std::io::Error::other(
-                        "NUMA allocation not supported on this platform",
-                    ));
-                }
+                assert!(numa_node.is_none(), "NUMA not supported on this platform; should have been rejected at build time");
                 self.inner.mapping.alloc(offset, len)
             }
         }

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -120,18 +120,20 @@ impl MapperTask {
                     mappable,
                     writable,
                     file_offset,
+                    numa_node,
                     ..
                 }) => {
                     tracing::debug!(%range, "mapping received for range");
 
                     self.inner
                         .mapping
-                        .map_file(
+                        .map_file_numa(
                             range.start() as usize,
                             range.len() as usize,
                             &mappable,
                             file_offset,
                             writable,
+                            numa_node,
                         )
                         .expect("oom mapping file");
 
@@ -290,12 +292,18 @@ impl VaMapper {
         self.process.as_ref()
     }
 
-    /// Allocates private anonymous memory for a range within the mapping.
+    /// Allocates private anonymous memory for a range within the mapping,
+    /// optionally bound to a specific host NUMA node.
     ///
     /// This replaces the placeholder at the given offset with committed
     /// anonymous memory.
-    pub(crate) fn alloc_range(&self, offset: usize, len: usize) -> Result<(), std::io::Error> {
-        self.inner.mapping.alloc(offset, len)
+    pub(crate) fn alloc_range(
+        &self,
+        offset: usize,
+        len: usize,
+        numa_node: Option<u32>,
+    ) -> Result<(), std::io::Error> {
+        self.inner.mapping.alloc_numa(offset, len, numa_node)
     }
 
     /// Names a range within the mapping for debugging (visible in smaps).

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -125,19 +125,58 @@ impl MapperTask {
                 }) => {
                     tracing::debug!(%range, "mapping received for range");
 
-                    self.inner
-                        .mapping
-                        .map_file_numa(
-                            range.start() as usize,
-                            range.len() as usize,
-                            &mappable,
-                            file_offset,
-                            writable,
-                            numa_node,
-                        )
-                        .expect("oom mapping file");
+                    let map_result = {
+                        #[cfg(unix)]
+                        {
+                            self.inner.mapping.map_file(
+                                range.start() as usize,
+                                range.len() as usize,
+                                &mappable,
+                                file_offset,
+                                writable,
+                            )
+                        }
+                        #[cfg(windows)]
+                        {
+                            self.inner.mapping.map_file_numa(
+                                range.start() as usize,
+                                range.len() as usize,
+                                &mappable,
+                                file_offset,
+                                writable,
+                                numa_node,
+                            )
+                        }
+                    };
 
-                    self.wake_waiters(range, Some(writable));
+                    match map_result {
+                        Ok(()) => {
+                            #[cfg(target_os = "linux")]
+                            if let Some(node) = numa_node {
+                                if let Err(e) = self.inner.mapping.mbind_at(
+                                    range.start() as usize,
+                                    range.len() as usize,
+                                    node,
+                                ) {
+                                    tracing::error!(
+                                        error = &e as &dyn std::error::Error,
+                                        %range,
+                                        node,
+                                        "NUMA binding failed, using default placement"
+                                    );
+                                }
+                            }
+                            self.wake_waiters(range, Some(writable));
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                error = &e as &dyn std::error::Error,
+                                %range,
+                                "failed to map file for range"
+                            );
+                            self.wake_waiters(range, None);
+                        }
+                    }
                 }
                 MapperRequest::NoMapping(range) => {
                     // Wake up waiters. They'll see a failure when they try to
@@ -303,7 +342,19 @@ impl VaMapper {
         len: usize,
         numa_node: Option<u32>,
     ) -> Result<(), std::io::Error> {
-        self.inner.mapping.alloc_numa(offset, len, numa_node)
+        #[cfg(windows)]
+        {
+            self.inner.mapping.alloc_numa(offset, len, numa_node)
+        }
+        #[cfg(unix)]
+        {
+            self.inner.mapping.alloc(offset, len)?;
+            #[cfg(target_os = "linux")]
+            if let Some(node) = numa_node {
+                self.inner.mapping.mbind_at(offset, len, node)?;
+            }
+            Ok(())
+        }
     }
 
     /// Names a range within the mapping for debugging (visible in smaps).

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -115,67 +115,14 @@ impl MapperTask {
                         .unmap(range.start() as usize, range.len() as usize)
                         .expect("invalidate request should be valid");
                 }),
-                MapperRequest::Map(MappingParams {
-                    range,
-                    mappable,
-                    writable,
-                    file_offset,
-                    numa_node,
-                    ..
-                }) => {
-                    tracing::debug!(%range, "mapping received for range");
+                MapperRequest::Map(params) => {
+                    tracing::debug!(range = %params.range, "mapping received for range");
 
-                    let map_result = {
-                        #[cfg(unix)]
-                        {
-                            self.inner.mapping.map_file(
-                                range.start() as usize,
-                                range.len() as usize,
-                                &mappable,
-                                file_offset,
-                                writable,
-                            )
-                        }
-                        #[cfg(windows)]
-                        {
-                            self.inner.mapping.map_file_numa(
-                                range.start() as usize,
-                                range.len() as usize,
-                                &mappable,
-                                file_offset,
-                                writable,
-                                numa_node,
-                            )
-                        }
-                    };
-
-                    match map_result {
-                        Ok(()) => {
-                            #[cfg(target_os = "linux")]
-                            if let Some(node) = numa_node {
-                                if let Err(e) = self.inner.mapping.mbind_at(
-                                    range.start() as usize,
-                                    range.len() as usize,
-                                    node,
-                                ) {
-                                    tracing::error!(
-                                        error = &e as &dyn std::error::Error,
-                                        %range,
-                                        node,
-                                        "NUMA binding failed, using default placement"
-                                    );
-                                }
-                            }
-                            self.wake_waiters(range, Some(writable));
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                error = &e as &dyn std::error::Error,
-                                %range,
-                                "failed to map file for range"
-                            );
-                            self.wake_waiters(range, None);
-                        }
+                    let (range, writable) = (params.range, params.writable);
+                    if self.map_file(params) {
+                        self.wake_waiters(range, Some(writable));
+                    } else {
+                        self.wake_waiters(range, None);
                     }
                 }
                 MapperRequest::NoMapping(range) => {
@@ -190,6 +137,80 @@ impl MapperTask {
         *self.inner.waiters.lock() = None;
         // Invalidate everything.
         let _ = self.inner.mapping.unmap(0, self.inner.mapping.len());
+    }
+
+    /// Maps a file-backed region into the VA space, applying NUMA policy where
+    /// supported. Returns `true` on success.
+    fn map_file(&self, params: MappingParams) -> bool {
+        let MappingParams {
+            range,
+            mappable,
+            writable,
+            file_offset,
+            numa_node,
+            ..
+        } = params;
+
+        let map_result = cfg_select! {
+            windows => {
+                self.inner.mapping.map_file_numa(
+                    range.start() as usize,
+                    range.len() as usize,
+                    &mappable,
+                    file_offset,
+                    writable,
+                    numa_node,
+                )
+            }
+            _ => {
+                self.inner.mapping.map_file(
+                    range.start() as usize,
+                    range.len() as usize,
+                    &mappable,
+                    file_offset,
+                    writable,
+                )
+            }
+        };
+
+        if let Err(e) = map_result {
+            tracing::error!(
+                error = &e as &dyn std::error::Error,
+                %range,
+                "failed to map file for range"
+            );
+            return false;
+        }
+
+        cfg_select! {
+            target_os = "linux" => {
+                if let Some(node) = numa_node {
+                    if let Err(e) = self.inner.mapping.mbind_at(
+                        range.start() as usize,
+                        range.len() as usize,
+                        node,
+                    ) {
+                        tracing::error!(
+                            error = &e as &dyn std::error::Error,
+                            %range,
+                            node,
+                            "NUMA binding failed, using default placement"
+                        );
+                    }
+                }
+            }
+            windows => {
+                // NUMA handled by map_file_numa above.
+                let _ = numa_node;
+            }
+            _ => {
+                if numa_node.is_some() {
+                    tracing::warn!(%range, "NUMA not supported on this platform, using default placement");
+                }
+            }
+        }
+
+        true
     }
 
     fn wake_waiters(&mut self, range: MemoryRange, writable: Option<bool>) {
@@ -336,24 +357,35 @@ impl VaMapper {
     ///
     /// This replaces the placeholder at the given offset with committed
     /// anonymous memory.
+    ///
+    /// Caution: on Linux, if NUMA binding fails, the allocation itself has
+    /// still succeeded — the returned error does not imply the memory is
+    /// unmapped.
     pub(crate) fn alloc_range(
         &self,
         offset: usize,
         len: usize,
         numa_node: Option<u32>,
     ) -> Result<(), std::io::Error> {
-        #[cfg(windows)]
-        {
-            self.inner.mapping.alloc_numa(offset, len, numa_node)
-        }
-        #[cfg(unix)]
-        {
-            self.inner.mapping.alloc(offset, len)?;
-            #[cfg(target_os = "linux")]
-            if let Some(node) = numa_node {
-                self.inner.mapping.mbind_at(offset, len, node)?;
+        cfg_select! {
+            windows => {
+                self.inner.mapping.alloc_numa(offset, len, numa_node)
             }
-            Ok(())
+            target_os = "linux" => {
+                self.inner.mapping.alloc(offset, len)?;
+                if let Some(node) = numa_node {
+                    self.inner.mapping.mbind_at(offset, len, node)?;
+                }
+                Ok(())
+            }
+            _ => {
+                if numa_node.is_some() {
+                    return Err(std::io::Error::other(
+                        "NUMA allocation not supported on this platform",
+                    ));
+                }
+                self.inner.mapping.alloc(offset, len)
+            }
         }
     }
 

--- a/openvmm/membacking/src/memory_manager/device_memory.rs
+++ b/openvmm/membacking/src/memory_manager/device_memory.rs
@@ -116,6 +116,7 @@ impl MappedMemoryRegion for DeviceMemoryRegion {
                 new_mapping.mappable.clone(),
                 new_mapping.file_offset,
                 new_mapping.writable,
+                None,
             ));
         }
         state.mappings.push(new_mapping);
@@ -173,6 +174,7 @@ impl MappableGuestMemory for DeviceMemoryControl {
                         mapping.mappable.clone(),
                         mapping.file_offset,
                         mapping.writable,
+                        None,
                     )
                     .await;
             }

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -143,6 +143,9 @@ pub enum MemoryBuildError {
     /// Hugepages are only supported on Linux.
     #[error("hugepages are only supported on Linux")]
     HugepagesUnsupportedPlatform,
+    /// Host NUMA node binding is only supported on Linux and Windows.
+    #[error("host NUMA node binding is only supported on Linux and Windows")]
+    HostNumaNodeUnsupportedPlatform,
     /// Hugepages require shared memory mode.
     #[error("hugepages require shared memory mode")]
     HugepagesWithPrivateMemory,
@@ -251,6 +254,10 @@ impl RamBackingRequest {
 
     /// Bind this backing's memory to a specific host NUMA node
     /// (Linux: `mbind(MPOL_BIND)`, Windows: `MemExtendedParameterNumaNode`).
+    ///
+    /// Only supported on Linux and Windows; returns
+    /// [`MemoryBuildError::HostNumaNodeUnsupportedPlatform`] at build time on
+    /// other targets.
     pub fn host_numa_node(mut self, node: Option<u32>) -> Self {
         self.host_numa_node = node;
         self
@@ -397,6 +404,9 @@ impl GuestMemoryBuilder {
                 if !cfg!(target_os = "linux") {
                     return Err(MemoryBuildError::ThpUnsupportedPlatform);
                 }
+            }
+            if req.host_numa_node.is_some() && cfg!(not(any(target_os = "linux", target_os = "windows"))) {
+                return Err(MemoryBuildError::HostNumaNodeUnsupportedPlatform);
             }
             if req.hugepages {
                 if !cfg!(target_os = "linux") {

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -68,6 +68,8 @@ struct RamBacking {
     /// THP is enabled for this backing.
     #[cfg_attr(not(target_os = "linux"), expect(dead_code))]
     transparent_hugepages: bool,
+    /// Host NUMA node for this backing. `None` means OS default placement.
+    host_numa_node: Option<u32>,
 }
 
 #[derive(Debug)]
@@ -193,6 +195,7 @@ pub struct RamBackingRequest {
     hugepages: bool,
     hugepage_size: Option<u64>,
     existing_mappable: Option<Mappable>,
+    host_numa_node: Option<u32>,
 }
 
 impl RamBackingRequest {
@@ -209,6 +212,7 @@ impl RamBackingRequest {
             hugepages: false,
             hugepage_size: None,
             existing_mappable: None,
+            host_numa_node: None,
         }
     }
 
@@ -242,6 +246,13 @@ impl RamBackingRequest {
     /// When set, no new allocation is performed for this backing.
     pub fn existing_mappable(mut self, mappable: Mappable) -> Self {
         self.existing_mappable = Some(mappable);
+        self
+    }
+
+    /// Bind this backing's memory to a specific host NUMA node
+    /// (Linux: `mbind(MPOL_BIND)`). Incompatible with `private_memory`.
+    pub fn host_numa_node(mut self, node: Option<u32>) -> Self {
+        self.host_numa_node = node;
         self
     }
 }
@@ -441,6 +452,7 @@ impl GuestMemoryBuilder {
                     ranges: req.ranges,
                     prefetch: req.prefetch,
                     transparent_hugepages: req.transparent_hugepages,
+                    host_numa_node: req.host_numa_node,
                 });
                 continue;
             }
@@ -479,11 +491,13 @@ impl GuestMemoryBuilder {
                         .into()
                 }
             };
+
             backings.push(RamBacking {
                 mappable: Some(mappable),
                 ranges: req.ranges,
                 prefetch: req.prefetch,
                 transparent_hugepages: false,
+                host_numa_node: req.host_numa_node,
             });
         }
 
@@ -549,11 +563,16 @@ impl GuestMemoryBuilder {
                                 mappable.clone(),
                                 file_offset,
                                 true,
+                                backing.host_numa_node,
                             )
                             .await;
                     } else {
                         va_mapper
-                            .alloc_range(sub_range.start() as usize, sub_range.len() as usize)
+                            .alloc_range(
+                                sub_range.start() as usize,
+                                sub_range.len() as usize,
+                                backing.host_numa_node,
+                            )
                             .map_err(|e| MemoryBuildError::PrivateRamAlloc(e, *sub_range))?;
                         va_mapper.set_range_name(
                             sub_range.start() as usize,

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -405,7 +405,9 @@ impl GuestMemoryBuilder {
                     return Err(MemoryBuildError::ThpUnsupportedPlatform);
                 }
             }
-            if req.host_numa_node.is_some() && cfg!(not(any(target_os = "linux", target_os = "windows"))) {
+            if req.host_numa_node.is_some()
+                && cfg!(not(any(target_os = "linux", target_os = "windows")))
+            {
                 return Err(MemoryBuildError::HostNumaNodeUnsupportedPlatform);
             }
             if req.hugepages {

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -250,7 +250,7 @@ impl RamBackingRequest {
     }
 
     /// Bind this backing's memory to a specific host NUMA node
-    /// (Linux: `mbind(MPOL_BIND)`). Incompatible with `private_memory`.
+    /// (Linux: `mbind(MPOL_BIND)`, Windows: `MemExtendedParameterNumaNode`).
     pub fn host_numa_node(mut self, node: Option<u32>) -> Self {
         self.host_numa_node = node;
         self
@@ -566,6 +566,10 @@ impl GuestMemoryBuilder {
                                 backing.host_numa_node,
                             )
                             .await;
+                        // TODO: file-backed RAM mappings are established lazily
+                        // via page faults, so NUMA binding errors are not
+                        // caught here. Replace lazy mapping with eager push
+                        // model to propagate errors at build time.
                     } else {
                         va_mapper
                             .alloc_range(

--- a/openvmm/membacking/src/region_manager.rs
+++ b/openvmm/membacking/src/region_manager.rs
@@ -271,6 +271,7 @@ struct RegionMappingParams {
     mappable: Mappable,
     file_offset: u64,
     writable: bool,
+    numa_node: Option<u32>,
 }
 
 fn range_within(outer: MemoryRange, inner: MemoryRange) -> MemoryRange {
@@ -589,6 +590,7 @@ impl RegionManagerTask {
                     file_offset: params.file_offset,
                     writable: params.writable,
                     dma_target: region.params.dma_target,
+                    numa_node: params.numa_node,
                 })
                 .await;
 
@@ -684,6 +686,7 @@ impl RegionManagerTaskInner {
                     file_offset: mapping.params.file_offset,
                     writable: mapping.params.writable && map_params.writable,
                     dma_target: region.params.dma_target,
+                    numa_node: mapping.params.numa_node,
                 })
                 .await;
         }
@@ -917,6 +920,7 @@ impl RegionHandle {
         mappable: Mappable,
         file_offset: u64,
         writable: bool,
+        numa_node: Option<u32>,
     ) {
         let _ = self
             .req_send
@@ -929,6 +933,7 @@ impl RegionHandle {
                         mappable,
                         file_offset,
                         writable,
+                        numa_node,
                     },
                 ),
             )
@@ -1127,6 +1132,7 @@ mod tests {
                         mappable: self.mappable.clone(),
                         file_offset: 0,
                         writable: true,
+                        numa_node: None,
                     },
                 )
                 .await;

--- a/support/sparse_mmap/src/lib.rs
+++ b/support/sparse_mmap/src/lib.rs
@@ -378,4 +378,54 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    #[cfg(any(target_os = "linux", windows))]
+    fn test_alloc_numa_node0() {
+        let page_size = SparseMapping::page_size();
+        let size = 4 * page_size;
+        let mapping = SparseMapping::new(size).unwrap();
+
+        // Allocate with NUMA node 0 (always present).
+        mapping.alloc_numa(0, size, Some(0)).unwrap();
+
+        // Memory should be accessible and writable.
+        let pattern = vec![0xABu8; page_size];
+        mapping.write_at(0, &pattern).unwrap();
+        let mut buf = vec![0u8; page_size];
+        mapping.read_at(0, &mut buf).unwrap();
+        assert_eq!(buf, pattern);
+    }
+
+    #[test]
+    #[cfg(any(target_os = "linux", windows))]
+    fn test_map_file_numa_node0() {
+        let page_size = SparseMapping::page_size();
+        let size = 4 * page_size;
+        let mapping = SparseMapping::new(size).unwrap();
+        let shmem = alloc_shared_memory(size, "test-numa").unwrap();
+
+        // Map with NUMA node 0 (always present).
+        mapping
+            .map_file_numa(0, size, &shmem, 0, true, Some(0))
+            .unwrap();
+
+        // Memory should be accessible and writable.
+        let pattern = vec![0xCDu8; page_size];
+        mapping.write_at(0, &pattern).unwrap();
+        let mut buf = vec![0u8; page_size];
+        mapping.read_at(0, &mut buf).unwrap();
+        assert_eq!(buf, pattern);
+    }
+
+    #[test]
+    #[cfg(any(target_os = "linux", windows))]
+    fn test_alloc_numa_invalid_node() {
+        let page_size = SparseMapping::page_size();
+        let mapping = SparseMapping::new(page_size).unwrap();
+
+        // A very large NUMA node number should fail with an error (not panic).
+        let result = mapping.alloc_numa(0, page_size, Some(99999));
+        assert!(result.is_err());
+    }
 }

--- a/support/sparse_mmap/src/lib.rs
+++ b/support/sparse_mmap/src/lib.rs
@@ -387,6 +387,12 @@ mod tests {
         let mapping = SparseMapping::new(size).unwrap();
 
         // Allocate with NUMA node 0 (always present).
+        #[cfg(unix)]
+        {
+            mapping.alloc(0, size).unwrap();
+            mapping.mbind_at(0, size, 0).unwrap();
+        }
+        #[cfg(windows)]
         mapping.alloc_numa(0, size, Some(0)).unwrap();
 
         // Memory should be accessible and writable.
@@ -406,6 +412,12 @@ mod tests {
         let shmem = alloc_shared_memory(size, "test-numa").unwrap();
 
         // Map with NUMA node 0 (always present).
+        #[cfg(unix)]
+        {
+            mapping.map_file(0, size, &shmem, 0, true).unwrap();
+            mapping.mbind_at(0, size, 0).unwrap();
+        }
+        #[cfg(windows)]
         mapping
             .map_file_numa(0, size, &shmem, 0, true, Some(0))
             .unwrap();
@@ -425,7 +437,16 @@ mod tests {
         let mapping = SparseMapping::new(page_size).unwrap();
 
         // A very large NUMA node number should fail with an error (not panic).
-        let result = mapping.alloc_numa(0, page_size, Some(99999));
-        assert!(result.is_err());
+        #[cfg(unix)]
+        {
+            mapping.alloc(0, page_size).unwrap();
+            let result = mapping.mbind_at(0, page_size, 99999);
+            assert!(result.is_err());
+        }
+        #[cfg(windows)]
+        {
+            let result = mapping.alloc_numa(0, page_size, Some(99999));
+            assert!(result.is_err());
+        }
     }
 }

--- a/support/sparse_mmap/src/unix.rs
+++ b/support/sparse_mmap/src/unix.rs
@@ -286,8 +286,9 @@ impl SparseMapping {
     /// `alloc`, `map_file`, etc.) before calling this.
     #[cfg(target_os = "linux")]
     pub fn mbind_at(&self, offset: usize, len: usize, numa_node: u32) -> Result<(), Error> {
-        // SAFETY: the caller has mapped this range within the
-        // SparseMapping, so `self.address + offset` is valid for `len` bytes.
+        let _ = self.validate_offset_len(offset, len)?;
+        // SAFETY: validate_offset_len confirmed offset+len is within the
+        // mapping, so `self.address + offset` is valid for `len` bytes.
         unsafe { mbind_range(self.address.add(offset), len, numa_node) }
     }
 
@@ -583,6 +584,15 @@ pub fn alloc_shared_memory_hugetlb(
 /// `addr` must point to a valid mapped region of at least `len` bytes.
 #[cfg(target_os = "linux")]
 unsafe fn mbind_range(addr: *mut c_void, len: usize, numa_node: u32) -> io::Result<()> {
+    // Cap the node ID to prevent accidental large allocations for the
+    // nodemask bitmask below.
+    if numa_node > 0xffff {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "NUMA node exceeds maximum supported value",
+        ));
+    }
+
     // Build nodemask bitmask. The kernel expects an array of unsigned long with
     // bit `numa_node` set.
     //

--- a/support/sparse_mmap/src/unix.rs
+++ b/support/sparse_mmap/src/unix.rs
@@ -587,7 +587,7 @@ unsafe fn mbind_range(addr: *mut c_void, len: usize, numa_node: u32) -> io::Resu
     // Cap the node ID to prevent accidental large allocations for the
     // nodemask bitmask below.
     if numa_node > 0xffff {
-        return Err(io::Error::new(
+        return Err(Error::new(
             io::ErrorKind::InvalidInput,
             "NUMA node exceeds maximum supported value",
         ));

--- a/support/sparse_mmap/src/unix.rs
+++ b/support/sparse_mmap/src/unix.rs
@@ -215,21 +215,6 @@ impl SparseMapping {
         }
     }
 
-    /// Allocates private, writable memory at the given offset, optionally
-    /// bound to a specific host NUMA node via `mbind(MPOL_BIND)`.
-    pub fn alloc_numa(
-        &self,
-        offset: usize,
-        len: usize,
-        numa_node: Option<u32>,
-    ) -> Result<(), Error> {
-        self.alloc(offset, len)?;
-        if let Some(node) = numa_node {
-            self.mbind_at(offset, len, node)?;
-        }
-        Ok(())
-    }
-
     /// Maps read-only zero pages at the given offset within the mapping.
     pub fn map_zero(&self, offset: usize, len: usize) -> Result<(), Error> {
         // SAFETY: The flags passed in are guaranteed to be valid
@@ -294,42 +279,16 @@ impl SparseMapping {
         }
     }
 
-    /// Maps a portion of a file mapping at `offset`, optionally bound to a
-    /// specific host NUMA node via `mbind(MPOL_BIND)`.
-    pub fn map_file_numa(
-        &self,
-        offset: usize,
-        len: usize,
-        file_mapping: impl AsFd,
-        file_offset: u64,
-        writable: bool,
-        numa_node: Option<u32>,
-    ) -> Result<(), Error> {
-        self.map_file(offset, len, file_mapping, file_offset, writable)?;
-        if let Some(node) = numa_node {
-            self.mbind_at(offset, len, node)?;
-        }
-        Ok(())
-    }
-
-    /// Calls `mbind(MPOL_BIND)` on a range within this mapping.
+    /// Calls `mbind(MPOL_BIND)` on a range within this mapping, binding
+    /// pages to a specific host NUMA node.
     ///
     /// The range at `offset..offset+len` must already be mapped (via
     /// `alloc`, `map_file`, etc.) before calling this.
     #[cfg(target_os = "linux")]
-    fn mbind_at(&self, offset: usize, len: usize, numa_node: u32) -> Result<(), Error> {
-        // SAFETY: the caller has just mapped this range within the
+    pub fn mbind_at(&self, offset: usize, len: usize, numa_node: u32) -> Result<(), Error> {
+        // SAFETY: the caller has mapped this range within the
         // SparseMapping, so `self.address + offset` is valid for `len` bytes.
         unsafe { mbind_range(self.address.add(offset), len, numa_node) }
-    }
-
-    /// Stub for non-Linux unix platforms where `mbind` is not available.
-    #[cfg(not(target_os = "linux"))]
-    fn mbind_at(&self, _offset: usize, _len: usize, _numa_node: u32) -> Result<(), Error> {
-        Err(Error::new(
-            io::ErrorKind::Unsupported,
-            "NUMA memory binding is not supported on this platform",
-        ))
     }
 
     /// Maps memory into the mapping, passing parameters through to the mmap
@@ -624,30 +583,31 @@ pub fn alloc_shared_memory_hugetlb(
 /// `addr` must point to a valid mapped region of at least `len` bytes.
 #[cfg(target_os = "linux")]
 unsafe fn mbind_range(addr: *mut c_void, len: usize, numa_node: u32) -> io::Result<()> {
-    // MPOL constants not provided by libc.
-    const MPOL_BIND: libc::c_int = 2;
-    const MPOL_MF_STRICT: libc::c_uint = 1;
-    const MPOL_MF_MOVE: libc::c_uint = 2;
-
-    // Build nodemask bitmask. The kernel expects an array of unsigned long
-    // with bit `numa_node` set. maxnode is the number of bits (1-based).
+    // Build nodemask bitmask. The kernel expects an array of unsigned long with
+    // bit `numa_node` set.
+    //
+    // maxnode should be the number of bits in the nodemask, but the kernel's
+    // get_nodes() has an off-by-one: it decrements maxnode before use, so we
+    // must pass numa_node + 2 instead of numa_node + 1. This is a known kernel
+    // bug since 2004 that will not be fixed (ABI). See
+    // <https://lore.kernel.org/linux-mm/20240720173543.897972-1-jglisse@google.com/>
+    let maxnode = numa_node as usize + 2;
     let word_bits = libc::c_ulong::BITS as usize;
-    let word_index = numa_node as usize / word_bits;
-    let bit_index = numa_node as usize % word_bits;
-    let num_words = word_index + 1;
+    let num_words = maxnode.div_ceil(word_bits);
     let mut nodemask = vec![0 as libc::c_ulong; num_words];
-    nodemask[word_index] = 1 << bit_index;
-    let maxnode = num_words * word_bits + 1;
+    nodemask[numa_node as usize / word_bits] = 1 << (numa_node as usize % word_bits);
 
+    // Use flags = 0: just set the NUMA policy for future page faults.
+    // The memory was just mapped, so there are no resident pages to move.
     let result = unsafe {
         libc::syscall(
             libc::SYS_mbind,
             addr,
             len,
-            MPOL_BIND,
+            libc::MPOL_BIND,
             nodemask.as_ptr(),
             maxnode,
-            MPOL_MF_STRICT | MPOL_MF_MOVE,
+            0,
         )
     };
 

--- a/support/sparse_mmap/src/unix.rs
+++ b/support/sparse_mmap/src/unix.rs
@@ -215,6 +215,21 @@ impl SparseMapping {
         }
     }
 
+    /// Allocates private, writable memory at the given offset, optionally
+    /// bound to a specific host NUMA node via `mbind(MPOL_BIND)`.
+    pub fn alloc_numa(
+        &self,
+        offset: usize,
+        len: usize,
+        numa_node: Option<u32>,
+    ) -> Result<(), Error> {
+        self.alloc(offset, len)?;
+        if let Some(node) = numa_node {
+            self.mbind_at(offset, len, node)?;
+        }
+        Ok(())
+    }
+
     /// Maps read-only zero pages at the given offset within the mapping.
     pub fn map_zero(&self, offset: usize, len: usize) -> Result<(), Error> {
         // SAFETY: The flags passed in are guaranteed to be valid
@@ -277,6 +292,44 @@ impl SparseMapping {
                 file_offset as i64,
             )
         }
+    }
+
+    /// Maps a portion of a file mapping at `offset`, optionally bound to a
+    /// specific host NUMA node via `mbind(MPOL_BIND)`.
+    pub fn map_file_numa(
+        &self,
+        offset: usize,
+        len: usize,
+        file_mapping: impl AsFd,
+        file_offset: u64,
+        writable: bool,
+        numa_node: Option<u32>,
+    ) -> Result<(), Error> {
+        self.map_file(offset, len, file_mapping, file_offset, writable)?;
+        if let Some(node) = numa_node {
+            self.mbind_at(offset, len, node)?;
+        }
+        Ok(())
+    }
+
+    /// Calls `mbind(MPOL_BIND)` on a range within this mapping.
+    ///
+    /// The range at `offset..offset+len` must already be mapped (via
+    /// `alloc`, `map_file`, etc.) before calling this.
+    #[cfg(target_os = "linux")]
+    fn mbind_at(&self, offset: usize, len: usize, numa_node: u32) -> Result<(), Error> {
+        // SAFETY: the caller has just mapped this range within the
+        // SparseMapping, so `self.address + offset` is valid for `len` bytes.
+        unsafe { mbind_range(self.address.add(offset), len, numa_node) }
+    }
+
+    /// Stub for non-Linux unix platforms where `mbind` is not available.
+    #[cfg(not(target_os = "linux"))]
+    fn mbind_at(&self, _offset: usize, _len: usize, _numa_node: u32) -> Result<(), Error> {
+        Err(Error::new(
+            io::ErrorKind::Unsupported,
+            "NUMA memory binding is not supported on this platform",
+        ))
     }
 
     /// Maps memory into the mapping, passing parameters through to the mmap
@@ -561,4 +614,46 @@ pub fn alloc_shared_memory_hugetlb(
         io::ErrorKind::Unsupported,
         "hugetlb shared memory is only supported on Linux",
     ))
+}
+
+/// Calls `mbind(MPOL_BIND)` on an already-mapped virtual address range,
+/// binding it to a specific host NUMA node.
+///
+/// # Safety
+///
+/// `addr` must point to a valid mapped region of at least `len` bytes.
+#[cfg(target_os = "linux")]
+unsafe fn mbind_range(addr: *mut c_void, len: usize, numa_node: u32) -> io::Result<()> {
+    // MPOL constants not provided by libc.
+    const MPOL_BIND: libc::c_int = 2;
+    const MPOL_MF_STRICT: libc::c_uint = 1;
+    const MPOL_MF_MOVE: libc::c_uint = 2;
+
+    // Build nodemask bitmask. The kernel expects an array of unsigned long
+    // with bit `numa_node` set. maxnode is the number of bits (1-based).
+    let word_bits = libc::c_ulong::BITS as usize;
+    let word_index = numa_node as usize / word_bits;
+    let bit_index = numa_node as usize % word_bits;
+    let num_words = word_index + 1;
+    let mut nodemask = vec![0 as libc::c_ulong; num_words];
+    nodemask[word_index] = 1 << bit_index;
+    let maxnode = num_words * word_bits + 1;
+
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_mbind,
+            addr,
+            len,
+            MPOL_BIND,
+            nodemask.as_ptr(),
+            maxnode,
+            MPOL_MF_STRICT | MPOL_MF_MOVE,
+        )
+    };
+
+    if result == -1 {
+        return Err(Error::last_os_error());
+    }
+
+    Ok(())
 }

--- a/support/sparse_mmap/src/windows.rs
+++ b/support/sparse_mmap/src/windows.rs
@@ -149,10 +149,14 @@ unsafe fn map_view_of_file(
 }
 
 /// Returns a NUMA node `MEM_EXTENDED_PARAMETER`, if a node is specified.
+///
+/// See <https://learn.microsoft.com/windows/win32/api/winnt/ns-winnt-mem_extended_parameter>
 fn numa_extended_param(numa_node: Option<u32>) -> Option<Memory::MEM_EXTENDED_PARAMETER> {
     let node = numa_node?;
-    // SAFETY: MEM_EXTENDED_PARAMETER is a C union struct; zeroing is valid.
-    let mut param: Memory::MEM_EXTENDED_PARAMETER = unsafe { std::mem::zeroed() };
+    let mut param = Memory::MEM_EXTENDED_PARAMETER::default();
+    // The `_bitfield` layout is: Type in the low 8 bits, Reserved in the
+    // upper 56 bits. windows-rs 0.62 does not expose typed accessors for
+    // this bitfield struct, so we set it directly.
     param.Anonymous1._bitfield = Memory::MemExtendedParameterNumaNode as u64 & 0xff;
     param.Anonymous2.ULong = node;
     Some(param)

--- a/support/sparse_mmap/src/windows.rs
+++ b/support/sparse_mmap/src/windows.rs
@@ -71,9 +71,16 @@ unsafe fn virtual_alloc(
     size: usize,
     allocation_type: u32,
     page_protection: u32,
-    extended_parameters: *mut Memory::MEM_EXTENDED_PARAMETER,
-    parameter_count: u32,
+    extended_parameters: &mut [Memory::MEM_EXTENDED_PARAMETER],
 ) -> Result<*mut c_void, Error> {
+    let (params_ptr, params_count) = if extended_parameters.is_empty() {
+        (null_mut(), 0)
+    } else {
+        (
+            extended_parameters.as_mut_ptr(),
+            extended_parameters.len() as u32,
+        )
+    };
     let address = unsafe {
         VirtualAlloc2(
             process.handle(),
@@ -81,8 +88,8 @@ unsafe fn virtual_alloc(
             size,
             allocation_type,
             page_protection,
-            extended_parameters,
-            parameter_count,
+            params_ptr,
+            params_count,
         )
     };
     if address.is_null() {
@@ -111,7 +118,16 @@ unsafe fn map_view_of_file(
     view_size: usize,
     allocation_type: u32,
     page_protection: u32,
+    extended_parameters: &mut [Memory::MEM_EXTENDED_PARAMETER],
 ) -> Result<*mut c_void, Error> {
+    let (params_ptr, params_count) = if extended_parameters.is_empty() {
+        (null_mut(), 0)
+    } else {
+        (
+            extended_parameters.as_mut_ptr(),
+            extended_parameters.len() as u32,
+        )
+    };
     let address = unsafe {
         MapViewOfFile3(
             file_mapping,
@@ -121,8 +137,8 @@ unsafe fn map_view_of_file(
             view_size,
             allocation_type,
             page_protection,
-            null_mut(),
-            0,
+            params_ptr,
+            params_count,
         )
     }
     .Value;
@@ -130,6 +146,16 @@ unsafe fn map_view_of_file(
         return Err(Error::last_os_error());
     }
     Ok(address)
+}
+
+/// Returns a NUMA node `MEM_EXTENDED_PARAMETER`, if a node is specified.
+fn numa_extended_param(numa_node: Option<u32>) -> Option<Memory::MEM_EXTENDED_PARAMETER> {
+    let node = numa_node?;
+    // SAFETY: MEM_EXTENDED_PARAMETER is a C union struct; zeroing is valid.
+    let mut param: Memory::MEM_EXTENDED_PARAMETER = unsafe { std::mem::zeroed() };
+    param.Anonymous1._bitfield = Memory::MemExtendedParameterNumaNode as u64 & 0xff;
+    param.Anonymous2.ULong = node;
+    Some(param)
 }
 
 unsafe fn unmap_view_of_file(
@@ -339,8 +365,7 @@ impl SparseMapping {
                 len,
                 MEM_RESERVE | MEM_RESERVE_PLACEHOLDER,
                 PAGE_NOACCESS,
-                null_mut(),
-                0,
+                &mut [],
             )?;
             Ok(Self {
                 address,
@@ -388,12 +413,23 @@ impl SparseMapping {
     /// Allocates private, writable memory at the given offset within the
     /// mapping.
     pub fn alloc(&self, offset: usize, len: usize) -> Result<(), Error> {
-        self.virtual_alloc(offset, len, PAGE_READWRITE)
+        self.virtual_alloc(offset, len, PAGE_READWRITE, None)
+    }
+
+    /// Allocates private, writable memory at the given offset, optionally
+    /// bound to a specific host NUMA node.
+    pub fn alloc_numa(
+        &self,
+        offset: usize,
+        len: usize,
+        numa_node: Option<u32>,
+    ) -> Result<(), Error> {
+        self.virtual_alloc(offset, len, PAGE_READWRITE, numa_node)
     }
 
     /// Maps read-only zero pages at the given offset within the mapping.
     pub fn map_zero(&self, offset: usize, len: usize) -> Result<(), Error> {
-        self.virtual_alloc(offset, len, PAGE_READONLY)
+        self.virtual_alloc(offset, len, PAGE_READONLY, None)
     }
 
     fn validate_offset_len(&self, offset: usize, len: usize) -> io::Result<usize> {
@@ -450,17 +486,23 @@ impl SparseMapping {
     }
 
     /// Allocates private memory at the given offset with memory protection
-    /// `protect`.
-    pub fn virtual_alloc(&self, offset: usize, len: usize, protect: u32) -> Result<(), Error> {
+    /// `protect`, optionally bound to a specific host NUMA node.
+    pub fn virtual_alloc(
+        &self,
+        offset: usize,
+        len: usize,
+        protect: u32,
+        numa_node: Option<u32>,
+    ) -> Result<(), Error> {
         self.map(offset, len, |addr| unsafe {
+            let mut param = numa_extended_param(numa_node);
             virtual_alloc(
                 self.process.as_ref(),
                 addr,
                 len,
                 MEM_RESERVE | MEM_COMMIT | MEM_REPLACE_PLACEHOLDER,
                 protect,
-                null_mut(),
-                0,
+                param.as_mut_slice(),
             )?;
             Ok(MappingInfo::Anonymous)
         })
@@ -480,10 +522,44 @@ impl SparseMapping {
         } else {
             PAGE_READONLY
         };
-        self.map_view_of_file(offset, len, file_mapping.as_handle(), file_offset, protect)
+        self.map_view_of_file(
+            offset,
+            len,
+            file_mapping.as_handle(),
+            file_offset,
+            protect,
+            None,
+        )
     }
 
-    /// Maps a portion of a file mapping at `offset` with protection `protect`.
+    /// Maps a portion of a file mapping at `offset`, optionally bound to a
+    /// specific host NUMA node.
+    pub fn map_file_numa(
+        &self,
+        offset: usize,
+        len: usize,
+        file_mapping: impl AsHandle,
+        file_offset: u64,
+        writable: bool,
+        numa_node: Option<u32>,
+    ) -> Result<(), Error> {
+        let protect = if writable {
+            PAGE_READWRITE
+        } else {
+            PAGE_READONLY
+        };
+        self.map_view_of_file(
+            offset,
+            len,
+            file_mapping.as_handle(),
+            file_offset,
+            protect,
+            numa_node,
+        )
+    }
+
+    /// Maps a portion of a file mapping at `offset` with protection `protect`,
+    /// optionally bound to a specific host NUMA node.
     pub fn map_view_of_file(
         &self,
         offset: usize,
@@ -491,6 +567,7 @@ impl SparseMapping {
         file_mapping: impl AsHandle,
         file_offset: u64,
         protect: u32,
+        numa_node: Option<u32>,
     ) -> Result<(), Error> {
         assert_ne!(len, 0);
         self.map(offset, len, |addr| unsafe {
@@ -505,6 +582,7 @@ impl SparseMapping {
                 p => panic!("unknown protection {:#x}", p),
             };
             let section = file_mapping.as_handle().duplicate(false, Some(access))?;
+            let mut param = numa_extended_param(numa_node);
             map_view_of_file(
                 self.process.as_ref(),
                 file_mapping.as_handle().as_raw_handle(),
@@ -513,6 +591,7 @@ impl SparseMapping {
                 len,
                 MEM_REPLACE_PLACEHOLDER,
                 protect,
+                param.as_mut_slice(),
             )?;
             Ok(MappingInfo::Section {
                 handle: section,
@@ -570,6 +649,7 @@ impl SparseMapping {
                             len,
                             MEM_REPLACE_PLACEHOLDER,
                             *protection,
+                            &mut [],
                         )
                         .expect("remap failed");
                     }
@@ -594,6 +674,7 @@ impl SparseMapping {
                             len,
                             MEM_REPLACE_PLACEHOLDER,
                             *protection,
+                            &mut [],
                         )
                         .expect("remap failed");
                     }
@@ -708,8 +789,7 @@ impl SparseMapping {
                 len,
                 MEM_COMMIT,
                 PAGE_READWRITE,
-                null_mut(),
-                0,
+                &mut [],
             )?;
         }
         Ok(())
@@ -784,7 +864,7 @@ mod tests {
         let shmem = alloc_shared_memory(0x100000, "test").unwrap();
         let sparse = SparseMapping::new(0x100000).unwrap();
         sparse
-            .map_view_of_file(0, 0x100000, &shmem, 0, PAGE_READWRITE)
+            .map_view_of_file(0, 0x100000, &shmem, 0, PAGE_READWRITE, None)
             .unwrap();
         let data: &mut [u32] =
             unsafe { std::slice::from_raw_parts_mut(sparse.as_ptr().cast(), sparse.len() / 4) };


### PR DESCRIPTION
Add cross-platform support for binding memory allocations and file mappings to specific host NUMA nodes.

On Linux, this uses mbind(MPOL_BIND) after mmap to set the page allocation policy. On Windows, this passes MemExtendedParameterNumaNode to VirtualAlloc2 and MapViewOfFile3.

The new SparseMapping methods (alloc_numa, map_file_numa) take Option<u32> for the NUMA node, falling through to the non-NUMA path when None. This avoids separate code paths at call sites.

The NUMA node flows through the full membacking pipeline: RamBackingRequest -> RamBacking -> RegionMappingParams -> MappingParams -> VaMapper, so both private (anonymous) and file-backed (memfd/section) RAM backings get NUMA-bound at the point where pages are actually committed or mapped into the guest memory VA space.