### PR TITLE
RFC: crypto: Rework backend selection to be more strict

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1639,7 +1639,7 @@ jobs:
     - name: generate nextest command
       run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 1
@@ -1653,9 +1653,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-windows-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
@@ -1919,7 +1919,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
@@ -1933,9 +1933,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2288,7 +2288,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
@@ -2302,9 +2302,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2698,7 +2698,7 @@ jobs:
     - name: generate nextest command
       run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 1
@@ -2712,9 +2712,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-windows-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
@@ -2954,7 +2954,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
@@ -2968,9 +2968,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -3323,7 +3323,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
@@ -3337,9 +3337,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -1518,7 +1518,7 @@ jobs:
     - name: generate nextest command
       run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 1
@@ -1532,9 +1532,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-windows-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
@@ -1724,7 +1724,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
@@ -1738,9 +1738,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2051,7 +2051,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
@@ -2065,9 +2065,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2463,7 +2463,7 @@ jobs:
     - name: generate nextest command
       run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 1
@@ -2477,9 +2477,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-windows-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
@@ -2721,7 +2721,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
@@ -2735,9 +2735,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -3092,7 +3092,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
@@ -3106,9 +3106,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1909,7 +1909,7 @@ jobs:
     - name: generate nextest command
       run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 1
@@ -1923,9 +1923,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-windows-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
@@ -2115,7 +2115,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
@@ -2129,9 +2129,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2442,7 +2442,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
@@ -2456,9 +2456,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2854,7 +2854,7 @@ jobs:
     - name: generate nextest command
       run: flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 1
@@ -2868,9 +2868,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-windows-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
@@ -3112,7 +3112,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 19 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 19 flowey_lib_common::run_cargo_nextest_run 3
@@ -3126,9 +3126,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -3667,7 +3667,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 20 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 20 flowey_lib_common::run_cargo_nextest_run 3
@@ -3681,9 +3681,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,6 +1113,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto_allow_multiple_backends"
+version = "0.0.0"
+dependencies = [
+ "crypto",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ members = [
   "vm/loader/igvmfilegen",
   "vm/vmgs/vmgs_lib",
   "vm/vmgs/vmgstool",
+  # crypto workspace feature unification hack
+  "support/crypto/allow_multiple_backends",
   # opentmk
   "opentmk",
   # support crates consumed by closed-source only

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -514,13 +514,13 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 2
       $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
       $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (none)' nextest tests
+    displayName: run 'unit-tests crypto (native)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar3)
-      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (none)
-    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (native)
+    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
@@ -796,13 +796,13 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 2
       $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
       $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (none)' nextest tests
+    displayName: run 'unit-tests crypto (native)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar3)
-      testRunTitle: x64-linux-unit-tests-unit-tests crypto (none)
-    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      testRunTitle: x64-linux-unit-tests-unit-tests crypto (native)
+    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
@@ -1052,13 +1052,13 @@ jobs:
       $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 0
       $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
       $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (none)' nextest tests
+    displayName: run 'unit-tests crypto (native)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar2)
-      testRunTitle: x64-windows-unit-tests-unit-tests crypto (none)
-    displayName: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      testRunTitle: x64-windows-unit-tests-unit-tests crypto (native)
+    displayName: 'publish test results: x64-windows-unit-tests-unit-tests crypto (native) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command

--- a/flowey/flowey_lib_common/src/run_cargo_doc.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_doc.rs
@@ -7,6 +7,7 @@
 //! dependencies are installed, etc...
 
 use crate::_util::cargo_output;
+use crate::run_cargo_build::CargoFeatureSet;
 use flowey::node::prelude::*;
 use flowey::shell::FloweyCmd;
 use std::collections::BTreeMap;
@@ -106,6 +107,8 @@ pub struct DocPackage {
     pub no_deps: bool,
     /// Whether to document private items (i.e: pass `--document-private-items`)
     pub document_private_items: bool,
+    /// The features to enable for the documented packages.
+    pub features: CargoFeatureSet,
 }
 
 flowey_request! {
@@ -119,13 +122,19 @@ flowey_request! {
     }
 }
 
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct DocKey {
+    no_deps: bool,
+    document_private_items: bool,
+    features: CargoFeatureSet,
+}
+
 #[derive(Default)]
 struct ResolvedDocPackages {
-    // where each (bool, bool) represents (no_deps, document_private_items)
-    workspace: Option<(bool, bool)>,
+    workspace: Option<DocKey>,
     exclude: Vec<String>,
-    crates: BTreeMap<(bool, bool), Vec<String>>,
-    crates_no_std: BTreeMap<(bool, bool), Vec<String>>,
+    crates: BTreeMap<DocKey, Vec<String>>,
+    crates_no_std: BTreeMap<DocKey, Vec<String>>,
 }
 
 new_flow_node!(struct Node);
@@ -159,6 +168,7 @@ impl FlowNode for Node {
                 kind,
                 no_deps,
                 document_private_items,
+                features,
             } in packages
             {
                 match kind {
@@ -167,16 +177,28 @@ impl FlowNode for Node {
                             anyhow::bail!("cannot pass Workspace variant multiple times")
                         }
                         targets.exclude.extend(exclude);
-                        targets.workspace = Some((no_deps, document_private_items))
+                        targets.workspace = Some(DocKey {
+                            no_deps,
+                            document_private_items,
+                            features,
+                        })
                     }
                     DocPackageKind::Crate(name) => targets
                         .crates
-                        .entry((no_deps, document_private_items))
+                        .entry(DocKey {
+                            no_deps,
+                            document_private_items,
+                            features,
+                        })
                         .or_default()
                         .push(name),
                     DocPackageKind::NoStdCrate(name) => targets
                         .crates_no_std
-                        .entry((no_deps, document_private_items))
+                        .entry(DocKey {
+                            no_deps,
+                            document_private_items,
+                            features,
+                        })
                         .or_default()
                         .push(name),
                 }
@@ -209,7 +231,12 @@ impl FlowNode for Node {
                         crates_no_std,
                     } = doc_targets;
 
-                    let base_cmd = |no_deps: bool, document_private_items: bool| -> Vec<String> {
+                    let base_cmd = |key| -> Vec<String> {
+                        let DocKey {
+                            no_deps,
+                            document_private_items,
+                            features,
+                        } = key;
                         let mut v = Vec::new();
                         v.push("cargo".into());
                         if let Some(rust_toolchain) = &rust_toolchain {
@@ -231,16 +258,17 @@ impl FlowNode for Node {
                         if document_private_items {
                             v.push("--document-private-items".into())
                         }
+                        v.extend(features.to_cargo_arg_strings());
                         v
                     };
 
                     // first command to run should be the workspace-level
                     // command (if one was provided)
-                    if let Some((no_deps, document_private_items)) = workspace {
+                    if let Some(key) = workspace {
                         // subsume crates with the same options
-                        crates.remove(&(no_deps, document_private_items));
+                        crates.remove(&key);
 
-                        let mut v = base_cmd(no_deps, document_private_items);
+                        let mut v = base_cmd(key);
 
                         v.push("--workspace".into());
 
@@ -255,8 +283,8 @@ impl FlowNode for Node {
                     }
 
                     // subsequently: document any specific std crates
-                    for ((no_deps, document_private_items), crates) in crates {
-                        let mut v = base_cmd(no_deps, document_private_items);
+                    for (key, crates) in crates {
+                        let mut v = base_cmd(key);
 
                         for c in crates {
                             v.push("-p".into());
@@ -267,8 +295,8 @@ impl FlowNode for Node {
                     }
 
                     // lastly: document any no_std crates
-                    for ((no_deps, document_private_items), crates) in crates_no_std {
-                        let mut v = base_cmd(no_deps, document_private_items);
+                    for (key, crates) in crates_no_std {
+                        let mut v = base_cmd(key);
 
                         for c in crates {
                             v.push("-p".into());

--- a/flowey/flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs
@@ -52,7 +52,7 @@ impl SimpleFlowNode for Node {
 
                 let path = rt.read(openvmm_repo_path);
                 rt.sh.change_dir(path);
-                flowey::shell_cmd!(rt, "cargo test --locked --doc --workspace --no-fail-fast --target {target} --profile {profile}").run()?;
+                flowey::shell_cmd!(rt, "cargo test --locked --doc --workspace --no-fail-fast --target {target} --profile {profile} --features crypto/allow-multiple-backends").run()?;
 
                 Ok(())
             }

--- a/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
@@ -142,8 +142,7 @@ impl SimpleFlowNode for Node {
                 let repo_path = rt.read(repo_path);
 
                 // guest_test_uefi is uefi-only, and is handled separately below
-                // crypto is handled separately in order to deal with its non-additive features
-                let mut exclude = vec!["guest_test_uefi".into(), "crypto".into()];
+                let mut exclude = vec!["guest_test_uefi".into()];
 
                 // packages depending on libfuzzer-sys are currently x86 only
                 if !(matches!(target.architecture, target_lexicon::Architecture::X86_64)
@@ -181,11 +180,14 @@ impl SimpleFlowNode for Node {
         //
         // We don't add the CI feature here, as it's used purely to exclude
         // tests that can't run in CI. We still want those tests to be linted.
+        //
+        // Adding the "crypto/allow_multiple_backends" feature is also used
+        // since we're running over the whole workspace.
         let features = if matches!(
             target.operating_system,
             target_lexicon::OperatingSystem::Windows | target_lexicon::OperatingSystem::Darwin(_)
         ) {
-            CargoFeatureSet::None
+            CargoFeatureSet::Specific(vec!["crypto/allow_multiple_backends".into()])
         } else {
             CargoFeatureSet::All
         };
@@ -205,12 +207,12 @@ impl SimpleFlowNode for Node {
         })];
 
         // crypto has non-additive features, we need to ensure full coverage of different backends.
-        // Always test the 'native' no-feature backends.
+        // Always test the native backend.
         reqs.push(ctx.reqv(|v| flowey_lib_common::run_cargo_clippy::Request {
             in_folder: openvmm_repo_path.clone(),
             package: CargoPackage::Crate("crypto".into()),
             profile: profile.clone(),
-            features: CargoFeatureSet::None,
+            features: CargoFeatureSet::Specific(vec!["native".into()]),
             target: target.clone(),
             extra_env: None,
             exclude: ReadVar::from_static(None),

--- a/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
@@ -181,13 +181,13 @@ impl SimpleFlowNode for Node {
         // We don't add the CI feature here, as it's used purely to exclude
         // tests that can't run in CI. We still want those tests to be linted.
         //
-        // Adding the "crypto/allow_multiple_backends" feature is also used
+        // Adding the "crypto/allow-multiple-backends" feature is also used
         // since we're running over the whole workspace.
         let features = if matches!(
             target.operating_system,
             target_lexicon::OperatingSystem::Windows | target_lexicon::OperatingSystem::Darwin(_)
         ) {
-            CargoFeatureSet::Specific(vec!["crypto/allow_multiple_backends".into()])
+            CargoFeatureSet::Specific(vec!["crypto/allow-multiple-backends".into()])
         } else {
             CargoFeatureSet::All
         };

--- a/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
@@ -181,8 +181,8 @@ impl SimpleFlowNode for Node {
         // We don't add the CI feature here, as it's used purely to exclude
         // tests that can't run in CI. We still want those tests to be linted.
         //
-        // Adding the "crypto/allow-multiple-backends" feature is also used
-        // since we're running over the whole workspace.
+        // We add the "crypto/allow-multiple-backends" feature since we're
+        // running over the whole workspace.
         let features = if matches!(
             target.operating_system,
             target_lexicon::OperatingSystem::Windows | target_lexicon::OperatingSystem::Darwin(_)

--- a/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
@@ -215,7 +215,7 @@ impl FlowNode for Node {
             // linux targets too, but we don't currently have a prebuilt
             // library for them.
             let mut crypto_feature_sets = vec![
-                ("none", CargoFeatureSet::Specific(vec!["native".into()])),
+                ("native", CargoFeatureSet::Specific(vec!["native".into()])),
                 ("rust", CargoFeatureSet::Specific(vec!["rust".into()])),
             ];
             if matches!(

--- a/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
@@ -105,8 +105,6 @@ impl FlowNode for Node {
                     "vmm_tests",
                     // Skip guest_test_uefi, as it's a no_std UEFI crate
                     "guest_test_uefi",
-                    // Skip crypto, handle it separately due to its non-additive features
-                    "crypto",
                     // Exclude various proc_macro crates, since they don't compile successfully
                     // under --test with panic=abort targets.
                     // https://github.com/rust-lang/cargo/issues/4336 is tracking this.
@@ -170,13 +168,19 @@ impl FlowNode for Node {
             // On Windows we can't run with all features since the TPM requires
             // OpenSSL for crypto, which isn't supported in Windows CI today.
             //
-            // Adding the "ci" feature is also used to skip certain tests that
+            // Adding the "ci" feature is used to skip certain tests that
             // fail in CI.
+            //
+            // Adding the "crypto/allow_multiple_backends" feature is also used
+            // since we're running over the whole workspace.
             let features = if matches!(
                 target.operating_system,
                 target_lexicon::OperatingSystem::Windows
             ) {
-                CargoFeatureSet::Specific(vec!["ci".into()])
+                CargoFeatureSet::Specific(vec![
+                    "ci".into(),
+                    "crypto/allow_multiple_backends".into(),
+                ])
             } else {
                 CargoFeatureSet::All
             };
@@ -198,20 +202,20 @@ impl FlowNode for Node {
                 extra_env: injected_env,
             };
 
-            // The first run is the main workspace run with --all-features.
+            // The first run is the main workspace run with the base features.
             let mut runs: Vec<(String, NextestBuildParams)> =
                 vec![("unit-tests".into(), base_build_params.clone())];
 
             // crypto has non-additive features, so it gets its own runs to
             // ensure full coverage of different backends. Always test the
-            // 'native' no-feature and pure-rust backends. On linux additionally
+            // native and pure-rust backends. On linux additionally
             // test the openssl & symcrypt backends and --all-features fallback.
             // We could test openssl on non-linux targets too, but setting up
             // builds for them is a pain. We could test Symcrypt on non-musl
             // linux targets too, but we don't currently have a prebuilt
             // library for them.
             let mut crypto_feature_sets = vec![
-                ("none", CargoFeatureSet::None),
+                ("none", CargoFeatureSet::Specific(vec!["native".into()])),
                 ("rust", CargoFeatureSet::Specific(vec!["rust".into()])),
             ];
             if matches!(

--- a/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
@@ -171,7 +171,7 @@ impl FlowNode for Node {
             // Adding the "ci" feature is used to skip certain tests that
             // fail in CI.
             //
-            // Adding the "crypto/allow_multiple_backends" feature is also used
+            // Adding the "crypto/allow-multiple-backends" feature is also used
             // since we're running over the whole workspace.
             let features = if matches!(
                 target.operating_system,
@@ -179,7 +179,7 @@ impl FlowNode for Node {
             ) {
                 CargoFeatureSet::Specific(vec![
                     "ci".into(),
-                    "crypto/allow_multiple_backends".into(),
+                    "crypto/allow-multiple-backends".into(),
                 ])
             } else {
                 CargoFeatureSet::All

--- a/flowey/flowey_lib_hvlite/src/build_rustdoc.rs
+++ b/flowey/flowey_lib_hvlite/src/build_rustdoc.rs
@@ -4,6 +4,7 @@
 //! Document crates in the hvlite repo using rustdoc (via `cargo doc`).
 
 use flowey::node::prelude::*;
+use flowey_lib_common::run_cargo_build::CargoFeatureSet;
 use flowey_lib_common::run_cargo_doc::DocPackage;
 use flowey_lib_common::run_cargo_doc::DocPackageKind;
 
@@ -75,11 +76,15 @@ impl FlowNode for Node {
                             },
                             no_deps,
                             document_private_items,
+                            features: CargoFeatureSet::Specific(vec![
+                                "crypto/allow-multiple-backends".into(),
+                            ]),
                         },
                         DocPackage {
                             kind: DocPackageKind::NoStdCrate("guest_test_uefi".into()),
                             no_deps,
                             document_private_items,
+                            features: CargoFeatureSet::None,
                         },
                     ],
                     target_triple: target_triple.clone(),

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -123,5 +123,5 @@ build_rs_guest_arch.workspace = true
 workspace = true
 
 [package.metadata.xtask.unused-deps]
-# keep the crypto dep so we can specify the vendored feature
+# keep the crypto dep so we can specify the vendored and backend features
 ignored = ["crypto"]

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -66,7 +66,7 @@ pcie_remote_resources.workspace = true
 
 clap_dyn_complete.workspace = true
 console_relay.workspace = true
-crypto = { workspace = true, optional = true }
+crypto = { workspace = true, features = ["native"] }
 guid.workspace = true
 inspect.workspace = true
 inspect_proto.workspace = true

--- a/rust-analyzer.toml
+++ b/rust-analyzer.toml
@@ -1,3 +1,3 @@
-# Specify the allow_multiple_backends feature so that workspace-wide analysis works correctly.
+# Specify the allow-multiple-backends feature so that workspace-wide analysis works correctly.
 [cargo]
-features = ["crypto/allow_multiple_backends"]
+features = ["crypto/allow-multiple-backends"]

--- a/rust-analyzer.toml
+++ b/rust-analyzer.toml
@@ -1,2 +1,3 @@
+# Specify the allow_multiple_backends feature so that workspace-wide analysis works correctly.
 [cargo]
 features = ["crypto/allow_multiple_backends"]

--- a/rust-analyzer.toml
+++ b/rust-analyzer.toml
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # Specify the allow-multiple-backends feature so that workspace-wide analysis works correctly.
 [cargo]
 features = ["crypto/allow-multiple-backends"]

--- a/rust-analyzer.toml
+++ b/rust-analyzer.toml
@@ -1,0 +1,2 @@
+[cargo]
+features = ["crypto/allow_multiple_backends"]

--- a/support/crypto/Cargo.toml
+++ b/support/crypto/Cargo.toml
@@ -7,6 +7,10 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
+# Allow multiple crypto backends to be enabled at the same time.
+# This is intended for testing purposes and should not be used in production.
+allow-multiple-backends = []
+
 # Enable test-only helper functions.
 test_helpers = ["x509-cert?/builder"]
 
@@ -14,6 +18,9 @@ test_helpers = ["x509-cert?/builder"]
 # If the chosen backend is natively available, this feature is a no-op.
 # If the chosen backend is not natively available and can't be vendored, this will trigger a compile error.
 vendored = ["openssl?/vendored"]
+
+# Require use of the native crypto backend (OpenSSL on Linux).
+native = []
 
 # Use OpenSSL instead of any native backend.
 openssl = ["dep:openssl", "dep:openssl_kdf"]

--- a/support/crypto/allow_multiple_backends/Cargo.toml
+++ b/support/crypto/allow_multiple_backends/Cargo.toml
@@ -11,3 +11,6 @@ crypto = { workspace = true, features = ["allow-multiple-backends"] }
 
 [lints]
 workspace = true
+
+[package.metadata.xtask.unused-deps]
+ignored = ["crypto"]

--- a/support/crypto/allow_multiple_backends/Cargo.toml
+++ b/support/crypto/allow_multiple_backends/Cargo.toml
@@ -1,0 +1,13 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "crypto_allow_multiple_backends"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+crypto = { workspace = true, features = ["allow-multiple-backends"] }
+
+[lints]
+workspace = true

--- a/support/crypto/allow_multiple_backends/src/lib.rs
+++ b/support/crypto/allow_multiple_backends/src/lib.rs
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! This crate exists solely to enable crypto's `allow-multiple-backends` feature for workspace-wide builds.
+//! Without it commands like `cargo check --workspace` would fail due to binaries enabling multiple backends.

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -11,7 +11,6 @@ fn main() {
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_SYMCRYPT");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_VENDORED");
     println!("cargo::rerun-if-env-changed=CARGO_CFG_TARGET_OS");
-    println!("cargo::rerun-if-env-changed=PROFILE");
 
     println!("cargo::rustc-check-cfg=cfg(native)");
     println!("cargo::rustc-check-cfg=cfg(openssl)");
@@ -24,7 +23,6 @@ fn main() {
     let symcrypt = std::env::var_os("CARGO_FEATURE_SYMCRYPT").is_some();
     let vendored = std::env::var_os("CARGO_FEATURE_VENDORED").is_some();
 
-    let profile = std::env::var("PROFILE").unwrap();
     let allow_multiple_backends =
         std::env::var_os("CARGO_FEATURE_ALLOW_MULTIPLE_BACKENDS").is_some();
 
@@ -69,9 +67,8 @@ fn main() {
         }
     }
     // If we see multiple backends enabled that's an error. However if we see
-    // allow-multiple-backends is enabled, or we're doing a debug build, print
-    // a warning and allow it.
-    else if allow_multiple_backends || profile == "debug" {
+    // if allow-multiple-backends is enabled print a warning and allow it.
+    else if allow_multiple_backends {
         println!(
             "cargo::warning=allow-multiple-backends is enabled, this may produce insecure binaries."
         );
@@ -80,7 +77,7 @@ fn main() {
         if openssl {
             println!("cargo::warning=Using OpenSSL backend.");
             println!("cargo::rustc-cfg=openssl");
-        } else if symcrypt {
+        } else if symcrypt && !vendored {
             println!("cargo::warning=Using Symcrypt backend.");
             println!("cargo::rustc-cfg=symcrypt");
         } else if rust {

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -4,7 +4,7 @@
 #![expect(missing_docs)]
 
 fn main() {
-    println!("cargo::rerun-if-env-changed=CARGO_FEATURE_ALLOW_MULTIPLE_BACKENDS");
+    println!("cargo::rerun-if-env-changed=CARGO_FEATURE_ALLOW-MULTIPLE-BACKENDS");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_NATIVE");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_OPENSSL");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_RUST");
@@ -26,7 +26,7 @@ fn main() {
 
     let profile = std::env::var("PROFILE").unwrap();
     let allow_multiple_backends =
-        std::env::var_os("CARGO_FEATURE_ALLOW_MULTIPLE_BACKENDS").is_some();
+        std::env::var_os("CARGO_FEATURE_ALLOW-MULTIPLE-BACKENDS").is_some();
 
     let linux = std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "linux";
 

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -4,7 +4,7 @@
 #![expect(missing_docs)]
 
 fn main() {
-    println!("cargo::rerun-if-env-changed=CARGO_FEATURE_ALLOW-MULTIPLE-BACKENDS");
+    println!("cargo::rerun-if-env-changed=CARGO_FEATURE_ALLOW_MULTIPLE_BACKENDS");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_NATIVE");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_OPENSSL");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_RUST");
@@ -26,7 +26,7 @@ fn main() {
 
     let profile = std::env::var("PROFILE").unwrap();
     let allow_multiple_backends =
-        std::env::var_os("CARGO_FEATURE_ALLOW-MULTIPLE-BACKENDS").is_some();
+        std::env::var_os("CARGO_FEATURE_ALLOW_MULTIPLE_BACKENDS").is_some();
 
     let linux = std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "linux";
 
@@ -75,23 +75,26 @@ fn main() {
         println!(
             "cargo::warning=allow-multiple-backends is enabled, this may produce insecure binaries."
         );
-        eprintln!("Backends enabled: {}", backend_list_str);
+        println!("cargo::warning=Backends enabled: {}", backend_list_str);
 
         if openssl {
-            eprintln!("Using OpenSSL backend.");
+            println!("cargo::warning=Using OpenSSL backend.");
             println!("cargo::rustc-cfg=openssl");
         } else if symcrypt {
-            eprintln!("Using Symcrypt backend.");
+            println!("cargo::warning=Using Symcrypt backend.");
             println!("cargo::rustc-cfg=symcrypt");
         } else if rust {
-            eprintln!("Using Rust backend.");
+            println!("cargo::warning=Using Rust backend.");
             println!("cargo::rustc-cfg=rust");
-        } else if native {
-            eprintln!("Using native backend.");
+        } else if native && !linux {
+            println!("cargo::warning=Using native backend.");
             println!("cargo::rustc-cfg=native");
+        } else if native && linux {
+            println!("cargo::warning=Using OpenSSL backend (native on Linux).");
+            println!("cargo::rustc-cfg=openssl");
         }
     } else {
-        eprintln!("Backends enabled: {}", backend_list_str);
+        println!("cargo::warning=Backends enabled: {}", backend_list_str);
         panic!(
             "Multiple crypto backends enabled. Please enable only one in your binary's dependencies."
         );

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -4,52 +4,96 @@
 #![expect(missing_docs)]
 
 fn main() {
+    println!("cargo::rerun-if-env-changed=CARGO_FEATURE_ALLOW_MULTIPLE_BACKENDS");
+    println!("cargo::rerun-if-env-changed=CARGO_FEATURE_NATIVE");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_OPENSSL");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_RUST");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_SYMCRYPT");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_VENDORED");
     println!("cargo::rerun-if-env-changed=CARGO_CFG_TARGET_OS");
+    println!("cargo::rerun-if-env-changed=PROFILE");
 
     println!("cargo::rustc-check-cfg=cfg(native)");
     println!("cargo::rustc-check-cfg=cfg(openssl)");
     println!("cargo::rustc-check-cfg=cfg(rust)");
     println!("cargo::rustc-check-cfg=cfg(symcrypt)");
 
+    let native = std::env::var_os("CARGO_FEATURE_NATIVE").is_some();
     let openssl = std::env::var_os("CARGO_FEATURE_OPENSSL").is_some();
     let rust = std::env::var_os("CARGO_FEATURE_RUST").is_some();
     let symcrypt = std::env::var_os("CARGO_FEATURE_SYMCRYPT").is_some();
     let vendored = std::env::var_os("CARGO_FEATURE_VENDORED").is_some();
+
+    let profile = std::env::var("PROFILE").unwrap();
+    let allow_multiple_backends =
+        std::env::var_os("CARGO_FEATURE_ALLOW_MULTIPLE_BACKENDS").is_some();
+
     let linux = std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "linux";
 
-    let all_features = openssl && rust && symcrypt && vendored;
-    let backend_count = openssl as u8 + rust as u8 + symcrypt as u8;
+    let backend_count = openssl as u8 + rust as u8 + symcrypt as u8 + native as u8;
 
-    // If we see multiple backends enabled that's an error. However if we see every
-    // backend, and vendoring, enabled, it's likely we're in an --all-features session.
-    // Since this is a common rust-analyzer configuration, allow it and fall back to
-    // platform defaults.
-    if backend_count > 1 && !all_features {
-        panic!("Multiple crypto backends enabled, but only one can be selected");
-    } else if backend_count == 0 || all_features {
-        // Default to openssl on linux, the dependencies are also marked
-        // non-optional and there is no native backend available
-        if linux {
+    let mut backend_list = Vec::new();
+    if openssl {
+        backend_list.push("openssl");
+    }
+    if symcrypt {
+        backend_list.push("symcrypt");
+    }
+    if rust {
+        backend_list.push("rust");
+    }
+    if native {
+        backend_list.push("native");
+    }
+    let backend_list_str = backend_list.join(", ");
+
+    // If no backends are enabled, abort. Binaries must choose a backend.
+    if backend_count == 0 {
+        panic!("No crypto backend enabled. Enable one in your binary's dependencies.");
+    }
+    // If exactly one backend is enabled, use it.
+    else if backend_count == 1 {
+        if openssl {
             println!("cargo::rustc-cfg=openssl");
-        } else {
+        } else if symcrypt {
+            if vendored {
+                panic!("Symcrypt does not support vendoring.");
+            }
+            println!("cargo::rustc-cfg=symcrypt");
+        } else if rust {
+            println!("cargo::rustc-cfg=rust");
+        } else if native && !linux {
             println!("cargo::rustc-cfg=native");
+        } else if native && linux {
+            println!("cargo::rustc-cfg=openssl");
         }
     }
-    // Symcrypt does not support vendoring, so fail early if the user tries to
-    // enable both the symcrypt backend and the vendored feature.
-    else if vendored && symcrypt {
-        panic!("The symcrypt backend does not support vendoring");
-    }
-    // Output a single config flag to indicate which backend should be used.
-    else if openssl {
-        println!("cargo::rustc-cfg=openssl");
-    } else if symcrypt {
-        println!("cargo::rustc-cfg=symcrypt");
-    } else if rust {
-        println!("cargo::rustc-cfg=rust");
+    // If we see multiple backends enabled that's an error. However if we see
+    // allow-multiple-backends is enabled, or we're doing a debug build, print
+    // a warning and allow it.
+    else if allow_multiple_backends || profile == "debug" {
+        println!(
+            "cargo::warning=allow-multiple-backends is enabled, this may produce insecure binaries."
+        );
+        eprintln!("Backends enabled: {}", backend_list_str);
+
+        if openssl {
+            eprintln!("Using OpenSSL backend.");
+            println!("cargo::rustc-cfg=openssl");
+        } else if symcrypt {
+            eprintln!("Using Symcrypt backend.");
+            println!("cargo::rustc-cfg=symcrypt");
+        } else if rust {
+            eprintln!("Using Rust backend.");
+            println!("cargo::rustc-cfg=rust");
+        } else if native {
+            eprintln!("Using native backend.");
+            println!("cargo::rustc-cfg=native");
+        }
+    } else {
+        eprintln!("Backends enabled: {}", backend_list_str);
+        panic!(
+            "Multiple crypto backends enabled. Please enable only one in your binary's dependencies."
+        );
     }
 }

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -66,8 +66,8 @@ fn main() {
             println!("cargo::rustc-cfg=openssl");
         }
     }
-    // If we see multiple backends enabled that's an error. However if we see
-    // if allow-multiple-backends is enabled print a warning and allow it.
+    // If we see multiple backends enabled that's an error. However if
+    // allow-multiple-backends is enabled print a warning and allow it.
     else if allow_multiple_backends {
         println!(
             "cargo::warning=allow-multiple-backends is enabled, this may produce insecure binaries."

--- a/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
-crypto = { workspace = true, features = ["test_helpers", "vendored"] }
+crypto = { workspace = true, features = ["test_helpers", "rust"] }
 firmware_uefi = { workspace = true, features = ["fuzzing"] }
 firmware_uefi_resources.workspace = true
 guid.workspace = true

--- a/vm/vmgs/vmgs_lib/Cargo.toml
+++ b/vm/vmgs/vmgs_lib/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-crypto = { workspace = true, features = ["vendored"] }
+crypto = { workspace = true, features = ["native", "vendored"] }
 disk_backend.workspace = true
 disk_vhd1.workspace = true
 futures.workspace = true

--- a/vm/vmgs/vmgstool/Cargo.toml
+++ b/vm/vmgs/vmgstool/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 [features]
 default = []
 
-encryption = ["vmgs/encryption", "crypto/vendored"]
+encryption = ["vmgs/encryption", "crypto/native", "crypto/vendored"]
 
 test_helpers = ["vmgs/test_helpers", "getrandom", "dep:resource_dll_parser"]
 

--- a/xsync/xsync/src/main.rs
+++ b/xsync/xsync/src/main.rs
@@ -57,6 +57,7 @@ struct Cli {
 enum Commands {
     CargoToml(tasks::CargoToml),
     CargoLock(tasks::CargoLock),
+    RustAnalyzerToml(tasks::RustAnalyzerToml),
     RustToolchainToml(tasks::RustToolchainToml),
     RustfmtToml(tasks::RustfmtToml),
 }
@@ -100,6 +101,7 @@ fn try_main() -> anyhow::Result<()> {
         Some(cmd) => match cmd {
             Commands::CargoToml(task) => task.run(ctx),
             Commands::CargoLock(task) => task.run(ctx),
+            Commands::RustAnalyzerToml(task) => task.run(ctx),
             Commands::RustToolchainToml(task) => task.run(ctx),
             Commands::RustfmtToml(task) => task.run(ctx),
         },
@@ -125,6 +127,14 @@ fn do_full_sync(ctx: &CmdCtx, check: bool) -> Result<(), anyhow::Error> {
     );
     tasks::RustToolchainToml {
         cmd: tasks::rust_toolchain_toml::Command::Regen,
+    }
+    .run(ctx.clone())?;
+
+    log::info!(
+        "running xsync cmd: `rust-analyzer regen`    (syncing overlay-repo's `rust-analyzer.toml` to base-repo's `rust-analyzer.toml`)"
+    );
+    tasks::RustAnalyzerToml {
+        cmd: tasks::rust_analyzer_toml::Command::Regen,
     }
     .run(ctx.clone())?;
 

--- a/xsync/xsync/src/tasks/mod.rs
+++ b/xsync/xsync/src/tasks/mod.rs
@@ -5,11 +5,13 @@
 
 pub mod cargo_lock;
 pub mod cargo_toml;
+pub mod rust_analyzer_toml;
 pub mod rust_toolchain_toml;
 pub mod rustfmt_toml;
 
 pub use self::cargo_lock::CargoLock;
 pub use self::cargo_toml::CargoToml;
+pub use self::rust_analyzer_toml::RustAnalyzerToml;
 pub use self::rust_toolchain_toml::RustToolchainToml;
 pub use self::rustfmt_toml::RustfmtToml;
 
@@ -50,6 +52,7 @@ mod custom_meta {
         pub profile: bool,
         pub patch: bool,
         pub workspace: InheritWorkspace,
+        pub rust_analyzer: bool,
         pub rust_toolchain: InheritRustToolchain,
         pub rustfmt: bool,
     }

--- a/xsync/xsync/src/tasks/rust_analyzer_toml.rs
+++ b/xsync/xsync/src/tasks/rust_analyzer_toml.rs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::Cmd;
+use anyhow::Context;
+use clap::Parser;
+use clap::Subcommand;
+use std::str::FromStr;
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Use base repo's `rust-analyzer.toml` to regenerate overlay's `rust-analyzer.toml`
+    Regen,
+}
+
+#[derive(Parser)]
+#[clap(
+    about = "Tools to keep rust-analyzer.toml files in-sync",
+    disable_help_subcommand = true
+)]
+pub struct RustAnalyzerToml {
+    #[clap(subcommand)]
+    pub cmd: Command,
+}
+
+impl Cmd for RustAnalyzerToml {
+    fn run(self, ctx: crate::CmdCtx) -> anyhow::Result<()> {
+        let Command::Regen = self.cmd;
+
+        // parse the Cargo.xsync.toml
+        let overlay_cargo_toml =
+            fs_err::read_to_string(ctx.overlay_workspace.join("Cargo.xsync.toml"))?;
+        let mut overlay_cargo_toml = cargo_toml::Manifest::<
+            super::custom_meta::CargoOverlayMetadata,
+        >::from_slice_with_metadata(
+            overlay_cargo_toml.as_bytes()
+        )?;
+
+        // extract the custom metadata
+        let meta = overlay_cargo_toml
+            .workspace
+            .as_mut()
+            .unwrap()
+            .metadata
+            .take()
+            .unwrap()
+            .xsync;
+
+        if !meta.inherit.rust_analyzer {
+            return Ok(());
+        }
+
+        let out = std::path::absolute(ctx.overlay_workspace.join("rust-analyzer.toml"))?;
+        let base_analyzer_toml =
+            fs_err::read_to_string(ctx.base_workspace.join("rust-analyzer.toml"));
+
+        // Ensure that the rust-analyzer.toml in the overlay matches that of the base repo exactly.
+        // This is a policy decision, and is open to changing in the future.
+        match base_analyzer_toml {
+            Ok(base_analyzer_toml) => {
+                log::info!(
+                    "base rust-analyzer.toml found, regenerating overlay rust-analyzer.toml",
+                );
+                let mut base_analyzer_toml = toml_edit::DocumentMut::from_str(&base_analyzer_toml)?;
+                base_analyzer_toml.fmt();
+                let generated_analyzer_toml = format!(
+                    "{}{}",
+                    super::GENERATED_HEADER.trim_start(),
+                    &base_analyzer_toml.to_string()
+                );
+                log::debug!("{generated_analyzer_toml}");
+                fs_err::write(out, generated_analyzer_toml.as_bytes())?;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                log::info!(
+                    "base rust-analyzer.toml not found, removing overlay rust-analyzer.toml if present"
+                );
+                match fs_err::remove_file(out) {
+                    Ok(_) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => Err(e).context("failed to remove overlay rust-analyzer.toml")?,
+                }
+            }
+            Err(e) => {
+                Err(e).context("failed to read base rust-analyzer.toml")?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/xtask/src/tasks/fuzz/html_coverage.rs
+++ b/xtask/src/tasks/fuzz/html_coverage.rs
@@ -89,7 +89,6 @@ pub(super) fn generate_html_coverage_report(
             .arg("-object")
             .arg(&coverage_bin)
             .args(["--ignore-filename-regex", "rustc"])
-            .args(["--ignore-filename-regex", "openssl-sys"])
             .stdout(std::process::Stdio::from(lcov_output))
             .spawn()?;
         if !cmd.wait()?.success() {


### PR DESCRIPTION
With this PR I'm trying to thread the needle between two slightly contradictory goals:

- A shipping binary should have a strong guarantee that it has linked in the crypto backend it expects
- Developers should have minimal friction when performing workspace-wide operations, despite binaries asking for disparate crypto backends

To accomplish this I've come up with the following protocol:

- Remove the "no features" default fallback. A binary **must** pick a crypto backend. This is a lot simpler now that way fewer crates depend on crypto, thanks to other refactors. Add a new 'native' feature to represent the previous implicit default.
- A new feature, 'allow-multiple-backends', is added as an escape hatch for things like CI and rust-analyzer. A rust-analyzer.toml file at the repo root ensures this feature is always enabled for developers.
- crypto's build script will enforce that either a single backend is chosen, or allow-multiple-backends is enabled.
- A new crate, 'crypto_allow_multiple_backends', is added to the workspace. This crate does nothing but enable the 'allow-multiple-backends' feature. This exists so that commands like `cargo build --workspace` can still succeed. Nothing depends on this crate, and nothing ever should.

I'm hoping that this flow will allow all common developer commands to continue working, while ensuring that we don't accidentally produce an insecure binary. 