### PR TITLE
[1.6] Bump openssl to 0.10.80 to address CVE alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,15 +4857,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -4889,18 +4888,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.0+3.5.0"
+version = "300.6.0+3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -478,7 +478,7 @@ nix = { version = "0.27", default-features = false }
 ntapi = "0.4"
 object = { version = "0.36.7", default-features = false }
 once_cell = "1.7"
-openssl = "0.10.72"
+openssl = "0.10.80"
 openssl-sys = "0.9"
 parking_lot = "0.12"
 paste = "1.0"


### PR DESCRIPTION
Bumps the openssl crate from 0.10.72 to 0.10.80 on the release/2505 (1.6) branch to address multiple security advisories:

- rust-openssl undefined behavior in X509Ref::ocsp_responders for certificates with non-UTF-8 OCSP URLs (fixed in 0.10.79)
- rust-openssl heap buffer overflow when encrypting with AES key-wrap-with-padding (fixed in 0.10.80)