### PR TITLE
pit: status and count and active-low in read-back command

### DIFF
--- a/vm/devices/chipset/src/pit/mod.rs
+++ b/vm/devices/chipset/src/pit/mod.rs
@@ -658,10 +658,10 @@ impl PortIoIntercept for PitDevice {
                                 .enumerate()
                         {
                             if select {
-                                if command.status() {
+                                if !command.status() {
                                     self.timers[i].state.latch_status();
                                 }
-                                if command.count() {
+                                if !command.count() {
                                     self.timers[i].state.latch_counter();
                                 }
                             }


### PR DESCRIPTION
This can be found on page 8 of the spec. A copy of which is available at this address:
https://www.scs.stanford.edu/10wi-cs140/pintos/specs/8254.pdf

qemu emulates this properly:
https://github.com/qemu/qemu/blob/6e9a825c1d4e7b62d072e99a89ecd1a74c7f0d55/hw/timer/i8254.c#L144