### PR TITLE
vmbus_server: don't use monitor info if interrupts are disabled

### DIFF
--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -1272,7 +1272,8 @@ impl OpenParams {
             },
             connection_id,
             event_flag,
-            monitor_info,
+            // Only include monitor info if the request has interrupts enabled.
+            monitor_info: request.target_vp.and(monitor_info),
             flags: request.flags.with_unused(0),
             reserved_target,
             channel_id: info.channel_id,

--- a/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
@@ -1790,6 +1790,41 @@ fn test_mnf_channel() {
 }
 
 #[test]
+fn test_mnf_channel_open_with_interrupts_disabled() {
+    // A channel with MNF enabled, opened by the guest with interrupts disabled (via
+    // VP_INDEX_DISABLE_INTERRUPT as the target VP), should not have monitor info in its
+    // OpenParams.
+    let mut env = TestEnv::new();
+    let offer_id = env.offer_with_mnf(1);
+
+    env.connect(Version::Copper, FeatureFlags::new());
+    env.c().handle_request_offers().unwrap();
+    env.notifier.messages.clear();
+
+    env.c()
+        .handle_open_channel(&protocol::OpenChannel2 {
+            open_channel: protocol::OpenChannel {
+                channel_id: ChannelId(1),
+                open_id: 1,
+                ring_buffer_gpadl_id: GpadlId(1),
+                target_vp: protocol::VP_INDEX_DISABLE_INTERRUPT,
+                downstream_ring_buffer_page_offset: 0,
+                user_data: UserDefinedData::new_zeroed(),
+            },
+            ..FromZeros::new_zeroed()
+        })
+        .unwrap();
+
+    let (id, action) = env.recv.recv().unwrap();
+    assert_eq!(id, offer_id);
+    let Action::Open(op, ..) = action else {
+        panic!("unexpected action: {:?}", action);
+    };
+    assert_eq!(op.open_data.target_vp, None);
+    assert_eq!(op.monitor_info, None);
+}
+
+#[test]
 fn test_server_monitor_page() {
     // Guest pages provided, but overridden by server-allocated pages.
     test_server_monitor_page_helper(true);


### PR DESCRIPTION
This change fixes an issue where channels with MNF enabled were supplied with information about the MNF usage when opened, even when the channel has interrupts disabled. This was unnecessary, as the MNF support set up for the channel would not be used anyway, but it would also cause the check in `ServerTaskInner::set_monitor_page` to fail during the handling of a `ModifyConnection` message because it believes a channel is using MNF when it really isn't.

This affects situations when the server is used to host a VM using OpenHCL with the VMBus relay, and a guest which is using synthetic kdnet. KD opens the networking channel (which is often configured to use MNF) as a reserved channel, but the OpenHCL relay forwards these to the host as a regular, non-reserved open. Reserved channels are explicitly excluded from using MNF, but because the channel is not reserved on the host, that didn't apply here. When the relay uses `ModifyChannel` to change connection parameters as the VTL0 guest reconnects, this would fail causing guest boot failure.

Because reserved channels don't use interrupts, the relay still forwards them with their interrupt target VP set to `VP_INDEX_DISABLE_INTERRUPT`. This change therefore removes the monitor info from the channel's `OpenParams` if interrupts are disabled, which fixes this problem.