### PR TITLE
kernel: update kernel release to latest 6.12 version

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -28,8 +28,8 @@ pub const NODEJS: &str = "18.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.52.12";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.52.12";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.52.8";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.52.8";
 pub const OPENVMM_DEPS: &str = "0.1.0-20250403.3";
 pub const PROTOC: &str = "27.1";
 


### PR DESCRIPTION
Looks like the previously referenced kernel release was deleted somehow, will follow up with the folks that own that repo to make sure this doesn't happen again.

I validated that these two tags are identical however:
```
ben@benhill-nimbus:~/OHCL-Linux-Kernel$ git log
commit 9218fd5bcdef89d155f18bd410e9a9add3f8eaa5 (HEAD, tag: rolling-lts/hcl-main/6.12.52.8, tag: rolling-lts/hcl-main/6.12.52.12, tag: rolling-lts/hcl-dev/6.12.52.8, origin/product/hcl-main/6.12)
Author: Daniel Paliulis <dpaliulis@microsoft.com>
Date:   Tue May 12 19:12:56 2026 +0000

    config: enabling madvise syscalls for user mode deallocations

    This config change includes madvise.o in the final build image, enabling madvise syscalls. This is necessary because MiMalloc (the allocator for OpenHCL) uses madvise syscalls to deallocate memory. Without this change, madvise is excluded from the final build image resulting in the syscalls for deallocating memory from the user mode being unrecognized by the kernel. This results in a major memory leak where no user mode process is able to free physical memory. OpenHCL builds with the kernel with this fix indicate steady memory usage in a reproduction scenario that would otherwise expose the memory leak.
```