### PR TITLE
sidecar: restore shared CR2 and FX state on VTL transition

### DIFF
--- a/openhcl/sidecar/src/arch/x86_64/vp.rs
+++ b/openhcl/sidecar/src/arch/x86_64/vp.rs
@@ -294,6 +294,8 @@ fn run_vp_once(command_page: &mut CommandPage) -> Result<bool, ()> {
         core::arch::asm! {
             "push rbp",
             "push rbx",
+            "mov rbx, fs:[0x20]",
+            "mov cr2, rbx",
             "mov rbp, fs:[0x28]",
             "mov rbx, fs:[0x18]",
             "call rax",

--- a/openhcl/sidecar/src/arch/x86_64/vp.rs
+++ b/openhcl/sidecar/src/arch/x86_64/vp.rs
@@ -292,6 +292,7 @@ fn run_vp_once(command_page: &mut CommandPage) -> Result<bool, ()> {
     // SAFETY: no safety requirements for this hypercall.
     unsafe {
         core::arch::asm! {
+            "fxrstor fs:[0x80]",
             "push rbp",
             "push rbx",
             "mov rbx, fs:[0x20]",


### PR DESCRIPTION
Restore the shared CR2 register and FX state to the saved values before transitioning to a lower VTL. This matches the rest of the shared registers already properly saved/restored.