### PR TITLE
virtiofs: negotiate FUSE_MAX_PAGES for larger I/O requests

### DIFF
--- a/vm/devices/support/fs/fuse/src/session.rs
+++ b/vm/devices/support/fs/fuse/src/session.rs
@@ -24,6 +24,7 @@ const DEFAULT_FLAGS: u32 = FUSE_ASYNC_READ
     | FUSE_ASYNC_DIO
     | FUSE_ATOMIC_O_TRUNC
     | FUSE_BIG_WRITES
+    | FUSE_MAX_PAGES
     | FUSE_INIT_EXT;
 
 // Default flags2 to negotiate when FUSE_INIT_EXT is supported.


### PR DESCRIPTION
Reapplies #3447, which was reverted in #3467.

The original revert was motivated by ERROR_NOT_ENOUGH_QUOTA stalls in the wsldevicehost HDV path: the 8x larger FUSE requests amplified per-access aperture churn against a 512-handle VID PPM table while the HDV aperture cache was disabled (`DISABLE_CACHE = true`).

This is safe to reapply because all of the per-request guest memory accesses get bounced through the same memory range / aperture, so the larger requests do not multiply the number of distinct aperture handles in flight.

## Original benefit

Without `FUSE_MAX_PAGES` the Linux kernel uses `FUSE_DEFAULT_MAX_PAGES_PER_REQ` (32 pages = 128 KiB) as the maximum request size. With the flag, the kernel uses `min(fuse_max_pages_limit, virtqueue_size - 4)` which is typically 252 pages (~1008 KiB) — an ~8x increase, significantly reducing per-request overhead for sequential I/O.

See #3447 for full benchmark numbers (sequential read +37–83%, sequential write +59–68%; random I/O unaffected as expected).