### PR TITLE
vmm_tests_run: selections and deps improvements

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
@@ -102,6 +102,12 @@ pub struct VmmTestsRunCli {
     /// Use when making changes to prep_steps
     #[clap(long)]
     no_reuse_prepped_vhds: bool,
+
+    /// Disable secure AVIC support for SNP. This adds the
+    /// `disable_secure_avic` cargo feature and sets `secure_avic` to
+    /// `disabled` in the IGVM manifest.
+    #[clap(long)]
+    pub disable_secure_avic: bool,
 }
 
 struct CargoNextestListRequest<'a> {
@@ -118,6 +124,7 @@ struct RustSuite {
 }
 
 /// Result of resolving artifact requirements to build/download selections
+#[derive(Default, Debug)]
 struct ResolvedArtifactSelections {
     /// What to build
     build: BuildSelections,
@@ -125,16 +132,10 @@ struct ResolvedArtifactSelections {
     downloads: BTreeSet<KnownTestArtifacts>,
     /// Whether any tests need release IGVM files from GitHub
     needs_release_igvm: bool,
-}
-
-impl Default for ResolvedArtifactSelections {
-    fn default() -> Self {
-        Self {
-            build: BuildSelections::none(),
-            downloads: BTreeSet::new(),
-            needs_release_igvm: false,
-        }
-    }
+    /// Whether any of the tests require Hyper-V
+    needs_hyperv: bool,
+    /// Whether any of the tests require hardware isolation
+    needs_hardware_isolation: bool,
 }
 
 impl IntoPipeline for VmmTestsRunCli {
@@ -159,6 +160,7 @@ impl IntoPipeline for VmmTestsRunCli {
             custom_uefi_firmware,
             ci_profile,
             no_reuse_prepped_vhds,
+            disable_secure_avic,
         } = self;
 
         let target = resolve_target(target, backend_hint)?;
@@ -209,6 +211,16 @@ impl IntoPipeline for VmmTestsRunCli {
             resolved.resolve_artifact(&artifact)?;
         }
 
+        // Determine whether we need hyper-v and/or hardware isolation
+        resolved.needs_hyperv = suites
+            .values()
+            .any(|s| s.testcases.iter().any(|name| name.contains("hyperv")));
+        resolved.needs_hardware_isolation = suites.values().any(|s| {
+            s.testcases
+                .iter()
+                .any(|name| name.contains("snp") || name.contains("tdx"))
+        });
+
         // Determine lazy fetch mode.
         //
         // By default, VHD/ISO downloads are skipped and disk images are
@@ -231,7 +243,7 @@ impl IntoPipeline for VmmTestsRunCli {
                 let hyperv_testcases: Vec<_> = suite
                     .testcases
                     .iter()
-                    .filter(|name| name.contains("hyperv_"))
+                    .filter(|name| name.contains("hyperv"))
                     .cloned()
                     .collect();
 
@@ -262,11 +274,7 @@ impl IntoPipeline for VmmTestsRunCli {
             }
         }
 
-        log::info!("Resolved build selections: {:?}", resolved.build);
-        log::info!(
-            "Resolved downloads: {:?}",
-            resolved.downloads.iter().collect::<Vec<_>>()
-        );
+        log::info!("Resolved selections: {:?}", resolved);
 
         let openvmm_repo = flowey_lib_common::git_checkout::RepoSource::ExistingClone(
             ReadVar::from_static(repo_root),
@@ -340,6 +348,7 @@ impl IntoPipeline for VmmTestsRunCli {
                         flowey_lib_hvlite::run_cargo_nextest_run::NextestProfile::Default
                     },
                     reuse_prepped_vhds: !no_reuse_prepped_vhds,
+                    disable_secure_avic,
                     done: ctx.new_done_handle(),
                 }
             });
@@ -584,9 +593,9 @@ fn selections_from_resolved(
         build: resolved.build.clone(),
         deps: match target_os {
             target_lexicon::OperatingSystem::Windows => VmmTestsDepSelections::Windows {
-                hyperv: true,
+                hyperv: resolved.needs_hyperv,
                 whp: resolved.build.openvmm,
-                hardware_isolation: resolved.build.prep_steps,
+                hardware_isolation: resolved.needs_hardware_isolation,
             },
             target_lexicon::OperatingSystem::Linux => VmmTestsDepSelections::Linux,
             _ => unreachable!(),
@@ -616,13 +625,22 @@ impl ResolvedArtifactSelections {
 
             // OpenHCL IGVM files
             petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_X64::GLOBAL_UNIQUE_ID
-            | petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_DEV_KERNEL_X64::GLOBAL_UNIQUE_ID
-            | petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_CVM_X64::GLOBAL_UNIQUE_ID
-            | petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_LINUX_DIRECT_TEST_X64::GLOBAL_UNIQUE_ID
-            | petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_AARCH64::GLOBAL_UNIQUE_ID
-            | petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_DEV_KERNEL_AARCH64::GLOBAL_UNIQUE_ID =>
+            | petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_AARCH64::GLOBAL_UNIQUE_ID =>
             {
-                self.build.openhcl = true;
+                self.build.openhcl_standard = true;
+            }
+            petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_DEV_KERNEL_X64::GLOBAL_UNIQUE_ID
+            | petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_DEV_KERNEL_AARCH64::GLOBAL_UNIQUE_ID => {
+                self.build.openhcl_standard_dev = true;
+            }
+            petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_CVM_X64::GLOBAL_UNIQUE_ID
+             =>
+            {
+                self.build.openhcl_cvm = true;
+            }
+            petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_LINUX_DIRECT_TEST_X64::GLOBAL_UNIQUE_ID =>
+            {
+                self.build.openhcl_linux_direct = true;
             }
 
             // Release IGVM files (downloaded, not built)
@@ -761,7 +779,7 @@ impl ResolvedArtifactSelections {
             petri_artifacts_vmm_test::artifacts::openhcl_igvm::um_bin::LATEST_LINUX_DIRECT_TEST_X64::GLOBAL_UNIQUE_ID
             | petri_artifacts_vmm_test::artifacts::openhcl_igvm::um_dbg::LATEST_LINUX_DIRECT_TEST_X64::GLOBAL_UNIQUE_ID =>
             {
-                self.build.openhcl = true;
+                self.build.openhcl_linux_direct = true;
             }
 
             // Common artifacts (always available, no build needed)

--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
@@ -16,6 +16,7 @@ use flowey_lib_hvlite::_jobs::local_build_and_run_nextest_vmm_tests::BuildSelect
 use flowey_lib_hvlite::_jobs::local_build_and_run_nextest_vmm_tests::VmmTestSelections;
 use flowey_lib_hvlite::common::CommonTriple;
 use flowey_lib_hvlite::install_vmm_tests_deps::VmmTestsDepSelections;
+use flowey_lib_hvlite::install_vmm_tests_deps::VmmTestsDepSelectionsWindows;
 use petri_artifacts_core::ArtifactId;
 use petri_artifacts_core::ArtifactListOutput;
 use std::collections::BTreeMap;
@@ -592,11 +593,13 @@ fn selections_from_resolved(
         artifacts: resolved.downloads.into_iter().collect(),
         build: resolved.build.clone(),
         deps: match target_os {
-            target_lexicon::OperatingSystem::Windows => VmmTestsDepSelections::Windows {
-                hyperv: resolved.needs_hyperv,
-                whp: resolved.build.openvmm,
-                hardware_isolation: resolved.needs_hardware_isolation,
-            },
+            target_lexicon::OperatingSystem::Windows => {
+                VmmTestsDepSelections::Windows(VmmTestsDepSelectionsWindows {
+                    hyperv: resolved.needs_hyperv,
+                    whp: resolved.build.openvmm,
+                    hardware_isolation: resolved.needs_hardware_isolation,
+                })
+            }
             target_lexicon::OperatingSystem::Linux => VmmTestsDepSelections::Linux,
             _ => unreachable!(),
         },

--- a/flowey/flowey_lib_hvlite/Cargo.toml
+++ b/flowey/flowey_lib_hvlite/Cargo.toml
@@ -10,8 +10,9 @@ rust-version.workspace = true
 flowey.workspace = true
 flowey_lib_common.workspace = true
 
-vmm_test_images = { workspace = true, features = ["serde"] }
+powershell_builder.workspace = true
 igvmfilegen_config.workspace = true
+vmm_test_images = { workspace = true, features = ["serde"] }
 
 anyhow.workspace = true
 crossterm = { workspace = true, features = ["events"] }
@@ -23,7 +24,6 @@ which.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 crossterm = { workspace = true, features = ["windows"] }
-powershell_builder.workspace = true
 
 [lints]
 workspace = true

--- a/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
@@ -15,6 +15,7 @@ use crate::build_tmks::TmksOutput;
 use crate::build_tpm_guest_tests::TpmGuestTestsOutput;
 use crate::build_vmgstool::VmgstoolOutput;
 use crate::install_vmm_tests_deps::VmmTestsDepSelections;
+use crate::install_vmm_tests_deps::VmmTestsDepSelectionsWindows;
 use crate::run_cargo_nextest_run::NextestProfile;
 use flowey::node::prelude::*;
 use std::collections::BTreeMap;
@@ -141,11 +142,13 @@ impl SimpleFlowNode for Node {
 
         ctx.config(crate::install_vmm_tests_deps::Config {
             selections: Some(match target.operating_system {
-                target_lexicon::OperatingSystem::Windows => VmmTestsDepSelections::Windows {
-                    hyperv: true,
-                    whp: true,
-                    hardware_isolation: false,
-                },
+                target_lexicon::OperatingSystem::Windows => {
+                    VmmTestsDepSelections::Windows(VmmTestsDepSelectionsWindows {
+                        hyperv: true,
+                        whp: true,
+                        hardware_isolation: false,
+                    })
+                }
                 target_lexicon::OperatingSystem::Linux => VmmTestsDepSelections::Linux,
                 os => anyhow::bail!("unsupported target operating system: {os}"),
             }),

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -35,9 +35,12 @@ pub struct VmmTestSelections {
     pub needs_release_igvm: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct BuildSelections {
-    pub openhcl: bool,
+    pub openhcl_standard: bool,
+    pub openhcl_standard_dev: bool,
+    pub openhcl_cvm: bool,
+    pub openhcl_linux_direct: bool,
     pub openvmm: bool,
     pub openvmm_vhost: bool,
     pub pipette_windows: bool,
@@ -51,27 +54,6 @@ pub struct BuildSelections {
     pub tpm_guest_tests_windows: bool,
     pub tpm_guest_tests_linux: bool,
     pub test_igvm_agent_rpc_server: bool,
-}
-
-impl BuildSelections {
-    pub fn none() -> Self {
-        Self {
-            prep_steps: false,
-            openhcl: false,
-            openvmm: false,
-            openvmm_vhost: false,
-            pipette_windows: false,
-            pipette_linux: false,
-            guest_test_uefi: false,
-            tmks: false,
-            tmk_vmm_windows: false,
-            tmk_vmm_linux: false,
-            vmgstool: false,
-            tpm_guest_tests_windows: false,
-            tpm_guest_tests_linux: false,
-            test_igvm_agent_rpc_server: false,
-        }
-    }
 }
 
 flowey_request! {
@@ -101,6 +83,8 @@ flowey_request! {
         pub nextest_profile: crate::run_cargo_nextest_run::NextestProfile,
 
         pub reuse_prepped_vhds: bool,
+
+        pub disable_secure_avic: bool,
 
         pub done: WriteVar<SideEffect>,
     }
@@ -151,6 +135,7 @@ impl SimpleFlowNode for Node {
             skip_vhd_prompt,
             nextest_profile,
             reuse_prepped_vhds,
+            disable_secure_avic,
             done,
         } = request;
 
@@ -171,47 +156,65 @@ impl SimpleFlowNode for Node {
         };
         let test_label = format!("{arch_tag}-{platform_tag}-vmm-tests");
 
-        // Some things can only be built on linux
-        let linux_host = matches!(ctx.platform(), FlowPlatform::Linux(_));
-
         let mut copy_to_dir = Vec::new();
         let extras_dir = Path::new("extras");
 
         let VmmTestSelections {
             filter: nextest_filter_expr,
             artifacts: test_artifacts,
-            mut build,
+            build,
             deps,
             needs_release_igvm,
         } = selections;
 
-        if !linux_host {
-            build.openhcl = false;
-            build.pipette_linux = false;
-            build.openvmm_vhost = false;
-            build.tmk_vmm_linux = false;
-            build.tpm_guest_tests_linux = false;
-            build.test_igvm_agent_rpc_server = false;
+        let build_openhcl = build.openhcl_standard
+            || build.openhcl_standard_dev
+            || build.openhcl_cvm
+            || build.openhcl_linux_direct;
+
+        // Some things can only be built on linux
+        if !matches!(ctx.platform(), FlowPlatform::Linux(_))
+            && (build_openhcl
+                || build.pipette_linux
+                || build.openvmm_vhost
+                || build.tmk_vmm_linux
+                || build.tpm_guest_tests_linux
+                || build.tpm_guest_tests_linux)
+        {
+            anyhow::bail!(
+                "Selected tests require artifacts that can only be build on linux. Try building from WSL2."
+            );
         }
 
-        let register_openhcl_igvm_files = build.openhcl.then(|| {
+        let register_openhcl_igvm_files = build_openhcl.then(|| {
             let openvmm_hcl_profile = if release {
                 OpenvmmHclBuildProfile::OpenvmmHclShip
             } else {
                 OpenvmmHclBuildProfile::Debug
             };
-            let openhcl_recipies = match arch {
-                CommonArch::X86_64 => vec![
-                    OpenhclIgvmRecipe::X64,
-                    OpenhclIgvmRecipe::X64Devkern,
-                    OpenhclIgvmRecipe::X64TestLinuxDirect,
-                    OpenhclIgvmRecipe::X64Cvm,
-                ],
+            let mut openhcl_recipies = Vec::new();
+            match arch {
+                CommonArch::X86_64 => {
+                    if build.openhcl_standard {
+                        openhcl_recipies.push(OpenhclIgvmRecipe::X64);
+                    }
+                    if build.openhcl_standard_dev {
+                        openhcl_recipies.push(OpenhclIgvmRecipe::X64Devkern);
+                    }
+                    if build.openhcl_cvm {
+                        openhcl_recipies.push(OpenhclIgvmRecipe::X64Cvm);
+                    }
+                    if build.openhcl_linux_direct {
+                        openhcl_recipies.push(OpenhclIgvmRecipe::X64TestLinuxDirect);
+                    }
+                }
                 CommonArch::Aarch64 => {
-                    vec![
-                        OpenhclIgvmRecipe::Aarch64,
-                        OpenhclIgvmRecipe::Aarch64Devkern,
-                    ]
+                    if build.openhcl_standard {
+                        openhcl_recipies.push(OpenhclIgvmRecipe::Aarch64);
+                    }
+                    if build.openhcl_standard_dev {
+                        openhcl_recipies.push(OpenhclIgvmRecipe::Aarch64Devkern);
+                    }
                 }
             };
             let openhcl_extras_dir = extras_dir.join("openhcl");
@@ -249,7 +252,7 @@ impl SimpleFlowNode for Node {
                     recipe: recipe_to_use,
                     custom_target: None,
                     extra_features: BTreeSet::new(),
-                    disable_secure_avic: false,
+                    disable_secure_avic,
                     built_openvmm_hcl,
                     built_openhcl_boot,
                     built_openhcl_igvm,

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -178,11 +178,10 @@ impl SimpleFlowNode for Node {
                 || build.pipette_linux
                 || build.openvmm_vhost
                 || build.tmk_vmm_linux
-                || build.tpm_guest_tests_linux
                 || build.tpm_guest_tests_linux)
         {
             anyhow::bail!(
-                "Selected tests require artifacts that can only be build on linux. Try building from WSL2."
+                "Selected tests require artifacts that can only be built on linux. Try building from WSL2."
             );
         }
 
@@ -192,35 +191,35 @@ impl SimpleFlowNode for Node {
             } else {
                 OpenvmmHclBuildProfile::Debug
             };
-            let mut openhcl_recipies = Vec::new();
+            let mut openhcl_recipes = Vec::new();
             match arch {
                 CommonArch::X86_64 => {
                     if build.openhcl_standard {
-                        openhcl_recipies.push(OpenhclIgvmRecipe::X64);
+                        openhcl_recipes.push(OpenhclIgvmRecipe::X64);
                     }
                     if build.openhcl_standard_dev {
-                        openhcl_recipies.push(OpenhclIgvmRecipe::X64Devkern);
+                        openhcl_recipes.push(OpenhclIgvmRecipe::X64Devkern);
                     }
                     if build.openhcl_cvm {
-                        openhcl_recipies.push(OpenhclIgvmRecipe::X64Cvm);
+                        openhcl_recipes.push(OpenhclIgvmRecipe::X64Cvm);
                     }
                     if build.openhcl_linux_direct {
-                        openhcl_recipies.push(OpenhclIgvmRecipe::X64TestLinuxDirect);
+                        openhcl_recipes.push(OpenhclIgvmRecipe::X64TestLinuxDirect);
                     }
                 }
                 CommonArch::Aarch64 => {
                     if build.openhcl_standard {
-                        openhcl_recipies.push(OpenhclIgvmRecipe::Aarch64);
+                        openhcl_recipes.push(OpenhclIgvmRecipe::Aarch64);
                     }
                     if build.openhcl_standard_dev {
-                        openhcl_recipies.push(OpenhclIgvmRecipe::Aarch64Devkern);
+                        openhcl_recipes.push(OpenhclIgvmRecipe::Aarch64Devkern);
                     }
                 }
             };
             let openhcl_extras_dir = extras_dir.join("openhcl");
 
             let mut register_openhcl_igvm_files = Vec::new();
-            for recipe in openhcl_recipies {
+            for recipe in openhcl_recipes {
                 let (read_built_openvmm_hcl, built_openvmm_hcl) = ctx.new_var();
                 let (read_built_openhcl_igvm, built_openhcl_igvm) = ctx.new_var();
                 let (read_built_openhcl_boot, built_openhcl_boot) = ctx.new_var();

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_igvm.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_igvm.rs
@@ -190,12 +190,6 @@ impl SimpleFlowNode for Node {
                 openvmm_hcl_features.insert(OpenvmmHclFeature::MiSecure);
             }
 
-            if disable_secure_avic {
-                openvmm_hcl_features.insert(OpenvmmHclFeature::LocalOnlyCustom(
-                    "disable_secure_avic".into(),
-                ));
-            }
-
             if let Some(arch) = override_arch {
                 *target = match arch {
                     CommonArch::X86_64 => CommonTriple::X86_64_LINUX_MUSL,

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
@@ -251,7 +251,6 @@ flowey_request! {
         pub custom_target: Option<CommonTriple>,
         /// Additional features to enable on top of the recipe's defaults.
         pub extra_features: BTreeSet<OpenvmmHclFeature>,
-        /// Patch the manifest to set secure_avic to disabled for SNP configs.
         pub disable_secure_avic: bool,
 
         pub built_openvmm_hcl: WriteVar<crate::build_openvmm_hcl::OpenvmmHclOutput>,
@@ -310,6 +309,12 @@ impl SimpleFlowNode for Node {
         } = recipe.recipe_details(release_cfg);
 
         openvmm_hcl_features.extend(extra_features);
+
+        if disable_secure_avic {
+            openvmm_hcl_features.insert(OpenvmmHclFeature::LocalOnlyCustom(
+                "disable_secure_avic".into(),
+            ));
+        }
 
         let OpenhclIgvmRecipeDetailsLocalOnly {
             openvmm_hcl_no_strip,

--- a/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
+++ b/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
@@ -170,6 +170,13 @@ fn install_windows_deps(
         features_to_enable.append(&mut WHP_TESTS_REQUIRED_FEATURES.into());
     }
 
+    // write commands for vmm_tests_run build only mode
+    for feature in features_to_enable.iter() {
+        commands.push(format!(
+            "DISM.exe /Online /NoRestart /Enable-Feature /All /FeatureName:{feature}"
+        ));
+    }
+
     // Check if features are already enabled (requires admin, so skip if not auto_install)
     if installing && auto_install && !features_to_enable.is_empty() {
         let features = flowey::shell_cmd!(rt, "DISM.exe /Online /Get-Features").output()?;
@@ -215,7 +222,7 @@ fn install_windows_deps(
             );
         } else {
             anyhow::bail!(
-                "Hyper-V is not installed. Re-run in an Administrator window with `--install-missing-deps`"
+                "Hyper-V is not installed or your user account is not in the \"Hyper-V Administrators\" group. Re-run in an Administrator window with `--install-missing-deps`"
             );
         }
 
@@ -261,9 +268,6 @@ Otherwise, press `ctrl-c` to cancel the run.
             )
             .run()?;
         }
-        commands.push(format!(
-            "DISM.exe /Online /NoRestart /Enable-Feature /All /FeatureName:{feature}"
-        ));
     }
 
     // Select required reg keys
@@ -286,6 +290,13 @@ Otherwise, press `ctrl-c` to cancel the run.
                 .entry(HYPERVISOR_REG_PATH)
                 .or_insert(BTreeMap::new())
                 .insert("EnableHardwareIsolation", ("REG_DWORD", "0x1", true));
+        }
+    }
+
+    // write commands for vmm_tests_run build only mode
+    for (p, k) in reg_keys_to_set.iter() {
+        for (v, (t, d, _)) in k {
+            commands.push(format!("reg.exe add \"{p}\" /v {v} /t {t} /d {d} /f"));
         }
     }
 
@@ -317,16 +328,14 @@ Otherwise, press `ctrl-c` to cancel the run.
         .into_iter()
         .flat_map(|(p, k)| k.into_iter().map(move |(v, (t, d, _))| (p, v, t, d)))
         .collect::<Vec<_>>();
-    let mut reg_cmds = reg_keys_to_set
-        .iter()
-        .map(|(p, v, t, d)| format!("reg.exe add \"{p}\" /v {v} /t {t} /d {d} /f"))
-        .collect::<Vec<_>>();
 
     // Prompt before changing registry when running locally
     if installing && !reg_keys_to_set.is_empty() && matches!(rt.backend(), FlowBackend::Local) {
         let mut reg_keys_to_set_string = String::new();
-        for cmd in reg_cmds.iter() {
-            reg_keys_to_set_string.push_str(cmd);
+        for (p, v, _, _) in reg_keys_to_set.iter() {
+            reg_keys_to_set_string.push_str(*p);
+            reg_keys_to_set_string.push(' ');
+            reg_keys_to_set_string.push_str(*v);
             reg_keys_to_set_string.push('\n');
         }
 
@@ -360,10 +369,7 @@ Please re-run in an Administrator window with `--install-missing-deps`.
     }
 
     // Modify the registry
-    commands.append(&mut reg_cmds);
     for (p, v, t, d) in reg_keys_to_set {
-        // TODO: figure out why reg.exe is not found if I
-        // render the command as a string first and share
         if installing && auto_install {
             flowey::shell_cmd!(rt, "reg.exe add {p} /v {v} /t {t} /d {d} /f").run()?;
         }

--- a/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
+++ b/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
@@ -6,6 +6,7 @@
 use flowey::node::prelude::*;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::process::Stdio;
 
 const HYPERV_TESTS_REQUIRED_FEATURES: [&str; 3] = [
     "Microsoft-Hyper-V",
@@ -141,6 +142,7 @@ fn install_windows_deps(
     write_commands: Vec<WriteVar<Vec<String>, VarClaimed>>,
 ) -> anyhow::Result<()> {
     let mut commands = Vec::new();
+    let mut needs_restart = false;
 
     if !matches!(rt.platform(), FlowPlatform::Windows)
         && !flowey_lib_common::_util::running_in_wsl(rt)
@@ -195,10 +197,28 @@ fn install_windows_deps(
             }
         }
     } else if installing && !auto_install && !features_to_enable.is_empty() {
-        // Not auto-installing, assume features are already present
-        log::info!(
-            "Skipping Windows feature check (requires admin). Assuming features are already enabled."
-        );
+        if powershell_builder::PowerShellBuilder::new()
+            .cmdlet("Get-VM")
+            .finish()
+            .build()
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|s| s.success())
+        {
+            log::info!(
+                "Verified that Hyper-V is installed, assuming related features are enabled."
+            );
+            log::info!(
+                "If you encounter issues, try re-running in an Administrator window with `--install-missing-deps`"
+            );
+        } else {
+            anyhow::bail!(
+                "Hyper-V is not installed. Re-run in an Administrator window with `--install-missing-deps`"
+            );
+        }
+
         features_to_enable.clear();
     }
 
@@ -228,6 +248,8 @@ Otherwise, press `ctrl-c` to cancel the run.
 "#
         );
         let _ = std::io::stdin().read_line(&mut String::new());
+
+        needs_restart = true;
     }
 
     // Install the features
@@ -251,24 +273,24 @@ Otherwise, press `ctrl-c` to cancel the run.
         reg_keys_to_set
             .entry(VIRT_REG_PATH)
             .or_insert(BTreeMap::new())
-            .insert("AllowFirmwareLoadFromFile", ("REG_DWORD", "0x1"));
+            .insert("AllowFirmwareLoadFromFile", ("REG_DWORD", "0x1", false));
 
         // Enable COM3 and COM4 for Hyper-V VMs so we can get the OpenHCL KMSG logs over serial
         reg_keys_to_set
             .entry(VIRT_REG_PATH)
             .or_insert(BTreeMap::new())
-            .insert("EnableAdditionalComPorts", ("REG_DWORD", "0x1"));
+            .insert("EnableAdditionalComPorts", ("REG_DWORD", "0x1", false));
 
         if hardware_isolation {
             reg_keys_to_set
                 .entry(HYPERVISOR_REG_PATH)
                 .or_insert(BTreeMap::new())
-                .insert("EnableHardwareIsolation", ("REG_DWORD", "0x1"));
+                .insert("EnableHardwareIsolation", ("REG_DWORD", "0x1", true));
         }
     }
 
     // Check if reg keys are set (skip if not auto_install, assume already set)
-    if installing && auto_install && !reg_keys_to_set.is_empty() {
+    if installing && !reg_keys_to_set.is_empty() {
         for (path, keys) in reg_keys_to_set.iter_mut() {
             let output = flowey::shell_cmd!(rt, "reg.exe query {path}").output()?;
             if output.status.success() {
@@ -278,23 +300,22 @@ Otherwise, press `ctrl-c` to cancel the run.
                     if components.len() == 3
                         && keys
                             .get(components[0])
-                            .is_some_and(|(t, d)| *t == components[1] && *d == components[2])
+                            .is_some_and(|(t, d, _)| *t == components[1] && *d == components[2])
                     {
                         assert!(keys.remove(components[0]).is_some());
                     }
                 }
             }
         }
-    } else if installing && !auto_install && !reg_keys_to_set.is_empty() {
-        // Not auto-installing, assume reg keys are already set
-        log::info!("Skipping registry key check. Assuming keys are already set.");
-        reg_keys_to_set.clear();
     }
 
     // flatten the keys
+    let reg_keys_would_require_restart = reg_keys_to_set
+        .iter()
+        .any(|(_, k)| k.iter().any(|(_, (_, _, needs_restart))| *needs_restart));
     let reg_keys_to_set = reg_keys_to_set
         .into_iter()
-        .flat_map(|(p, k)| k.into_iter().map(move |(v, (t, d))| (p, v, t, d)))
+        .flat_map(|(p, k)| k.into_iter().map(move |(v, (t, d, _))| (p, v, t, d)))
         .collect::<Vec<_>>();
     let mut reg_cmds = reg_keys_to_set
         .iter()
@@ -302,19 +323,16 @@ Otherwise, press `ctrl-c` to cancel the run.
         .collect::<Vec<_>>();
 
     // Prompt before changing registry when running locally
-    if installing
-        && auto_install
-        && !reg_keys_to_set.is_empty()
-        && matches!(rt.backend(), FlowBackend::Local)
-    {
+    if installing && !reg_keys_to_set.is_empty() && matches!(rt.backend(), FlowBackend::Local) {
         let mut reg_keys_to_set_string = String::new();
         for cmd in reg_cmds.iter() {
             reg_keys_to_set_string.push_str(cmd);
             reg_keys_to_set_string.push('\n');
         }
 
-        log::warn!(
-            r#"
+        if auto_install {
+            log::warn!(
+                r#"
 ================================================================================
 To run the VMM tests, the following registry keys need to be set:
 {reg_keys_to_set_string}
@@ -323,8 +341,22 @@ If you're OK with changing the registry, please press <enter>.
 Otherwise, press `ctrl-c` to cancel the run.
 ================================================================================
 "#
-        );
-        let _ = std::io::stdin().read_line(&mut String::new());
+            );
+            let _ = std::io::stdin().read_line(&mut String::new());
+
+            needs_restart |= reg_keys_would_require_restart;
+        } else {
+            anyhow::bail!(
+                r#"
+================================================================================
+To run the VMM tests, the following registry keys need to be set:
+{reg_keys_to_set_string}
+
+Please re-run in an Administrator window with `--install-missing-deps`.
+================================================================================
+"#
+            );
+        }
     }
 
     // Modify the registry
@@ -333,8 +365,14 @@ Otherwise, press `ctrl-c` to cancel the run.
         // TODO: figure out why reg.exe is not found if I
         // render the command as a string first and share
         if installing && auto_install {
-            flowey::shell_cmd!(rt, "reg.exe add \"{p}\" /v {v} /t {t} /d {d} /f").run()?;
+            flowey::shell_cmd!(rt, "reg.exe add {p} /v {v} /t {t} /d {d} /f").run()?;
         }
+    }
+
+    if needs_restart {
+        anyhow::bail!(
+            "Installed dependencies require a restart. Please restart and re-run this command"
+        );
     }
 
     for write_cmds in write_commands {

--- a/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
+++ b/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
@@ -99,189 +99,15 @@ impl FlowNodeWithConfig for Node {
                     let write_commands = write_commands.claim(ctx);
 
                     move |rt| {
-                        let mut commands = Vec::new();
-
-                        if !matches!(rt.platform(), FlowPlatform::Windows)
-                            && !flowey_lib_common::_util::running_in_wsl(rt)
-                        {
-                            anyhow::bail!("Must be on Windows or WSL2 to install Windows deps.")
-                        }
-
-                        // Resolve auto_install for local backend
-                        let auto_install = match rt.backend() {
-                            FlowBackend::Local => auto_install.ok_or_else(|| {
-                                anyhow::anyhow!("Missing essential request: AutoInstall")
-                            })?,
-                            // CI backends always auto-install
-                            FlowBackend::Ado | FlowBackend::Github => true,
-                        };
-
-                        // TODO: add these features and reg keys to the initial CI image
-
-                        // Select required features
-                        let mut features_to_enable = BTreeSet::new();
-                        if hyperv {
-                            features_to_enable.append(&mut HYPERV_TESTS_REQUIRED_FEATURES.into());
-                        }
-                        if whp {
-                            features_to_enable.append(&mut WHP_TESTS_REQUIRED_FEATURES.into());
-                        }
-
-                        // Check if features are already enabled (requires admin, so skip if not auto_install)
-                        if installing && auto_install && !features_to_enable.is_empty() {
-                            let features = flowey::shell_cmd!(rt, "DISM.exe /Online /Get-Features").output()?;
-                            assert!(features.status.success());
-                            let features = String::from_utf8_lossy(&features.stdout).to_string();
-                            let mut feature = None;
-                            for line in features.lines() {
-                                if let Some((k, v)) = line.split_once(":") {
-                                    if let Some(f) = feature {
-                                        assert_eq!(k.trim(), "State");
-                                        match v.trim() {
-                                            "Enabled" => {
-                                                assert!(features_to_enable.remove(f));
-                                            }
-                                            "Disabled" => {}
-                                            _ => anyhow::bail!("Unknown feature enablement state"),
-                                        }
-                                        feature = None;
-                                    } else if k.trim() == "Feature Name" {
-                                        let new_feature = v.trim();
-                                        feature = features_to_enable.contains(new_feature).then_some(new_feature);
-                                    }
-                                }
-                            }
-                        } else if installing && !auto_install && !features_to_enable.is_empty() {
-                            // Not auto-installing, assume features are already present
-                            log::info!("Skipping Windows feature check (requires admin). Assuming features are already enabled.");
-                            features_to_enable.clear();
-                        }
-
-                        // Prompt before enabling when running locally
-                        if installing && auto_install && !features_to_enable.is_empty() && matches!(rt.backend(), FlowBackend::Local) {
-                            let mut features_to_install_string = String::new();
-                            for feature in features_to_enable.iter() {
-                                features_to_install_string.push_str(feature);
-                                features_to_install_string.push('\n');
-                            }
-
-                            log::warn!(
-                                r#"
-================================================================================
-To run the VMM tests, the following features need to be enabled:
-{features_to_install_string}
-
-You may need to restart your system for the changes to take effect.
-
-If you're OK with installing these features, please press <enter>.
-Otherwise, press `ctrl-c` to cancel the run.
-================================================================================
-"#
-                            );
-                            let _ = std::io::stdin().read_line(&mut String::new());
-                        }
-
-                        // Install the features
-                        for feature in features_to_enable {
-                            if installing && auto_install {
-                                flowey::shell_cmd!(rt, "DISM.exe /Online /NoRestart /Enable-Feature /All /FeatureName:{feature}").run()?;
-                            }
-                            commands.push(format!("DISM.exe /Online /NoRestart /Enable-Feature /All /FeatureName:{feature}"));
-                        }
-
-                        // Select required reg keys
-                        let mut reg_keys_to_set = BTreeMap::new();
-                        if hyperv {
-                            reg_keys_to_set.insert(VIRT_REG_PATH, BTreeMap::new());
-
-                            // Allow loading IGVM from file (to run custom OpenHCL firmware)
-                            reg_keys_to_set.get_mut(VIRT_REG_PATH).unwrap().insert("AllowFirmwareLoadFromFile", ("REG_DWORD", "0x1"));
-
-                            // Enable COM3 and COM4 for Hyper-V VMs so we can get the OpenHCL KMSG logs over serial
-                            reg_keys_to_set.get_mut(VIRT_REG_PATH).unwrap().insert("EnableAdditionalComPorts", ("REG_DWORD", "0x1"));
-
-                            if hardware_isolation {
-                                reg_keys_to_set.insert(HYPERVISOR_REG_PATH, BTreeMap::new());
-
-                                reg_keys_to_set.get_mut(VIRT_REG_PATH).unwrap().insert("EnableHardwareIsolation", ("REG_DWORD", "0x1"));
-                            }
-                        }
-
-                        // Check if reg keys are set (skip if not auto_install, assume already set)
-                        if installing && auto_install && !reg_keys_to_set.is_empty() {
-                            for (path, keys) in reg_keys_to_set.iter_mut() {
-                                let output = flowey::shell_cmd!(rt, "reg.exe query {path}").output()?;
-                                if output.status.success() {
-                                    let output = String::from_utf8_lossy(&output.stdout).to_string();
-                                    let mut existing_keys = BTreeMap::new();
-                                    for line in output.lines() {
-                                        let components = line.split_whitespace().collect::<Vec<_>>();
-                                        if components.len() == 3 {
-                                        existing_keys.insert(components[0], (components[1], components[2]));
-                                        }
-                                    }
-                                    for (key, (existing_type, existing_value)) in existing_keys.iter() {
-                                        if let Some((new_type, new_value)) = keys.get(key)
-                                            
-                                        {
-                                            if *existing_type == *new_type
-                                            && *existing_value == *new_value {
-                                                assert!( keys.remove(key).is_some());
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            
-                        } else if installing && !auto_install && !reg_keys_to_set.is_empty() {
-                            // Not auto-installing, assume reg keys are already set
-                            log::info!("Skipping registry key check. Assuming keys are already set.");
-                            reg_keys_to_set.clear();
-                        }
-
-                        // flatten the keys
-                        let reg_keys_to_set = reg_keys_to_set.into_iter().flat_map(|(p, k)| k.into_iter().map(move |(v, (t, d))| (p, v, t, d))).collect::<Vec<_>>();
-                        let mut reg_cmds = reg_keys_to_set.iter().map(|(p, v, t, d)| format!("reg.exe add \"{p}\" /v {v} /t {t} /d {d} /f")).collect::<Vec<_>>();
-
-                        // Prompt before changing registry when running locally
-                        if installing && auto_install && !reg_keys_to_set.is_empty() && matches!(rt.backend(), FlowBackend::Local) {
-                            
-                            let mut reg_keys_to_set_string = String::new();
-                            for cmd in reg_cmds.iter() {
-                                reg_keys_to_set_string.push_str(cmd);
-                                reg_keys_to_set_string.push('\n');
-                                
-                            }
-
-                            log::warn!(
-                                r#"
-================================================================================
-To run the VMM tests, the following registry keys need to be set:
-{reg_keys_to_set_string}
-
-If you're OK with changing the registry, please press <enter>.
-Otherwise, press `ctrl-c` to cancel the run.
-================================================================================
-"#
-                            );
-                            let _ = std::io::stdin().read_line(&mut String::new());
-                        }
-
-                        // Modify the registry
-                        commands.append(&mut reg_cmds);
-                        for (p, v, t, d) in reg_keys_to_set {
-                            // TODO: figure out why reg.exe is not found if I
-                            // render the command as a string first and share
-                            if installing && auto_install {
-                                flowey::shell_cmd!(rt, "reg.exe add \"{p}\" /v {v} /t {t} /d {d} /f").run()?;
-                            }
-                        }
-
-                        for write_cmds in write_commands {
-                            rt.write(write_cmds, &commands);
-                        }
-
-                        Ok(())
+                        install_windows_deps(
+                            rt,
+                            installing,
+                            auto_install,
+                            hyperv,
+                            whp,
+                            hardware_isolation,
+                            write_commands,
+                        )
                     }
                 });
             }
@@ -303,4 +129,217 @@ Otherwise, press `ctrl-c` to cancel the run.
 
         Ok(())
     }
+}
+
+fn install_windows_deps(
+    rt: &mut RustRuntimeServices<'_>,
+    installing: bool,
+    auto_install: Option<bool>,
+    hyperv: bool,
+    whp: bool,
+    hardware_isolation: bool,
+    write_commands: Vec<WriteVar<Vec<String>, VarClaimed>>,
+) -> anyhow::Result<()> {
+    let mut commands = Vec::new();
+
+    if !matches!(rt.platform(), FlowPlatform::Windows)
+        && !flowey_lib_common::_util::running_in_wsl(rt)
+    {
+        anyhow::bail!("Must be on Windows or WSL2 to install Windows deps.")
+    }
+
+    // Resolve auto_install for local backend
+    let auto_install = match rt.backend() {
+        FlowBackend::Local => {
+            auto_install.ok_or_else(|| anyhow::anyhow!("Missing essential request: AutoInstall"))?
+        }
+        // CI backends always auto-install
+        FlowBackend::Ado | FlowBackend::Github => true,
+    };
+
+    // TODO: add these features and reg keys to the initial CI image
+
+    // Select required features
+    let mut features_to_enable = BTreeSet::new();
+    if hyperv {
+        features_to_enable.append(&mut HYPERV_TESTS_REQUIRED_FEATURES.into());
+    }
+    if whp {
+        features_to_enable.append(&mut WHP_TESTS_REQUIRED_FEATURES.into());
+    }
+
+    // Check if features are already enabled (requires admin, so skip if not auto_install)
+    if installing && auto_install && !features_to_enable.is_empty() {
+        let features = flowey::shell_cmd!(rt, "DISM.exe /Online /Get-Features").output()?;
+        assert!(features.status.success());
+        let features = String::from_utf8_lossy(&features.stdout).to_string();
+        let mut feature = None;
+        for line in features.lines() {
+            if let Some((k, v)) = line.split_once(":") {
+                if let Some(f) = feature {
+                    assert_eq!(k.trim(), "State");
+                    match v.trim() {
+                        "Enabled" => {
+                            assert!(features_to_enable.remove(f));
+                        }
+                        "Disabled" => {}
+                        _ => anyhow::bail!("Unknown feature enablement state"),
+                    }
+                    feature = None;
+                } else if k.trim() == "Feature Name" {
+                    let new_feature = v.trim();
+                    feature = features_to_enable
+                        .contains(new_feature)
+                        .then_some(new_feature);
+                }
+            }
+        }
+    } else if installing && !auto_install && !features_to_enable.is_empty() {
+        // Not auto-installing, assume features are already present
+        log::info!(
+            "Skipping Windows feature check (requires admin). Assuming features are already enabled."
+        );
+        features_to_enable.clear();
+    }
+
+    // Prompt before enabling when running locally
+    if installing
+        && auto_install
+        && !features_to_enable.is_empty()
+        && matches!(rt.backend(), FlowBackend::Local)
+    {
+        let mut features_to_install_string = String::new();
+        for feature in features_to_enable.iter() {
+            features_to_install_string.push_str(feature);
+            features_to_install_string.push('\n');
+        }
+
+        log::warn!(
+            r#"
+================================================================================
+To run the VMM tests, the following features need to be enabled:
+{features_to_install_string}
+
+You may need to restart your system for the changes to take effect.
+
+If you're OK with installing these features, please press <enter>.
+Otherwise, press `ctrl-c` to cancel the run.
+================================================================================
+"#
+        );
+        let _ = std::io::stdin().read_line(&mut String::new());
+    }
+
+    // Install the features
+    for feature in features_to_enable {
+        if installing && auto_install {
+            flowey::shell_cmd!(
+                rt,
+                "DISM.exe /Online /NoRestart /Enable-Feature /All /FeatureName:{feature}"
+            )
+            .run()?;
+        }
+        commands.push(format!(
+            "DISM.exe /Online /NoRestart /Enable-Feature /All /FeatureName:{feature}"
+        ));
+    }
+
+    // Select required reg keys
+    let mut reg_keys_to_set = BTreeMap::new();
+    if hyperv {
+        // Allow loading IGVM from file (to run custom OpenHCL firmware)
+        reg_keys_to_set
+            .entry(VIRT_REG_PATH)
+            .or_insert(BTreeMap::new())
+            .insert("AllowFirmwareLoadFromFile", ("REG_DWORD", "0x1"));
+
+        // Enable COM3 and COM4 for Hyper-V VMs so we can get the OpenHCL KMSG logs over serial
+        reg_keys_to_set
+            .entry(VIRT_REG_PATH)
+            .or_insert(BTreeMap::new())
+            .insert("EnableAdditionalComPorts", ("REG_DWORD", "0x1"));
+
+        if hardware_isolation {
+            reg_keys_to_set
+                .entry(HYPERVISOR_REG_PATH)
+                .or_insert(BTreeMap::new())
+                .insert("EnableHardwareIsolation", ("REG_DWORD", "0x1"));
+        }
+    }
+
+    // Check if reg keys are set (skip if not auto_install, assume already set)
+    if installing && auto_install && !reg_keys_to_set.is_empty() {
+        for (path, keys) in reg_keys_to_set.iter_mut() {
+            let output = flowey::shell_cmd!(rt, "reg.exe query {path}").output()?;
+            if output.status.success() {
+                let output = String::from_utf8_lossy(&output.stdout).to_string();
+                for line in output.lines() {
+                    let components = line.split_whitespace().collect::<Vec<_>>();
+                    if components.len() == 3
+                        && keys
+                            .get(components[0])
+                            .is_some_and(|(t, d)| *t == components[1] && *d == components[2])
+                    {
+                        assert!(keys.remove(components[0]).is_some());
+                    }
+                }
+            }
+        }
+    } else if installing && !auto_install && !reg_keys_to_set.is_empty() {
+        // Not auto-installing, assume reg keys are already set
+        log::info!("Skipping registry key check. Assuming keys are already set.");
+        reg_keys_to_set.clear();
+    }
+
+    // flatten the keys
+    let reg_keys_to_set = reg_keys_to_set
+        .into_iter()
+        .flat_map(|(p, k)| k.into_iter().map(move |(v, (t, d))| (p, v, t, d)))
+        .collect::<Vec<_>>();
+    let mut reg_cmds = reg_keys_to_set
+        .iter()
+        .map(|(p, v, t, d)| format!("reg.exe add \"{p}\" /v {v} /t {t} /d {d} /f"))
+        .collect::<Vec<_>>();
+
+    // Prompt before changing registry when running locally
+    if installing
+        && auto_install
+        && !reg_keys_to_set.is_empty()
+        && matches!(rt.backend(), FlowBackend::Local)
+    {
+        let mut reg_keys_to_set_string = String::new();
+        for cmd in reg_cmds.iter() {
+            reg_keys_to_set_string.push_str(cmd);
+            reg_keys_to_set_string.push('\n');
+        }
+
+        log::warn!(
+            r#"
+================================================================================
+To run the VMM tests, the following registry keys need to be set:
+{reg_keys_to_set_string}
+
+If you're OK with changing the registry, please press <enter>.
+Otherwise, press `ctrl-c` to cancel the run.
+================================================================================
+"#
+        );
+        let _ = std::io::stdin().read_line(&mut String::new());
+    }
+
+    // Modify the registry
+    commands.append(&mut reg_cmds);
+    for (p, v, t, d) in reg_keys_to_set {
+        // TODO: figure out why reg.exe is not found if I
+        // render the command as a string first and share
+        if installing && auto_install {
+            flowey::shell_cmd!(rt, "reg.exe add \"{p}\" /v {v} /t {t} /d {d} /f").run()?;
+        }
+    }
+
+    for write_cmds in write_commands {
+        rt.write(write_cmds, &commands);
+    }
+
+    Ok(())
 }

--- a/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
+++ b/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
@@ -4,6 +4,7 @@
 //! Hyper-V test pre-reqs
 
 use flowey::node::prelude::*;
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
 const HYPERV_TESTS_REQUIRED_FEATURES: [&str; 3] = [
@@ -15,6 +16,7 @@ const HYPERV_TESTS_REQUIRED_FEATURES: [&str; 3] = [
 const WHP_TESTS_REQUIRED_FEATURES: [&str; 1] = ["HypervisorPlatform"];
 
 const VIRT_REG_PATH: &str = r#"HKLM\Software\Microsoft\Windows NT\CurrentVersion\Virtualization"#;
+const HYPERVISOR_REG_PATH: &str = r#"HKLM\System\CurrentControlSet\Control\Hypervisor"#;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub enum VmmTestsDepSelections {
@@ -188,52 +190,73 @@ Otherwise, press `ctrl-c` to cancel the run.
                         }
 
                         // Select required reg keys
-                        let mut reg_keys_to_set = BTreeSet::new();
+                        let mut reg_keys_to_set = BTreeMap::new();
                         if hyperv {
+                            reg_keys_to_set.insert(VIRT_REG_PATH, BTreeMap::new());
+
                             // Allow loading IGVM from file (to run custom OpenHCL firmware)
-                            reg_keys_to_set.insert("AllowFirmwareLoadFromFile");
+                            reg_keys_to_set.get_mut(VIRT_REG_PATH).unwrap().insert("AllowFirmwareLoadFromFile", ("REG_DWORD", "0x1"));
+
                             // Enable COM3 and COM4 for Hyper-V VMs so we can get the OpenHCL KMSG logs over serial
-                            reg_keys_to_set.insert("EnableAdditionalComPorts");
+                            reg_keys_to_set.get_mut(VIRT_REG_PATH).unwrap().insert("EnableAdditionalComPorts", ("REG_DWORD", "0x1"));
 
                             if hardware_isolation {
-                                reg_keys_to_set.insert("EnableHardwareIsolation");
+                                reg_keys_to_set.insert(HYPERVISOR_REG_PATH, BTreeMap::new());
+
+                                reg_keys_to_set.get_mut(VIRT_REG_PATH).unwrap().insert("EnableHardwareIsolation", ("REG_DWORD", "0x1"));
                             }
                         }
 
                         // Check if reg keys are set (skip if not auto_install, assume already set)
                         if installing && auto_install && !reg_keys_to_set.is_empty() {
-                            let output = flowey::shell_cmd!(rt, "reg.exe query {VIRT_REG_PATH}").output()?;
-                            if output.status.success() {
-                                let output = String::from_utf8_lossy(&output.stdout).to_string();
-                                for line in output.lines() {
-                                    let components = line.split_whitespace().collect::<Vec<_>>();
-                                    if components.len() == 3
-                                        && reg_keys_to_set.contains(components[0])
-                                        && components[1] == "REG_DWORD"
-                                        && components[2] == "0x1"
-                                    {
-                                        assert!(reg_keys_to_set.remove(components[0]));
+                            for (path, keys) in reg_keys_to_set.iter_mut() {
+                                let output = flowey::shell_cmd!(rt, "reg.exe query {path}").output()?;
+                                if output.status.success() {
+                                    let output = String::from_utf8_lossy(&output.stdout).to_string();
+                                    let mut existing_keys = BTreeMap::new();
+                                    for line in output.lines() {
+                                        let components = line.split_whitespace().collect::<Vec<_>>();
+                                        if components.len() == 3 {
+                                        existing_keys.insert(components[0], (components[1], components[2]));
+                                        }
+                                    }
+                                    for (key, (existing_type, existing_value)) in existing_keys.iter() {
+                                        if let Some((new_type, new_value)) = keys.get(key)
+                                            
+                                        {
+                                            if *existing_type == *new_type
+                                            && *existing_value == *new_value {
+                                                assert!( keys.remove(key).is_some());
+                                            }
+                                        }
                                     }
                                 }
                             }
+                            
                         } else if installing && !auto_install && !reg_keys_to_set.is_empty() {
                             // Not auto-installing, assume reg keys are already set
                             log::info!("Skipping registry key check. Assuming keys are already set.");
                             reg_keys_to_set.clear();
                         }
 
+                        // flatten the keys
+                        let reg_keys_to_set = reg_keys_to_set.into_iter().flat_map(|(p, k)| k.into_iter().map(move |(v, (t, d))| (p, v, t, d))).collect::<Vec<_>>();
+                        let mut reg_cmds = reg_keys_to_set.iter().map(|(p, v, t, d)| format!("reg.exe add \"{p}\" /v {v} /t {t} /d {d} /f")).collect::<Vec<_>>();
+
                         // Prompt before changing registry when running locally
                         if installing && auto_install && !reg_keys_to_set.is_empty() && matches!(rt.backend(), FlowBackend::Local) {
+                            
                             let mut reg_keys_to_set_string = String::new();
-                            for feature in reg_keys_to_set.iter() {
-                                reg_keys_to_set_string.push_str(feature);
+                            for cmd in reg_cmds.iter() {
+                                reg_keys_to_set_string.push_str(cmd);
                                 reg_keys_to_set_string.push('\n');
+                                
                             }
 
                             log::warn!(
                                 r#"
 ================================================================================
-To run the VMM tests, the following registry keys need to be set to 1:
+To run the VMM tests, the following registry keys need to be set:
 {reg_keys_to_set_string}
 
 If you're OK with changing the registry, please press <enter>.
@@ -245,13 +268,13 @@ Otherwise, press `ctrl-c` to cancel the run.
                         }
 
                         // Modify the registry
-                        for v in reg_keys_to_set {
+                        commands.append(&mut reg_cmds);
+                        for (p, v, t, d) in reg_keys_to_set {
                             // TODO: figure out why reg.exe is not found if I
                             // render the command as a string first and share
                             if installing && auto_install {
-                                flowey::shell_cmd!(rt, "reg.exe add {VIRT_REG_PATH} /v {v} /t REG_DWORD /d 1 /f").run()?;
+                                flowey::shell_cmd!(rt, "reg.exe add \"{p}\" /v {v} /t {t} /d {d} /f").run()?;
                             }
-                            commands.push(format!("reg.exe add \"{VIRT_REG_PATH}\" /v {v} /t REG_DWORD /d 1 /f"));
                         }
 
                         for write_cmds in write_commands {

--- a/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
+++ b/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
@@ -21,12 +21,15 @@ const HYPERVISOR_REG_PATH: &str = r#"HKLM\System\CurrentControlSet\Control\Hyper
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub enum VmmTestsDepSelections {
-    Windows {
-        hyperv: bool,
-        whp: bool,
-        hardware_isolation: bool,
-    },
+    Windows(VmmTestsDepSelectionsWindows),
     Linux,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct VmmTestsDepSelectionsWindows {
+    pub hyperv: bool,
+    pub whp: bool,
+    pub hardware_isolation: bool,
 }
 
 flowey_config! {
@@ -36,8 +39,7 @@ flowey_config! {
         pub selections: Option<VmmTestsDepSelections>,
         /// Automatically install dependencies (requires admin privileges).
         ///
-        /// When false, assume all dependencies are already present and skip
-        /// checks that require admin privileges (e.g., DISM.exe).
+        /// When false, skip checks that require admin privileges.
         ///
         /// Must be set to true/false when running locally.
         pub auto_install: Option<bool>,
@@ -90,11 +92,7 @@ impl FlowNodeWithConfig for Node {
         let installing = !installed.is_empty();
 
         match selections {
-            VmmTestsDepSelections::Windows {
-                hyperv,
-                whp,
-                hardware_isolation,
-            } => {
+            VmmTestsDepSelections::Windows(selections) => {
                 ctx.emit_rust_step("install vmm tests deps (windows)", move |ctx| {
                     installed.claim(ctx);
                     let write_commands = write_commands.claim(ctx);
@@ -104,9 +102,7 @@ impl FlowNodeWithConfig for Node {
                             rt,
                             installing,
                             auto_install,
-                            hyperv,
-                            whp,
-                            hardware_isolation,
+                            selections,
                             write_commands,
                         )
                     }
@@ -136,11 +132,14 @@ fn install_windows_deps(
     rt: &mut RustRuntimeServices<'_>,
     installing: bool,
     auto_install: Option<bool>,
-    hyperv: bool,
-    whp: bool,
-    hardware_isolation: bool,
+    selections: VmmTestsDepSelectionsWindows,
     write_commands: Vec<WriteVar<Vec<String>, VarClaimed>>,
 ) -> anyhow::Result<()> {
+    let VmmTestsDepSelectionsWindows {
+        hyperv,
+        whp,
+        hardware_isolation,
+    } = selections;
     let mut commands = Vec::new();
     let mut needs_restart = false;
 
@@ -300,7 +299,7 @@ Otherwise, press `ctrl-c` to cancel the run.
         }
     }
 
-    // Check if reg keys are set (skip if not auto_install, assume already set)
+    // Check if reg keys are set
     if installing && !reg_keys_to_set.is_empty() {
         for (path, keys) in reg_keys_to_set.iter_mut() {
             let output = flowey::shell_cmd!(rt, "reg.exe query {path}").output()?;
@@ -333,9 +332,9 @@ Otherwise, press `ctrl-c` to cancel the run.
     if installing && !reg_keys_to_set.is_empty() && matches!(rt.backend(), FlowBackend::Local) {
         let mut reg_keys_to_set_string = String::new();
         for (p, v, _, _) in reg_keys_to_set.iter() {
-            reg_keys_to_set_string.push_str(*p);
+            reg_keys_to_set_string.push_str(p);
             reg_keys_to_set_string.push(' ');
-            reg_keys_to_set_string.push_str(*v);
+            reg_keys_to_set_string.push_str(v);
             reg_keys_to_set_string.push('\n');
         }
 

--- a/support/powershell_builder/Cargo.toml
+++ b/support/powershell_builder/Cargo.toml
@@ -6,7 +6,7 @@ name = "powershell_builder"
 edition.workspace = true
 rust-version.workspace = true
 
-[target.'cfg(windows)'.dependencies]
+[dependencies]
 guid.workspace = true
 jiff.workspace = true
 

--- a/support/powershell_builder/src/lib.rs
+++ b/support/powershell_builder/src/lib.rs
@@ -6,7 +6,6 @@
 //! Provides a builder for constructing PowerShell commands with various
 //! argument data types and pipelining.
 
-#![cfg(windows)]
 #![forbid(unsafe_code)]
 
 use std::ffi::OsStr;


### PR DESCRIPTION
Makes the following improvements to `xflowey vmm_tests_run`:
- Set the correct registry key for hardware isolation.
- Indicate that a restart is required when installing test deps.
- Check whether registry keys are set and hyper-v is installed even when running without `--install-missing-deps` in a way that doesn't require admin.
- Always add all dep install commands to install_deps.ps1 in case the output (when running without `--build-only`; this was already the case when the tests were not run locally) is copied to another machine later without the deps installed on the machine that built and ran the tests originally.
- Correctly detect whether a test filter requires hyperv-v and hardware isolation.
- Add option for disabling secure avic and move the feature configuration to build_openhcl_igvm_from_recipe. 
- Only build the necessary OpenHCL recipes, rather than all or nothing.