### PR TITLE
bump openvmm-deps to 0.3.0-33 and openhcl-kernel to 6.18.0.3

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -32,7 +32,7 @@ pub const NODEJS: &str = "24.x";
 //      increases with each release from the respective branch.
 pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.3";
 pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.3";
-pub const OPENVMM_DEPS: &str = "0.3.0-29";
+pub const OPENVMM_DEPS: &str = "0.3.0-33";
 pub const PROTOC: &str = "27.1";
 
 flowey_request! {

--- a/nix/openhcl_kernel.nix
+++ b/nix/openhcl_kernel.nix
@@ -1,7 +1,7 @@
 { system, stdenv, fetchzip, targetArch ? null, is_dev ? false, is_cvm ? false }:
 
 let
-  version = if is_dev then "6.18.0.2" else "6.18.0.2";
+  version = if is_dev then "6.18.0.3" else "6.18.0.3";
   # Allow explicit override of architecture, otherwise derive from host system
   # Note: targetArch uses "x86_64"/"aarch64", but URLs use "x64"/"arm64"
   arch = if targetArch == "x86_64" then "x64"
@@ -18,21 +18,21 @@ let
   hashes = {
     hcl-main = {
       std = {
-        x64 = "sha256-YMi5VLU51eBjOy3SkxIFqFZHpctfXw5c8VR8rg6wOys=";
-        arm64 = "sha256-MmpQbHe20dxq7XU8/d0nVPJvyAct/tqxNKasNpOy/A8=";
+        x64 = "sha256-bE7exmjCaR+g0pFKmQCpFgMS/7eqLCmWj4UN04qlCwQ=";
+        arm64 = "sha256-FFC4826tOleHvRouF+KwquFPHQKT3hanUfXbWtWFO50=";
       };
       cvm = {
-        x64 = "sha256-vOrq8A1s6aLyOGidxLl48v59McDb8dAxDe5V0QC2Dzo=";
+        x64 = "sha256-WtTHIHec4rmQPFCKfPzAdMDJkN0/WimV/l77ZX49KdU=";
         arm64 = throw "openhcl-kernel: cvm arm64 variant not available";
       };
     };
     hcl-dev = {
       std = {
-        x64 = "sha256-sFqwcX9c0/fk7ZylM82QSYxBMVXaALDgKN/A82ChyGs=";
-        arm64 = "sha256-AuUeQF4yr8sdJIMIicSlB1PH+mOQ0Gnr4SP/R/SFi2I=";
+        x64 = "sha256-l41pBU22R2NjdRpLT1JSwEj3ROf8Stqp6N5Rw/mi90E=";
+        arm64 = "sha256-taGhLFIiYwmqeTk5zOUDkHafdyW7Nc7w95EMIuJaEy8=";
       };
       cvm = {
-        x64 = "sha256-ClS82fGHeXUeiENJh+6+DfErTPui44wPkhVQQKIIx3o=";
+        x64 = "sha256-Ohjbjz1wjKjyKL9vCBejClNGYCS/0Ir7XtijKRJtvc0=";
         arm64 = throw "openhcl-kernel: dev cvm arm64 variant not available";
       };
     };

--- a/nix/openvmm_deps.nix
+++ b/nix/openvmm_deps.nix
@@ -6,17 +6,17 @@ let
          else if system == "aarch64-linux" then "aarch64"
          else "x86_64";
   hash = {
-    "aarch64" = "sha256-yLGLoQrzA07jrG4G1HMb2P3fcmnGS3KF5H/4AtzDO4w=";
-    "x86_64" = "sha256-uDCEo4wbHya3KEYVgFHxr+/OOkzyMCUwhLNX7kppojQ=";
+    "aarch64" = "sha256-4Q63EMsSgxLtU4c7l+dvGlxyVpk5ewKtTn+WgF7ScBM=";
+    "x86_64" = "sha256-XYSAKiRGYqPghEa2cMijgf9k21AiDhkCxIbxE/OCk5o=";
   }.${arch};
 
 in stdenv.mkDerivation {
   pname = "openvmm-deps-${arch}";
-  version = "0.1.0-20250403.3";
+  version = "0.3.0-33";
 
   src = fetchzip {
     url =
-      "https://github.com/microsoft/openvmm-deps/releases/download/0.1.0-20250403.3/openvmm-deps.${arch}.0.1.0-20250403.3.tar.bz2";
+      "https://github.com/microsoft/openvmm-deps/releases/download/0.3.0-33/openvmm-deps.${arch}.0.3.0-33.tar.gz";
     stripRoot = false;
     inherit hash;
   };


### PR DESCRIPTION
Updates the flowey \`OPENVMM_DEPS\` pin from \`0.3.0-29\` to \`0.3.0-33\` and aligns the nix derivations with what flowey now uses.

### Changes

- **\`flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs\`**: bump \`OPENVMM_DEPS\` to \`0.3.0-33\`. This single const drives the flowey \`resolve_openvmm_deps\`, \`resolve_openvmm_test_linux_kernel\`, and \`resolve_openvmm_test_initrd\` nodes, so the test-kernel and test-initrd downloads bump alongside it.

- **\`nix/openvmm_deps.nix\`**: bump from the stale \`0.1.0-20250403.3\` pin to \`0.3.0-33\`, switch the artifact extension from \`.tar.bz2\` to \`.tar.gz\` (the \`0.3.0-x\` releases only ship \`.tar.gz\`), and update both sha256 hashes. The new openvmm-deps archive no longer bundles \`vmlinux\`/\`initrd\` — those moved to separate \`openvmm-test-linux-*\` and \`openvmm-test-initrd-*\` release assets that flowey already handles via dedicated resolver nodes. The nix \`installPhase\` here only ever consumed \`sysroot.tar.gz\` / \`*.cpio.gz\` / \`petritools.erofs\`, all of which are still at the same top-level paths in the new archive.

- **\`nix/openhcl_kernel.nix\`**: bump from \`6.18.0.2\` to \`6.18.0.3\` to match \`OPENHCL_KERNEL_DEV_VERSION\` / \`OPENHCL_KERNEL_STABLE_VERSION\` in \`cfg_versions.rs\` (the \`6.18.0.2\` release was unreachable from the pinned URL, breaking \`nix-shell --pure\`). All five hashes recomputed (3 std + 2 cvm).

### Validation

- \`nix-shell --pure shell.nix\` succeeded end-to-end against the pinned nixpkgs; all six kernel variants (x64/arm64 × std/cvm/dev) plus both openvmm-deps derivations build cleanly.
- \`cargo clippy --all-targets -p flowey_lib_hvlite\` — clean
- \`cargo doc --no-deps -p flowey_lib_hvlite\` — clean
- \`cargo xtask fmt --fix\` — no changes (also re-ran flowey \`regen\`, no YAML diffs)