### PR TITLE
pci_resource_assignment: add PCI resource assignment crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5433,6 +5433,7 @@ dependencies = [
  "pal_async",
  "pci_bus",
  "pci_core",
+ "pci_resource_assignment",
  "pci_resources",
  "pcie",
  "range_map_vec",
@@ -6020,6 +6021,16 @@ dependencies = [
  "tracing",
  "vmcore",
  "zerocopy",
+]
+
+[[package]]
+name = "pci_resource_assignment"
+version = "0.0.0"
+dependencies = [
+ "parking_lot",
+ "pci_core",
+ "thiserror 2.0.16",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6027,6 +6027,7 @@ dependencies = [
 name = "pci_resource_assignment"
 version = "0.0.0"
 dependencies = [
+ "pal_async",
  "parking_lot",
  "pci_core",
  "thiserror 2.0.16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,6 @@ members = [
   "opentmk",
   # support crates consumed by closed-source only
   "support/debug_output_tracing",
-  "vm/devices/pci/pci_resource_assignment",
 ]
 exclude = [
   "xsync",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ members = [
   "opentmk",
   # support crates consumed by closed-source only
   "support/debug_output_tracing",
+  "vm/devices/pci/pci_resource_assignment",
 ]
 exclude = [
   "xsync",
@@ -290,6 +291,7 @@ vfio_assigned_device = { path = "vm/devices/pci/vfio_assigned_device" }
 vfio_assigned_device_resources = { path = "vm/devices/pci/vfio_assigned_device_resources" }
 pci_bus = { path = "vm/devices/pci/pci_bus" }
 pci_core = { path = "vm/devices/pci/pci_core" }
+pci_resource_assignment = { path = "vm/devices/pci/pci_resource_assignment" }
 pci_resources = { path = "vm/devices/pci/pci_resources" }
 pcie = { path = "vm/devices/pci/pcie" }
 smmu = { path = "vm/devices/iommu/smmu" }

--- a/openvmm/openvmm_core/Cargo.toml
+++ b/openvmm/openvmm_core/Cargo.toml
@@ -68,6 +68,7 @@ input_core.workspace = true
 missing_dev.workspace = true
 pci_bus.workspace = true
 pci_core.workspace = true
+pci_resource_assignment.workspace = true
 pci_resources.workspace = true
 pcie.workspace = true
 smmu.workspace = true

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 mod dump;
+mod ecam_config_access;
 mod pcie_wiring;
 mod smmu_wiring;
 
@@ -749,6 +750,7 @@ struct LoadedVmInner {
     client_notify_send: mesh::Sender<HaltReason>,
     /// allow the guest to reset without notifying the client
     automatic_guest_reset: bool,
+    chipset: Arc<vmotherboard::Chipset>,
     pcie_host_bridges: Vec<PcieHostBridge>,
     pcie_root_complexes: Vec<Arc<closeable_mutex::CloseableMutex<GenericPcieRootComplex>>>,
     /// SMMU configurations, one per instance.
@@ -2718,6 +2720,7 @@ impl InitializedVm {
                 halt_recv,
                 client_notify_send,
                 automatic_guest_reset: cfg.automatic_guest_reset,
+                chipset: chipset.chipset.clone(),
                 pcie_host_bridges,
                 pcie_root_complexes,
                 pcie_hotplug_devices: Vec::new(),
@@ -2734,6 +2737,7 @@ impl InitializedVm {
                 .context("loadedvm restore failed")?;
         } else {
             this.inner.load_firmware(false).await?;
+            this.assign_pci_resources().await?;
         }
 
         Ok(this)
@@ -3029,6 +3033,45 @@ impl LoadedVm {
         self.state_units.stop().await;
         self.running = false;
         true
+    }
+
+    /// Assign PCI bus numbers and BAR addresses for Linux direct boot.
+    ///
+    /// UEFI and PCAT firmware perform their own PCI enumeration, so this
+    /// is only needed when booting without firmware. This is called after
+    /// `load_firmware` on both initial boot and reset.
+    ///
+    /// Config space accesses go through device state units (via the ECAM
+    /// MMIO path), so devices must be running. This method temporarily
+    /// starts state units with VPs held stopped, performs the assignment,
+    /// then stops state units again. The caller is responsible for
+    /// resuming normally afterward.
+    async fn assign_pci_resources(&mut self) -> anyhow::Result<()> {
+        if !matches!(self.inner.load_mode, LoadMode::Linux { .. })
+            || self.inner.pcie_host_bridges.is_empty()
+        {
+            return Ok(());
+        }
+
+        // Hold VPs so they don't execute when state units start the
+        // partition unit.
+        let stop_guard = self.inner.partition_unit.temporarily_stop_vps().await;
+
+        // Start state units so device config space is accessible.
+        self.state_units.start().await;
+
+        let result = ecam_config_access::assign_pci_resources_for_root_complexes(
+            &self.inner.chipset,
+            &self.inner.pcie_host_bridges,
+        )
+        .await
+        .context("PCI resource assignment failed");
+
+        // Stop state units again; the caller will resume normally.
+        self.state_units.stop().await;
+        drop(stop_guard);
+
+        result
     }
 
     pub async fn run(
@@ -3563,6 +3606,7 @@ impl LoadedVm {
         // Load again
         if reload_firmware {
             self.inner.load_firmware(false).await?;
+            self.assign_pci_resources().await?;
         }
 
         if resume {

--- a/openvmm/openvmm_core/src/worker/dispatch/ecam_config_access.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/ecam_config_access.rs
@@ -33,8 +33,8 @@ impl<'a> EcamConfigAccess<'a> {
     /// Compute the ECAM GPA for a config space access.
     ///
     /// ECAM layout: each function gets a 4 KiB page.
-    /// GPA = ecam_base + ((bus - start_bus) << 20) + (device << 15) + (function << 12) + offset
-    fn ecam_addr(&self, bus: u8, device: u8, function: u8, offset: u16) -> u64 {
+    /// GPA = ecam_base + ((bus - start_bus) << 20) + (devfn << 12) + offset
+    fn ecam_addr(&self, bus: u8, devfn: u8, offset: u16) -> u64 {
         assert!(
             bus >= self.start_bus && bus <= self.end_bus,
             "bus {bus} is outside range {}..={}",
@@ -42,11 +42,7 @@ impl<'a> EcamConfigAccess<'a> {
             self.end_bus
         );
         let bus_offset = (bus - self.start_bus) as u64;
-        self.ecam_base
-            + (bus_offset << 20)
-            + ((device as u64) << 15)
-            + ((function as u64) << 12)
-            + offset as u64
+        self.ecam_base + (bus_offset << 20) + ((devfn as u64) << 12) + offset as u64
     }
 }
 
@@ -79,15 +75,15 @@ pub async fn assign_pci_resources_for_root_complexes(
 }
 
 impl PciConfigAccess for EcamConfigAccess<'_> {
-    async fn read_u32(&mut self, bus: u8, device: u8, function: u8, offset: u16) -> u32 {
-        let addr = self.ecam_addr(bus, device, function, offset);
+    async fn read_u32(&mut self, bus: u8, devfn: u8, offset: u16) -> u32 {
+        let addr = self.ecam_addr(bus, devfn, offset);
         let mut data = [0u8; 4];
         self.chipset.mmio_read(0, addr, &mut data).await;
         u32::from_le_bytes(data)
     }
 
-    async fn write_u32(&mut self, bus: u8, device: u8, function: u8, offset: u16, value: u32) {
-        let addr = self.ecam_addr(bus, device, function, offset);
+    async fn write_u32(&mut self, bus: u8, devfn: u8, offset: u16, value: u32) {
+        let addr = self.ecam_addr(bus, devfn, offset);
         self.chipset.mmio_write(0, addr, &value.to_le_bytes()).await;
     }
 }

--- a/openvmm/openvmm_core/src/worker/dispatch/ecam_config_access.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/ecam_config_access.rs
@@ -17,14 +17,16 @@ struct EcamConfigAccess<'a> {
     chipset: &'a Chipset,
     ecam_base: u64,
     start_bus: u8,
+    end_bus: u8,
 }
 
 impl<'a> EcamConfigAccess<'a> {
-    fn new(chipset: &'a Chipset, ecam_base: u64, start_bus: u8) -> Self {
+    fn new(chipset: &'a Chipset, ecam_base: u64, start_bus: u8, end_bus: u8) -> Self {
         Self {
             chipset,
             ecam_base,
             start_bus,
+            end_bus,
         }
     }
 
@@ -34,9 +36,10 @@ impl<'a> EcamConfigAccess<'a> {
     /// GPA = ecam_base + ((bus - start_bus) << 20) + (device << 15) + (function << 12) + offset
     fn ecam_addr(&self, bus: u8, device: u8, function: u8, offset: u16) -> u64 {
         assert!(
-            bus >= self.start_bus,
-            "bus {bus} is below start_bus {}",
-            self.start_bus
+            bus >= self.start_bus && bus <= self.end_bus,
+            "bus {bus} is outside range {}..={}",
+            self.start_bus,
+            self.end_bus
         );
         let bus_offset = (bus - self.start_bus) as u64;
         self.ecam_base
@@ -68,7 +71,8 @@ pub async fn assign_pci_resources_for_root_complexes(
                 len: hb.high_mmio.len(),
             }),
         };
-        let mut ecam = EcamConfigAccess::new(chipset, hb.ecam_range.start(), hb.start_bus);
+        let mut ecam =
+            EcamConfigAccess::new(chipset, hb.ecam_range.start(), hb.start_bus, hb.end_bus);
         pci_resource_assignment::assign_pci_resources(&mut ecam, &params).await?;
     }
     Ok(())

--- a/openvmm/openvmm_core/src/worker/dispatch/ecam_config_access.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/ecam_config_access.rs
@@ -33,6 +33,11 @@ impl<'a> EcamConfigAccess<'a> {
     /// ECAM layout: each function gets a 4 KiB page.
     /// GPA = ecam_base + ((bus - start_bus) << 20) + (device << 15) + (function << 12) + offset
     fn ecam_addr(&self, bus: u8, device: u8, function: u8, offset: u16) -> u64 {
+        assert!(
+            bus >= self.start_bus,
+            "bus {bus} is below start_bus {}",
+            self.start_bus
+        );
         let bus_offset = (bus - self.start_bus) as u64;
         self.ecam_base
             + (bus_offset << 20)

--- a/openvmm/openvmm_core/src/worker/dispatch/ecam_config_access.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/ecam_config_access.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! ECAM-based [`PciConfigAccess`] implementation for PCI resource assignment.
+//!
+//! Routes config space reads/writes through the [`Chipset`]'s MMIO dispatch,
+//! exercising the same code path the guest uses.
+
+use pci_resource_assignment::AssignmentError;
+use pci_resource_assignment::PciConfigAccess;
+use vm_topology::pcie::PcieHostBridge;
+use vmotherboard::Chipset;
+
+/// Implements [`PciConfigAccess`] by performing MMIO reads/writes through
+/// the [`Chipset`]'s MMIO dispatch at the ECAM address range.
+struct EcamConfigAccess<'a> {
+    chipset: &'a Chipset,
+    ecam_base: u64,
+    start_bus: u8,
+}
+
+impl<'a> EcamConfigAccess<'a> {
+    fn new(chipset: &'a Chipset, ecam_base: u64, start_bus: u8) -> Self {
+        Self {
+            chipset,
+            ecam_base,
+            start_bus,
+        }
+    }
+
+    /// Compute the ECAM GPA for a config space access.
+    ///
+    /// ECAM layout: each function gets a 4 KiB page.
+    /// GPA = ecam_base + ((bus - start_bus) << 20) + (device << 15) + (function << 12) + offset
+    fn ecam_addr(&self, bus: u8, device: u8, function: u8, offset: u16) -> u64 {
+        let bus_offset = (bus - self.start_bus) as u64;
+        self.ecam_base
+            + (bus_offset << 20)
+            + ((device as u64) << 15)
+            + ((function as u64) << 12)
+            + offset as u64
+    }
+}
+
+/// Assign PCI resources (bus numbers and BAR addresses) for all root complexes.
+///
+/// Iterates over each host bridge and runs the resource assignment algorithm
+/// via ECAM config space through the chipset's MMIO dispatch.
+pub async fn assign_pci_resources_for_root_complexes(
+    chipset: &Chipset,
+    pcie_host_bridges: &[PcieHostBridge],
+) -> Result<(), AssignmentError> {
+    for hb in pcie_host_bridges {
+        let params = pci_resource_assignment::AssignmentParams {
+            start_bus: hb.start_bus,
+            end_bus: hb.end_bus,
+            low_mmio: (!hb.low_mmio.is_empty()).then(|| pci_resource_assignment::MmioAperture {
+                base: hb.low_mmio.start(),
+                len: hb.low_mmio.len(),
+            }),
+            high_mmio: (!hb.high_mmio.is_empty()).then(|| pci_resource_assignment::MmioAperture {
+                base: hb.high_mmio.start(),
+                len: hb.high_mmio.len(),
+            }),
+        };
+        let mut ecam = EcamConfigAccess::new(chipset, hb.ecam_range.start(), hb.start_bus);
+        pci_resource_assignment::assign_pci_resources(&mut ecam, &params).await?;
+    }
+    Ok(())
+}
+
+impl PciConfigAccess for EcamConfigAccess<'_> {
+    async fn read_u32(&mut self, bus: u8, device: u8, function: u8, offset: u16) -> u32 {
+        let addr = self.ecam_addr(bus, device, function, offset);
+        let mut data = [0u8; 4];
+        self.chipset.mmio_read(0, addr, &mut data).await;
+        u32::from_le_bytes(data)
+    }
+
+    async fn write_u32(&mut self, bus: u8, device: u8, function: u8, offset: u16, value: u32) {
+        let addr = self.ecam_addr(bus, device, function, offset);
+        self.chipset.mmio_write(0, addr, &value.to_le_bytes()).await;
+    }
+}

--- a/vm/devices/pci/pci_resource_assignment/Cargo.toml
+++ b/vm/devices/pci/pci_resource_assignment/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "pci_resource_assignment"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+pci_core.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+parking_lot.workspace = true
+
+[lints]
+workspace = true

--- a/vm/devices/pci/pci_resource_assignment/Cargo.toml
+++ b/vm/devices/pci/pci_resource_assignment/Cargo.toml
@@ -12,6 +12,7 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+pal_async.workspace = true
 parking_lot.workspace = true
 
 [lints]

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -83,10 +83,10 @@ pub fn assign_addresses(
 ) -> Result<AssignmentResult, AssignmentError> {
     let mut entries = Vec::new();
 
-    // Phase 1: Bottom-up — compute total resource requirements.
+    // Step 1: Bottom-up — compute total resource requirements.
     let root_req = compute_subtree_requirement(devices);
 
-    // Phase 2: Top-down — allocate from apertures and assign addresses.
+    // Step 2: Top-down — allocate from apertures and assign addresses.
     // Align the effective base to the root's alignment requirement so that
     // internal bump allocation matches the sizing (which starts from zero).
     if root_req.mem32 > 0 {
@@ -430,21 +430,14 @@ pub async fn program_assignments(cfg: &mut impl PciConfigAccess, result: &Assign
         // (write-readback) doesn't mistake zeroed registers for a valid window.
         if entry.secondary_bus.is_some() {
             // I/O window — we don't assign I/O BARs, so always disable.
-            // Read-modify-write to preserve the secondary status bits.
-            let sec_status = cfg
-                .read_u32(
-                    entry.bus,
-                    entry.device,
-                    entry.function,
-                    HeaderType01::SEC_STATUS_IO_RANGE.0,
-                )
-                .await;
+            // Write zeros to the upper 16 bits (Secondary Status) since
+            // those bits are W1C — writing back a read value would clear them.
             cfg.write_u32(
                 entry.bus,
                 entry.device,
                 entry.function,
                 HeaderType01::SEC_STATUS_IO_RANGE.0,
-                (sec_status & 0xFFFF_0000) | 0x00F0, // base 0xF0 > limit 0x00
+                0x0000_00F0, // base 0xF0 > limit 0x00, status bits zeroed
             )
             .await;
 
@@ -466,63 +459,46 @@ pub async fn program_assignments(cfg: &mut impl PciConfigAccess, result: &Assign
             .await;
 
             // Prefetchable memory window (64-bit capable).
-            if let (Some(base), Some(limit)) = (entry.prefetchable_base, entry.prefetchable_limit) {
+            // Use base > limit to disable when no window is assigned.
+            let (pf_range, pf_base_upper, pf_limit_upper) = if let (Some(base), Some(limit)) =
+                (entry.prefetchable_base, entry.prefetchable_limit)
+            {
                 let pf_base_reg =
                     ((base >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32 | 0x1;
                 let pf_limit_reg =
                     ((limit >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32 | 0x1;
-                cfg.write_u32(
-                    entry.bus,
-                    entry.device,
-                    entry.function,
-                    HeaderType01::PREFETCH_RANGE.0,
+                (
                     pf_base_reg | (pf_limit_reg << 16),
-                )
-                .await;
-                cfg.write_u32(
-                    entry.bus,
-                    entry.device,
-                    entry.function,
-                    HeaderType01::PREFETCH_BASE_UPPER.0,
                     (base >> 32) as u32,
-                )
-                .await;
-                cfg.write_u32(
-                    entry.bus,
-                    entry.device,
-                    entry.function,
-                    HeaderType01::PREFETCH_LIMIT_UPPER.0,
                     (limit >> 32) as u32,
                 )
-                .await;
             } else {
-                // Disable: write limit upper first, then base > limit, then
-                // base upper high so the range is clearly invalid.
-                cfg.write_u32(
-                    entry.bus,
-                    entry.device,
-                    entry.function,
-                    HeaderType01::PREFETCH_LIMIT_UPPER.0,
-                    0,
-                )
-                .await;
-                cfg.write_u32(
-                    entry.bus,
-                    entry.device,
-                    entry.function,
-                    HeaderType01::PREFETCH_RANGE.0,
-                    0x0000_fff0, // base 0xFFF0 > limit 0x0000
-                )
-                .await;
-                cfg.write_u32(
-                    entry.bus,
-                    entry.device,
-                    entry.function,
-                    HeaderType01::PREFETCH_BASE_UPPER.0,
-                    0xFFFF_FFFF,
-                )
-                .await;
-            }
+                (0x0000_fff0, 0xFFFF_FFFF, 0)
+            };
+            cfg.write_u32(
+                entry.bus,
+                entry.device,
+                entry.function,
+                HeaderType01::PREFETCH_LIMIT_UPPER.0,
+                pf_limit_upper,
+            )
+            .await;
+            cfg.write_u32(
+                entry.bus,
+                entry.device,
+                entry.function,
+                HeaderType01::PREFETCH_RANGE.0,
+                pf_range,
+            )
+            .await;
+            cfg.write_u32(
+                entry.bus,
+                entry.device,
+                entry.function,
+                HeaderType01::PREFETCH_BASE_UPPER.0,
+                pf_base_upper,
+            )
+            .await;
         }
 
         if entry.bars.is_empty() {

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -89,16 +89,20 @@ pub fn assign_addresses(
     // Step 2: Top-down — allocate from apertures and assign addresses.
     // Align the effective base to the root's alignment requirement so that
     // internal bump allocation matches the sizing (which starts from zero).
+    // Track where mem32 ends so that mem64 can start after it when
+    // sharing the same aperture.
+    let mut mem32_end: Option<u64> = None;
+
     if root_req.mem32 > 0 {
-        let aperture =
-            params
-                .low_mmio
-                .or(params.high_mmio)
-                .ok_or(AssignmentError::MmioExhaustion {
-                    required: root_req.mem32,
-                    available: 0,
-                    aperture: "low_mmio",
-                })?;
+        // 32-bit BARs and non-prefetchable bridge windows are inherently
+        // 32-bit, so the aperture must be below 4 GB. Do not fall back
+        // to high_mmio — placing 32-bit BARs above 4 GB would silently
+        // truncate addresses.
+        let aperture = params.low_mmio.ok_or(AssignmentError::MmioExhaustion {
+            required: root_req.mem32,
+            available: 0,
+            aperture: "low_mmio",
+        })?;
 
         let base = align_up(aperture.base, root_req.align32);
         let aperture_end = aperture.base + aperture.len;
@@ -112,6 +116,7 @@ pub fn assign_addresses(
         }
 
         assign_subtree(devices, false, base, &mut entries);
+        mem32_end = Some(base + root_req.mem32);
     }
 
     if root_req.mem64 > 0 {
@@ -125,11 +130,12 @@ pub fn assign_addresses(
                     aperture: "high_mmio",
                 })?;
 
-        // If sharing the same aperture as mem32, allocate after them.
-        let base = if params.high_mmio.is_some() {
-            align_up(aperture.base, root_req.align64)
+        // If sharing the same aperture as mem32, allocate after the
+        // actual aligned mem32 end to avoid overlapping assignments.
+        let base = if let Some(end) = mem32_end.filter(|_| params.high_mmio.is_none()) {
+            align_up(end, root_req.align64)
         } else {
-            align_up(aperture.base + root_req.mem32, root_req.align64)
+            align_up(aperture.base, root_req.align64)
         };
 
         let aperture_end = aperture.base + aperture.len;

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -403,25 +403,13 @@ pub async fn program_assignments(cfg: &mut impl PciConfigAccess, result: &Assign
         // Program BAR addresses.
         for bar in &entry.bars {
             let offset = HeaderType00::BAR0.0 + (bar.index as u16) * 4;
-            cfg.write_u32(
-                entry.bus,
-                entry.device,
-                entry.function,
-                offset,
-                bar.address as u32,
-            )
-            .await;
+            entry.write_cfg(cfg, offset, bar.address as u32).await;
 
             if bar.is_64bit {
                 let upper_offset = HeaderType00::BAR0.0 + ((bar.index + 1) as u16) * 4;
-                cfg.write_u32(
-                    entry.bus,
-                    entry.device,
-                    entry.function,
-                    upper_offset,
-                    (bar.address >> 32) as u32,
-                )
-                .await;
+                entry
+                    .write_cfg(cfg, upper_offset, (bar.address >> 32) as u32)
+                    .await;
             }
         }
 
@@ -432,14 +420,9 @@ pub async fn program_assignments(cfg: &mut impl PciConfigAccess, result: &Assign
             // I/O window — we don't assign I/O BARs, so always disable.
             // Write zeros to the upper 16 bits (Secondary Status) since
             // those bits are W1C — writing back a read value would clear them.
-            cfg.write_u32(
-                entry.bus,
-                entry.device,
-                entry.function,
-                HeaderType01::SEC_STATUS_IO_RANGE.0,
-                0x0000_00F0, // base 0xF0 > limit 0x00, status bits zeroed
-            )
-            .await;
+            entry
+                .write_cfg(cfg, HeaderType01::SEC_STATUS_IO_RANGE.0, 0x0000_00F0)
+                .await;
 
             // Non-prefetchable memory window (32-bit only).
             let value = if let (Some(base), Some(limit)) = (entry.memory_base, entry.memory_limit) {
@@ -447,16 +430,11 @@ pub async fn program_assignments(cfg: &mut impl PciConfigAccess, result: &Assign
                 let mem_limit_reg = ((limit >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32;
                 mem_base_reg | (mem_limit_reg << 16)
             } else {
-                0x0000_fff0 // base 0xFFF0 > limit 0x0000
+                0x0000_fff0
             };
-            cfg.write_u32(
-                entry.bus,
-                entry.device,
-                entry.function,
-                HeaderType01::MEMORY_RANGE.0,
-                value,
-            )
-            .await;
+            entry
+                .write_cfg(cfg, HeaderType01::MEMORY_RANGE.0, value)
+                .await;
 
             // Prefetchable memory window (64-bit capable).
             // Use base > limit to disable when no window is assigned.
@@ -475,30 +453,15 @@ pub async fn program_assignments(cfg: &mut impl PciConfigAccess, result: &Assign
             } else {
                 (0x0000_fff0, 0xFFFF_FFFF, 0)
             };
-            cfg.write_u32(
-                entry.bus,
-                entry.device,
-                entry.function,
-                HeaderType01::PREFETCH_LIMIT_UPPER.0,
-                pf_limit_upper,
-            )
-            .await;
-            cfg.write_u32(
-                entry.bus,
-                entry.device,
-                entry.function,
-                HeaderType01::PREFETCH_RANGE.0,
-                pf_range,
-            )
-            .await;
-            cfg.write_u32(
-                entry.bus,
-                entry.device,
-                entry.function,
-                HeaderType01::PREFETCH_BASE_UPPER.0,
-                pf_base_upper,
-            )
-            .await;
+            entry
+                .write_cfg(cfg, HeaderType01::PREFETCH_LIMIT_UPPER.0, pf_limit_upper)
+                .await;
+            entry
+                .write_cfg(cfg, HeaderType01::PREFETCH_RANGE.0, pf_range)
+                .await;
+            entry
+                .write_cfg(cfg, HeaderType01::PREFETCH_BASE_UPPER.0, pf_base_upper)
+                .await;
         }
 
         if entry.bars.is_empty() {

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -1,0 +1,561 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Phase 2: Bottom-up aperture computation and top-down address assignment.
+
+use crate::AssignmentEntry;
+use crate::AssignmentError;
+use crate::AssignmentParams;
+use crate::AssignmentResult;
+use crate::BarAssignment;
+use crate::PciConfigAccess;
+use crate::enumerate::DiscoveredDevice;
+use pci_core::spec::cfg_space::HeaderType00;
+use pci_core::spec::cfg_space::HeaderType01;
+use pci_core::spec::cfg_space::MEMORY_BASE_LIMIT_ADDRESS_MASK;
+
+/// Bridge memory window granularity: 1 MB.
+const BRIDGE_WINDOW_ALIGN: u64 = 1 << 20;
+
+fn find_or_create_entry(
+    entries: &mut Vec<AssignmentEntry>,
+    bus: u8,
+    device: u8,
+    function: u8,
+) -> &mut AssignmentEntry {
+    let pos = entries
+        .iter()
+        .position(|e| e.bus == bus && e.device == device && e.function == function);
+    if let Some(idx) = pos {
+        &mut entries[idx]
+    } else {
+        entries.push(AssignmentEntry {
+            bus,
+            device,
+            function,
+            bars: Vec::new(),
+            secondary_bus: None,
+            subordinate_bus: None,
+            memory_base: None,
+            memory_limit: None,
+            prefetchable_base: None,
+            prefetchable_limit: None,
+        });
+        entries.last_mut().unwrap()
+    }
+}
+
+/// Resource requirement for a subtree (bridge or root).
+struct SubtreeRequirement {
+    /// Total aligned size needed in the mem32 (non-prefetchable) pool.
+    mem32: u64,
+    /// Total aligned size needed in the mem64 (prefetchable) pool.
+    mem64: u64,
+    /// Required alignment for the mem32 pool (max of bridge granularity
+    /// and the largest BAR in the subtree).
+    align32: u64,
+    /// Required alignment for the mem64 pool.
+    align64: u64,
+}
+
+/// Assign addresses to all discovered devices.
+///
+/// Uses hierarchical bottom-up/top-down allocation:
+///
+/// 1. **Bottom-up sizing**: Each bridge computes the total aligned
+///    resource requirement of its subtree.
+/// 2. **Top-down assignment**: The host bridge carves its aperture among
+///    top-level devices/bridges. Each bridge subdivides its allocated
+///    range among children, largest-first.
+///
+/// BARs are split into two pools:
+///
+/// - **mem32 (low MMIO):** all non-prefetchable BARs and 32-bit
+///   prefetchable BARs. These use the non-prefetchable bridge window.
+///
+/// - **mem64 (high MMIO):** 64-bit prefetchable BARs only. These use
+///   the prefetchable bridge window.
+///
+/// Returns an error if any BAR cannot be placed.
+pub fn assign_addresses(
+    devices: &[DiscoveredDevice],
+    params: &AssignmentParams,
+) -> Result<AssignmentResult, AssignmentError> {
+    let mut entries = Vec::new();
+
+    // Phase 1: Bottom-up — compute total resource requirements.
+    let root_req = compute_subtree_requirement(devices);
+
+    // Phase 2: Top-down — allocate from apertures and assign addresses.
+    // Align the effective base to the root's alignment requirement so that
+    // internal bump allocation matches the sizing (which starts from zero).
+    if root_req.mem32 > 0 {
+        let aperture =
+            params
+                .low_mmio
+                .or(params.high_mmio)
+                .ok_or(AssignmentError::MmioExhaustion {
+                    required: root_req.mem32,
+                    available: 0,
+                    aperture: "low_mmio",
+                })?;
+
+        let base = align_up(aperture.base, root_req.align32);
+        let aperture_end = aperture.base + aperture.len;
+        let available = aperture_end.saturating_sub(base);
+        if root_req.mem32 > available {
+            return Err(AssignmentError::MmioExhaustion {
+                required: root_req.mem32,
+                available,
+                aperture: "low_mmio",
+            });
+        }
+
+        assign_subtree(devices, false, base, &mut entries);
+    }
+
+    if root_req.mem64 > 0 {
+        let aperture =
+            params
+                .high_mmio
+                .or(params.low_mmio)
+                .ok_or(AssignmentError::MmioExhaustion {
+                    required: root_req.mem64,
+                    available: 0,
+                    aperture: "high_mmio",
+                })?;
+
+        // If sharing the same aperture as mem32, allocate after them.
+        let base = if params.high_mmio.is_some() {
+            align_up(aperture.base, root_req.align64)
+        } else {
+            align_up(aperture.base + root_req.mem32, root_req.align64)
+        };
+
+        let aperture_end = aperture.base + aperture.len;
+        let available = aperture_end.saturating_sub(base);
+        if root_req.mem64 > available {
+            return Err(AssignmentError::MmioExhaustion {
+                required: root_req.mem64,
+                available,
+                aperture: "high_mmio",
+            });
+        }
+
+        assign_subtree(devices, true, base, &mut entries);
+    }
+
+    let result = AssignmentResult { entries };
+    validate_assignments(&result, params);
+    Ok(result)
+}
+
+/// Verify that all assigned BAR addresses fall within the provided apertures.
+fn validate_assignments(result: &AssignmentResult, params: &AssignmentParams) {
+    for entry in &result.entries {
+        for bar in &entry.bars {
+            let bar_end = bar.address + bar.size;
+            let in_low = params
+                .low_mmio
+                .is_some_and(|a| bar.address >= a.base && bar_end <= a.base + a.len);
+            let in_high = params
+                .high_mmio
+                .is_some_and(|a| bar.address >= a.base && bar_end <= a.base + a.len);
+            assert!(
+                in_low || in_high,
+                "BAR {bus:02x}:{dev:02x}.{func} index {idx} at {addr:#x}..{end:#x} \
+                 is outside all MMIO apertures",
+                bus = entry.bus,
+                dev = entry.device,
+                func = entry.function,
+                idx = bar.index,
+                addr = bar.address,
+                end = bar_end,
+            );
+        }
+    }
+}
+fn is_mem64_bar(bar: &crate::enumerate::DiscoveredBar) -> bool {
+    bar.is_64bit && bar.is_prefetchable
+}
+
+/// Bottom-up: compute the total aligned resource requirement for a list
+/// of devices (which may be the root level or children behind a bridge).
+fn compute_subtree_requirement(devices: &[DiscoveredDevice]) -> SubtreeRequirement {
+    let mut mem32: u64 = 0;
+    let mut mem64: u64 = 0;
+
+    // Track the required alignment for each pool. This is the maximum of
+    // BRIDGE_WINDOW_ALIGN and the largest BAR (or nested bridge alignment)
+    // in the subtree — the parent must place this subtree at an address
+    // aligned to this value so that internal bump allocation matches the
+    // sizing computed here (which starts from zero, where all alignments
+    // are trivially satisfied).
+    let mut align32: u64 = BRIDGE_WINDOW_ALIGN;
+    let mut align64: u64 = BRIDGE_WINDOW_ALIGN;
+
+    struct Demand {
+        size: u64,
+        alignment: u64,
+        is_mem64: bool,
+    }
+
+    let mut demands: Vec<Demand> = Vec::new();
+
+    for dev in devices {
+        for bar in &dev.bars {
+            demands.push(Demand {
+                size: bar.size,
+                alignment: bar.size, // BARs are naturally aligned
+                is_mem64: is_mem64_bar(bar),
+            });
+        }
+
+        if dev.is_bridge {
+            let child_req = compute_subtree_requirement(&dev.children);
+            if child_req.mem32 > 0 {
+                let size = align_up(child_req.mem32, BRIDGE_WINDOW_ALIGN);
+                demands.push(Demand {
+                    size,
+                    alignment: child_req.align32,
+                    is_mem64: false,
+                });
+            }
+            if child_req.mem64 > 0 {
+                let size = align_up(child_req.mem64, BRIDGE_WINDOW_ALIGN);
+                demands.push(Demand {
+                    size,
+                    alignment: child_req.align64,
+                    is_mem64: true,
+                });
+            }
+        }
+    }
+
+    // Sum with proper alignment, largest-alignment-first within each pool.
+    // Placing the most alignment-demanding items first minimizes padding
+    // waste, since the offset is most likely well-aligned at the start.
+    let mut demands_32: Vec<&Demand> = demands.iter().filter(|d| !d.is_mem64).collect();
+    let mut demands_64: Vec<&Demand> = demands.iter().filter(|d| d.is_mem64).collect();
+    demands_32.sort_by_key(|d| std::cmp::Reverse(d.alignment));
+    demands_64.sort_by_key(|d| std::cmp::Reverse(d.alignment));
+
+    for d in &demands_32 {
+        mem32 = align_up(mem32, d.alignment);
+        mem32 += d.size;
+        align32 = align32.max(d.alignment);
+    }
+    for d in &demands_64 {
+        mem64 = align_up(mem64, d.alignment);
+        mem64 += d.size;
+        align64 = align64.max(d.alignment);
+    }
+
+    SubtreeRequirement {
+        mem32,
+        mem64,
+        align32,
+        align64,
+    }
+}
+
+/// Top-down: assign addresses to devices within a subtree, carving from
+/// the given base address. `alloc_64bit` selects which pool (mem32 or
+/// mem64) we are assigning.
+fn assign_subtree(
+    devices: &[DiscoveredDevice],
+    alloc_64bit: bool,
+    base: u64,
+    entries: &mut Vec<AssignmentEntry>,
+) {
+    // Collect all demands at this level as (size, device_index, kind).
+    // Kind distinguishes endpoint BARs from bridge subtree requirements.
+    enum Demand {
+        Bar {
+            dev_idx: usize,
+            bar_index: u8,
+            is_64bit: bool,
+        },
+        BridgeSubtree {
+            dev_idx: usize,
+            alignment: u64,
+        },
+    }
+
+    let mut demands: Vec<(u64, Demand)> = Vec::new();
+
+    for (i, dev) in devices.iter().enumerate() {
+        for bar in &dev.bars {
+            if is_mem64_bar(bar) == alloc_64bit {
+                demands.push((
+                    bar.size,
+                    Demand::Bar {
+                        dev_idx: i,
+                        bar_index: bar.index,
+                        is_64bit: bar.is_64bit,
+                    },
+                ));
+            }
+        }
+
+        if dev.is_bridge {
+            let child_req = compute_subtree_requirement(&dev.children);
+            let (size, alignment) = if alloc_64bit {
+                (child_req.mem64, child_req.align64)
+            } else {
+                (child_req.mem32, child_req.align32)
+            };
+            if size > 0 {
+                let aligned = align_up(size, BRIDGE_WINDOW_ALIGN);
+                demands.push((
+                    aligned,
+                    Demand::BridgeSubtree {
+                        dev_idx: i,
+                        alignment,
+                    },
+                ));
+            }
+        }
+    }
+
+    // Sort by alignment descending. This must match the order used in
+    // compute_subtree_requirement so that the sizing and assignment
+    // produce consistent results.
+    demands.sort_by_key(|d| {
+        let alignment = match &d.1 {
+            Demand::Bar { .. } => d.0,
+            Demand::BridgeSubtree { alignment, .. } => *alignment,
+        };
+        std::cmp::Reverse(alignment)
+    });
+
+    // Bump-allocate.
+    let mut offset = base;
+    for (size, demand) in &demands {
+        // BARs are naturally aligned to their size (always a power of two).
+        // Bridge subtrees are aligned to the max of bridge window
+        // granularity and the largest internal alignment requirement.
+        let alignment = match demand {
+            Demand::Bar { .. } => *size,
+            Demand::BridgeSubtree { alignment, .. } => *alignment,
+        };
+        offset = align_up(offset, alignment);
+
+        match demand {
+            Demand::Bar {
+                dev_idx,
+                bar_index,
+                is_64bit,
+            } => {
+                let dev = &devices[*dev_idx];
+                let entry = find_or_create_entry(entries, dev.bus, dev.device, dev.function);
+                entry.bars.push(BarAssignment {
+                    index: *bar_index,
+                    address: offset,
+                    size: *size,
+                    is_64bit: *is_64bit,
+                });
+            }
+            Demand::BridgeSubtree { dev_idx, .. } => {
+                let dev = &devices[*dev_idx];
+                let entry = find_or_create_entry(entries, dev.bus, dev.device, dev.function);
+                entry.secondary_bus = dev.secondary_bus;
+                entry.subordinate_bus = dev.subordinate_bus;
+
+                // Set the bridge window to the carved-out range.
+                let window_base = offset;
+                let window_limit = offset + size - 1;
+                if alloc_64bit {
+                    entry.prefetchable_base = Some(window_base);
+                    entry.prefetchable_limit = Some(window_limit);
+                } else {
+                    entry.memory_base = Some(window_base);
+                    entry.memory_limit = Some(window_limit);
+                }
+
+                // Recurse into children with this bridge's carved-out range.
+                assign_subtree(&dev.children, alloc_64bit, offset, entries);
+            }
+        }
+
+        offset += size;
+    }
+
+    // Ensure bridge entries exist even if they have no BARs in this pool
+    // (needed for bridges that only have resources in the other pool).
+    for dev in devices {
+        if dev.is_bridge {
+            let entry = find_or_create_entry(entries, dev.bus, dev.device, dev.function);
+            entry.secondary_bus = dev.secondary_bus;
+            entry.subordinate_bus = dev.subordinate_bus;
+        }
+    }
+}
+
+/// Program all assignments into config space.
+///
+/// Writes BAR addresses and bridge memory windows for every entry in
+/// `result`. This function assumes MMIO decode (MSE) has already been
+/// cleared by the enumeration phase and does not modify the command
+/// register.
+pub async fn program_assignments(cfg: &mut impl PciConfigAccess, result: &AssignmentResult) {
+    for entry in &result.entries {
+        // Program BAR addresses.
+        for bar in &entry.bars {
+            let offset = HeaderType00::BAR0.0 + (bar.index as u16) * 4;
+            cfg.write_u32(
+                entry.bus,
+                entry.device,
+                entry.function,
+                offset,
+                bar.address as u32,
+            )
+            .await;
+
+            if bar.is_64bit {
+                let upper_offset = HeaderType00::BAR0.0 + ((bar.index + 1) as u16) * 4;
+                cfg.write_u32(
+                    entry.bus,
+                    entry.device,
+                    entry.function,
+                    upper_offset,
+                    (bar.address >> 32) as u32,
+                )
+                .await;
+            }
+        }
+
+        // Program bridge windows. For bridges, explicitly disable any unused
+        // window by writing base > limit so that the guest OS's probe
+        // (write-readback) doesn't mistake zeroed registers for a valid window.
+        if entry.secondary_bus.is_some() {
+            // I/O window — we don't assign I/O BARs, so always disable.
+            // Read-modify-write to preserve the secondary status bits.
+            let sec_status = cfg
+                .read_u32(
+                    entry.bus,
+                    entry.device,
+                    entry.function,
+                    HeaderType01::SEC_STATUS_IO_RANGE.0,
+                )
+                .await;
+            cfg.write_u32(
+                entry.bus,
+                entry.device,
+                entry.function,
+                HeaderType01::SEC_STATUS_IO_RANGE.0,
+                (sec_status & 0xFFFF_0000) | 0x00F0, // base 0xF0 > limit 0x00
+            )
+            .await;
+
+            // Non-prefetchable memory window (32-bit only).
+            let value = if let (Some(base), Some(limit)) = (entry.memory_base, entry.memory_limit) {
+                let mem_base_reg = ((base >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32;
+                let mem_limit_reg = ((limit >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32;
+                mem_base_reg | (mem_limit_reg << 16)
+            } else {
+                0x0000_fff0 // base 0xFFF0 > limit 0x0000
+            };
+            cfg.write_u32(
+                entry.bus,
+                entry.device,
+                entry.function,
+                HeaderType01::MEMORY_RANGE.0,
+                value,
+            )
+            .await;
+
+            // Prefetchable memory window (64-bit capable).
+            if let (Some(base), Some(limit)) = (entry.prefetchable_base, entry.prefetchable_limit) {
+                let pf_base_reg =
+                    ((base >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32 | 0x1;
+                let pf_limit_reg =
+                    ((limit >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32 | 0x1;
+                cfg.write_u32(
+                    entry.bus,
+                    entry.device,
+                    entry.function,
+                    HeaderType01::PREFETCH_RANGE.0,
+                    pf_base_reg | (pf_limit_reg << 16),
+                )
+                .await;
+                cfg.write_u32(
+                    entry.bus,
+                    entry.device,
+                    entry.function,
+                    HeaderType01::PREFETCH_BASE_UPPER.0,
+                    (base >> 32) as u32,
+                )
+                .await;
+                cfg.write_u32(
+                    entry.bus,
+                    entry.device,
+                    entry.function,
+                    HeaderType01::PREFETCH_LIMIT_UPPER.0,
+                    (limit >> 32) as u32,
+                )
+                .await;
+            } else {
+                // Disable: write limit upper first, then base > limit, then
+                // base upper high so the range is clearly invalid.
+                cfg.write_u32(
+                    entry.bus,
+                    entry.device,
+                    entry.function,
+                    HeaderType01::PREFETCH_LIMIT_UPPER.0,
+                    0,
+                )
+                .await;
+                cfg.write_u32(
+                    entry.bus,
+                    entry.device,
+                    entry.function,
+                    HeaderType01::PREFETCH_RANGE.0,
+                    0x0000_fff0, // base 0xFFF0 > limit 0x0000
+                )
+                .await;
+                cfg.write_u32(
+                    entry.bus,
+                    entry.device,
+                    entry.function,
+                    HeaderType01::PREFETCH_BASE_UPPER.0,
+                    0xFFFF_FFFF,
+                )
+                .await;
+            }
+        }
+
+        if entry.bars.is_empty() {
+            tracing::debug!(
+                bus = entry.bus,
+                device = entry.device,
+                function = entry.function,
+                ?entry.secondary_bus,
+                ?entry.subordinate_bus,
+                ?entry.memory_base,
+                ?entry.memory_limit,
+                ?entry.prefetchable_base,
+                ?entry.prefetchable_limit,
+                "bridge programmed"
+            );
+        } else {
+            for bar in &entry.bars {
+                tracing::debug!(
+                    bus = entry.bus,
+                    device = entry.device,
+                    function = entry.function,
+                    bar_index = bar.index,
+                    address = format_args!("{:#x}", bar.address),
+                    size = format_args!("{:#x}", bar.size),
+                    is_64bit = bar.is_64bit,
+                    "BAR programmed"
+                );
+            }
+        }
+    }
+}
+
+fn align_up(value: u64, alignment: u64) -> u64 {
+    assert!(alignment.is_power_of_two());
+    (value + alignment - 1) & !(alignment - 1)
+}

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -180,6 +180,13 @@ async fn scan_bus(
                 if let Some(max_vf_bus) =
                     probe_sriov_bus_requirement(cfg, bus, device_num, function).await
                 {
+                    if max_vf_bus > end_bus {
+                        return Err(AssignmentError::BusExhaustion {
+                            bus,
+                            device: device_num,
+                            function,
+                        });
+                    }
                     if max_vf_bus >= *next_bus {
                         *next_bus = max_vf_bus.wrapping_add(1);
                     }

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -73,14 +73,22 @@ async fn scan_bus(
 
     for device_num in 0..32u8 {
         let vendor = cfg
-            .read_u32(bus, device_num, 0, CommonHeader::DEVICE_VENDOR.0)
+            .read_u32(
+                bus,
+                crate::devfn(device_num, 0),
+                CommonHeader::DEVICE_VENDOR.0,
+            )
             .await;
         if vendor == !0u32 {
             continue;
         }
 
         let bist_header_raw = cfg
-            .read_u32(bus, device_num, 0, HeaderType00::BIST_HEADER.0)
+            .read_u32(
+                bus,
+                crate::devfn(device_num, 0),
+                HeaderType00::BIST_HEADER.0,
+            )
             .await;
         let bist = BistHeader::from(bist_header_raw);
         let header_type = bist.header_type();
@@ -89,9 +97,11 @@ async fn scan_bus(
         let max_func = if multi_function { 8 } else { 1 };
 
         for function in 0..max_func {
+            let devfn = crate::devfn(device_num, function);
+
             if function > 0 {
                 let vendor = cfg
-                    .read_u32(bus, device_num, function, CommonHeader::DEVICE_VENDOR.0)
+                    .read_u32(bus, devfn, CommonHeader::DEVICE_VENDOR.0)
                     .await;
                 if vendor == !0u32 {
                     continue;
@@ -99,16 +109,14 @@ async fn scan_bus(
             }
 
             let func_header = if function > 0 {
-                let bh = cfg
-                    .read_u32(bus, device_num, function, HeaderType00::BIST_HEADER.0)
-                    .await;
+                let bh = cfg.read_u32(bus, devfn, HeaderType00::BIST_HEADER.0).await;
                 BistHeader::from(bh).header_type()
             } else {
                 header_type
             };
 
             let is_bridge = func_header == 1;
-            let bars = probe_bars(cfg, bus, device_num, function, is_bridge).await;
+            let bars = probe_bars(cfg, bus, devfn, is_bridge).await;
 
             let mut dev = DiscoveredDevice {
                 bus,
@@ -135,14 +143,8 @@ async fn scan_bus(
                 *next_bus = next_bus.wrapping_add(1);
 
                 let bus_reg = (bus as u32) | ((secondary as u32) << 8) | ((end_bus as u32) << 16);
-                cfg.write_u32(
-                    bus,
-                    device_num,
-                    function,
-                    HeaderType01::LATENCY_BUS_NUMBERS.0,
-                    bus_reg,
-                )
-                .await;
+                cfg.write_u32(bus, devfn, HeaderType01::LATENCY_BUS_NUMBERS.0, bus_reg)
+                    .await;
 
                 // NOTE: This is still logically recursive (scan_bus calls
                 // itself indirectly via this path), but the Rust compiler
@@ -154,14 +156,8 @@ async fn scan_bus(
                 let subordinate = next_bus.wrapping_sub(1).max(secondary);
                 let bus_reg =
                     (bus as u32) | ((secondary as u32) << 8) | ((subordinate as u32) << 16);
-                cfg.write_u32(
-                    bus,
-                    device_num,
-                    function,
-                    HeaderType01::LATENCY_BUS_NUMBERS.0,
-                    bus_reg,
-                )
-                .await;
+                cfg.write_u32(bus, devfn, HeaderType01::LATENCY_BUS_NUMBERS.0, bus_reg)
+                    .await;
 
                 dev.secondary_bus = Some(secondary);
                 dev.subordinate_bus = Some(subordinate);
@@ -177,9 +173,7 @@ async fn scan_bus(
                 );
             } else {
                 // Reserve bus numbers for SR-IOV VFs on this endpoint.
-                if let Some(max_vf_bus) =
-                    probe_sriov_bus_requirement(cfg, bus, device_num, function).await
-                {
+                if let Some(max_vf_bus) = probe_sriov_bus_requirement(cfg, bus, devfn).await {
                     if max_vf_bus > end_bus {
                         return Err(AssignmentError::BusExhaustion {
                             bus,
@@ -217,8 +211,7 @@ async fn scan_bus(
 async fn probe_bars(
     cfg: &mut impl PciConfigAccess,
     bus: u8,
-    device: u8,
-    function: u8,
+    devfn: u8,
     is_bridge: bool,
 ) -> Vec<DiscoveredBar> {
     let max_bars: u8 = if is_bridge { 2 } else { 6 };
@@ -229,15 +222,14 @@ async fn probe_bars(
     // The command register is left with MMIO disabled; program_assignments
     // will enable it once valid addresses have been programmed.
     let cmd = cfg
-        .read_u32(bus, device, function, CommonHeader::STATUS_COMMAND.0)
+        .read_u32(bus, devfn, CommonHeader::STATUS_COMMAND.0)
         .await;
     let command = Command::from(cmd as u16);
     if command.mmio_enabled() {
         // Status bits are W1C, so avoid writing them.
         cfg.write_u32(
             bus,
-            device,
-            function,
+            devfn,
             CommonHeader::STATUS_COMMAND.0,
             command.with_mmio_enabled(false).into_bits().into(),
         )
@@ -249,8 +241,8 @@ async fn probe_bars(
         let offset = HeaderType00::BAR0.0 + (i as u16) * 4;
 
         // Write all-ones to probe size.
-        cfg.write_u32(bus, device, function, offset, !0u32).await;
-        let readback = cfg.read_u32(bus, device, function, offset).await;
+        cfg.write_u32(bus, devfn, offset, !0u32).await;
+        let readback = cfg.read_u32(bus, devfn, offset).await;
 
         if readback == 0 {
             // BAR not implemented.
@@ -272,9 +264,8 @@ async fn probe_bars(
         let size = if is_64bit && (i + 1) < max_bars {
             // Probe upper 32 bits.
             let upper_offset = HeaderType00::BAR0.0 + ((i + 1) as u16) * 4;
-            cfg.write_u32(bus, device, function, upper_offset, !0u32)
-                .await;
-            let upper_readback = cfg.read_u32(bus, device, function, upper_offset).await;
+            cfg.write_u32(bus, devfn, upper_offset, !0u32).await;
+            let upper_readback = cfg.read_u32(bus, devfn, upper_offset).await;
 
             let mask = ((upper_readback as u64) << 32) | (readback as u64 & !0xF);
             if mask == 0 {
@@ -324,8 +315,7 @@ mod sriov {
 async fn probe_sriov_bus_requirement(
     cfg: &mut impl PciConfigAccess,
     bus: u8,
-    device: u8,
-    function: u8,
+    devfn: u8,
 ) -> Option<u8> {
     // Walk extended capabilities starting at 0x100.
     let mut offset = EXT_CAP_START;
@@ -333,7 +323,7 @@ async fn probe_sriov_bus_requirement(
         if offset < EXT_CAP_START || offset & 0x3 != 0 {
             break;
         }
-        let header = cfg.read_u32(bus, device, function, offset).await;
+        let header = cfg.read_u32(bus, devfn, offset).await;
         if header == 0 || header == !0u32 {
             break;
         }
@@ -343,7 +333,7 @@ async fn probe_sriov_bus_requirement(
         if cap_id == ExtendedCapabilityId::SRIOV.0 {
             // Read TotalVFs.
             let vfs_dword = cfg
-                .read_u32(bus, device, function, offset + sriov::INITIAL_TOTAL_VFS)
+                .read_u32(bus, devfn, offset + sriov::INITIAL_TOTAL_VFS)
                 .await;
             let total_vfs = (vfs_dword >> 16) as u16;
             if total_vfs == 0 {
@@ -352,7 +342,7 @@ async fn probe_sriov_bus_requirement(
 
             // Read VF Offset and VF Stride.
             let offset_stride = cfg
-                .read_u32(bus, device, function, offset + sriov::VF_OFFSET_STRIDE)
+                .read_u32(bus, devfn, offset + sriov::VF_OFFSET_STRIDE)
                 .await;
             let vf_offset = offset_stride as u16;
             let vf_stride = (offset_stride >> 16) as u16;
@@ -362,9 +352,9 @@ async fn probe_sriov_bus_requirement(
             }
 
             // Compute the BDF of the last VF.
-            // First VF routing ID = (bus << 8 | device << 3 | function) + vf_offset
+            // First VF routing ID = (bus << 8 | devfn) + vf_offset
             // Last VF routing ID = first + (total_vfs - 1) * vf_stride
-            let pf_rid = (bus as u16) << 8 | (device as u16) << 3 | function as u16;
+            let pf_rid = (bus as u16) << 8 | devfn as u16;
             let last_vf_rid = pf_rid
                 .wrapping_add(vf_offset)
                 .wrapping_add((total_vfs - 1).wrapping_mul(vf_stride));

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -1,0 +1,374 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Phase 1: PCI bus enumeration and BAR size probing.
+
+use crate::AssignmentError;
+use crate::AssignmentParams;
+use crate::PciConfigAccess;
+use pci_core::spec::caps::EXT_CAP_START;
+use pci_core::spec::caps::ExtendedCapabilityId;
+use pci_core::spec::cfg_space::BarEncodingBits;
+use pci_core::spec::cfg_space::BistHeader;
+use pci_core::spec::cfg_space::Command;
+use pci_core::spec::cfg_space::CommonHeader;
+use pci_core::spec::cfg_space::HeaderType00;
+use pci_core::spec::cfg_space::HeaderType01;
+
+/// A discovered PCI device or bridge with probed BAR sizes.
+#[derive(Debug, Clone)]
+pub struct DiscoveredDevice {
+    pub bus: u8,
+    pub device: u8,
+    pub function: u8,
+    #[expect(dead_code)] // stored for future use in Phase 2+ diagnostics
+    pub(crate) header_type: u8,
+    pub is_bridge: bool,
+    #[expect(dead_code)] // stored for future use in Phase 2+ diagnostics
+    pub(crate) is_multi_function: bool,
+    pub bars: Vec<DiscoveredBar>,
+    /// For bridges: children behind this bridge.
+    pub children: Vec<DiscoveredDevice>,
+    /// For bridges: the secondary bus number assigned during enumeration.
+    pub secondary_bus: Option<u8>,
+    /// For bridges: the subordinate bus number assigned during enumeration.
+    pub subordinate_bus: Option<u8>,
+}
+
+/// A discovered BAR with its size.
+#[derive(Debug, Clone)]
+pub struct DiscoveredBar {
+    pub index: u8,
+    pub size: u64,
+    pub is_64bit: bool,
+    pub is_prefetchable: bool,
+}
+
+/// Enumerate all devices starting from the host bridge's start bus,
+/// assigning bus numbers to bridges and probing BAR sizes.
+///
+/// As a side effect, MMIO decode (MSE) is cleared in each device's
+/// command register. This is necessary to safely probe BAR sizes, and
+/// the bit is intentionally left cleared so that devices do not decode
+/// stale addresses. The caller must use [`crate::assign::program_assignments`]
+/// to write valid BAR addresses before re-enabling MMIO decode.
+pub async fn enumerate_and_probe(
+    cfg: &mut impl PciConfigAccess,
+    params: &AssignmentParams,
+) -> Result<Vec<DiscoveredDevice>, AssignmentError> {
+    let mut next_bus = params.start_bus.wrapping_add(1);
+    scan_bus(cfg, params.start_bus, params.end_bus, &mut next_bus).await
+}
+
+/// Scan a single bus (non-recursive helper that does DFS via inner calls).
+/// This is called for secondary buses behind bridges. It's not async-recursive
+/// itself because we use the pattern of scanning children inline.
+async fn scan_bus(
+    cfg: &mut impl PciConfigAccess,
+    bus: u8,
+    end_bus: u8,
+    next_bus: &mut u8,
+) -> Result<Vec<DiscoveredDevice>, AssignmentError> {
+    let mut devices = Vec::new();
+
+    for device_num in 0..32u8 {
+        let vendor = cfg
+            .read_u32(bus, device_num, 0, CommonHeader::DEVICE_VENDOR.0)
+            .await;
+        if vendor == !0u32 {
+            continue;
+        }
+
+        let bist_header_raw = cfg
+            .read_u32(bus, device_num, 0, HeaderType00::BIST_HEADER.0)
+            .await;
+        let bist = BistHeader::from(bist_header_raw);
+        let header_type = bist.header_type();
+        let multi_function = bist.multi_function();
+
+        let max_func = if multi_function { 8 } else { 1 };
+
+        for function in 0..max_func {
+            if function > 0 {
+                let vendor = cfg
+                    .read_u32(bus, device_num, function, CommonHeader::DEVICE_VENDOR.0)
+                    .await;
+                if vendor == !0u32 {
+                    continue;
+                }
+            }
+
+            let func_header = if function > 0 {
+                let bh = cfg
+                    .read_u32(bus, device_num, function, HeaderType00::BIST_HEADER.0)
+                    .await;
+                BistHeader::from(bh).header_type()
+            } else {
+                header_type
+            };
+
+            let is_bridge = func_header == 1;
+            let bars = probe_bars(cfg, bus, device_num, function, is_bridge).await;
+
+            let mut dev = DiscoveredDevice {
+                bus,
+                device: device_num,
+                function,
+                header_type: func_header,
+                is_bridge,
+                is_multi_function: multi_function,
+                bars,
+                children: Vec::new(),
+                secondary_bus: None,
+                subordinate_bus: None,
+            };
+
+            if is_bridge {
+                if *next_bus > end_bus {
+                    return Err(AssignmentError::BusExhaustion {
+                        bus,
+                        device: device_num,
+                        function,
+                    });
+                }
+                let secondary = *next_bus;
+                *next_bus = next_bus.wrapping_add(1);
+
+                let bus_reg = (bus as u32) | ((secondary as u32) << 8) | ((end_bus as u32) << 16);
+                cfg.write_u32(
+                    bus,
+                    device_num,
+                    function,
+                    HeaderType01::LATENCY_BUS_NUMBERS.0,
+                    bus_reg,
+                )
+                .await;
+
+                // NOTE: This is still logically recursive (scan_bus calls
+                // itself indirectly via this path), but the Rust compiler
+                // handles it because each call is a separate monomorphized
+                // async block that goes through the same function, and we
+                // box it to avoid infinite-size futures.
+                let children = Box::pin(scan_bus(cfg, secondary, end_bus, next_bus)).await?;
+
+                let subordinate = next_bus.wrapping_sub(1).max(secondary);
+                let bus_reg =
+                    (bus as u32) | ((secondary as u32) << 8) | ((subordinate as u32) << 16);
+                cfg.write_u32(
+                    bus,
+                    device_num,
+                    function,
+                    HeaderType01::LATENCY_BUS_NUMBERS.0,
+                    bus_reg,
+                )
+                .await;
+
+                dev.secondary_bus = Some(secondary);
+                dev.subordinate_bus = Some(subordinate);
+                dev.children = children;
+
+                tracing::debug!(
+                    bus,
+                    device = device_num,
+                    function,
+                    secondary,
+                    subordinate,
+                    "bridge enumerated"
+                );
+            } else {
+                // Reserve bus numbers for SR-IOV VFs on this endpoint.
+                if let Some(max_vf_bus) =
+                    probe_sriov_bus_requirement(cfg, bus, device_num, function).await
+                {
+                    if max_vf_bus >= *next_bus {
+                        *next_bus = max_vf_bus.wrapping_add(1);
+                    }
+                }
+
+                tracing::debug!(
+                    bus,
+                    device = device_num,
+                    function,
+                    bar_count = dev.bars.len(),
+                    "endpoint enumerated"
+                );
+            }
+
+            devices.push(dev);
+        }
+    }
+
+    Ok(devices)
+}
+
+/// Probe BAR sizes for a device by writing all-ones and reading back.
+///
+/// Disables MMIO decode (MSE) in the device's command register before
+/// probing and does not restore it. BAR registers are also left in an
+/// undefined state. The caller is responsible for programming valid BAR
+/// addresses and re-enabling MMIO decode afterward.
+async fn probe_bars(
+    cfg: &mut impl PciConfigAccess,
+    bus: u8,
+    device: u8,
+    function: u8,
+    is_bridge: bool,
+) -> Vec<DiscoveredBar> {
+    let max_bars: u8 = if is_bridge { 2 } else { 6 };
+    let mut bars = Vec::new();
+
+    // Disable MMIO decode so that writing all-ones to BARs during
+    // probing does not cause the device to decode a bogus address range.
+    // The command register is left with MMIO disabled; program_assignments
+    // will enable it once valid addresses have been programmed.
+    let cmd = cfg
+        .read_u32(bus, device, function, CommonHeader::STATUS_COMMAND.0)
+        .await;
+    let command = Command::from(cmd as u16);
+    if command.mmio_enabled() {
+        // Status bits are W1C, so avoid writing them.
+        cfg.write_u32(
+            bus,
+            device,
+            function,
+            CommonHeader::STATUS_COMMAND.0,
+            command.with_mmio_enabled(false).into_bits().into(),
+        )
+        .await;
+    }
+
+    let mut i = 0u8;
+    while i < max_bars {
+        let offset = HeaderType00::BAR0.0 + (i as u16) * 4;
+
+        // Write all-ones to probe size.
+        cfg.write_u32(bus, device, function, offset, !0u32).await;
+        let readback = cfg.read_u32(bus, device, function, offset).await;
+
+        if readback == 0 {
+            // BAR not implemented.
+            i += 1;
+            continue;
+        }
+
+        let is_io = BarEncodingBits::from(readback).use_pio();
+        if is_io {
+            // Skip I/O BARs for now.
+            i += 1;
+            continue;
+        }
+
+        let encoding = BarEncodingBits::from(readback);
+        let is_64bit = encoding.type_64_bit();
+        let is_prefetchable = encoding.prefetchable();
+
+        let size = if is_64bit && (i + 1) < max_bars {
+            // Probe upper 32 bits.
+            let upper_offset = HeaderType00::BAR0.0 + ((i + 1) as u16) * 4;
+            cfg.write_u32(bus, device, function, upper_offset, !0u32)
+                .await;
+            let upper_readback = cfg.read_u32(bus, device, function, upper_offset).await;
+
+            let mask = ((upper_readback as u64) << 32) | (readback as u64 & !0xF);
+            if mask == 0 {
+                i += 2;
+                continue;
+            }
+            (!mask).wrapping_add(1)
+        } else {
+            let mask = readback & !0xF;
+            if mask == 0 {
+                i += 1;
+                continue;
+            }
+            (!(mask as u64 | (!0u64 << 32))).wrapping_add(1)
+        };
+
+        if size > 0 {
+            bars.push(DiscoveredBar {
+                index: i,
+                size,
+                is_64bit,
+                is_prefetchable,
+            });
+        }
+
+        if is_64bit {
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+
+    bars
+}
+
+/// SR-IOV capability register offsets (relative to capability start).
+mod sriov {
+    /// Offset of the DWORD containing InitialVFs (low u16) and TotalVFs (high u16).
+    pub const INITIAL_TOTAL_VFS: u16 = 0x0C;
+    /// Offset of the DWORD containing VF Offset (low u16) and VF Stride (high u16).
+    pub const VF_OFFSET_STRIDE: u16 = 0x14;
+}
+
+/// Probe SR-IOV capability to determine how many extra bus numbers
+/// this device's VFs will need. Returns the highest bus number a VF
+/// could land on, or `None` if the device has no SR-IOV capability.
+async fn probe_sriov_bus_requirement(
+    cfg: &mut impl PciConfigAccess,
+    bus: u8,
+    device: u8,
+    function: u8,
+) -> Option<u8> {
+    // Walk extended capabilities starting at 0x100.
+    let mut offset = EXT_CAP_START;
+    loop {
+        if offset < EXT_CAP_START || offset & 0x3 != 0 {
+            break;
+        }
+        let header = cfg.read_u32(bus, device, function, offset).await;
+        if header == 0 || header == !0u32 {
+            break;
+        }
+        let cap_id = (header & 0xFFFF) as u16;
+        let next = ((header >> 20) & 0xFFC) as u16;
+
+        if cap_id == ExtendedCapabilityId::SRIOV.0 {
+            // Read TotalVFs.
+            let vfs_dword = cfg
+                .read_u32(bus, device, function, offset + sriov::INITIAL_TOTAL_VFS)
+                .await;
+            let total_vfs = (vfs_dword >> 16) as u16;
+            if total_vfs == 0 {
+                return None;
+            }
+
+            // Read VF Offset and VF Stride.
+            let offset_stride = cfg
+                .read_u32(bus, device, function, offset + sriov::VF_OFFSET_STRIDE)
+                .await;
+            let vf_offset = offset_stride as u16;
+            let vf_stride = (offset_stride >> 16) as u16;
+
+            if vf_stride == 0 {
+                return None;
+            }
+
+            // Compute the BDF of the last VF.
+            // First VF routing ID = (bus << 8 | device << 3 | function) + vf_offset
+            // Last VF routing ID = first + (total_vfs - 1) * vf_stride
+            let pf_rid = (bus as u16) << 8 | (device as u16) << 3 | function as u16;
+            let last_vf_rid = pf_rid
+                .wrapping_add(vf_offset)
+                .wrapping_add((total_vfs - 1).wrapping_mul(vf_stride));
+            let max_bus = (last_vf_rid >> 8) as u8;
+            return Some(max_bus);
+        }
+
+        offset = next;
+        if offset == 0 {
+            break;
+        }
+    }
+    None
+}

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -372,10 +372,10 @@ async fn probe_sriov_bus_requirement(
             return Some(max_bus);
         }
 
-        offset = next;
-        if offset == 0 {
+        if next == 0 || next <= offset {
             break;
         }
+        offset = next;
     }
     None
 }

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -56,7 +56,7 @@ pub async fn enumerate_and_probe(
     cfg: &mut impl PciConfigAccess,
     params: &AssignmentParams,
 ) -> Result<Vec<DiscoveredDevice>, AssignmentError> {
-    let mut next_bus = params.start_bus.wrapping_add(1);
+    let mut next_bus = params.start_bus as u16 + 1;
     scan_bus(cfg, params.start_bus, params.end_bus, &mut next_bus).await
 }
 
@@ -67,7 +67,7 @@ async fn scan_bus(
     cfg: &mut impl PciConfigAccess,
     bus: u8,
     end_bus: u8,
-    next_bus: &mut u8,
+    next_bus: &mut u16,
 ) -> Result<Vec<DiscoveredDevice>, AssignmentError> {
     let mut devices = Vec::new();
 
@@ -132,15 +132,15 @@ async fn scan_bus(
             };
 
             if is_bridge {
-                if *next_bus > end_bus {
+                if *next_bus > end_bus as u16 {
                     return Err(AssignmentError::BusExhaustion {
                         bus,
                         device: device_num,
                         function,
                     });
                 }
-                let secondary = *next_bus;
-                *next_bus = next_bus.wrapping_add(1);
+                let secondary = *next_bus as u8;
+                *next_bus += 1;
 
                 let bus_reg = (bus as u32) | ((secondary as u32) << 8) | ((end_bus as u32) << 16);
                 cfg.write_u32(bus, devfn, HeaderType01::LATENCY_BUS_NUMBERS.0, bus_reg)
@@ -153,7 +153,7 @@ async fn scan_bus(
                 // box it to avoid infinite-size futures.
                 let children = Box::pin(scan_bus(cfg, secondary, end_bus, next_bus)).await?;
 
-                let subordinate = next_bus.wrapping_sub(1).max(secondary);
+                let subordinate = (*next_bus - 1).max(secondary as u16) as u8;
                 let bus_reg =
                     (bus as u32) | ((secondary as u32) << 8) | ((subordinate as u32) << 16);
                 cfg.write_u32(bus, devfn, HeaderType01::LATENCY_BUS_NUMBERS.0, bus_reg)
@@ -174,15 +174,29 @@ async fn scan_bus(
             } else {
                 // Reserve bus numbers for SR-IOV VFs on this endpoint.
                 if let Some(max_vf_bus) = probe_sriov_bus_requirement(cfg, bus, devfn).await {
-                    if max_vf_bus > end_bus {
+                    if max_vf_bus > end_bus as u16 {
                         return Err(AssignmentError::BusExhaustion {
                             bus,
                             device: device_num,
                             function,
                         });
                     }
-                    if max_vf_bus >= *next_bus {
-                        *next_bus = max_vf_bus.wrapping_add(1);
+                    // VF bus numbers are fixed by the device's VF Offset
+                    // and VF Stride. VFs that stay on the PF's own bus
+                    // don't need any bus reservation. VFs that extend to
+                    // other buses must not collide with buses already
+                    // assigned to sibling bridges.
+                    if max_vf_bus > bus as u16 {
+                        if max_vf_bus < *next_bus {
+                            return Err(AssignmentError::SriovBusConflict {
+                                bus,
+                                device: device_num,
+                                function,
+                                max_vf_bus,
+                                next_bus: *next_bus,
+                            });
+                        }
+                        *next_bus = max_vf_bus + 1;
                     }
                 }
 
@@ -316,7 +330,7 @@ async fn probe_sriov_bus_requirement(
     cfg: &mut impl PciConfigAccess,
     bus: u8,
     devfn: u8,
-) -> Option<u8> {
+) -> Option<u16> {
     // Walk extended capabilities starting at 0x100.
     let mut offset = EXT_CAP_START;
     loop {
@@ -351,14 +365,12 @@ async fn probe_sriov_bus_requirement(
                 return None;
             }
 
-            // Compute the BDF of the last VF.
+            // Compute the BDF of the last VF in u32 to detect overflow.
             // First VF routing ID = (bus << 8 | devfn) + vf_offset
             // Last VF routing ID = first + (total_vfs - 1) * vf_stride
-            let pf_rid = (bus as u16) << 8 | devfn as u16;
-            let last_vf_rid = pf_rid
-                .wrapping_add(vf_offset)
-                .wrapping_add((total_vfs - 1).wrapping_mul(vf_stride));
-            let max_bus = (last_vf_rid >> 8) as u8;
+            let pf_rid = (bus as u32) << 8 | devfn as u32;
+            let last_vf_rid = pf_rid + vf_offset as u32 + (total_vfs - 1) as u32 * vf_stride as u32;
+            let max_bus = (last_vf_rid >> 8) as u16;
             return Some(max_bus);
         }
 

--- a/vm/devices/pci/pci_resource_assignment/src/lib.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/lib.rs
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! PCI resource assignment — bus enumeration and BAR address allocation.
+//!
+//! This crate implements PCI bus enumeration and resource assignment,
+//! operating purely through config space reads and writes via the
+//! [`PciConfigAccess`] trait.
+//!
+//! **Phase 1 — Enumerate and probe:** DFS walk assigning bus numbers. At each
+//! device, disable MMIO decode and probe BAR sizes by writing all-ones and
+//! reading back.
+//!
+//! **Phase 2 — Assign addresses:** Bottom-up subtree sizing, then top-down
+//! address assignment with bridge window programming.
+
+#![forbid(unsafe_code)]
+
+mod assign;
+mod enumerate;
+mod tests;
+
+/// Trait abstracting PCI configuration space access.
+///
+/// The methods are async because PCI config space accesses can be deferred
+/// (e.g., for devices that need cross-process communication). The ECAM
+/// implementation handles deferred completions; tests use a synchronous mock.
+pub trait PciConfigAccess {
+    /// Read a 32-bit value from PCI config space.
+    fn read_u32(
+        &mut self,
+        bus: u8,
+        device: u8,
+        function: u8,
+        offset: u16,
+    ) -> impl Future<Output = u32>;
+
+    /// Write a 32-bit value to PCI config space.
+    fn write_u32(
+        &mut self,
+        bus: u8,
+        device: u8,
+        function: u8,
+        offset: u16,
+        value: u32,
+    ) -> impl Future<Output = ()>;
+}
+
+/// MMIO aperture available for allocation.
+#[derive(Debug, Clone, Copy)]
+pub struct MmioAperture {
+    /// Base address of the aperture (must be naturally aligned to the
+    /// aperture's purpose — typically 1 MB for bridge windows).
+    pub base: u64,
+    /// Length in bytes.
+    pub len: u64,
+}
+
+/// Parameters for PCI resource assignment on a single host bridge.
+#[derive(Debug, Clone)]
+pub struct AssignmentParams {
+    /// First bus number owned by this host bridge.
+    pub start_bus: u8,
+    /// Last bus number owned by this host bridge (inclusive).
+    pub end_bus: u8,
+    /// Low MMIO aperture (below 4 GB) available for BAR allocation.
+    pub low_mmio: Option<MmioAperture>,
+    /// High MMIO aperture (above 4 GB) available for 64-bit BAR allocation.
+    pub high_mmio: Option<MmioAperture>,
+}
+
+/// Assign PCI resources (bus numbers and BAR addresses) for a host bridge.
+///
+/// This walks the PCI topology starting at `params.start_bus`, assigns bus
+/// numbers to bridges, probes BAR sizes, and programs BAR addresses from
+/// the provided MMIO apertures.
+pub async fn assign_pci_resources(
+    cfg: &mut impl PciConfigAccess,
+    params: &AssignmentParams,
+) -> Result<(), AssignmentError> {
+    assign_pci_resources_inner(cfg, params).await?;
+    Ok(())
+}
+
+/// Inner implementation that returns the assignment result for internal use
+/// (e.g., tests).
+pub(crate) async fn assign_pci_resources_inner(
+    cfg: &mut impl PciConfigAccess,
+    params: &AssignmentParams,
+) -> Result<AssignmentResult, AssignmentError> {
+    let devices = enumerate::enumerate_and_probe(cfg, params).await?;
+    let assignments = assign::assign_addresses(&devices, params)?;
+    assign::program_assignments(cfg, &assignments).await;
+    Ok(assignments)
+}
+
+/// Result of a successful resource assignment.
+#[derive(Debug, Clone)]
+struct AssignmentResult {
+    /// All device and bridge assignments made.
+    entries: Vec<AssignmentEntry>,
+}
+
+/// A single device or bridge assignment.
+#[derive(Debug, Clone)]
+struct AssignmentEntry {
+    /// Bus number.
+    bus: u8,
+    /// Device number.
+    device: u8,
+    /// Function number.
+    function: u8,
+    /// BAR assignments (index → address). Only populated BARs are included.
+    bars: Vec<BarAssignment>,
+    /// For bridges: the secondary bus number assigned.
+    secondary_bus: Option<u8>,
+    /// For bridges: the subordinate bus number assigned.
+    subordinate_bus: Option<u8>,
+    /// For bridges: the non-prefetchable memory window base (32-bit only).
+    memory_base: Option<u64>,
+    /// For bridges: the non-prefetchable memory window limit (32-bit only).
+    memory_limit: Option<u64>,
+    /// For bridges: the prefetchable memory window base (64-bit capable).
+    prefetchable_base: Option<u64>,
+    /// For bridges: the prefetchable memory window limit (64-bit capable).
+    prefetchable_limit: Option<u64>,
+}
+
+/// A BAR address assignment.
+#[derive(Debug, Clone)]
+struct BarAssignment {
+    /// BAR index (0–5 for endpoints, 0–1 for bridges).
+    index: u8,
+    /// Assigned base address.
+    address: u64,
+    /// Size in bytes.
+    size: u64,
+    /// Whether the BAR register is 64-bit (occupies two config space DWORDs).
+    is_64bit: bool,
+}
+
+/// Errors during resource assignment.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum AssignmentError {
+    /// Ran out of bus numbers during enumeration.
+    #[error("bus number exhaustion at bridge {bus:02x}:{device:02x}.{function}")]
+    BusExhaustion {
+        /// The bridge that needed another bus number.
+        bus: u8,
+        /// Device number of the bridge.
+        device: u8,
+        /// Function number of the bridge.
+        function: u8,
+    },
+    /// Not enough MMIO space for all BAR allocations.
+    #[error("{aperture} MMIO exhaustion: need {required:#x} bytes, have {available:#x}")]
+    MmioExhaustion {
+        /// Total MMIO required across all devices.
+        required: u64,
+        /// Total MMIO available.
+        available: u64,
+        /// Whether this was the low or high aperture.
+        aperture: &'static str,
+    },
+}

--- a/vm/devices/pci/pci_resource_assignment/src/lib.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/lib.rs
@@ -20,6 +20,13 @@ mod assign;
 mod enumerate;
 mod tests;
 
+/// Compute the devfn byte from a device number and function number.
+///
+/// This is the standard PCI encoding: `(device << 3) | function`.
+pub fn devfn(device: u8, function: u8) -> u8 {
+    (device << 3) | function
+}
+
 /// Trait abstracting PCI configuration space access.
 ///
 /// The methods are async because PCI config space accesses can be deferred
@@ -27,20 +34,13 @@ mod tests;
 /// implementation handles deferred completions; tests use a synchronous mock.
 pub trait PciConfigAccess {
     /// Read a 32-bit value from PCI config space.
-    fn read_u32(
-        &mut self,
-        bus: u8,
-        device: u8,
-        function: u8,
-        offset: u16,
-    ) -> impl Future<Output = u32>;
+    fn read_u32(&mut self, bus: u8, devfn: u8, offset: u16) -> impl Future<Output = u32>;
 
     /// Write a 32-bit value to PCI config space.
     fn write_u32(
         &mut self,
         bus: u8,
-        device: u8,
-        function: u8,
+        devfn: u8,
         offset: u16,
         value: u32,
     ) -> impl Future<Output = ()>;
@@ -124,6 +124,16 @@ struct AssignmentEntry {
     prefetchable_base: Option<u64>,
     /// For bridges: the prefetchable memory window limit (64-bit capable).
     prefetchable_limit: Option<u64>,
+}
+
+impl AssignmentEntry {
+    fn devfn(&self) -> u8 {
+        devfn(self.device, self.function)
+    }
+
+    async fn write_cfg(&self, cfg: &mut impl PciConfigAccess, offset: u16, value: u32) {
+        cfg.write_u32(self.bus, self.devfn(), offset, value).await
+    }
 }
 
 /// A BAR address assignment.

--- a/vm/devices/pci/pci_resource_assignment/src/lib.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/lib.rs
@@ -162,6 +162,23 @@ pub enum AssignmentError {
         /// Function number of the bridge.
         function: u8,
     },
+    /// SR-IOV VF bus numbers conflict with buses already assigned to bridges.
+    #[error(
+        "SR-IOV VF bus conflict at {bus:02x}:{device:02x}.{function}: \
+         VFs need bus {max_vf_bus} but buses up to {next_bus} are already assigned"
+    )]
+    SriovBusConflict {
+        /// Bus of the PF.
+        bus: u8,
+        /// Device number of the PF.
+        device: u8,
+        /// Function number of the PF.
+        function: u8,
+        /// Highest bus number needed by VFs.
+        max_vf_bus: u16,
+        /// Next bus number already allocated (VF buses below this are taken).
+        next_bus: u16,
+    },
     /// Not enough MMIO space for all BAR allocations.
     #[error("{aperture} MMIO exhaustion: need {required:#x} bytes, have {available:#x}")]
     MmioExhaustion {

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -944,10 +944,8 @@ async fn sriov_bus_reservation_exceeding_end_bus_returns_error() {
     let mut cfg = mock;
     let result = assign_pci_resources_inner(&mut cfg, &params).await;
 
-    // SR-IOV VFs need bus 2, but end_bus is 1. The code should return
+    // SR-IOV VFs need bus 2, but end_bus is 1. The code returns
     // BusExhaustion because the VF bus range exceeds the allowed range.
-    // BUG: currently the code silently sets subordinate_bus = 2 (past
-    // end_bus) instead of returning an error.
     assert!(
         matches!(result, Err(crate::AssignmentError::BusExhaustion { .. })),
         "expected BusExhaustion when SR-IOV reservation exceeds end_bus, got {result:?}"

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -951,3 +951,151 @@ async fn sriov_bus_reservation_exceeding_end_bus_returns_error() {
         "expected BusExhaustion when SR-IOV reservation exceeds end_bus, got {result:?}"
     );
 }
+
+/// Bug B: When low_mmio is None, 32-bit (non-prefetchable) BARs fall back
+/// to high_mmio via `.or(params.high_mmio)`. If high_mmio is above 4 GB,
+/// the BAR address is truncated by `bar.address as u32` and bridge memory
+/// base/limit registers (inherently 32-bit) silently lose upper bits.
+/// 32-bit BARs must never be placed above 4 GB.
+#[async_test]
+async fn mem32_bar_must_not_be_placed_above_4gb() {
+    let mock = MockConfigSpace::new();
+
+    // 32-bit non-prefetchable BAR.
+    mock.add_endpoint(0, 0, 0, &[(0, 0x10000, false, false)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: None,
+        high_mmio: Some(MmioAperture {
+            base: 0x1_0000_0000, // Above 4 GB
+            len: 0x1_0000_0000,
+        }),
+    };
+
+    let mut cfg = mock;
+    let result = assign_pci_resources_inner(&mut cfg, &params).await;
+
+    // No sub-4GB aperture exists, so 32-bit BARs cannot be placed.
+    // Must fail rather than silently placing them above 4 GB.
+    assert!(
+        result.is_err(),
+        "expected error when only aperture is above 4 GB, but got assignments: {:#?}",
+        result.unwrap().entries
+    );
+}
+
+/// Bug C: When both mem32 and mem64 pools share the same aperture (only
+/// one of low_mmio/high_mmio is provided), the mem64 base is computed
+/// from `aperture.base + root_req.mem32` instead of from the actual
+/// aligned mem32 end address. If aperture.base needs alignment for mem32,
+/// mem64 can start inside the mem32 region, causing overlapping
+/// assignments.
+#[async_test]
+async fn shared_aperture_mem32_mem64_must_not_overlap() {
+    let mock = MockConfigSpace::new();
+
+    // Device 0: 4 MB 32-bit non-prefetchable BAR (needs 4 MB alignment).
+    mock.add_endpoint(0, 0, 0, &[(0, 0x40_0000, false, false)]);
+    // Device 1: 1 MB 64-bit prefetchable BAR.
+    mock.add_endpoint(0, 1, 0, &[(0, 0x10_0000, true, true)]);
+
+    // Single aperture, misaligned so that mem32 alignment pushes its base
+    // forward, creating a gap between aperture.base and mem32 start.
+    // aperture.base = 0x1020_0000 (2 MB past a 4 MB boundary)
+    // mem32 aligns up to 0x1040_0000, occupies [0x1040_0000, 0x1080_0000)
+    // Bug: mem64 base = align_up(0x1020_0000 + 0x40_0000, 1MB)
+    //                  = 0x1060_0000, which is INSIDE the mem32 region.
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1020_0000,
+            len: 0x0100_0000, // 16 MB — plenty of room
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock;
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+
+    // Collect all BAR regions and verify no overlaps.
+    let mut regions: Vec<(u64, u64, String)> = Vec::new();
+    for entry in &result.entries {
+        for bar in &entry.bars {
+            regions.push((
+                bar.address,
+                bar.address + bar.size,
+                format!(
+                    "{:02x}:{:02x}.{} BAR{}",
+                    entry.bus, entry.device, entry.function, bar.index
+                ),
+            ));
+        }
+    }
+
+    for i in 0..regions.len() {
+        for j in (i + 1)..regions.len() {
+            let (a_start, a_end, a_name) = &regions[i];
+            let (b_start, b_end, b_name) = &regions[j];
+            assert!(
+                a_end <= b_start || b_end <= a_start,
+                "BAR regions overlap: {a_name} [{a_start:#x}..{a_end:#x}) vs \
+                 {b_name} [{b_start:#x}..{b_end:#x})"
+            );
+        }
+    }
+}
+
+/// Bug A: When bus 255 is consumed (by a bridge secondary or SR-IOV VF
+/// range), `wrapping_add(1)` wraps `*next_bus` to 0. The subsequent
+/// `*next_bus > end_bus` guard (0 > 255) is false, so the next bridge
+/// gets secondary bus 0, colliding with the host bridge. Should return
+/// BusExhaustion instead.
+#[async_test]
+async fn bus_wrap_to_zero_must_return_exhaustion() {
+    let mock = MockConfigSpace::new();
+
+    // Bridge 0 on bus 0 → secondary = 1.
+    mock.add_bridge(0, 0, 0);
+
+    // Endpoint on bus 1 with SR-IOV: 256 VFs, offset = 0x100, stride = 1.
+    // PF routing ID = (1 << 8) | 0 = 0x100
+    // Last VF routing ID = 0x100 + 0x100 + 255*1 = 0x2FF → bus 2
+    // But we'll craft it so max_vf_bus = 255:
+    // PF on bus 1, devfn 0. vf_offset = 0x700, stride = 1, total_vfs = 1.
+    // First VF RID = 0x100 + 0x700 = 0x800 → bus 8? No...
+    // We want last VF on bus 255. RID of last VF = 0xFF00..0xFFFF → bus 255.
+    // PF RID = (1 << 8) | 0 = 0x100.
+    // last_vf_rid = 0x100 + vf_offset + (total_vfs - 1) * vf_stride = 0xFF00
+    // With total_vfs=1, stride=1: last_vf_rid = 0x100 + vf_offset = 0xFF00
+    // → vf_offset = 0xFE00
+    mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.add_sriov(1, 0, 0, 1, 0xFE00, 1);
+
+    // Second bridge on bus 0 → needs secondary bus, but next_bus wrapped to 0.
+    mock.add_bridge(0, 1, 0);
+    // Empty device behind it (bus 256 which doesn't exist).
+    // The bridge just needs to exist to trigger the next bus allocation.
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock;
+    let result = assign_pci_resources_inner(&mut cfg, &params).await;
+
+    // The SR-IOV reservation consumes up through bus 255. The next bridge
+    // should fail with BusExhaustion, not silently wrap to bus 0.
+    assert!(
+        matches!(result, Err(crate::AssignmentError::BusExhaustion { .. })),
+        "expected BusExhaustion when next_bus wraps past 255, got {result:?}"
+    );
+}

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -177,12 +177,12 @@ impl MockConfigSpace {
 }
 
 impl PciConfigAccess for MockConfigSpace {
-    async fn read_u32(&mut self, bus: u8, device: u8, function: u8, offset: u16) -> u32 {
-        self.read_reg(bus, device, function, offset)
+    async fn read_u32(&mut self, bus: u8, devfn: u8, offset: u16) -> u32 {
+        self.read_reg(bus, devfn >> 3, devfn & 0x7, offset)
     }
 
-    async fn write_u32(&mut self, bus: u8, device: u8, function: u8, offset: u16, value: u32) {
-        self.write_reg(bus, device, function, offset, value);
+    async fn write_u32(&mut self, bus: u8, devfn: u8, offset: u16, value: u32) {
+        self.write_reg(bus, devfn >> 3, devfn & 0x7, offset, value);
     }
 }
 

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -113,9 +113,6 @@ impl MockConfigSpace {
         inner.regs.insert(key(0x2C), 0x0000_0000);
     }
 
-    /// For a bridge, make devices on its secondary bus visible.
-    /// This simulates config space routing: reads to the secondary bus
-    /// only succeed after the bridge's bus numbers are programmed.
     /// Add an SR-IOV extended capability to a device.
     /// `total_vfs`: max VFs supported, `vf_offset`: routing ID offset to first VF,
     /// `vf_stride`: routing ID increment per VF.
@@ -189,23 +186,12 @@ impl PciConfigAccess for MockConfigSpace {
     }
 }
 
-use std::future::Future;
-
-fn block_on<F: Future<Output = T>, T>(f: F) -> T {
-    // Simple poll-once executor — all our futures resolve immediately.
-    let mut f = std::pin::pin!(f);
-    let waker = std::task::Waker::noop();
-    let mut cx = std::task::Context::from_waker(waker);
-    match f.as_mut().poll(&mut cx) {
-        std::task::Poll::Ready(v) => v,
-        std::task::Poll::Pending => panic!("mock future unexpectedly pending"),
-    }
-}
+use pal_async::async_test;
 
 // ---- Tests ----
 
-#[test]
-fn single_endpoint_32bit_bar() {
+#[async_test]
+async fn single_endpoint_32bit_bar() {
     let mock = MockConfigSpace::new();
     // Device on bus 0, device 0, function 0 with a 64KB 32-bit non-pref BAR at index 0.
     mock.add_endpoint(0, 0, 0, &[(0, 0x10000, false, false)]);
@@ -221,7 +207,7 @@ fn single_endpoint_32bit_bar() {
     };
 
     let mut cfg = mock.clone();
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     assert_eq!(result.entries.len(), 1);
     let entry = &result.entries[0];
@@ -238,8 +224,8 @@ fn single_endpoint_32bit_bar() {
     assert_eq!(bar_val, 0x1000_0000);
 }
 
-#[test]
-fn single_endpoint_64bit_bar() {
+#[async_test]
+async fn single_endpoint_64bit_bar() {
     let mock = MockConfigSpace::new();
     // 1 MB 64-bit prefetchable BAR at index 0.
     mock.add_endpoint(0, 1, 0, &[(0, 0x100000, true, true)]);
@@ -255,7 +241,7 @@ fn single_endpoint_64bit_bar() {
     };
 
     let mut cfg = mock.clone();
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     assert_eq!(result.entries.len(), 1);
     let bar = &result.entries[0].bars[0];
@@ -270,8 +256,8 @@ fn single_endpoint_64bit_bar() {
     assert_eq!(bar_hi, 0x0000_0001);
 }
 
-#[test]
-fn bridge_with_endpoint() {
+#[async_test]
+async fn bridge_with_endpoint() {
     let mock = MockConfigSpace::new();
 
     // Bridge at bus 0, device 0, function 0.
@@ -291,7 +277,7 @@ fn bridge_with_endpoint() {
     };
 
     let mut cfg = mock.clone();
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     // Should have 2 entries: bridge + endpoint.
     assert_eq!(result.entries.len(), 2);
@@ -323,8 +309,8 @@ fn bridge_with_endpoint() {
     assert_eq!((bus_reg >> 16) & 0xFF, 1, "subordinate bus");
 }
 
-#[test]
-fn multiple_endpoints_sorted_by_size() {
+#[async_test]
+async fn multiple_endpoints_sorted_by_size() {
     let mock = MockConfigSpace::new();
 
     // Two devices with different BAR sizes.
@@ -344,7 +330,7 @@ fn multiple_endpoints_sorted_by_size() {
     };
 
     let mut cfg = mock.clone();
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     assert_eq!(result.entries.len(), 2);
 
@@ -360,8 +346,8 @@ fn multiple_endpoints_sorted_by_size() {
     assert_eq!(dev0.bars[0].size, 0x1000);
 }
 
-#[test]
-fn multi_function_device() {
+#[async_test]
+async fn multi_function_device() {
     let mock = MockConfigSpace::new();
 
     // Function 0: 4KB BAR.
@@ -382,7 +368,7 @@ fn multi_function_device() {
     };
 
     let mut cfg = mock.clone();
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     // Should find both functions.
     assert_eq!(result.entries.len(), 2);
@@ -391,8 +377,8 @@ fn multi_function_device() {
     assert_ne!(f0.bars[0].address, f1.bars[0].address);
 }
 
-#[test]
-fn switch_with_multiple_endpoints() {
+#[async_test]
+async fn switch_with_multiple_endpoints() {
     let mock = MockConfigSpace::new();
 
     // Upstream bridge on bus 0.
@@ -422,7 +408,7 @@ fn switch_with_multiple_endpoints() {
     };
 
     let mut cfg = mock.clone();
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     // Should have entries for: upstream bridge, 2 downstream bridges, 2 endpoints.
     assert!(result.entries.len() >= 4);
@@ -470,8 +456,8 @@ fn switch_with_multiple_endpoints() {
     assert!(ds_bridge_32.prefetchable_base.is_none());
 }
 
-#[test]
-fn bus_exhaustion_error() {
+#[async_test]
+async fn bus_exhaustion_error() {
     let mock = MockConfigSpace::new();
     mock.add_bridge(0, 0, 0);
 
@@ -483,7 +469,7 @@ fn bus_exhaustion_error() {
     };
 
     let mut cfg = mock;
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params));
+    let result = assign_pci_resources_inner(&mut cfg, &params).await;
     assert!(result.is_err());
     assert!(
         matches!(
@@ -494,8 +480,8 @@ fn bus_exhaustion_error() {
     );
 }
 
-#[test]
-fn no_devices_is_ok() {
+#[async_test]
+async fn no_devices_is_ok() {
     let mock = MockConfigSpace::new();
 
     let params = AssignmentParams {
@@ -509,12 +495,12 @@ fn no_devices_is_ok() {
     };
 
     let mut cfg = mock;
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
     assert!(result.entries.is_empty());
 }
 
-#[test]
-fn mmio_exhaustion_error() {
+#[async_test]
+async fn mmio_exhaustion_error() {
     let mock = MockConfigSpace::new();
 
     // Two devices totaling 192KB — exceeds the 128KB aperture.
@@ -532,7 +518,7 @@ fn mmio_exhaustion_error() {
     };
 
     let mut cfg = mock;
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params));
+    let result = assign_pci_resources_inner(&mut cfg, &params).await;
     assert!(result.is_err());
     assert!(
         matches!(
@@ -543,8 +529,8 @@ fn mmio_exhaustion_error() {
     );
 }
 
-#[test]
-fn no_aperture_error() {
+#[async_test]
+async fn no_aperture_error() {
     let mock = MockConfigSpace::new();
 
     mock.add_endpoint(0, 0, 0, &[(0, 0x1000, false, false)]);
@@ -558,7 +544,7 @@ fn no_aperture_error() {
     };
 
     let mut cfg = mock;
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params));
+    let result = assign_pci_resources_inner(&mut cfg, &params).await;
     assert!(result.is_err());
     assert!(
         matches!(
@@ -569,8 +555,8 @@ fn no_aperture_error() {
     );
 }
 
-#[test]
-fn sriov_reserves_bus_numbers() {
+#[async_test]
+async fn sriov_reserves_bus_numbers() {
     let mock = MockConfigSpace::new();
 
     // Bridge on bus 0.
@@ -593,7 +579,7 @@ fn sriov_reserves_bus_numbers() {
     };
 
     let mut cfg = mock.clone();
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     // Bridge should have subordinate >= 2 to cover VF buses.
     let bridge = result
@@ -614,8 +600,8 @@ fn sriov_reserves_bus_numbers() {
     assert!(subordinate >= 2, "subordinate {subordinate} should be >= 2");
 }
 
-#[test]
-fn sriov_no_vfs_no_reservation() {
+#[async_test]
+async fn sriov_no_vfs_no_reservation() {
     let mock = MockConfigSpace::new();
 
     // Bridge on bus 0.
@@ -636,7 +622,7 @@ fn sriov_no_vfs_no_reservation() {
     };
 
     let mut cfg = mock.clone();
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     // No extra buses reserved — subordinate should be 1.
     let bridge = result
@@ -647,8 +633,8 @@ fn sriov_no_vfs_no_reservation() {
     assert_eq!(bridge.subordinate_bus, Some(1));
 }
 
-#[test]
-fn bridge_prefetchable_window_programmed() {
+#[async_test]
+async fn bridge_prefetchable_window_programmed() {
     let mock = MockConfigSpace::new();
 
     // Bridge on bus 0 with a 64-bit endpoint behind it.
@@ -666,7 +652,7 @@ fn bridge_prefetchable_window_programmed() {
     };
 
     let mut cfg = mock.clone();
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     // The bridge should have a prefetchable window, not a non-prefetchable one.
     let bridge = result
@@ -706,8 +692,8 @@ fn bridge_prefetchable_window_programmed() {
     assert_eq!(pf_limit_upper, 0x1, "upper limit should be 0x1");
 }
 
-#[test]
-fn sibling_bridge_windows_must_not_overlap() {
+#[async_test]
+async fn sibling_bridge_windows_must_not_overlap() {
     let mock = MockConfigSpace::new();
 
     // Upstream bridge on bus 0.
@@ -739,7 +725,7 @@ fn sibling_bridge_windows_must_not_overlap() {
     };
 
     let mut cfg = mock.clone();
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     // Find bridge windows for the two downstream bridges.
     let bridge_a = result
@@ -774,8 +760,8 @@ fn sibling_bridge_windows_must_not_overlap() {
     );
 }
 
-#[test]
-fn large_bar_alignment_fits_in_bridge_window() {
+#[async_test]
+async fn large_bar_alignment_fits_in_bridge_window() {
     let mock = MockConfigSpace::new();
 
     // Bridge on bus 0.
@@ -795,7 +781,7 @@ fn large_bar_alignment_fits_in_bridge_window() {
     };
 
     let mut cfg = mock.clone();
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     let bridge = result
         .entries
@@ -831,8 +817,8 @@ fn large_bar_alignment_fits_in_bridge_window() {
     );
 }
 
-#[test]
-fn alignment_first_sort_avoids_wasted_padding() {
+#[async_test]
+async fn alignment_first_sort_avoids_wasted_padding() {
     let mock = MockConfigSpace::new();
 
     // Bridge A: three 1 MB BARs → subtree size = 3 MB, alignment = 1 MB.
@@ -861,7 +847,7 @@ fn alignment_first_sort_avoids_wasted_padding() {
     };
 
     let mut cfg = mock.clone();
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params));
+    let result = assign_pci_resources_inner(&mut cfg, &params).await;
 
     assert!(
         result.is_ok(),
@@ -870,8 +856,8 @@ fn alignment_first_sort_avoids_wasted_padding() {
     );
 }
 
-#[test]
-fn misaligned_aperture_does_not_overflow() {
+#[async_test]
+async fn misaligned_aperture_does_not_overflow() {
     let mock = MockConfigSpace::new();
 
     // Single endpoint with a 4 MB BAR (needs 4 MB natural alignment).
@@ -893,7 +879,7 @@ fn misaligned_aperture_does_not_overflow() {
     };
 
     let mut cfg = mock.clone();
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params));
+    let result = assign_pci_resources_inner(&mut cfg, &params).await;
 
     // The aperture is too small after alignment padding — this must fail.
     assert!(
@@ -902,8 +888,8 @@ fn misaligned_aperture_does_not_overflow() {
     );
 }
 
-#[test]
-fn alignment_exceeds_aperture_returns_error() {
+#[async_test]
+async fn alignment_exceeds_aperture_returns_error() {
     let mock = MockConfigSpace::new();
 
     // Single endpoint with a 16 MB BAR (needs 16 MB alignment).
@@ -923,10 +909,47 @@ fn alignment_exceeds_aperture_returns_error() {
     };
 
     let mut cfg = mock.clone();
-    let result = block_on(assign_pci_resources_inner(&mut cfg, &params));
+    let result = assign_pci_resources_inner(&mut cfg, &params).await;
 
     assert!(
         matches!(result, Err(crate::AssignmentError::MmioExhaustion { .. })),
         "expected MmioExhaustion when alignment exceeds aperture, got {result:?}"
+    );
+}
+
+#[async_test]
+async fn sriov_bus_reservation_exceeding_end_bus_returns_error() {
+    let mock = MockConfigSpace::new();
+
+    // Bridge on bus 0.
+    mock.add_bridge(0, 0, 0);
+
+    // Endpoint on bus 1 with SR-IOV: 256 VFs, offset=1, stride=1.
+    // PF routing ID = (1 << 8) | (0 << 3) | 0 = 0x100
+    // Last VF routing ID = 0x100 + 1 + 255*1 = 0x200 → bus 2
+    // But end_bus is 1, so VF bus 2 is out of range.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.add_sriov(1, 0, 0, 256, 1, 1);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 1, // Only buses 0 and 1 allowed.
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock;
+    let result = assign_pci_resources_inner(&mut cfg, &params).await;
+
+    // SR-IOV VFs need bus 2, but end_bus is 1. The code should return
+    // BusExhaustion because the VF bus range exceeds the allowed range.
+    // BUG: currently the code silently sets subordinate_bus = 2 (past
+    // end_bus) instead of returning an error.
+    assert!(
+        matches!(result, Err(crate::AssignmentError::BusExhaustion { .. })),
+        "expected BusExhaustion when SR-IOV reservation exceeds end_bus, got {result:?}"
     );
 }

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -1,0 +1,932 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![cfg(test)]
+
+use crate::AssignmentParams;
+use crate::MmioAperture;
+use crate::PciConfigAccess;
+use crate::assign_pci_resources_inner;
+use parking_lot::Mutex;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+/// Mock PCI config space: a flat map from (bus, device, function, offset) → u32.
+///
+/// Supports BAR probing: when a BAR register is written with 0xFFFFFFFF, the
+/// subsequent read returns the size mask. The mock handles this by tracking
+/// a separate "bar_masks" map.
+#[derive(Clone)]
+struct MockConfigSpace {
+    inner: Arc<Mutex<MockInner>>,
+}
+
+struct MockInner {
+    /// Config space registers: (bus, dev, func, offset) → value.
+    regs: BTreeMap<(u8, u8, u8, u16), u32>,
+    /// BAR size masks: (bus, dev, func, bar_offset) → mask.
+    /// When a BAR is written with 0xFFFFFFFF and MMIO is disabled,
+    /// the next read returns (0xFFFFFFFF & mask) | encoding_bits.
+    bar_masks: BTreeMap<(u8, u8, u8, u16), u32>,
+    /// Track whether a BAR is in "probing" state (written with 0xFFFFFFFF).
+    bar_probing: BTreeMap<(u8, u8, u8, u16), bool>,
+}
+
+impl MockConfigSpace {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(MockInner {
+                regs: BTreeMap::new(),
+                bar_masks: BTreeMap::new(),
+                bar_probing: BTreeMap::new(),
+            })),
+        }
+    }
+
+    /// Add a Type 0 endpoint at (bus, device, function) with the given BARs.
+    fn add_endpoint(&self, bus: u8, device: u8, function: u8, bars: &[(u8, u64, bool, bool)]) {
+        let mut inner = self.inner.lock();
+        let key = |off: u16| (bus, device, function, off);
+
+        // Vendor/Device ID (non-0xFFFF).
+        inner.regs.insert(key(0x00), 0x1234_5678);
+        // Class/Revision.
+        inner.regs.insert(key(0x08), 0x0200_0000);
+        // BIST/Header: Type 0, single function.
+        inner.regs.insert(key(0x0C), 0x0000_0000);
+        // Command: MMIO disabled initially.
+        inner.regs.insert(key(0x04), 0x0000_0000);
+
+        for &(bar_idx, size, is_64bit, prefetchable) in bars {
+            let offset = 0x10 + (bar_idx as u16) * 4;
+            // Initial BAR value: encoding bits only.
+            let mut encoding: u32 = 0;
+            if is_64bit {
+                encoding |= 0x04; // 64-bit
+            }
+            if prefetchable {
+                encoding |= 0x08;
+            }
+            inner.regs.insert(key(offset), encoding);
+
+            // Compute mask: size must be power of 2, mask = !(size - 1).
+            let mask = (!(size - 1)) as u32;
+            inner.bar_masks.insert(key(offset), mask | encoding);
+
+            if is_64bit {
+                let upper_offset = offset + 4;
+                let upper_mask = ((!(size - 1)) >> 32) as u32;
+                inner.regs.insert(key(upper_offset), 0);
+                inner.bar_masks.insert(key(upper_offset), upper_mask);
+            }
+        }
+    }
+
+    /// Add a Type 0 multi-function device (mark function 0 as multi-function).
+    fn set_multi_function(&self, bus: u8, device: u8) {
+        let mut inner = self.inner.lock();
+        let key = (bus, device, 0, 0x0Cu16);
+        let val = inner.regs.get(&key).copied().unwrap_or(0);
+        inner.regs.insert(key, val | 0x0080_0000); // multi-function bit
+    }
+
+    /// Add a Type 1 bridge at (bus, device, function).
+    fn add_bridge(&self, bus: u8, device: u8, function: u8) {
+        let mut inner = self.inner.lock();
+        let key = |off: u16| (bus, device, function, off);
+
+        // Vendor/Device ID.
+        inner.regs.insert(key(0x00), 0xABCD_EF01);
+        // Class/Revision: Bridge class (0x06), PCI-to-PCI subclass (0x04).
+        inner.regs.insert(key(0x08), 0x0604_0000);
+        // BIST/Header: Type 1.
+        inner.regs.insert(key(0x0C), 0x0001_0000);
+        // Command.
+        inner.regs.insert(key(0x04), 0x0000_0000);
+        // Bus numbers (will be programmed by enumeration).
+        inner.regs.insert(key(0x18), 0x0000_0000);
+        // Memory range (will be programmed).
+        inner.regs.insert(key(0x20), 0x0000_0000);
+        // Prefetchable range.
+        inner.regs.insert(key(0x24), 0x0000_0000);
+        inner.regs.insert(key(0x28), 0x0000_0000);
+        inner.regs.insert(key(0x2C), 0x0000_0000);
+    }
+
+    /// For a bridge, make devices on its secondary bus visible.
+    /// This simulates config space routing: reads to the secondary bus
+    /// only succeed after the bridge's bus numbers are programmed.
+    /// Add an SR-IOV extended capability to a device.
+    /// `total_vfs`: max VFs supported, `vf_offset`: routing ID offset to first VF,
+    /// `vf_stride`: routing ID increment per VF.
+    fn add_sriov(
+        &self,
+        bus: u8,
+        device: u8,
+        function: u8,
+        total_vfs: u16,
+        vf_offset: u16,
+        vf_stride: u16,
+    ) {
+        let mut inner = self.inner.lock();
+        let key = |off: u16| (bus, device, function, off);
+
+        // Extended capability header at 0x100: SR-IOV cap ID (0x10), next = 0.
+        let sriov_id: u16 = 0x10;
+        inner.regs.insert(key(0x100), sriov_id as u32); // cap_id=0x10, version=0, next=0
+
+        // InitialVFs (low u16) | TotalVFs (high u16) at cap + 0x0C.
+        inner.regs.insert(
+            key(0x100 + 0x0C),
+            (total_vfs as u32) << 16 | total_vfs as u32,
+        );
+
+        // VF Offset (low u16) | VF Stride (high u16) at cap + 0x14.
+        inner.regs.insert(
+            key(0x100 + 0x14),
+            (vf_stride as u32) << 16 | vf_offset as u32,
+        );
+    }
+
+    fn read_reg(&self, bus: u8, device: u8, function: u8, offset: u16) -> u32 {
+        let inner = self.inner.lock();
+        let key = (bus, device, function, offset);
+
+        // Check if this is a BAR in probing state.
+        if inner.bar_probing.get(&key).copied().unwrap_or(false) {
+            return inner.bar_masks.get(&key).copied().unwrap_or(0);
+        }
+
+        inner.regs.get(&key).copied().unwrap_or(!0u32)
+    }
+
+    fn write_reg(&self, bus: u8, device: u8, function: u8, offset: u16, value: u32) {
+        let mut inner = self.inner.lock();
+        let key = (bus, device, function, offset);
+
+        // Check if this is a BAR offset being probed.
+        let is_bar_offset = (0x10..=0x24).contains(&offset) && (offset & 0x3) == 0;
+        if is_bar_offset && inner.bar_masks.contains_key(&key) {
+            if value == !0u32 {
+                inner.bar_probing.insert(key, true);
+                return;
+            } else {
+                inner.bar_probing.insert(key, false);
+            }
+        }
+
+        inner.regs.insert(key, value);
+    }
+}
+
+impl PciConfigAccess for MockConfigSpace {
+    async fn read_u32(&mut self, bus: u8, device: u8, function: u8, offset: u16) -> u32 {
+        self.read_reg(bus, device, function, offset)
+    }
+
+    async fn write_u32(&mut self, bus: u8, device: u8, function: u8, offset: u16, value: u32) {
+        self.write_reg(bus, device, function, offset, value);
+    }
+}
+
+use std::future::Future;
+
+fn block_on<F: Future<Output = T>, T>(f: F) -> T {
+    // Simple poll-once executor — all our futures resolve immediately.
+    let mut f = std::pin::pin!(f);
+    let waker = std::task::Waker::noop();
+    let mut cx = std::task::Context::from_waker(waker);
+    match f.as_mut().poll(&mut cx) {
+        std::task::Poll::Ready(v) => v,
+        std::task::Poll::Pending => panic!("mock future unexpectedly pending"),
+    }
+}
+
+// ---- Tests ----
+
+#[test]
+fn single_endpoint_32bit_bar() {
+    let mock = MockConfigSpace::new();
+    // Device on bus 0, device 0, function 0 with a 64KB 32-bit non-pref BAR at index 0.
+    mock.add_endpoint(0, 0, 0, &[(0, 0x10000, false, false)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock.clone();
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+
+    assert_eq!(result.entries.len(), 1);
+    let entry = &result.entries[0];
+    assert_eq!(entry.bus, 0);
+    assert_eq!(entry.device, 0);
+    assert_eq!(entry.function, 0);
+    assert_eq!(entry.bars.len(), 1);
+    assert_eq!(entry.bars[0].address, 0x1000_0000);
+    assert_eq!(entry.bars[0].size, 0x10000);
+    assert!(!entry.bars[0].is_64bit);
+
+    // Verify BAR was programmed in config space.
+    let bar_val = mock.read_reg(0, 0, 0, 0x10);
+    assert_eq!(bar_val, 0x1000_0000);
+}
+
+#[test]
+fn single_endpoint_64bit_bar() {
+    let mock = MockConfigSpace::new();
+    // 1 MB 64-bit prefetchable BAR at index 0.
+    mock.add_endpoint(0, 1, 0, &[(0, 0x100000, true, true)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: None,
+        high_mmio: Some(MmioAperture {
+            base: 0x1_0000_0000,
+            len: 0x1_0000_0000,
+        }),
+    };
+
+    let mut cfg = mock.clone();
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+
+    assert_eq!(result.entries.len(), 1);
+    let bar = &result.entries[0].bars[0];
+    assert_eq!(bar.address, 0x1_0000_0000);
+    assert_eq!(bar.size, 0x100000);
+    assert!(bar.is_64bit);
+
+    // Verify both BAR registers were programmed.
+    let bar_lo = mock.read_reg(0, 1, 0, 0x10);
+    let bar_hi = mock.read_reg(0, 1, 0, 0x14);
+    assert_eq!(bar_lo, 0x0000_0000);
+    assert_eq!(bar_hi, 0x0000_0001);
+}
+
+#[test]
+fn bridge_with_endpoint() {
+    let mock = MockConfigSpace::new();
+
+    // Bridge at bus 0, device 0, function 0.
+    mock.add_bridge(0, 0, 0);
+    // Endpoint behind bridge at bus 1, device 0, function 0.
+    // 64KB non-prefetchable BAR.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x10000, false, false)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock.clone();
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+
+    // Should have 2 entries: bridge + endpoint.
+    assert_eq!(result.entries.len(), 2);
+
+    // Find the bridge entry.
+    let bridge = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 0 && e.device == 0)
+        .unwrap();
+    assert_eq!(bridge.secondary_bus, Some(1));
+    assert_eq!(bridge.subordinate_bus, Some(1));
+    assert!(bridge.memory_base.is_some());
+    assert!(bridge.memory_limit.is_some());
+
+    // Find the endpoint entry.
+    let endpoint = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 1 && e.device == 0)
+        .unwrap();
+    assert_eq!(endpoint.bars.len(), 1);
+    assert_eq!(endpoint.bars[0].size, 0x10000);
+
+    // Verify bus numbers were programmed on the bridge.
+    let bus_reg = mock.read_reg(0, 0, 0, 0x18);
+    assert_eq!(bus_reg & 0xFF, 0, "primary bus");
+    assert_eq!((bus_reg >> 8) & 0xFF, 1, "secondary bus");
+    assert_eq!((bus_reg >> 16) & 0xFF, 1, "subordinate bus");
+}
+
+#[test]
+fn multiple_endpoints_sorted_by_size() {
+    let mock = MockConfigSpace::new();
+
+    // Two devices with different BAR sizes.
+    // Device 0: 4KB BAR.
+    mock.add_endpoint(0, 0, 0, &[(0, 0x1000, false, false)]);
+    // Device 1: 1MB BAR.
+    mock.add_endpoint(0, 1, 0, &[(0, 0x100000, false, false)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock.clone();
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+
+    assert_eq!(result.entries.len(), 2);
+
+    // The 1MB BAR should be allocated first (sorted by size desc) and
+    // aligned to 1MB.
+    let dev1 = result.entries.iter().find(|e| e.device == 1).unwrap();
+    assert_eq!(dev1.bars[0].address, 0x1000_0000);
+    assert_eq!(dev1.bars[0].size, 0x100000);
+
+    // The 4KB BAR should follow.
+    let dev0 = result.entries.iter().find(|e| e.device == 0).unwrap();
+    assert_eq!(dev0.bars[0].address, 0x1010_0000);
+    assert_eq!(dev0.bars[0].size, 0x1000);
+}
+
+#[test]
+fn multi_function_device() {
+    let mock = MockConfigSpace::new();
+
+    // Function 0: 4KB BAR.
+    mock.add_endpoint(0, 0, 0, &[(0, 0x1000, false, false)]);
+    // Function 1: 4KB BAR.
+    mock.add_endpoint(0, 0, 1, &[(0, 0x1000, false, false)]);
+    // Mark as multi-function.
+    mock.set_multi_function(0, 0);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock.clone();
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+
+    // Should find both functions.
+    assert_eq!(result.entries.len(), 2);
+    let f0 = result.entries.iter().find(|e| e.function == 0).unwrap();
+    let f1 = result.entries.iter().find(|e| e.function == 1).unwrap();
+    assert_ne!(f0.bars[0].address, f1.bars[0].address);
+}
+
+#[test]
+fn switch_with_multiple_endpoints() {
+    let mock = MockConfigSpace::new();
+
+    // Upstream bridge on bus 0.
+    mock.add_bridge(0, 0, 0);
+
+    // Two downstream bridges on bus 1.
+    mock.add_bridge(1, 0, 0);
+    mock.add_bridge(1, 1, 0);
+
+    // Endpoint behind first downstream bridge (bus 2).
+    mock.add_endpoint(2, 0, 0, &[(0, 0x10000, false, false)]);
+
+    // Endpoint behind second downstream bridge (bus 3).
+    mock.add_endpoint(3, 0, 0, &[(0, 0x10000, true, true)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: Some(MmioAperture {
+            base: 0x1_0000_0000,
+            len: 0x1_0000_0000,
+        }),
+    };
+
+    let mut cfg = mock.clone();
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+
+    // Should have entries for: upstream bridge, 2 downstream bridges, 2 endpoints.
+    assert!(result.entries.len() >= 4);
+
+    // Verify bus numbers were assigned correctly.
+    let upstream = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 0 && e.device == 0)
+        .unwrap();
+    assert_eq!(upstream.secondary_bus, Some(1));
+
+    // Both endpoints should have BAR addresses assigned.
+    let ep1 = result.entries.iter().find(|e| e.bus == 2).unwrap();
+    let ep2 = result.entries.iter().find(|e| e.bus == 3).unwrap();
+    assert_eq!(ep1.bars.len(), 1);
+    assert_eq!(ep2.bars.len(), 1);
+    // 32-bit BAR on bus 2 should be in low MMIO.
+    assert!(ep1.bars[0].address >= 0x1000_0000);
+    assert!(ep1.bars[0].address < 0x2000_0000);
+    // 64-bit BAR on bus 3 should be in high MMIO.
+    assert!(ep2.bars[0].address >= 0x1_0000_0000);
+
+    // The downstream bridge for the 64-bit endpoint should have a
+    // prefetchable window covering high MMIO.
+    let ds_bridge_64 = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 1 && e.device == 1)
+        .unwrap();
+    assert!(
+        ds_bridge_64.prefetchable_base.is_some(),
+        "bridge behind 64-bit endpoint should have prefetchable window"
+    );
+    assert!(ds_bridge_64.prefetchable_base.unwrap() >= 0x1_0000_0000);
+
+    // The downstream bridge for the 32-bit endpoint should have a
+    // non-prefetchable window in low MMIO, and no prefetchable window.
+    let ds_bridge_32 = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 1 && e.device == 0)
+        .unwrap();
+    assert!(ds_bridge_32.memory_base.is_some());
+    assert!(ds_bridge_32.prefetchable_base.is_none());
+}
+
+#[test]
+fn bus_exhaustion_error() {
+    let mock = MockConfigSpace::new();
+    mock.add_bridge(0, 0, 0);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 0, // No room for secondary bus.
+        low_mmio: None,
+        high_mmio: None,
+    };
+
+    let mut cfg = mock;
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params));
+    assert!(result.is_err());
+    assert!(
+        matches!(
+            result.unwrap_err(),
+            crate::AssignmentError::BusExhaustion { .. }
+        ),
+        "expected BusExhaustion"
+    );
+}
+
+#[test]
+fn no_devices_is_ok() {
+    let mock = MockConfigSpace::new();
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock;
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+    assert!(result.entries.is_empty());
+}
+
+#[test]
+fn mmio_exhaustion_error() {
+    let mock = MockConfigSpace::new();
+
+    // Two devices totaling 192KB — exceeds the 128KB aperture.
+    mock.add_endpoint(0, 0, 0, &[(0, 0x10000, false, false)]); // 64KB
+    mock.add_endpoint(0, 1, 0, &[(0, 0x20000, false, false)]); // 128KB
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x20000, // 128KB — not enough for both
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock;
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params));
+    assert!(result.is_err());
+    assert!(
+        matches!(
+            result.unwrap_err(),
+            crate::AssignmentError::MmioExhaustion { .. }
+        ),
+        "expected MmioExhaustion"
+    );
+}
+
+#[test]
+fn no_aperture_error() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_endpoint(0, 0, 0, &[(0, 0x1000, false, false)]);
+
+    // No MMIO apertures at all.
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: None,
+        high_mmio: None,
+    };
+
+    let mut cfg = mock;
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params));
+    assert!(result.is_err());
+    assert!(
+        matches!(
+            result.unwrap_err(),
+            crate::AssignmentError::MmioExhaustion { .. }
+        ),
+        "expected MmioExhaustion"
+    );
+}
+
+#[test]
+fn sriov_reserves_bus_numbers() {
+    let mock = MockConfigSpace::new();
+
+    // Bridge on bus 0.
+    mock.add_bridge(0, 0, 0);
+
+    // Endpoint on bus 1 with SR-IOV: 256 VFs, offset=1, stride=1.
+    // PF routing ID = (1 << 8) | (0 << 3) | 0 = 0x100
+    // Last VF routing ID = 0x100 + 1 + 255*1 = 0x200 → bus 2
+    mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.add_sriov(1, 0, 0, 256, 1, 1);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock.clone();
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+
+    // Bridge should have subordinate >= 2 to cover VF buses.
+    let bridge = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 0 && e.device == 0)
+        .unwrap();
+    assert_eq!(bridge.secondary_bus, Some(1));
+    assert!(
+        bridge.subordinate_bus.unwrap() >= 2,
+        "subordinate bus {} should be >= 2 to cover SR-IOV VFs",
+        bridge.subordinate_bus.unwrap()
+    );
+
+    // Verify bus numbers programmed on the bridge.
+    let bus_reg = mock.read_reg(0, 0, 0, 0x18);
+    let subordinate = (bus_reg >> 16) & 0xFF;
+    assert!(subordinate >= 2, "subordinate {subordinate} should be >= 2");
+}
+
+#[test]
+fn sriov_no_vfs_no_reservation() {
+    let mock = MockConfigSpace::new();
+
+    // Bridge on bus 0.
+    mock.add_bridge(0, 0, 0);
+
+    // Endpoint on bus 1 with SR-IOV but 0 VFs.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.add_sriov(1, 0, 0, 0, 1, 1);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock.clone();
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+
+    // No extra buses reserved — subordinate should be 1.
+    let bridge = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 0 && e.device == 0)
+        .unwrap();
+    assert_eq!(bridge.subordinate_bus, Some(1));
+}
+
+#[test]
+fn bridge_prefetchable_window_programmed() {
+    let mock = MockConfigSpace::new();
+
+    // Bridge on bus 0 with a 64-bit endpoint behind it.
+    mock.add_bridge(0, 0, 0);
+    mock.add_endpoint(1, 0, 0, &[(0, 0x100000, true, true)]); // 1 MB 64-bit pref
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: None,
+        high_mmio: Some(MmioAperture {
+            base: 0x1_0000_0000,
+            len: 0x1_0000_0000,
+        }),
+    };
+
+    let mut cfg = mock.clone();
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+
+    // The bridge should have a prefetchable window, not a non-prefetchable one.
+    let bridge = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 0 && e.device == 0)
+        .unwrap();
+    assert!(
+        bridge.memory_base.is_none(),
+        "no non-prefetchable window expected"
+    );
+    assert!(
+        bridge.prefetchable_base.is_some(),
+        "prefetchable window expected"
+    );
+    assert!(bridge.prefetchable_base.unwrap() >= 0x1_0000_0000);
+
+    // Verify the prefetchable window registers were programmed.
+    // Offset 0x24: prefetchable base/limit (lower 16 bits each, with 64-bit flag).
+    let pf_range = mock.read_reg(0, 0, 0, 0x24);
+    assert_ne!(
+        pf_range, 0,
+        "prefetchable range register should be programmed"
+    );
+    // Bit 0 of base should be 1 (64-bit indicator).
+    assert_eq!(pf_range & 0x1, 0x1, "64-bit indicator should be set");
+
+    // Offset 0x28: prefetchable base upper 32 bits.
+    let pf_base_upper = mock.read_reg(0, 0, 0, 0x28);
+    assert_eq!(
+        pf_base_upper, 0x1,
+        "upper base should be 0x1 for address >= 0x1_0000_0000"
+    );
+
+    // Offset 0x2C: prefetchable limit upper 32 bits.
+    let pf_limit_upper = mock.read_reg(0, 0, 0, 0x2C);
+    assert_eq!(pf_limit_upper, 0x1, "upper limit should be 0x1");
+}
+
+#[test]
+fn sibling_bridge_windows_must_not_overlap() {
+    let mock = MockConfigSpace::new();
+
+    // Upstream bridge on bus 0.
+    mock.add_bridge(0, 0, 0);
+
+    // Two downstream bridges on bus 1.
+    mock.add_bridge(1, 0, 0); // Bridge A → bus 2
+    mock.add_bridge(1, 1, 0); // Bridge B → bus 3
+
+    // Bridge A has two BARs behind it: 1 MB + 4 KB.
+    mock.add_endpoint(
+        2,
+        0,
+        0,
+        &[(0, 0x100000, false, false), (2, 0x1000, false, false)],
+    );
+
+    // Bridge B has one BAR behind it: 512 KB.
+    mock.add_endpoint(3, 0, 0, &[(0, 0x80000, false, false)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock.clone();
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+
+    // Find bridge windows for the two downstream bridges.
+    let bridge_a = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 1 && e.device == 0)
+        .unwrap();
+    let bridge_b = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 1 && e.device == 1)
+        .unwrap();
+
+    let a_base = bridge_a
+        .memory_base
+        .expect("bridge A should have memory window");
+    let a_limit = bridge_a
+        .memory_limit
+        .expect("bridge A should have memory window");
+    let b_base = bridge_b
+        .memory_base
+        .expect("bridge B should have memory window");
+    let b_limit = bridge_b
+        .memory_limit
+        .expect("bridge B should have memory window");
+
+    // Sibling bridge windows must not overlap — if they do, both bridges
+    // will claim the same addresses on the upstream bus.
+    assert!(
+        a_limit < b_base || b_limit < a_base,
+        "bridge windows overlap: A=[{a_base:#x}..={a_limit:#x}], B=[{b_base:#x}..={b_limit:#x}]"
+    );
+}
+
+#[test]
+fn large_bar_alignment_fits_in_bridge_window() {
+    let mock = MockConfigSpace::new();
+
+    // Bridge on bus 0.
+    mock.add_bridge(0, 0, 0);
+
+    // Endpoint behind bridge with a 1 GB BAR (needs 1 GB natural alignment).
+    mock.add_endpoint(1, 0, 0, &[(0, 0x4000_0000, false, false)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,  // 256 MB — not 1 GB aligned
+            len: 0x2_0000_0000, // 8 GB
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock.clone();
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params)).unwrap();
+
+    let bridge = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 0 && e.device == 0)
+        .unwrap();
+    let ep = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 1 && e.device == 0)
+        .unwrap();
+
+    let window_base = bridge
+        .memory_base
+        .expect("bridge should have memory window");
+    let window_limit = bridge
+        .memory_limit
+        .expect("bridge should have memory window");
+    let bar_addr = ep.bars[0].address;
+    let bar_end = bar_addr + ep.bars[0].size - 1;
+
+    // The BAR must be naturally aligned.
+    assert_eq!(
+        bar_addr % 0x4000_0000,
+        0,
+        "1 GB BAR at {bar_addr:#x} is not 1 GB aligned"
+    );
+
+    // The BAR must fit within the bridge window.
+    assert!(
+        bar_addr >= window_base && bar_end <= window_limit,
+        "BAR [{bar_addr:#x}..={bar_end:#x}] overflows bridge window [{window_base:#x}..={window_limit:#x}]"
+    );
+}
+
+#[test]
+fn alignment_first_sort_avoids_wasted_padding() {
+    let mock = MockConfigSpace::new();
+
+    // Bridge A: three 1 MB BARs → subtree size = 3 MB, alignment = 1 MB.
+    mock.add_bridge(0, 0, 0);
+    mock.add_endpoint(1, 0, 0, &[(0, 0x100000, false, false)]);
+    mock.add_endpoint(1, 1, 0, &[(0, 0x100000, false, false)]);
+    mock.add_endpoint(1, 2, 0, &[(0, 0x100000, false, false)]);
+
+    // Bridge B: one 2 MB BAR → subtree size = 2 MB, alignment = 2 MB.
+    mock.add_bridge(0, 1, 0);
+    mock.add_endpoint(2, 0, 0, &[(0, 0x200000, false, false)]);
+
+    // 5 MB aperture. With alignment-first ordering (B then A), total is
+    // exactly 5 MB: B at 0 (2 MB aligned, uses 2 MB), A at 2 MB (1 MB
+    // aligned, uses 3 MB). With size-first ordering (A then B), A uses
+    // 3 MB, then B needs 2 MB alignment → next 2 MB boundary is 4 MB,
+    // total = 6 MB, which overflows.
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x500000, // 5 MB
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock.clone();
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params));
+
+    assert!(
+        result.is_ok(),
+        "5 MB aperture should be sufficient for 3 MB + 2 MB: {}",
+        result.unwrap_err()
+    );
+}
+
+#[test]
+fn misaligned_aperture_does_not_overflow() {
+    let mock = MockConfigSpace::new();
+
+    // Single endpoint with a 4 MB BAR (needs 4 MB natural alignment).
+    mock.add_endpoint(0, 0, 0, &[(0, 0x400000, false, false)]);
+
+    // Aperture base is only 2 MB aligned, not 4 MB aligned.
+    // The allocator must align up to the next 4 MB boundary, losing 2 MB,
+    // so it needs at least 6 MB of aperture. Give it exactly 4 MB — this
+    // should fail because the BAR won't fit after alignment, but must not
+    // silently place the BAR past the end of the aperture.
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1020_0000, // 2 MB aligned, NOT 4 MB aligned
+            len: 0x400000,     // 4 MB — exactly the BAR size, but not enough after alignment
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock.clone();
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params));
+
+    // The aperture is too small after alignment padding — this must fail.
+    assert!(
+        matches!(result, Err(crate::AssignmentError::MmioExhaustion { .. })),
+        "expected MmioExhaustion for misaligned aperture, got {result:?}"
+    );
+}
+
+#[test]
+fn alignment_exceeds_aperture_returns_error() {
+    let mock = MockConfigSpace::new();
+
+    // Single endpoint with a 16 MB BAR (needs 16 MB alignment).
+    mock.add_endpoint(0, 0, 0, &[(0, 0x1000000, false, false)]);
+
+    // Aperture is only 2 MB total. Alignment pushes base past the end,
+    // which must produce MmioExhaustion rather than wrapping the
+    // available-space calculation.
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1020_0000, // 2 MB past a 16 MB boundary
+            len: 0x200000,     // 2 MB total
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock.clone();
+    let result = block_on(assign_pci_resources_inner(&mut cfg, &params));
+
+    assert!(
+        matches!(result, Err(crate::AssignmentError::MmioExhaustion { .. })),
+        "expected MmioExhaustion when alignment exceeds aperture, got {result:?}"
+    );
+}


### PR DESCRIPTION
When booting Linux directly (without UEFI), there is no firmware to enumerate the PCI bus, assign bus numbers, probe BAR sizes, or program BAR addresses and bridge windows. Devices behind PCIe root ports are invisible to the guest because their config space and MMIO regions are unconfigured. This crate fills that gap for Linux direct boot.

Longer term, this will also replace UEFI's PCI enumeration for all boot modes. Performing resource assignment in the VMM rather than in guest firmware lets us validate the PCI topology and MMIO layout before the guest ever runs, catching configuration errors (undersized apertures, impossible BAR placements, bus exhaustion) as clear VMM-side errors instead of mysterious guest boot failures.

The algorithm has two phases. Phase 1 walks the bus topology depth-first, assigning secondary and subordinate bus numbers to bridges and probing each device's BAR sizes. SR-IOV VF bus requirements are accounted for when setting subordinate bus numbers.

Phase 2 uses hierarchical bottom-up/top-down allocation. Each bridge computes the total aligned resource requirement of its subtree, then the host bridge carves its MMIO aperture among top-level devices, with each bridge subdividing its allocated range among children. This guarantees non-overlapping bridge windows and correct alignment at every level. BARs are split into two pools: non-prefetchable BARs go to low MMIO (32-bit bridge window), while 64-bit prefetchable BARs go to high MMIO (prefetchable bridge window, the only window capable of 64-bit addresses).

The crate is wired into openvmm_core for Linux direct boot: after loading the kernel, state units are temporarily started with VPs held so that config space accesses route through the chipset's MMIO dispatch, the assignment runs, then state units stop again before the guest resumes.