### PR TITLE
crypto: Move some functions behind a test feature

### DIFF
--- a/openhcl/underhill_attestation/Cargo.toml
+++ b/openhcl/underhill_attestation/Cargo.toml
@@ -30,6 +30,7 @@ thiserror.workspace = true
 zerocopy.workspace = true
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
+crypto = { workspace = true, features = ["test_helpers"] }
 disklayer_ram.workspace = true
 disk_backend.workspace = true
 vmgs = { workspace = true, features = ["encryption", "test_helpers"] }

--- a/support/crypto/Cargo.toml
+++ b/support/crypto/Cargo.toml
@@ -86,6 +86,7 @@ openssl.workspace = true
 
 [dev-dependencies]
 hex.workspace = true
+x509-cert = { workspace = true, features = ["builder"] }
 
 [lints]
 workspace = true

--- a/support/crypto/Cargo.toml
+++ b/support/crypto/Cargo.toml
@@ -7,6 +7,9 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
+# Enable test-only helper functions.
+test_helpers = ["x509-cert?/builder"]
+
 # If the chosen backend supports it, vendor it.
 # If the chosen backend is natively available, this feature is a no-op.
 # If the chosen backend is not natively available and can't be vendored, this will trigger a compile error.
@@ -62,7 +65,7 @@ rsa = { workspace = true, optional = true, features = ["encoding", "sha2"] }
 sha1 = { workspace = true, optional = true, features = ["oid"] }
 sha2 = { workspace = true, optional = true }
 signature = { workspace = true, optional = true, features = ["alloc"] }
-x509-cert = { workspace = true, optional = true, features = ["builder"] }
+x509-cert = { workspace = true, optional = true }
 
 anyhow.workspace = true
 thiserror.workspace = true

--- a/support/crypto/src/rsa/mod.rs
+++ b/support/crypto/src/rsa/mod.rs
@@ -45,7 +45,6 @@ pub struct RsaError(
 pub struct RsaKeyPair(pub(crate) sys::RsaKeyPairInner);
 
 impl RsaKeyPair {
-    #[cfg(any(test, feature = "test_helpers"))]
     /// Generate a new RSA key pair with the given bit size.
     pub fn generate(bits: u32) -> Result<Self, RsaError> {
         sys::RsaKeyPairInner::generate(bits).map(Self)

--- a/support/crypto/src/rsa/mod.rs
+++ b/support/crypto/src/rsa/mod.rs
@@ -45,6 +45,7 @@ pub struct RsaError(
 pub struct RsaKeyPair(pub(crate) sys::RsaKeyPairInner);
 
 impl RsaKeyPair {
+    #[cfg(any(test, feature = "test_helpers"))]
     /// Generate a new RSA key pair with the given bit size.
     pub fn generate(bits: u32) -> Result<Self, RsaError> {
         sys::RsaKeyPairInner::generate(bits).map(Self)
@@ -55,6 +56,7 @@ impl RsaKeyPair {
         sys::RsaKeyPairInner::from_pkcs8_der(der).map(Self)
     }
 
+    #[cfg(any(test, feature = "test_helpers"))]
     /// Convert the RSA private key to PKCS#8 DER-encoded bytes.
     pub fn to_pkcs8_der(&self) -> Result<Vec<u8>, RsaError> {
         self.0.to_pkcs8_der()

--- a/support/crypto/src/rsa/ossl.rs
+++ b/support/crypto/src/rsa/ossl.rs
@@ -14,6 +14,7 @@ fn err(err: openssl::error::ErrorStack, op: &'static str) -> RsaError {
 pub struct RsaKeyPairInner(pub(crate) openssl::pkey::PKey<openssl::pkey::Private>);
 
 impl RsaKeyPairInner {
+    #[cfg(any(test, feature = "test_helpers"))]
     pub fn generate(bits: u32) -> Result<Self, RsaError> {
         let rsa = openssl::rsa::Rsa::generate(bits).map_err(|e| err(e, "generating RSA key"))?;
         let pkey =
@@ -29,6 +30,7 @@ impl RsaKeyPairInner {
         Ok(Self(pkey))
     }
 
+    #[cfg(any(test, feature = "test_helpers"))]
     pub fn to_pkcs8_der(&self) -> Result<Vec<u8>, RsaError> {
         self.0
             .private_key_to_pkcs8()

--- a/support/crypto/src/rsa/ossl.rs
+++ b/support/crypto/src/rsa/ossl.rs
@@ -14,7 +14,6 @@ fn err(err: openssl::error::ErrorStack, op: &'static str) -> RsaError {
 pub struct RsaKeyPairInner(pub(crate) openssl::pkey::PKey<openssl::pkey::Private>);
 
 impl RsaKeyPairInner {
-    #[cfg(any(test, feature = "test_helpers"))]
     pub fn generate(bits: u32) -> Result<Self, RsaError> {
         let rsa = openssl::rsa::Rsa::generate(bits).map_err(|e| err(e, "generating RSA key"))?;
         let pkey =

--- a/support/crypto/src/rsa/rust.rs
+++ b/support/crypto/src/rsa/rust.rs
@@ -9,7 +9,6 @@ use super::RsaError;
 use crate::HashAlgorithm;
 use getrandom::SysRng;
 use pkcs8::DecodePrivateKey;
-use pkcs8::EncodePrivateKey;
 use rsa::Oaep;
 use rsa::Pkcs1v15Sign;
 use rsa::RsaPrivateKey;
@@ -26,6 +25,7 @@ const fn rng() -> impl rand_core::CryptoRng {
 pub struct RsaKeyPairInner(pub(crate) RsaPrivateKey);
 
 impl RsaKeyPairInner {
+    #[cfg(any(test, feature = "test_helpers"))]
     pub fn generate(bits: u32) -> Result<Self, RsaError> {
         let rsa = RsaPrivateKey::new(&mut rng(), bits as usize)
             .map_err(|e| RsaError(e, "generating RSA key"))?;
@@ -38,7 +38,9 @@ impl RsaKeyPairInner {
         Ok(Self(parsed))
     }
 
+    #[cfg(any(test, feature = "test_helpers"))]
     pub fn to_pkcs8_der(&self) -> Result<Vec<u8>, RsaError> {
+        use pkcs8::EncodePrivateKey;
         Ok(self
             .0
             .to_pkcs8_der()

--- a/support/crypto/src/rsa/rust.rs
+++ b/support/crypto/src/rsa/rust.rs
@@ -25,7 +25,6 @@ const fn rng() -> impl rand_core::CryptoRng {
 pub struct RsaKeyPairInner(pub(crate) RsaPrivateKey);
 
 impl RsaKeyPairInner {
-    #[cfg(any(test, feature = "test_helpers"))]
     pub fn generate(bits: u32) -> Result<Self, RsaError> {
         let rsa = RsaPrivateKey::new(&mut rng(), bits as usize)
             .map_err(|e| RsaError(e, "generating RSA key"))?;

--- a/support/crypto/src/rsa/symcrypt.rs
+++ b/support/crypto/src/rsa/symcrypt.rs
@@ -20,7 +20,6 @@ fn der_err(e: der::Error, op: &'static str) -> RsaError {
 pub struct RsaKeyPairInner(pub(crate) RsaKey);
 
 impl RsaKeyPairInner {
-    #[cfg(any(test, feature = "test_helpers"))]
     pub fn generate(bits: u32) -> Result<Self, RsaError> {
         let rsa = RsaKey::generate_key_pair(bits, None, RsaKeyUsage::SignAndEncrypt)
             .map_err(|e| err(e, "generating RSA key"))?;

--- a/support/crypto/src/rsa/symcrypt.rs
+++ b/support/crypto/src/rsa/symcrypt.rs
@@ -5,12 +5,8 @@
 
 use super::RsaError;
 use der::Decode;
-use der::Encode;
-use der::asn1::OctetString;
-use der::asn1::UintRef;
 use symcrypt::rsa::RsaKey;
 use symcrypt::rsa::RsaKeyUsage;
-use x509_cert::spki::AlgorithmIdentifierOwned;
 
 fn err(err: symcrypt::errors::SymCryptError, op: &'static str) -> RsaError {
     RsaError(crate::BackendError::SymCrypt(err, op))
@@ -24,6 +20,7 @@ fn der_err(e: der::Error, op: &'static str) -> RsaError {
 pub struct RsaKeyPairInner(pub(crate) RsaKey);
 
 impl RsaKeyPairInner {
+    #[cfg(any(test, feature = "test_helpers"))]
     pub fn generate(bits: u32) -> Result<Self, RsaError> {
         let rsa = RsaKey::generate_key_pair(bits, None, RsaKeyUsage::SignAndEncrypt)
             .map_err(|e| err(e, "generating RSA key"))?;
@@ -58,7 +55,13 @@ impl RsaKeyPairInner {
         Ok(Self(rsa))
     }
 
+    #[cfg(any(test, feature = "test_helpers"))]
     pub fn to_pkcs8_der(&self) -> Result<Vec<u8>, RsaError> {
+        use der::Encode;
+        use der::asn1::OctetString;
+        use der::asn1::UintRef;
+        use x509_cert::spki::AlgorithmIdentifierOwned;
+
         let blob = self
             .0
             .export_key_pair_blob()

--- a/support/crypto/src/x509/mod.rs
+++ b/support/crypto/src/x509/mod.rs
@@ -64,11 +64,13 @@ impl X509Certificate {
         self.0.issued(&subject.0)
     }
 
+    #[cfg(any(test, feature = "test_helpers"))]
     /// Encode this certificate as DER bytes.
     pub fn to_der(&self) -> Result<Vec<u8>, X509Error> {
         self.0.to_der()
     }
 
+    #[cfg(any(test, feature = "test_helpers"))]
     /// Build a self-signed never-expiring X.509 certificate (for testing).
     pub fn build_self_signed(
         key: &crate::rsa::RsaKeyPair,

--- a/support/crypto/src/x509/ossl.rs
+++ b/support/crypto/src/x509/ossl.rs
@@ -52,12 +52,14 @@ impl X509CertificateInner {
         Ok(self.0.issued(&subject.0) == openssl::x509::X509VerifyResult::OK)
     }
 
+    #[cfg(any(test, feature = "test_helpers"))]
     pub fn to_der(&self) -> Result<Vec<u8>, X509Error> {
         self.0
             .to_der()
             .map_err(|e| err(e, "encoding certificate as DER"))
     }
 
+    #[cfg(any(test, feature = "test_helpers"))]
     pub fn build_self_signed(
         key: &crate::rsa::RsaKeyPair,
         country: &str,

--- a/support/crypto/src/x509/symcrypt_rust.rs
+++ b/support/crypto/src/x509/symcrypt_rust.rs
@@ -4,12 +4,9 @@
 //! X.509 certificate parsing and verification using the `x509-cert` RustCrypto crate.
 
 use super::X509Error;
-use core::str::FromStr;
 use der::Decode;
 use der::Encode;
 use x509_cert::Certificate;
-use x509_cert::builder::Builder;
-use x509_cert::name::Name;
 
 #[cfg(symcrypt)]
 fn der_err(err: der::Error, op: &'static str) -> X509Error {
@@ -143,12 +140,14 @@ impl X509CertificateInner {
         Ok(true)
     }
 
+    #[cfg(any(test, feature = "test_helpers"))]
     pub fn to_der(&self) -> Result<Vec<u8>, X509Error> {
         self.0
             .to_der()
             .map_err(|e| der_err(e, "encoding certificate as DER"))
     }
 
+    #[cfg(any(test, feature = "test_helpers"))]
     pub fn build_self_signed(
         key: &crate::rsa::RsaKeyPair,
         country: &str,
@@ -157,6 +156,10 @@ impl X509CertificateInner {
         organization: &str,
         common_name: &str,
     ) -> anyhow::Result<Self> {
+        use core::str::FromStr;
+        use x509_cert::builder::Builder;
+        use x509_cert::name::Name;
+
         // Profile that produces a basic self-signed certificate with no
         // extensions and the same `Name` for both the subject and issuer.
         struct SelfSignedProfile {
@@ -225,7 +228,7 @@ impl X509CertificateInner {
 /// Adapters that implement the `signature` and `spki` traits required by
 /// `x509_cert::builder::CertificateBuilder::build` on top of SymCrypt's
 /// PKCS#1 v1.5 signing primitive.
-#[cfg(symcrypt)]
+#[cfg(all(symcrypt, any(test, feature = "test_helpers")))]
 mod symcrypt_signer {
     use der::Encode;
 


### PR DESCRIPTION
Move a couple of functions behind a new test_helpers feature so that they don't get accidentally used in a production context. This gets one use of sha1 (the x509-cert builder feature) out of the main dependency paths.