### PR TITLE
firmware_uefi: Add a missing fuzzer crypto feature

### DIFF
--- a/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
-crypto = { workspace = true, features = ["vendored"] }
+crypto = { workspace = true, features = ["test_helpers", "vendored"] }
 firmware_uefi = { workspace = true, features = ["fuzzing"] }
 firmware_uefi_resources.workspace = true
 guid.workspace = true


### PR DESCRIPTION
Not sure yet why this passed CI in a broken state, but this is needed.