### PR TITLE
netvsp: fix sub-channel panic on CQE_TX_GDMA_ERR 

### DIFF
--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4148,16 +4148,22 @@ impl Coordinator {
             };
             match message {
                 Message::Internal(msg) => {
+                    self.stop_workers().await;
                     self.handle_coordinator_message(msg, state).await;
+                    // If a restart message has been queued, handle it now
+                    // to ensure worker queues are restarted prior to
+                    // `worker.start()` in the next loop.
+                    self.handle_queued_coordinator_messages(state).await;
                 }
                 Message::UpdateFromVf(rpc) => {
+                    self.stop_workers().await;
                     rpc.handle(async |_| {
                         self.update_guest_vf_state(state).await;
                     })
                     .await;
                 }
                 Message::OfferVfDevice => {
-                    self.workers[0].stop().await;
+                    self.stop_workers().await;
                     if let Some(primary) = self.primary_mut() {
                         if matches!(
                             primary.guest_vf_state,
@@ -4170,11 +4176,12 @@ impl Coordinator {
                     state.pending_vf_state = CoordinatorStatePendingVfState::Pending;
                 }
                 Message::PendingVfStateComplete => {
+                    // Worker state unchanged, calling `stop_workers()` is not necessary.
                     state.pending_vf_state = CoordinatorStatePendingVfState::Ready;
                 }
                 Message::TimerExpired => {
                     // Kick the worker as requested.
-                    self.workers[0].stop().await;
+                    self.stop_workers().await;
                     if let Some(primary) = self.primary_mut() {
                         if let PendingLinkAction::Delay(up) = primary.pending_link_action {
                             primary.pending_link_action = PendingLinkAction::Active(up);
@@ -4197,8 +4204,7 @@ impl Coordinator {
         match action {
             EndpointAction::RestartRequired => self.restart = true,
             EndpointAction::LinkStatusNotify(connect) => {
-                self.workers[0].stop().await;
-
+                self.stop_workers().await;
                 // These are the only link state transitions that are tracked.
                 // 1. up -> down or down -> up
                 // 2. up -> down -> up or down -> up -> down.
@@ -4216,8 +4222,8 @@ impl Coordinator {
         }
     }
 
-    /// Called from the [`Self::process`] loop when a `Restart` message has
-    /// been observed from any channel.
+    /// Called from the [`Self::process`] loop when either `CoordinatorMessage::Restart`
+    /// or `EndpointAction::RestartRequired` is observed.
     async fn restart_worker_queues(
         &mut self,
         stop: &mut StopTask<'_>,
@@ -4228,12 +4234,10 @@ impl Coordinator {
         // All workers are stopped and cannot push new messages.
         // Drain any messages that arrived prior to or during the stop.
         // Coalesce restart messages. Handle non-restart Primary messages.
-        while let Ok(Some(msg)) = self.recv.try_next() {
-            self.handle_coordinator_message(msg, state).await;
-        }
+        self.handle_queued_coordinator_messages(state).await;
 
-        // Handle any endpoint actions queued at this moment.
-        // Best-effort attempt to coalesce `RestartRequired` into this operation.
+        // Best-effort attempt to coalesce any `RestartRequired` endpoint
+        // action into this restart operation.
         while let Some(action) = state.endpoint.wait_for_endpoint_action().now_or_never() {
             self.handle_endpoint_action(action).await;
         }
@@ -4259,6 +4263,12 @@ impl Coordinator {
         self.restore_guest_vf_state(state).await;
         self.restart = false;
         Ok(())
+    }
+
+    async fn handle_queued_coordinator_messages(&mut self, state: &mut CoordinatorState) {
+        while let Ok(Some(msg)) = self.recv.try_next() {
+            self.handle_coordinator_message(msg, state).await;
+        }
     }
 
     async fn handle_coordinator_message(
@@ -4803,7 +4813,6 @@ impl Coordinator {
     }
 
     async fn update_guest_vf_state(&mut self, c_state: &mut CoordinatorState) {
-        self.workers[0].stop().await;
         self.restore_guest_vf_state(c_state).await;
     }
 }

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -1548,8 +1548,9 @@ impl Nic {
         driver_builder.run_on_target(!self.adapter.tx_fast_completions);
 
         #[expect(clippy::disallowed_methods)] // TODO
-        // Capacity equals the number of workers.
-        // Each channel (primary or subchannel) can send at most one message.
+        // Setting `capacity == number of workers` prevents `try_send` failure,
+        // as long as each worker (primary or sub-channel) holds at most one
+        // outstanding message.
         let (send, recv) = mpsc::channel(self.adapter.max_queues as usize);
         self.coordinator_send = Some(send);
         self.coordinator.insert(
@@ -4232,7 +4233,7 @@ impl Coordinator {
         stop: &mut StopTask<'_>,
         state: &mut CoordinatorState,
     ) -> Result<(), task_control::Cancelled> {
-        tracing::info!("beginning restart cycle");
+        tracelimit::info_ratelimited!("beginning restart cycle");
         stop.until_stopped(self.stop_workers()).await?;
 
         // All workers are stopped and cannot push new messages.
@@ -4269,7 +4270,7 @@ impl Coordinator {
     ) {
         match msg {
             CoordinatorMessage::Restart { channel_idx } if channel_idx != 0 => {
-                tracing::info!(channel_idx, "sub-channel triggered restart");
+                tracelimit::info_ratelimited!(channel_idx, "sub-channel triggered restart");
                 self.restart = true;
             }
             _ => self.handle_primary_message(msg, state).await,
@@ -4319,7 +4320,7 @@ impl Coordinator {
             }
             CoordinatorMessage::Restart { channel_idx } => {
                 assert_eq!(channel_idx, 0);
-                tracing::info!(channel_idx, "primary-channel triggered restart");
+                tracelimit::info_ratelimited!(channel_idx, "primary-channel triggered restart");
                 self.restart = true;
             }
         }
@@ -4862,6 +4863,8 @@ impl<T: RingMem + 'static> Worker<T> {
                         .coordinator_send
                         .try_send(CoordinatorMessage::Restart { channel_idx: 0 })
                     {
+                        // Coordinator channel was sized at `max_queues` capacity,
+                        // so `try_send` should not fail in practice.
                         tracelimit::error_ratelimited!(
                             error = &err as &dyn std::error::Error,
                             channel_idx = self.channel_idx,

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -203,7 +203,7 @@ impl<T: RingMem + 'static + Sync> InspectTaskMut<Worker<T>> for NetQueue {
                 worker.channel.can_use_ring_size_opt,
             );
 
-            if let WorkerState::Ready(state) = &worker.state {
+            if let Some(state) = worker.state.ready() {
                 resp.field(
                     "outstanding_tx_packets",
                     state.state.pending_tx_packets.len() - state.state.free_tx_packets.len(),
@@ -239,18 +239,16 @@ enum WorkerState {
 
 impl WorkerState {
     fn ready(&self) -> Option<&ReadyState> {
-        if let Self::Ready(state) = self {
-            Some(state)
-        } else {
-            None
+        match self {
+            Self::Ready(state) | Self::WaitingForCoordinator(Some(state)) => Some(state),
+            _ => None,
         }
     }
 
     fn ready_mut(&mut self) -> Option<&mut ReadyState> {
-        if let Self::Ready(state) = self {
-            Some(state)
-        } else {
-            None
+        match self {
+            Self::Ready(state) | Self::WaitingForCoordinator(Some(state)) => Some(state),
+            _ => None,
         }
     }
 }
@@ -1548,10 +1546,7 @@ impl Nic {
         driver_builder.run_on_target(!self.adapter.tx_fast_completions);
 
         #[expect(clippy::disallowed_methods)] // TODO
-        // Setting `capacity == number of workers` prevents `try_send` failure,
-        // as long as each worker (primary or sub-channel) holds at most one
-        // outstanding message.
-        let (send, recv) = mpsc::channel(self.adapter.max_queues as usize);
+        let (send, recv) = mpsc::channel(1);
         self.coordinator_send = Some(send);
         self.coordinator.insert(
             &self.adapter.driver,
@@ -4055,15 +4050,11 @@ impl Coordinator {
         state: &mut CoordinatorState,
     ) -> Result<(), task_control::Cancelled> {
         loop {
-            // Drain any messages already queued on `recv` to decide
-            // whether to run the restart cycle.
-            self.drain_pending_messages(state).await;
-
-            // Restart is set to true by either:
+            // `self.restart` is set in a prior iteration when either:
             // `CoordinatorMessage::Restart` from Primary or sub-channel worker.
-            // `EndpointAction::RestartRequired` in previous loop.
+            // `EndpointAction::RestartRequired`.
             if self.restart {
-                self.run_restart_cycle(stop, state).await?;
+                self.restart_worker_queues(stop, state).await?;
             }
 
             // Ensure that all workers except the primary are started. The
@@ -4191,23 +4182,8 @@ impl Coordinator {
                     }
                     self.sleep_deadline = None;
                 }
-                Message::UpdateFromEndpoint(EndpointAction::RestartRequired) => self.restart = true,
-                Message::UpdateFromEndpoint(EndpointAction::LinkStatusNotify(connect)) => {
-                    self.workers[0].stop().await;
-
-                    // These are the only link state transitions that are tracked.
-                    // 1. up -> down or down -> up
-                    // 2. up -> down -> up or down -> up -> down.
-                    // All other state transitions are coalesced into one of the above cases.
-                    // For example, up -> down -> up -> down is treated as up -> down.
-                    // N.B - Always queue up the incoming state to minimize the effects of loss
-                    //       of any notifications (for example, during vtl2 servicing).
-                    if let Some(primary) = self.primary_mut() {
-                        primary.pending_link_action = PendingLinkAction::Active(connect);
-                    }
-
-                    // If there is any existing sleep timer running, cancel it out.
-                    self.sleep_deadline = None;
+                Message::UpdateFromEndpoint(endpoint_action) => {
+                    self.handle_endpoint_action(endpoint_action).await;
                 }
                 Message::ChannelDisconnected => {
                     break;
@@ -4217,29 +4193,50 @@ impl Coordinator {
         Ok(())
     }
 
-    /// Called at the top of each iteration of [`Self::process`] loop.
-    /// Sub-channel restart requests are coalesced into `self.restart = true`.
-    /// Any Primary message landing concurrently with a `Restart` will be
-    /// handled prior to the worker restart.
-    async fn drain_pending_messages(&mut self, state: &mut CoordinatorState) {
-        while let Ok(Some(msg)) = self.recv.try_next() {
-            self.handle_coordinator_message(msg, state).await;
+    async fn handle_endpoint_action(&mut self, action: EndpointAction) {
+        match action {
+            EndpointAction::RestartRequired => self.restart = true,
+            EndpointAction::LinkStatusNotify(connect) => {
+                self.workers[0].stop().await;
+
+                // These are the only link state transitions that are tracked.
+                // 1. up -> down or down -> up
+                // 2. up -> down -> up or down -> up -> down.
+                // All other state transitions are coalesced into one of the above cases.
+                // For example, up -> down -> up -> down is treated as up -> down.
+                // N.B - Always queue up the incoming state to minimize the effects of loss
+                //       of any notifications (for example, during vtl2 servicing).
+                if let Some(primary) = self.primary_mut() {
+                    primary.pending_link_action = PendingLinkAction::Active(connect);
+                }
+
+                // If there is any existing sleep timer running, cancel it out.
+                self.sleep_deadline = None;
+            }
         }
     }
 
     /// Called from the [`Self::process`] loop when a `Restart` message has
     /// been observed from any channel.
-    async fn run_restart_cycle(
+    async fn restart_worker_queues(
         &mut self,
         stop: &mut StopTask<'_>,
         state: &mut CoordinatorState,
     ) -> Result<(), task_control::Cancelled> {
-        tracelimit::info_ratelimited!("beginning restart cycle");
         stop.until_stopped(self.stop_workers()).await?;
 
         // All workers are stopped and cannot push new messages.
         // Drain any messages that arrived prior to or during the stop.
-        self.drain_pending_messages(state).await;
+        // Coalesce restart messages. Handle non-restart Primary messages.
+        while let Ok(Some(msg)) = self.recv.try_next() {
+            self.handle_coordinator_message(msg, state).await;
+        }
+
+        // Handle any endpoint actions queued at this moment.
+        // Best-effort attempt to coalesce `RestartRequired` into this operation.
+        while let Some(action) = state.endpoint.wait_for_endpoint_action().now_or_never() {
+            self.handle_endpoint_action(action).await;
+        }
 
         // The queue restart operation is not restartable; do not poll on stop here.
         if let Err(err) = self
@@ -4321,7 +4318,6 @@ impl Coordinator {
             }
             CoordinatorMessage::Restart { channel_idx } => {
                 assert_eq!(channel_idx, 0);
-                tracelimit::info_ratelimited!(channel_idx, "primary-channel triggered restart");
                 self.restart = true;
             }
         }

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4232,6 +4232,7 @@ impl Coordinator {
         stop: &mut StopTask<'_>,
         state: &mut CoordinatorState,
     ) -> Result<(), task_control::Cancelled> {
+        tracing::info!("beginning restart cycle");
         stop.until_stopped(self.stop_workers()).await?;
 
         // All workers are stopped and cannot push new messages.
@@ -4857,9 +4858,16 @@ impl<T: RingMem + 'static> Worker<T> {
                     };
 
                     // Wake up the coordinator task to start the queues.
-                    let _ = self
+                    if let Err(err) = self
                         .coordinator_send
-                        .try_send(CoordinatorMessage::Restart { channel_idx: 0 });
+                        .try_send(CoordinatorMessage::Restart { channel_idx: 0 })
+                    {
+                        tracelimit::error_ratelimited!(
+                            error = &err as &dyn std::error::Error,
+                            channel_idx = self.channel_idx,
+                            "failed to send restart message to coordinator"
+                        );
+                    }
 
                     tracelimit::info_ratelimited!("network initialized");
                     self.state = WorkerState::WaitingForCoordinator(Some(state));

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -158,7 +158,8 @@ enum CoordinatorMessage {
     Update(CoordinatorMessageUpdateType),
     /// Restart endpoints and resume processing. This will also attempt to set VF and data path state to match current
     /// expectations.
-    Restart,
+    /// Identifies the channel that requested the restart. 0 = primary; >0 = sub-channel
+    Restart { channel_idx: u16 },
     /// Start a timer.
     StartTimer(Instant),
 }
@@ -1547,7 +1548,9 @@ impl Nic {
         driver_builder.run_on_target(!self.adapter.tx_fast_completions);
 
         #[expect(clippy::disallowed_methods)] // TODO
-        let (send, recv) = mpsc::channel(1);
+        // Capacity equals the number of workers.
+        // Each channel (primary or subchannel) can send at most one message.
+        let (send, recv) = mpsc::channel(self.adapter.max_queues as usize);
         self.coordinator_send = Some(send);
         self.coordinator.insert(
             &self.adapter.driver,
@@ -3065,7 +3068,7 @@ impl<T: RingMem> NetChannel<T> {
                         // Restart the endpoint if the OID changed some critical
                         // endpoint property.
                         if restart_endpoint {
-                            self.restart = Some(CoordinatorMessage::Restart);
+                            self.restart = Some(CoordinatorMessage::Restart { channel_idx: 0 });
                         }
                         if let Some(filter) = packet_filter {
                             if self.packet_filter != filter {
@@ -3267,7 +3270,7 @@ impl<T: RingMem> NetChannel<T> {
                 guest_vf_state: guest_vf,
                 filter_state: packet_filter,
             }));
-        } else if let Some(CoordinatorMessage::Restart) = self.restart {
+        } else if let Some(CoordinatorMessage::Restart { .. }) = self.restart {
             // If a restart message is pending, do nothing.
             // A restart will try to switch the data path based on primary.guest_vf_state.
             // A restart will apply packet filter changes.
@@ -4051,30 +4054,14 @@ impl Coordinator {
         state: &mut CoordinatorState,
     ) -> Result<(), task_control::Cancelled> {
         loop {
+            // Drain any messages already queued on `recv` to decide
+            // whether to run the restart cycle.
+            self.drain_pending_messages(state).await;
+
+            // If anything (primary, sub, or endpoint) requested a restart, do
+            // it. Then loop back to re-drain in case more messages arrived.
             if self.restart {
-                stop.until_stopped(self.stop_workers()).await?;
-                // The queue restart operation is not restartable, so do not
-                // poll on `stop` here.
-                if let Err(err) = self
-                    .restart_queues(state)
-                    .instrument(tracing::info_span!("netvsp_restart_queues"))
-                    .await
-                {
-                    tracing::error!(
-                        error = &err as &dyn std::error::Error,
-                        "failed to restart queues"
-                    );
-                }
-                if let Some(primary) = self.primary_mut() {
-                    primary.is_data_path_switched =
-                        state.endpoint.get_data_path_to_guest_vf().await.ok();
-                    tracing::info!(
-                        is_data_path_switched = primary.is_data_path_switched,
-                        "Query data path state"
-                    );
-                }
-                self.restore_guest_vf_state(state).await;
-                self.restart = false;
+                self.run_restart_cycle(stop, state).await?;
             }
 
             // Ensure that all workers except the primary are started. The
@@ -4228,7 +4215,78 @@ impl Coordinator {
         Ok(())
     }
 
+    /// Called at the top of each iteration of [`Self::process`] loop.
+    /// Coalesce Sub-channel restart requests into `self.restart = true`.
+    /// Any Primary message landing concurrently with a `Restart` is
+    /// handled prior to running the restart cycle.
+    async fn drain_pending_messages(&mut self, state: &mut CoordinatorState) {
+        while let Ok(Some(msg)) = self.recv.try_next() {
+            self.handle_coordinator_message(msg, state).await;
+        }
+    }
+
+    /// Called from the [`Self::process`] loop when a `Restart` message has
+    /// been observed from any channel.
+    async fn run_restart_cycle(
+        &mut self,
+        stop: &mut StopTask<'_>,
+        state: &mut CoordinatorState,
+    ) -> Result<(), task_control::Cancelled> {
+        stop.until_stopped(self.stop_workers()).await?;
+
+        // All workers are stopped and cannot push new messages.
+        // Drain any messages that arrived prior to the stop.
+        while let Ok(Some(msg)) = self.recv.try_next() {
+            match msg {
+                CoordinatorMessage::Restart { .. } => {
+                    // Discarding any additional Restart messages.
+                }
+                // Ensure any non-restart message from the Primary is
+                // handled prior to restarting the workers.
+                other => {
+                    self.handle_primary_message(other, state).await;
+                }
+            }
+        }
+
+        // The queue restart operation is not restartable; do not poll on stop here.
+        if let Err(err) = self
+            .restart_queues(state)
+            .instrument(tracing::info_span!("netvsp_restart_queues"))
+            .await
+        {
+            tracing::error!(
+                error = &err as &dyn std::error::Error,
+                "failed to restart queues"
+            );
+        }
+        if let Some(primary) = self.primary_mut() {
+            primary.is_data_path_switched = state.endpoint.get_data_path_to_guest_vf().await.ok();
+            tracing::info!(
+                is_data_path_switched = primary.is_data_path_switched,
+                "Query data path state"
+            );
+        }
+        self.restore_guest_vf_state(state).await;
+        self.restart = false;
+        Ok(())
+    }
+
     async fn handle_coordinator_message(
+        &mut self,
+        msg: CoordinatorMessage,
+        state: &mut CoordinatorState,
+    ) {
+        match msg {
+            CoordinatorMessage::Restart { channel_idx } if channel_idx != 0 => {
+                tracing::info!(channel_idx, "sub-channel triggered restart");
+                self.restart = true;
+            }
+            _ => self.handle_primary_message(msg, state).await,
+        }
+    }
+
+    async fn handle_primary_message(
         &mut self,
         msg: CoordinatorMessage,
         state: &mut CoordinatorState,
@@ -4269,7 +4327,11 @@ impl Coordinator {
             CoordinatorMessage::StartTimer(deadline) => {
                 self.sleep_deadline = Some(deadline);
             }
-            CoordinatorMessage::Restart => self.restart = true,
+            CoordinatorMessage::Restart { channel_idx } => {
+                assert_eq!(channel_idx, 0);
+                tracing::info!(channel_idx, "primary-channel triggered restart");
+                self.restart = true;
+            }
         }
     }
 
@@ -4806,7 +4868,9 @@ impl<T: RingMem + 'static> Worker<T> {
                     };
 
                     // Wake up the coordinator task to start the queues.
-                    let _ = self.coordinator_send.try_send(CoordinatorMessage::Restart);
+                    let _ = self
+                        .coordinator_send
+                        .try_send(CoordinatorMessage::Restart { channel_idx: 0 });
 
                     tracelimit::info_ratelimited!("network initialized");
                     self.state = WorkerState::WaitingForCoordinator(Some(state));
@@ -4846,23 +4910,30 @@ impl<T: RingMem + 'static> Worker<T> {
                         Err(WorkerError::EndpointRequiresQueueRestart(err)) => {
                             tracelimit::warn_ratelimited!(
                                 err = err.as_ref() as &dyn std::error::Error,
+                                channel_idx = self.channel_idx,
                                 "Endpoint requires queues to restart",
                             );
-                            CoordinatorMessage::Restart
+                            CoordinatorMessage::Restart {
+                                channel_idx: self.channel_idx,
+                            }
                         }
                         Err(err) => return Err(err),
                     };
 
-                    let WorkerState::Ready(ready) = std::mem::replace(
-                        &mut self.state,
-                        WorkerState::WaitingForCoordinator(None),
-                    ) else {
-                        unreachable!("must be running in ready state")
-                    };
-                    let _ = std::mem::replace(
-                        &mut self.state,
-                        WorkerState::WaitingForCoordinator(Some(ready)),
-                    );
+                    // Only the Primary channel transitions to `WaitingForCoordinator`.
+                    // Sub-channels stay in `Ready(_)`.
+                    if self.channel_idx == 0 {
+                        let WorkerState::Ready(ready) = std::mem::replace(
+                            &mut self.state,
+                            WorkerState::WaitingForCoordinator(None),
+                        ) else {
+                            unreachable!("must be running in ready state")
+                        };
+                        let _ = std::mem::replace(
+                            &mut self.state,
+                            WorkerState::WaitingForCoordinator(Some(ready)),
+                        );
+                    }
                     self.coordinator_send
                         .try_send(msg)
                         .map_err(WorkerError::CoordinatorMessageSendFailed)?;
@@ -5637,7 +5708,7 @@ impl<T: 'static + RingMem> NetChannel<T> {
                         let primary = state.primary.as_mut().unwrap();
                         primary.requested_num_queues = subchannel_count as u16 + 1;
                         primary.tx_spread_sent = false;
-                        self.restart = Some(CoordinatorMessage::Restart);
+                        self.restart = Some(CoordinatorMessage::Restart { channel_idx: 0 });
                     }
                 }
                 PacketData::RevokeReceiveBuffer(protocol::Message1RevokeReceiveBuffer { id })

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4236,18 +4236,7 @@ impl Coordinator {
 
         // All workers are stopped and cannot push new messages.
         // Drain any messages that arrived prior to the stop.
-        while let Ok(Some(msg)) = self.recv.try_next() {
-            match msg {
-                CoordinatorMessage::Restart { .. } => {
-                    // Discarding any additional Restart messages.
-                }
-                // Ensure any non-restart message from the Primary is
-                // handled prior to restarting the workers.
-                other => {
-                    self.handle_primary_message(other, state).await;
-                }
-            }
-        }
+        self.drain_pending_messages(state).await;
 
         // The queue restart operation is not restartable; do not poll on stop here.
         if let Err(err) = self

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4059,8 +4059,9 @@ impl Coordinator {
             // whether to run the restart cycle.
             self.drain_pending_messages(state).await;
 
-            // If anything (primary, sub, or endpoint) requested a restart, do
-            // it. Then loop back to re-drain in case more messages arrived.
+            // Restart is set to true by either:
+            // `CoordinatorMessage::Restart` from Primary or sub-channel worker.
+            // `EndpointAction::RestartRequired` in previous loop.
             if self.restart {
                 self.run_restart_cycle(stop, state).await?;
             }
@@ -4217,9 +4218,9 @@ impl Coordinator {
     }
 
     /// Called at the top of each iteration of [`Self::process`] loop.
-    /// Coalesce Sub-channel restart requests into `self.restart = true`.
-    /// Any Primary message landing concurrently with a `Restart` is
-    /// handled prior to running the restart cycle.
+    /// Sub-channel restart requests are coalesced into `self.restart = true`.
+    /// Any Primary message landing concurrently with a `Restart` will be
+    /// handled prior to the worker restart.
     async fn drain_pending_messages(&mut self, state: &mut CoordinatorState) {
         while let Ok(Some(msg)) = self.recv.try_next() {
             self.handle_coordinator_message(msg, state).await;
@@ -4237,7 +4238,7 @@ impl Coordinator {
         stop.until_stopped(self.stop_workers()).await?;
 
         // All workers are stopped and cannot push new messages.
-        // Drain any messages that arrived prior to the stop.
+        // Drain any messages that arrived prior to or during the stop.
         self.drain_pending_messages(state).await;
 
         // The queue restart operation is not restartable; do not poll on stop here.
@@ -4863,8 +4864,8 @@ impl<T: RingMem + 'static> Worker<T> {
                         .coordinator_send
                         .try_send(CoordinatorMessage::Restart { channel_idx: 0 })
                     {
-                        // Coordinator channel was sized at `max_queues` capacity,
-                        // so `try_send` should not fail in practice.
+                        // Coordinator channel is sized to `max_queues` capacity,
+                        // so `try_send` should not fail.
                         tracelimit::error_ratelimited!(
                             error = &err as &dyn std::error::Error,
                             channel_idx = self.channel_idx,

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4860,8 +4860,6 @@ impl<T: RingMem + 'static> Worker<T> {
                         .coordinator_send
                         .try_send(CoordinatorMessage::Restart { channel_idx: 0 })
                     {
-                        // Coordinator channel is sized to `max_queues` capacity,
-                        // so `try_send` should not fail.
                         tracelimit::error_ratelimited!(
                             error = &err as &dyn std::error::Error,
                             channel_idx = self.channel_idx,

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4277,7 +4277,11 @@ impl Coordinator {
     ) {
         match msg {
             CoordinatorMessage::Restart { channel_idx } if channel_idx != 0 => {
-                tracelimit::info_ratelimited!(channel_idx, "sub-channel triggered restart");
+                tracelimit::event_ratelimited!(
+                    tracing::Level::DEBUG,
+                    channel_idx,
+                    "sub-channel triggered restart"
+                );
                 self.restart = true;
             }
             _ => self.handle_primary_message(msg, state).await,

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4149,9 +4149,6 @@ impl Coordinator {
             };
             match message {
                 Message::Internal(msg) => {
-                    // `handle_coordinator_message` will stop the primary worker
-                    // only for primary messages; sub-channel `Restart` messages
-                    // do not require stopping any workers.
                     self.handle_coordinator_message(msg, state).await;
                     // If a restart message has been queued, handle it now
                     // to ensure worker queues are restarted prior to
@@ -4192,8 +4189,6 @@ impl Coordinator {
                     self.sleep_deadline = None;
                 }
                 Message::UpdateFromEndpoint(endpoint_action) => {
-                    // `handle_endpoint_action` will stop the primary worker for
-                    // `LinkStatusNotify` actions, but not for `RestartRequired`.
                     self.handle_endpoint_action(endpoint_action).await;
                 }
                 Message::ChannelDisconnected => {

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4148,7 +4148,9 @@ impl Coordinator {
             };
             match message {
                 Message::Internal(msg) => {
-                    self.stop_workers().await;
+                    // `handle_coordinator_message` will stop the primary worker
+                    // only for primary messages; sub-channel `Restart` messages
+                    // do not require stopping any workers.
                     self.handle_coordinator_message(msg, state).await;
                     // If a restart message has been queued, handle it now
                     // to ensure worker queues are restarted prior to
@@ -4156,14 +4158,14 @@ impl Coordinator {
                     self.handle_queued_coordinator_messages(state).await;
                 }
                 Message::UpdateFromVf(rpc) => {
-                    self.stop_workers().await;
+                    self.stop_primary_worker().await;
                     rpc.handle(async |_| {
                         self.update_guest_vf_state(state).await;
                     })
                     .await;
                 }
                 Message::OfferVfDevice => {
-                    self.stop_workers().await;
+                    self.stop_primary_worker().await;
                     if let Some(primary) = self.primary_mut() {
                         if matches!(
                             primary.guest_vf_state,
@@ -4176,12 +4178,12 @@ impl Coordinator {
                     state.pending_vf_state = CoordinatorStatePendingVfState::Pending;
                 }
                 Message::PendingVfStateComplete => {
-                    // Worker state unchanged, calling `stop_workers()` is not necessary.
+                    // Worker state unchanged, no worker needs to be stopped.
                     state.pending_vf_state = CoordinatorStatePendingVfState::Ready;
                 }
                 Message::TimerExpired => {
                     // Kick the worker as requested.
-                    self.stop_workers().await;
+                    self.stop_primary_worker().await;
                     if let Some(primary) = self.primary_mut() {
                         if let PendingLinkAction::Delay(up) = primary.pending_link_action {
                             primary.pending_link_action = PendingLinkAction::Active(up);
@@ -4190,6 +4192,8 @@ impl Coordinator {
                     self.sleep_deadline = None;
                 }
                 Message::UpdateFromEndpoint(endpoint_action) => {
+                    // `handle_endpoint_action` will stop the primary worker for
+                    // `LinkStatusNotify` actions, but not for `RestartRequired`.
                     self.handle_endpoint_action(endpoint_action).await;
                 }
                 Message::ChannelDisconnected => {
@@ -4204,7 +4208,7 @@ impl Coordinator {
         match action {
             EndpointAction::RestartRequired => self.restart = true,
             EndpointAction::LinkStatusNotify(connect) => {
-                self.stop_workers().await;
+                self.stop_primary_worker().await;
                 // These are the only link state transitions that are tracked.
                 // 1. up -> down or down -> up
                 // 2. up -> down -> up or down -> up -> down.
@@ -4290,7 +4294,7 @@ impl Coordinator {
         msg: CoordinatorMessage,
         state: &mut CoordinatorState,
     ) {
-        self.workers[0].stop().await;
+        self.stop_primary_worker().await;
         if let Some(worker) = self.workers[0].state_mut() {
             if matches!(worker.state, WorkerState::WaitingForCoordinator(_)) {
                 let WorkerState::WaitingForCoordinator(Some(ready)) =
@@ -4337,6 +4341,10 @@ impl Coordinator {
         for worker in &mut self.workers {
             worker.stop().await;
         }
+    }
+
+    async fn stop_primary_worker(&mut self) {
+        self.workers[0].stop().await;
     }
 
     async fn restore_guest_vf_state(&mut self, c_state: &mut CoordinatorState) {

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4050,9 +4050,10 @@ impl Coordinator {
         state: &mut CoordinatorState,
     ) -> Result<(), task_control::Cancelled> {
         loop {
-            // `self.restart` is set in a prior iteration when either:
+            // `self.restart` is set in a prior iteration when:
             // `CoordinatorMessage::Restart` from Primary or sub-channel worker.
             // `EndpointAction::RestartRequired`.
+            // Or in `insert_coordinator` when Restoring from saved state.
             if self.restart {
                 self.restart_worker_queues(stop, state).await?;
             }
@@ -4158,7 +4159,6 @@ impl Coordinator {
                     self.handle_queued_coordinator_messages(state).await;
                 }
                 Message::UpdateFromVf(rpc) => {
-                    self.stop_primary_worker().await;
                     rpc.handle(async |_| {
                         self.update_guest_vf_state(state).await;
                     })
@@ -4821,6 +4821,7 @@ impl Coordinator {
     }
 
     async fn update_guest_vf_state(&mut self, c_state: &mut CoordinatorState) {
+        self.stop_primary_worker().await;
         self.restore_guest_vf_state(c_state).await;
     }
 }

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -148,6 +148,9 @@ struct TestNicEndpointState {
     /// `(false, N)`, leaving packets in-flight.
     pub sync_tx: bool,
     pub tx_metadata: Vec<net_backend::TxMetadata>,
+    /// Per-queue one-shot trigger: when `tx_restart_triggers[idx]` is true,
+    /// the next `tx_poll` call on queue `idx` returns `TxError::TryRestart(_)`.
+    pub tx_restart_triggers: Vec<bool>,
 }
 
 impl TestNicEndpointState {
@@ -162,6 +165,7 @@ impl TestNicEndpointState {
             queues: Vec::new(),
             sync_tx: true,
             tx_metadata: Vec::new(),
+            tx_restart_triggers: Vec::new(),
         }))
     }
 
@@ -184,6 +188,15 @@ impl TestNicEndpointState {
     /// Send an RX packet on the given queue with explicit metadata.
     pub fn send_rx_with_metadata(&self, queue_idx: usize, data: Vec<u8>, metadata: RxMetadata) {
         self.queues[queue_idx].send((data, metadata));
+    }
+
+    /// Arm a one-shot trigger so the next `tx_poll` on `queue_idx` returns TryRestart.
+    pub fn trigger_tx_restart(&mut self, queue_idx: usize) {
+        assert!(
+            queue_idx < self.tx_restart_triggers.len(),
+            "trigger_tx_restart called before get_queues populated triggers"
+        );
+        self.tx_restart_triggers[queue_idx] = true;
     }
 }
 
@@ -260,13 +273,15 @@ impl net_backend::Endpoint for TestNicEndpoint {
             .is_none_or(|s| s.lock().sync_tx);
         let senders = config
             .into_iter()
-            .map(|config| {
+            .enumerate()
+            .map(|(queue_idx, config)| {
                 let (tx, rx) = mesh::channel();
                 queues.push(Box::new(TestNicQueue::new(
                     config,
                     rx,
                     sync_tx,
                     inner.endpoint_state.clone(),
+                    queue_idx,
                 )));
                 tx
             })
@@ -274,6 +289,7 @@ impl net_backend::Endpoint for TestNicEndpoint {
 
         if let Some(endpoint_state) = &inner.endpoint_state {
             let mut locked_data = endpoint_state.lock();
+            locked_data.tx_restart_triggers = vec![false; senders.len()];
             locked_data.queues = senders;
         }
         Ok(())
@@ -365,6 +381,7 @@ struct TestNicQueue {
     #[inspect(skip)]
     next_rx_packet: Option<(Vec<u8>, RxMetadata)>,
     sync_tx: bool,
+    queue_idx: usize,
 }
 
 impl TestNicQueue {
@@ -373,6 +390,7 @@ impl TestNicQueue {
         rx: mesh::Receiver<(Vec<u8>, RxMetadata)>,
         sync_tx: bool,
         endpoint_state: Option<Arc<parking_lot::Mutex<TestNicEndpointState>>>,
+        queue_idx: usize,
     ) -> Self {
         Self {
             rx_ids: VecDeque::new(),
@@ -380,6 +398,7 @@ impl TestNicQueue {
             endpoint_state,
             next_rx_packet: None,
             sync_tx,
+            queue_idx,
         }
     }
 }
@@ -471,6 +490,21 @@ impl NetQueue for TestNicQueue {
         _pool: &mut dyn BufferAccess,
         _done: &mut [TxId],
     ) -> Result<usize, TxError> {
+        if let Some(endpoint_state) = &self.endpoint_state {
+            let mut locked = endpoint_state.lock();
+            if locked
+                .tx_restart_triggers
+                .get(self.queue_idx)
+                .copied()
+                .unwrap_or(false)
+            {
+                locked.tx_restart_triggers[self.queue_idx] = false;
+                return Err(TxError::TryRestart(anyhow::anyhow!(
+                    "test-injected tx_poll restart on queue {}",
+                    self.queue_idx
+                )));
+            }
+        }
         Ok(0)
     }
 }
@@ -7409,4 +7443,237 @@ async fn vlan_rx_counter_increments(driver: DefaultDriver) {
         1,
         "netvsp should count 1 VLAN RX packet"
     );
+}
+
+#[async_test]
+async fn subchannel_tx_restart(driver: DefaultDriver) {
+    const TOTAL_QUEUES: u32 = 4;
+    let endpoint_state = TestNicEndpointState::new();
+    let endpoint = TestNicEndpoint::new(Some(endpoint_state.clone()));
+    let nic = Nic::builder().build(
+        &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
+        Guid::new_random(),
+        Box::new(endpoint),
+        [1, 2, 3, 4, 5, 6].into(),
+        0,
+    );
+
+    let mut nic = TestNicDevice::new_with_nic(&driver, nic).await;
+    nic.start_vmbus_channel();
+    let mut channel = nic.connect_vmbus_channel().await;
+    channel
+        .initialize(
+            TOTAL_QUEUES as usize - 1,
+            protocol::NdisConfigCapabilities::new(),
+        )
+        .await;
+
+    // RNDIS initialize.
+    channel
+        .send_rndis_control_message(
+            rndisprot::MESSAGE_TYPE_INITIALIZE_MSG,
+            rndisprot::InitializeRequest {
+                request_id: 1,
+                major_version: rndisprot::MAJOR_VERSION,
+                minor_version: rndisprot::MINOR_VERSION,
+                max_transfer_size: 0,
+            },
+            &[],
+        )
+        .await;
+    let _: rndisprot::InitializeComplete = channel
+        .read_rndis_control_message(rndisprot::MESSAGE_TYPE_INITIALIZE_CMPLT)
+        .await
+        .unwrap();
+
+    // Allocate the sub-channels.
+    let alloc_message = NvspMessage {
+        header: protocol::MessageHeader {
+            message_type: protocol::MESSAGE5_TYPE_SUB_CHANNEL,
+        },
+        data: protocol::Message5SubchannelRequest {
+            operation: protocol::SubchannelOperation::ALLOCATE,
+            num_sub_channels: TOTAL_QUEUES - 1,
+        },
+        padding: &[],
+    };
+    channel
+        .write(OutgoingPacket {
+            transaction_id: 123,
+            packet_type: OutgoingPacketType::InBandWithCompletion,
+            payload: &alloc_message.payload(),
+        })
+        .await;
+    channel
+        .read_with(|packet| match packet {
+            IncomingPacket::Completion(completion) => {
+                let mut reader = completion.reader();
+                let header: protocol::MessageHeader = reader.read_plain().unwrap();
+                assert_eq!(header.message_type, protocol::MESSAGE5_TYPE_SUB_CHANNEL);
+                let completion_data: protocol::Message5SubchannelComplete =
+                    reader.read_plain().unwrap();
+                assert_eq!(completion_data.status, protocol::Status::SUCCESS);
+                assert_eq!(completion_data.num_sub_channels, TOTAL_QUEUES - 1);
+            }
+            _ => panic!("Unexpected packet"),
+        })
+        .await
+        .expect("sub-channel allocation completion");
+
+    for idx in 1..TOTAL_QUEUES {
+        channel.connect_subchannel(idx).await;
+    }
+
+    // Drain the indirection-table data packet from the primary and complete it.
+    let transaction_id = channel
+        .read_with(|packet| match packet {
+            IncomingPacket::Data(packet) => {
+                let mut reader = packet.reader();
+                let header: protocol::MessageHeader = reader.read_plain().unwrap();
+                assert_eq!(
+                    header.message_type,
+                    protocol::MESSAGE5_TYPE_SEND_INDIRECTION_TABLE
+                );
+                packet.transaction_id()
+            }
+            _ => panic!("Unexpected packet"),
+        })
+        .await
+        .expect("indirection table message");
+    if let Some(transaction_id) = transaction_id {
+        channel
+            .write(OutgoingPacket {
+                transaction_id,
+                packet_type: OutgoingPacketType::Completion,
+                payload: &NvspMessage {
+                    header: protocol::MessageHeader {
+                        message_type: protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET_COMPLETE,
+                    },
+                    data: protocol::Message1SendRndisPacketComplete {
+                        status: protocol::Status::SUCCESS,
+                    },
+                    padding: &[],
+                }
+                .payload(),
+            })
+            .await;
+    }
+
+    // Enable a packet filter so RX traffic is delivered to the guest.
+    let request_id = 456;
+    channel
+        .send_rndis_control_message(
+            rndisprot::MESSAGE_TYPE_SET_MSG,
+            rndisprot::SetRequest {
+                request_id,
+                oid: rndisprot::Oid::OID_GEN_CURRENT_PACKET_FILTER,
+                information_buffer_length: size_of::<u32>() as u32,
+                information_buffer_offset: size_of::<rndisprot::SetRequest>() as u32,
+                device_vc_handle: 0,
+            },
+            &rndisprot::NPROTO_PACKET_FILTER.to_le_bytes(),
+        )
+        .await;
+    let set_complete: rndisprot::SetComplete = channel
+        .read_rndis_control_message(rndisprot::MESSAGE_TYPE_SET_CMPLT)
+        .await
+        .unwrap();
+    assert_eq!(set_complete.request_id, request_id);
+    assert_eq!(set_complete.status, rndisprot::STATUS_SUCCESS);
+
+    // Send a SECOND OID_GEN_CURRENT_PACKET_FILTER SET with a different
+    // filter value. The primary worker handles this OID inline, then pushes
+    // a `CoordinatorMessage::Update` to the coordinator.
+    const NEW_FILTER: u32 = rndisprot::NDIS_PACKET_TYPE_DIRECTED;
+    let request_id_filter_change = 457;
+    channel
+        .send_rndis_control_message(
+            rndisprot::MESSAGE_TYPE_SET_MSG,
+            rndisprot::SetRequest {
+                request_id: request_id_filter_change,
+                oid: rndisprot::Oid::OID_GEN_CURRENT_PACKET_FILTER,
+                information_buffer_length: size_of::<u32>() as u32,
+                information_buffer_offset: size_of::<rndisprot::SetRequest>() as u32,
+                device_vc_handle: 0,
+            },
+            &NEW_FILTER.to_le_bytes(),
+        )
+        .await;
+    let set_complete: rndisprot::SetComplete = channel
+        .read_rndis_control_message(rndisprot::MESSAGE_TYPE_SET_CMPLT)
+        .await
+        .unwrap();
+    assert_eq!(set_complete.request_id, request_id_filter_change);
+    assert_eq!(set_complete.status, rndisprot::STATUS_SUCCESS);
+
+    let stop_before = endpoint_state.lock().stop_endpoint_counter;
+
+    // Arm a one-shot TryRestart on every sub-channel queue and wake each
+    // one by routing an RX packet through it. Each sub-channel's main_loop
+    // will call tx_poll, hit TryRestart, and route a Restart to the coordinator.
+    {
+        let mut locked = endpoint_state.lock();
+        for idx in 1..TOTAL_QUEUES as usize {
+            locked.trigger_tx_restart(idx);
+            locked.send_rx(idx, vec![0xAA + idx as u8; 60]);
+        }
+    }
+
+    // Wait for the coordinator to observe at least one Restart message and
+    // run restart_queues (which calls endpoint.stop()).
+    // All three `Restart` messages coalesce into a single restart cycle.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if endpoint_state.lock().stop_endpoint_counter > stop_before {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "restart_queues did not run within timeout (stop_before={}, current={})",
+                stop_before,
+                endpoint_state.lock().stop_endpoint_counter
+            );
+        }
+        // Yield to let the workers and coordinator make progress.
+        let mut ctx = mesh::CancelContext::new().with_timeout(Duration::from_millis(50));
+        let _ = ctx.until_cancelled(pending::<()>()).await;
+    }
+
+    // Bound the number of restart cycles.
+    let stop_after = endpoint_state.lock().stop_endpoint_counter;
+    let cycles = stop_after - stop_before;
+    assert_eq!(
+        cycles, 1,
+        "expected exactly 1 restart cycle (pass B coalesces all in-flight sub-channel TryRestarts), got {cycles}",
+    );
+
+    // The `Update` filter change being visible on every sub-channel proves
+    // the Primary channel message was not lost.
+    for idx in 1..TOTAL_QUEUES as usize {
+        let current =
+            read_netvsp_counter(&channel.nic.channel, &format!("queues/{idx}/packet_filter")).await
+                as u32;
+        assert_eq!(
+            current, NEW_FILTER,
+            "sub-channel {idx} packet_filter not propagated before restart cycle finished",
+        );
+    }
+
+    // Deliver another RX packet on every sub-channel and verify each worker
+    // is alive and functional.
+    {
+        let locked = endpoint_state.lock();
+        for idx in 1..TOTAL_QUEUES as usize {
+            locked.send_rx(idx, vec![0xBB + idx as u8; 60]);
+        }
+    }
+    for idx in 1..TOTAL_QUEUES {
+        channel
+            .read_subchannel_with(idx, |packet| match packet {
+                IncomingPacket::Data(_) => (),
+                _ => panic!("Unexpected packet on sub-channel {idx}"),
+            })
+            .await
+            .unwrap_or_else(|_| panic!("sub-channel {idx} RX packet after restart cycle"));
+    }
 }

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -16,6 +16,7 @@ use futures::Future;
 use futures::FutureExt;
 use futures::StreamExt;
 use futures::TryFutureExt;
+use futures_concurrency::future::Race;
 use guestmem::MemoryRead;
 use guestmem::MemoryWrite;
 use guestmem::ranges::PagedRanges;
@@ -151,6 +152,9 @@ struct TestNicEndpointState {
     /// Per-queue one-shot trigger: when `tx_restart_triggers[idx]` is true,
     /// the next `tx_poll` call on queue `idx` returns `TxError::TryRestart(_)`.
     pub tx_restart_triggers: Vec<bool>,
+    /// Sender for injecting arbitrary `EndpointAction`s into the endpoint's
+    /// `wait_for_endpoint_action` path. Populated by `TestNicEndpoint::new`.
+    pub endpoint_action_updater: Option<mesh::Sender<EndpointAction>>,
 }
 
 impl TestNicEndpointState {
@@ -166,6 +170,7 @@ impl TestNicEndpointState {
             sync_tx: true,
             tx_metadata: Vec::new(),
             tx_restart_triggers: Vec::new(),
+            endpoint_action_updater: None,
         }))
     }
 
@@ -217,14 +222,17 @@ struct TestNicEndpoint {
     multiqueue_support: MultiQueueSupport,
     link_status_rx: mesh::Receiver<VecDeque<bool>>,
     pending_link_status_updates: VecDeque<bool>,
+    endpoint_action_rx: mesh::Receiver<EndpointAction>,
 }
 
 impl TestNicEndpoint {
     pub fn new(endpoint_state: Option<Arc<parking_lot::Mutex<TestNicEndpointState>>>) -> Self {
         let (link_status_tx, link_status_rx) = mesh::channel();
+        let (endpoint_action_tx, endpoint_action_rx) = mesh::channel();
         if let Some(endpoint_state) = endpoint_state.as_ref() {
             let mut locked_state = endpoint_state.lock();
             locked_state.link_status_updater = Some(link_status_tx);
+            locked_state.endpoint_action_updater = Some(endpoint_action_tx);
         }
         let inner = TestNicEndpointInner::new(endpoint_state);
         let tx_offload_support = TxOffloadSupport {
@@ -245,6 +253,7 @@ impl TestNicEndpoint {
             multiqueue_support,
             link_status_rx,
             pending_link_status_updates: VecDeque::new(),
+            endpoint_action_rx,
         }
     }
 }
@@ -362,11 +371,17 @@ impl net_backend::Endpoint for TestNicEndpoint {
     }
 
     async fn wait_for_endpoint_action(&mut self) -> EndpointAction {
-        if self.pending_link_status_updates.is_empty() {
-            self.pending_link_status_updates
-                .append(&mut self.link_status_rx.select_next_some().await);
-        }
-        EndpointAction::LinkStatusNotify(self.pending_link_status_updates.pop_front().unwrap())
+        let pending = &mut self.pending_link_status_updates;
+        let link_rx = &mut self.link_status_rx;
+        let action_rx = &mut self.endpoint_action_rx;
+        let link = async {
+            if pending.is_empty() {
+                pending.append(&mut link_rx.select_next_some().await);
+            }
+            EndpointAction::LinkStatusNotify(pending.pop_front().unwrap())
+        };
+        let action = action_rx.select_next_some();
+        (link, action).race().await
     }
 }
 
@@ -7611,12 +7626,20 @@ async fn subchannel_tx_restart(driver: DefaultDriver) {
     // Arm a one-shot TryRestart on every sub-channel queue and wake each
     // one by routing an RX packet through it. Each sub-channel's main_loop
     // will call tx_poll, hit TryRestart, and route a Restart to the coordinator.
+    // Additionally inject an `EndpointAction::RestartRequired` so the
+    // coordinator races sub-channel `Restart` messages against an endpoint
+    // restart request - both must coalesce into a single `restart_queues` call.
     {
         let mut locked = endpoint_state.lock();
         for idx in 1..TOTAL_QUEUES as usize {
             locked.trigger_tx_restart(idx);
             locked.send_rx(idx, vec![0xAA + idx as u8; 60]);
         }
+        locked
+            .endpoint_action_updater
+            .as_ref()
+            .expect("endpoint_action_updater populated by TestNicEndpoint::new")
+            .send(EndpointAction::RestartRequired);
     }
 
     // Wait for the coordinator to observe at least one Restart message and
@@ -7644,7 +7667,7 @@ async fn subchannel_tx_restart(driver: DefaultDriver) {
     let cycles = stop_after - stop_before;
     assert_eq!(
         cycles, 1,
-        "expected exactly 1 restart cycle (pass B coalesces all in-flight sub-channel TryRestarts), got {cycles}",
+        "expected exactly 1 restart cycle (coordinator coalesces all in-flight sub-channel TryRestarts and the injected EndpointAction::RestartRequired into a single restart_queues call), got {cycles}",
     );
 
     // The `Update` filter change being visible on every sub-channel proves

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -7596,13 +7596,12 @@ async fn subchannel_tx_restart(driver: DefaultDriver) {
     assert_eq!(set_complete.request_id, request_id);
     assert_eq!(set_complete.status, rndisprot::STATUS_SUCCESS);
 
-    // Send a SECOND OID_GEN_CURRENT_PACKET_FILTER SET with a different
-    // filter value. The primary worker handles this OID inline, then pushes
-    // a `CoordinatorMessage::Update` to the coordinator.
+    // Queue a filter-change SET without awaiting its completion.
+    // The primary worker sends `CoordinatorMessage::Update`.
     const NEW_FILTER: u32 = rndisprot::NDIS_PACKET_TYPE_DIRECTED;
     let request_id_filter_change = 457;
     channel
-        .send_rndis_control_message(
+        .send_rndis_control_message_no_completion(
             rndisprot::MESSAGE_TYPE_SET_MSG,
             rndisprot::SetRequest {
                 request_id: request_id_filter_change,
@@ -7614,27 +7613,19 @@ async fn subchannel_tx_restart(driver: DefaultDriver) {
             &NEW_FILTER.to_le_bytes(),
         )
         .await;
-    let set_complete: rndisprot::SetComplete = channel
-        .read_rndis_control_message(rndisprot::MESSAGE_TYPE_SET_CMPLT)
-        .await
-        .unwrap();
-    assert_eq!(set_complete.request_id, request_id_filter_change);
-    assert_eq!(set_complete.status, rndisprot::STATUS_SUCCESS);
 
     let stop_before = endpoint_state.lock().stop_endpoint_counter;
 
-    // Arm a one-shot TryRestart on every sub-channel queue and wake each
-    // one by routing an RX packet through it. Each sub-channel's main_loop
-    // will call tx_poll, hit TryRestart, and route a Restart to the coordinator.
-    // Additionally inject an `EndpointAction::RestartRequired` so the
-    // coordinator races sub-channel `Restart` messages against an endpoint
-    // restart request - both must coalesce into a single `restart_queues` call.
     {
+        // Arm a one-shot TryRestart on every sub-channel queue and wake each
+        // one by routing an RX packet through it.
+        // Each sub-channel sends `CoordinatorMessage::Restart`.
         let mut locked = endpoint_state.lock();
         for idx in 1..TOTAL_QUEUES as usize {
             locked.trigger_tx_restart(idx);
             locked.send_rx(idx, vec![0xAA + idx as u8; 60]);
         }
+        // Additionally inject an `EndpointAction::RestartRequired`.
         locked
             .endpoint_action_updater
             .as_ref()
@@ -7642,9 +7633,33 @@ async fn subchannel_tx_restart(driver: DefaultDriver) {
             .send(EndpointAction::RestartRequired);
     }
 
-    // Wait for the coordinator to observe at least one Restart message and
+    // Drain primary-channel packets until we observe the SET_CMPLT for the
+    // filter change.
+    let parser = channel.rndis_message_parser();
+    let mut received_set_complete = false;
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !received_set_complete {
+        if std::time::Instant::now() >= deadline {
+            panic!("timeout waiting for SET_CMPLT for filter change");
+        }
+        channel
+            .read_with_timeout(Duration::from_secs(1), |packet| match packet {
+                IncomingPacket::Completion(_) => {}
+                IncomingPacket::Data(data) => {
+                    let (rndis_header, external_ranges) = parser.parse_control_message(data);
+                    assert_eq!(rndis_header.message_type, rndisprot::MESSAGE_TYPE_SET_CMPLT);
+                    let set_complete: rndisprot::SetComplete = parser.get(&external_ranges);
+                    assert_eq!(set_complete.request_id, request_id_filter_change);
+                    assert_eq!(set_complete.status, rndisprot::STATUS_SUCCESS);
+                    received_set_complete = true;
+                }
+            })
+            .await
+            .expect("packet from primary channel during racing phase");
+    }
+
+    // Wait for the coordinator to observe at least one Restart-trigger and
     // run restart_queues (which calls endpoint.stop()).
-    // All three `Restart` messages coalesce into a single restart cycle.
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
     loop {
         if endpoint_state.lock().stop_endpoint_counter > stop_before {
@@ -7662,28 +7677,35 @@ async fn subchannel_tx_restart(driver: DefaultDriver) {
         let _ = ctx.until_cancelled(pending::<()>()).await;
     }
 
-    // Bound the number of restart cycles.
+    // The coordinator must coalesce restarts into one cycle.
     let stop_after = endpoint_state.lock().stop_endpoint_counter;
     let cycles = stop_after - stop_before;
-    assert_eq!(
-        cycles, 1,
-        "expected exactly 1 restart cycle (coordinator coalesces all in-flight sub-channel TryRestarts and the injected EndpointAction::RestartRequired into a single restart_queues call), got {cycles}",
-    );
+    assert_eq!(cycles, 1, "expected exactly 1 restart cycle, got {cycles}");
 
-    // The `Update` filter change being visible on every sub-channel proves
-    // the Primary channel message was not lost.
-    for idx in 1..TOTAL_QUEUES as usize {
-        let current =
-            read_netvsp_counter(&channel.nic.channel, &format!("queues/{idx}/packet_filter")).await
-                as u32;
-        assert_eq!(
-            current, NEW_FILTER,
-            "sub-channel {idx} packet_filter not propagated before restart cycle finished",
-        );
+    // Poll the packet-filter counter on every sub-channel until it
+    // converges to NEW_FILTER.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let mut all_match = true;
+        for idx in 1..TOTAL_QUEUES as usize {
+            let current =
+                read_netvsp_counter(&channel.nic.channel, &format!("queues/{idx}/packet_filter"))
+                    .await as u32;
+            if current != NEW_FILTER {
+                all_match = false;
+                break;
+            }
+        }
+        if all_match {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("packet filter did not update on all sub-channels");
+        }
     }
 
     // Deliver another RX packet on every sub-channel and verify each worker
-    // is alive and functional.
+    // is alive and functional after the restart cycle.
     {
         let locked = endpoint_state.lock();
         for idx in 1..TOTAL_QUEUES as usize {


### PR DESCRIPTION
When the MANA backend returns a `CQE_TX_GDMA_ERR` on a sub-channel, a TxError::TryRestart is returned causing the sub-channel's worker process to transition from `Ready → WaitingForCoordinator`. This is the same transition used by the primary worker process. However the `WaitingForCoordinator` logic has a hardcoded assertion `assert_eq!(self.channel_idx, 0)` that causes netvsp to crash. Netvsp needs to be robust to the `CQE_TX_GDMA_ERR` arriving on a sub-channel, as well as multiple sub-channels simultaneously.

Repro Steps: Traffic leaving Guest on synthetic datapath, Guest has multiple sub-channels, CQE_TX_GDMA_ERR returned from the backend, but on a sub-channel and not the primary.

- `CoordinatorMessage::Restart` now contains `channel_idx` so we can differentiate primary or sub.
- Multiple sub-channel restarts coalesce.
- Sub-channel workers stay in Ready, and do not enter `WaitingForCoordinator`.
- Coordinator message channel capacity increased to `max_queues` so signals from Sub-channels don't prevent or over-write an important message from the Primary. (Each worker can have at most one in-flight message at a time.)
- Coordinator loop restructured to drain messages prior to restarting.
  - Any Primary `Update` or `StartTimer` messages are handled prior to its worker being restarted.
- Added unit test to show multiple messages are handled without panics.