### PR TITLE
smmu: fix CD bitfield ordering and enforce CD.A for terminal fault model

### DIFF
--- a/vm/devices/iommu/smmu/src/emulator.rs
+++ b/vm/devices/iommu/smmu/src/emulator.rs
@@ -146,6 +146,8 @@ impl SmmuDevice {
             .with_asid16(true)
             .with_msi(false)
             .with_ttendian(0b10) // Little-endian
+            .with_stall_model(0b01) // Stall not supported
+            .with_term_model(true) // Terminate faults (no stall)
             .with_st_level(0b00); // Linear stream table only
 
         let idr1 = registers::Idr1::new()
@@ -1946,6 +1948,7 @@ mod tests {
                 .with_tg0(Tg0::GRAN_4K.0)
                 .with_ips(Ips::IPS_40.0)
                 .with_aa64(true)
+                .with_a(true)
                 .with_asid(1),
             qw1: CdDw1::new().with_ttb0(PT_L1_GPA >> 4),
             _qw2: 0,

--- a/vm/devices/iommu/smmu/src/shared.rs
+++ b/vm/devices/iommu/smmu/src/shared.rs
@@ -921,6 +921,7 @@ mod tests {
                 .with_tg0(Tg0::GRAN_4K.0)
                 .with_ips(Ips::IPS_40.0)
                 .with_aa64(true)
+                .with_a(true)
                 .with_asid(1),
             qw1: CdDw1::new().with_ttb0(PT_L1_BASE >> 4),
             _qw2: 0,

--- a/vm/devices/iommu/smmu/src/spec/cd.rs
+++ b/vm/devices/iommu/smmu/src/spec/cd.rs
@@ -126,6 +126,18 @@ pub struct CdDw0 {
     pub ips: u8,
     /// Access flag fault disable.
     pub affd: bool,
+    /// Write implies XN.
+    pub wxn: bool,
+    /// Unprivileged write implies XN.
+    pub uwxn: bool,
+    /// Top byte ignore for TTB0 addresses.
+    pub tbi0: bool,
+    /// Top byte ignore for TTB1 addresses.
+    pub tbi1: bool,
+    /// Privileged Access Never.
+    pub pan: bool,
+    /// VMSAv8-64 mode (must be 1 for AArch64 page tables).
+    pub aa64: bool,
     /// HW dirty bit management.
     pub hd: bool,
     /// HW access flag update.
@@ -138,18 +150,6 @@ pub struct CdDw0 {
     pub a: bool,
     /// ASID set (for TLB invalidation).
     pub aset: bool,
-    /// Top byte ignore for TTB0 addresses.
-    pub tbi0: bool,
-    /// Top byte ignore for TTB1 addresses.
-    pub tbi1: bool,
-    /// Privileged Access Never.
-    pub pan: bool,
-    /// VMSAv8-64 mode (must be 1 for AArch64 page tables).
-    pub aa64: bool,
-    /// Write implies XN.
-    pub wxn: bool,
-    /// Unprivileged write implies XN.
-    pub uwxn: bool,
     /// ASID (16-bit).
     #[bits(16)]
     pub asid: u16,

--- a/vm/devices/iommu/smmu/src/translate.rs
+++ b/vm/devices/iommu/smmu/src/translate.rs
@@ -171,6 +171,13 @@ pub fn lookup_cd(
         return Err(SmmuFault::bad_cd(sid));
     }
 
+    // TERM_MODEL=1 requires CD.A=1 (abort flag set). With STALL_MODEL=1
+    // (no stall) and TERM_MODEL=1 (terminate on fault), an access flag
+    // fault would be unrecoverable, so the guest must pre-set A=1.
+    if !cd.qw0.a() {
+        return Err(SmmuFault::bad_cd(sid));
+    }
+
     Ok(cd)
 }
 
@@ -460,6 +467,7 @@ mod tests {
                 .with_tg0(tg0.0)
                 .with_ips(ips.0)
                 .with_aa64(true)
+                .with_a(true)
                 .with_asid(1),
             qw1: CdDw1::new().with_ttb0(ttb0 >> 4),
             _qw2: 0,


### PR DESCRIPTION
The CdDw0 bitfield had several fields in the wrong order relative to the SMMUv3 spec: wxn, uwxn, tbi0, tbi1, pan, and aa64 were placed after the hd/ha/s/r/a/aset fields when they should come before them. Fix the ordering so the struct matches the hardware layout.

Advertise STALL_MODEL=0b01 (stall not supported) and TERM_MODEL=1 (terminate on fault) in IDR0, reflecting the emulator's actual behavior. Since faults are terminal and cannot be retried via a stall queue, require CD.A=1 (access flag pre-set) in context descriptors—an access flag fault under this model would be unrecoverable, so the guest must avoid it by pre-setting the flag.