### PR TITLE
feat(vmm-tests): add per-test Linux kernel version selection

### DIFF
--- a/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
+++ b/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
@@ -140,6 +140,36 @@ impl SimpleFlowNode for Node {
                     })
                 });
 
+        // Request all supported kernel versions for version-specific paths
+        let versioned_kernels: Vec<_> =
+            crate::resolve_openvmm_test_linux_kernel::LinuxTestKernelVersion::ALL
+                .iter()
+                .map(|&kver| {
+                    let kernel = ctx.reqv(|v| {
+                        crate::resolve_openvmm_test_linux_kernel::Request::Get(
+                            crate::resolve_openvmm_test_linux_kernel::OpenvmmTestKernelFile::Kernel,
+                            arch,
+                            kver,
+                            v,
+                        )
+                    });
+                    let bzimage =
+                        crate::resolve_openvmm_test_linux_kernel::OpenvmmTestKernelFile::BzImage
+                            .is_available_for(arch)
+                            .then(|| {
+                                ctx.reqv(|v| {
+                                    crate::resolve_openvmm_test_linux_kernel::Request::Get(
+                                        crate::resolve_openvmm_test_linux_kernel::OpenvmmTestKernelFile::BzImage,
+                                        arch,
+                                        kver,
+                                        v,
+                                    )
+                                })
+                            });
+                    (kver, kernel, bzimage)
+                })
+                .collect();
+
         let uefi =
             ctx.reqv(|v| crate::download_uefi_mu_msvm::Request::GetMsvmFd { arch, msvm_fd: v });
 
@@ -164,6 +194,10 @@ impl SimpleFlowNode for Node {
             let test_linux_initrd = test_linux_initrd.claim(ctx);
             let test_linux_kernel = test_linux_kernel.claim(ctx);
             let test_linux_bzimage = test_linux_bzimage.claim(ctx);
+            let versioned_kernels: Vec<_> = versioned_kernels
+                .into_iter()
+                .map(|(kver, kernel, bzimage)| (kver, kernel.claim(ctx), bzimage.claim(ctx)))
+                .collect();
             let uefi = uefi.claim(ctx);
             let release_igvm_files_dir = release_igvm_files.claim(ctx);
             move |rt| {
@@ -453,6 +487,16 @@ impl SimpleFlowNode for Node {
                         bzimage_path,
                         test_content_dir.join(arch_dir).join("bzImage"),
                     )?;
+                }
+
+                // Place version-specific kernels at versioned paths
+                for (kver, kernel_var, bzimage_var) in versioned_kernels {
+                    let version_dir = test_content_dir.join(arch_dir).join(kver.artifact_tag());
+                    fs_err::create_dir_all(&version_dir)?;
+                    fs_err::copy(rt.read(kernel_var), version_dir.join(kernel_file_name))?;
+                    if let Some(bz_var) = bzimage_var {
+                        fs_err::copy(rt.read(bz_var), version_dir.join("bzImage"))?;
+                    }
                 }
 
                 let uefi_dir = test_content_dir.join(match arch {

--- a/flowey/flowey_lib_hvlite/src/resolve_openvmm_test_linux_kernel.rs
+++ b/flowey/flowey_lib_hvlite/src/resolve_openvmm_test_linux_kernel.rs
@@ -28,6 +28,7 @@ use std::collections::BTreeSet;
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LinuxTestKernelVersion {
     Linux6_1,
+    Linux6_18,
 }
 
 impl LinuxTestKernelVersion {
@@ -36,8 +37,12 @@ impl LinuxTestKernelVersion {
     pub fn artifact_tag(self) -> &'static str {
         match self {
             Self::Linux6_1 => "6.1",
+            Self::Linux6_18 => "6.18",
         }
     }
+
+    /// All supported kernel versions.
+    pub const ALL: &'static [LinuxTestKernelVersion] = &[Self::Linux6_1, Self::Linux6_18];
 }
 
 /// Which file to extract from a per-(arch, kver) `openvmm-test-linux` archive.

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -2484,6 +2484,36 @@ impl Firmware {
         }
     }
 
+    /// Constructs a [`Firmware::LinuxDirect`] configuration with a specific
+    /// kernel version.
+    pub fn linux_direct_with_version(
+        resolver: &ArtifactResolver<'_>,
+        arch: MachineArch,
+        version: petri_artifacts_vmm_test::LinuxDirectKernelVersion,
+    ) -> Self {
+        use petri_artifacts_vmm_test::LinuxDirectKernelVersion;
+        use petri_artifacts_vmm_test::artifacts::loadable::*;
+        let kernel = match (arch, version) {
+            (MachineArch::X86_64, LinuxDirectKernelVersion::V6_1) => {
+                resolver.require(LINUX_DIRECT_TEST_KERNEL_X64_6_1).erase()
+            }
+            (MachineArch::X86_64, LinuxDirectKernelVersion::V6_18) => {
+                resolver.require(LINUX_DIRECT_TEST_KERNEL_X64_6_18).erase()
+            }
+            (MachineArch::Aarch64, LinuxDirectKernelVersion::V6_1) => resolver
+                .require(LINUX_DIRECT_TEST_KERNEL_AARCH64_6_1)
+                .erase(),
+            (MachineArch::Aarch64, LinuxDirectKernelVersion::V6_18) => resolver
+                .require(LINUX_DIRECT_TEST_KERNEL_AARCH64_6_18)
+                .erase(),
+        };
+        let initrd = match arch {
+            MachineArch::X86_64 => resolver.require(LINUX_DIRECT_TEST_INITRD_X64).erase(),
+            MachineArch::Aarch64 => resolver.require(LINUX_DIRECT_TEST_INITRD_AARCH64).erase(),
+        };
+        Firmware::LinuxDirect { kernel, initrd }
+    }
+
     /// Constructs a [`Firmware::LinuxDirect`] configuration that uses a
     /// compressed bzImage kernel instead of an uncompressed ELF.
     ///
@@ -2492,6 +2522,28 @@ impl Firmware {
         use petri_artifacts_vmm_test::artifacts::loadable::*;
         Firmware::LinuxDirect {
             kernel: resolver.require(LINUX_DIRECT_TEST_BZIMAGE_X64).erase(),
+            initrd: resolver.require(LINUX_DIRECT_TEST_INITRD_X64).erase(),
+        }
+    }
+
+    /// Constructs a [`Firmware::LinuxDirect`] bzImage configuration with a
+    /// specific kernel version.
+    pub fn linux_direct_bzimage_with_version(
+        resolver: &ArtifactResolver<'_>,
+        version: petri_artifacts_vmm_test::LinuxDirectKernelVersion,
+    ) -> Self {
+        use petri_artifacts_vmm_test::LinuxDirectKernelVersion;
+        use petri_artifacts_vmm_test::artifacts::loadable::*;
+        let kernel = match version {
+            LinuxDirectKernelVersion::V6_1 => {
+                resolver.require(LINUX_DIRECT_TEST_BZIMAGE_X64_6_1).erase()
+            }
+            LinuxDirectKernelVersion::V6_18 => {
+                resolver.require(LINUX_DIRECT_TEST_BZIMAGE_X64_6_18).erase()
+            }
+        };
+        Firmware::LinuxDirect {
+            kernel,
             initrd: resolver.require(LINUX_DIRECT_TEST_INITRD_X64).erase(),
         }
     }

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -71,6 +71,14 @@ impl petri_artifacts_core::ResolveTestArtifact for OpenvmmKnownPathsTestArtifact
             _ if id == loadable::LINUX_DIRECT_TEST_INITRD_X64 => linux_direct_test_initrd_path(MachineArch::X86_64),
             _ if id == loadable::LINUX_DIRECT_TEST_INITRD_AARCH64 => linux_direct_test_initrd_path(MachineArch::Aarch64),
 
+            // Version-specific kernel artifacts
+            _ if id == loadable::LINUX_DIRECT_TEST_KERNEL_X64_6_1 => linux_direct_versioned_kernel_path("x64", "6.1", "vmlinux"),
+            _ if id == loadable::LINUX_DIRECT_TEST_KERNEL_X64_6_18 => linux_direct_versioned_kernel_path("x64", "6.18", "vmlinux"),
+            _ if id == loadable::LINUX_DIRECT_TEST_KERNEL_AARCH64_6_1 => linux_direct_versioned_kernel_path("aarch64", "6.1", "Image"),
+            _ if id == loadable::LINUX_DIRECT_TEST_KERNEL_AARCH64_6_18 => linux_direct_versioned_kernel_path("aarch64", "6.18", "Image"),
+            _ if id == loadable::LINUX_DIRECT_TEST_BZIMAGE_X64_6_1 => linux_direct_versioned_kernel_path("x64", "6.1", "bzImage"),
+            _ if id == loadable::LINUX_DIRECT_TEST_BZIMAGE_X64_6_18 => linux_direct_versioned_kernel_path("x64", "6.18", "bzImage"),
+
             _ if id == petritools::PETRITOOLS_EROFS_X64 => petritools_erofs_path(MachineArch::X86_64),
             _ if id == petritools::PETRITOOLS_EROFS_AARCH64 => petritools_erofs_path(MachineArch::Aarch64),
 
@@ -192,6 +200,13 @@ pub fn resolve_bundle_name(id: ErasedArtifactHandle) -> Option<&'static str> {
         _ if id == loadable::LINUX_DIRECT_TEST_KERNEL_AARCH64 => Some("aarch64/Image"),
         _ if id == loadable::LINUX_DIRECT_TEST_INITRD_X64 => Some("x64/initrd"),
         _ if id == loadable::LINUX_DIRECT_TEST_INITRD_AARCH64 => Some("aarch64/initrd"),
+        // Version-specific kernel bundle names
+        _ if id == loadable::LINUX_DIRECT_TEST_KERNEL_X64_6_1 => Some("x64/6.1/vmlinux"),
+        _ if id == loadable::LINUX_DIRECT_TEST_KERNEL_X64_6_18 => Some("x64/6.18/vmlinux"),
+        _ if id == loadable::LINUX_DIRECT_TEST_KERNEL_AARCH64_6_1 => Some("aarch64/6.1/Image"),
+        _ if id == loadable::LINUX_DIRECT_TEST_KERNEL_AARCH64_6_18 => Some("aarch64/6.18/Image"),
+        _ if id == loadable::LINUX_DIRECT_TEST_BZIMAGE_X64_6_1 => Some("x64/6.1/bzImage"),
+        _ if id == loadable::LINUX_DIRECT_TEST_BZIMAGE_X64_6_18 => Some("x64/6.18/bzImage"),
         _ if id == petritools::PETRITOOLS_EROFS_X64 => Some("x64/petritools.erofs"),
         _ if id == petritools::PETRITOOLS_EROFS_AARCH64 => Some("aarch64/petritools.erofs"),
         _ if id == loadable::UEFI_FIRMWARE_X64 => {
@@ -491,6 +506,22 @@ fn linux_direct_arm_image_path() -> anyhow::Result<PathBuf> {
         resolve_bundle_name(loadable::LINUX_DIRECT_TEST_KERNEL_AARCH64.erase()).unwrap(),
         MissingCommand::Restore {
             description: "linux direct test kernel",
+        },
+    )
+}
+
+/// Path to a version-specific linux direct kernel or bzImage file.
+fn linux_direct_versioned_kernel_path(
+    arch_dir: &str,
+    version: &str,
+    filename: &str,
+) -> anyhow::Result<PathBuf> {
+    let bundle_name = format!("{arch_dir}/{version}/{filename}");
+    get_path(
+        ".packages/underhill-deps-private",
+        bundle_name,
+        MissingCommand::Restore {
+            description: "version-specific linux direct test kernel",
         },
     )
 }

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -5,6 +5,18 @@
 
 #![forbid(unsafe_code)]
 
+/// Which Linux kernel version to use for linux-direct tests.
+///
+/// Used by test macros and petri firmware selection to pick
+/// version-specific kernel artifacts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinuxDirectKernelVersion {
+    /// Linux 6.1
+    V6_1,
+    /// Linux 6.18
+    V6_18,
+}
+
 /// Artifact declarations
 pub mod artifacts {
     use petri_artifacts_common::tags::IsVmgsTool;
@@ -123,16 +135,31 @@ pub mod artifacts {
         > = petri_artifacts_core::ArtifactHandle::new();
 
         declare_artifacts! {
-            /// Test linux direct kernel (from OpenVMM deps)
+            /// Test linux direct kernel (from OpenVMM deps) — default version
             LINUX_DIRECT_TEST_KERNEL_X64,
             /// Test linux direct initrd (from OpenVMM deps)
             LINUX_DIRECT_TEST_INITRD_X64,
-            /// Test linux direct kernel (from OpenVMM deps)
+            /// Test linux direct kernel (from OpenVMM deps) — default version
             LINUX_DIRECT_TEST_KERNEL_AARCH64,
             /// Test linux direct initrd (from OpenVMM deps)
             LINUX_DIRECT_TEST_INITRD_AARCH64,
-            /// Test linux direct bzImage kernel (from OpenVMM deps)
+            /// Test linux direct bzImage kernel (from OpenVMM deps) — default version
             LINUX_DIRECT_TEST_BZIMAGE_X64,
+
+            // Version-specific kernel artifacts
+            /// Test linux direct kernel 6.1 (from OpenVMM deps)
+            LINUX_DIRECT_TEST_KERNEL_X64_6_1,
+            /// Test linux direct kernel 6.18 (from OpenVMM deps)
+            LINUX_DIRECT_TEST_KERNEL_X64_6_18,
+            /// Test linux direct kernel 6.1 (from OpenVMM deps)
+            LINUX_DIRECT_TEST_KERNEL_AARCH64_6_1,
+            /// Test linux direct kernel 6.18 (from OpenVMM deps)
+            LINUX_DIRECT_TEST_KERNEL_AARCH64_6_18,
+            /// Test linux direct bzImage kernel 6.1 (from OpenVMM deps)
+            LINUX_DIRECT_TEST_BZIMAGE_X64_6_1,
+            /// Test linux direct bzImage kernel 6.18 (from OpenVMM deps)
+            LINUX_DIRECT_TEST_BZIMAGE_X64_6_18,
+
             /// PCAT firmware DLL
             PCAT_FIRMWARE_X64,
             /// SVGA firmware DLL
@@ -160,6 +187,31 @@ pub mod artifacts {
         }
 
         impl IsLoadable for LINUX_DIRECT_TEST_BZIMAGE_X64 {
+            const ARCH: MachineArch = MachineArch::X86_64;
+        }
+
+        // Version-specific IsLoadable impls
+        impl IsLoadable for LINUX_DIRECT_TEST_KERNEL_X64_6_1 {
+            const ARCH: MachineArch = MachineArch::X86_64;
+        }
+
+        impl IsLoadable for LINUX_DIRECT_TEST_KERNEL_X64_6_18 {
+            const ARCH: MachineArch = MachineArch::X86_64;
+        }
+
+        impl IsLoadable for LINUX_DIRECT_TEST_KERNEL_AARCH64_6_1 {
+            const ARCH: MachineArch = MachineArch::Aarch64;
+        }
+
+        impl IsLoadable for LINUX_DIRECT_TEST_KERNEL_AARCH64_6_18 {
+            const ARCH: MachineArch = MachineArch::Aarch64;
+        }
+
+        impl IsLoadable for LINUX_DIRECT_TEST_BZIMAGE_X64_6_1 {
+            const ARCH: MachineArch = MachineArch::X86_64;
+        }
+
+        impl IsLoadable for LINUX_DIRECT_TEST_BZIMAGE_X64_6_18 {
             const ARCH: MachineArch = MachineArch::X86_64;
         }
 

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -46,13 +46,29 @@ enum Vmm {
 }
 
 enum Firmware {
-    LinuxDirect,
-    LinuxDirectBzImage,
+    LinuxDirect(Option<LinuxKernelVersion>),
+    LinuxDirectBzImage(Option<LinuxKernelVersion>),
     Pcat(PcatGuest),
     Uefi(UefiGuest),
-    OpenhclLinuxDirect,
+    OpenhclLinuxDirect(Option<LinuxKernelVersion>),
     OpenhclPcat(PcatGuest),
     OpenhclUefi(OpenhclUefiOptions, UefiGuest),
+}
+
+/// Kernel version selection for linux-direct tests (macro-internal).
+#[derive(Clone, Copy)]
+enum LinuxKernelVersion {
+    V6_1,
+    V6_18,
+}
+
+impl LinuxKernelVersion {
+    fn name_prefix(self) -> String {
+        match self {
+            LinuxKernelVersion::V6_1 => "kernel_6_1".to_string(),
+            LinuxKernelVersion::V6_18 => "kernel_6_18".to_string(),
+        }
+    }
 }
 
 #[derive(Default)]
@@ -114,6 +130,17 @@ fn arch_to_tokens(arch: MachineArch) -> TokenStream {
     }
 }
 
+fn kernel_version_to_tokens(version: LinuxKernelVersion) -> TokenStream {
+    match version {
+        LinuxKernelVersion::V6_1 => {
+            quote!(::petri_artifacts_vmm_test::LinuxDirectKernelVersion::V6_1)
+        }
+        LinuxKernelVersion::V6_18 => {
+            quote!(::petri_artifacts_vmm_test::LinuxDirectKernelVersion::V6_18)
+        }
+    }
+}
+
 impl ResolvedConfig {
     fn name_prefix(&self) -> String {
         let arch_prefix = arch_to_str(self.arch);
@@ -124,30 +151,33 @@ impl ResolvedConfig {
         };
 
         let firmware_prefix = match &self.firmware {
-            Firmware::LinuxDirect => "linux",
-            Firmware::LinuxDirectBzImage => "linux_bzimage",
+            Firmware::LinuxDirect(_) => "linux",
+            Firmware::LinuxDirectBzImage(_) => "linux_bzimage",
             Firmware::Pcat(_) => "pcat",
             Firmware::Uefi(_) => "uefi",
-            Firmware::OpenhclLinuxDirect => "openhcl_linux",
+            Firmware::OpenhclLinuxDirect(_) => "openhcl_linux",
             Firmware::OpenhclPcat(..) => "openhcl_pcat",
             Firmware::OpenhclUefi(..) => "openhcl_uefi",
         };
 
         let guest_prefix = match &self.firmware {
-            Firmware::LinuxDirect | Firmware::LinuxDirectBzImage | Firmware::OpenhclLinuxDirect => {
-                None
-            }
+            Firmware::LinuxDirect(_)
+            | Firmware::LinuxDirectBzImage(_)
+            | Firmware::OpenhclLinuxDirect(_) => None,
             Firmware::Pcat(guest) | Firmware::OpenhclPcat(guest) => Some(guest.name_prefix()),
             Firmware::Uefi(guest) | Firmware::OpenhclUefi(_, guest) => guest.name_prefix(),
         };
 
         let options_prefix = match &self.firmware {
-            Firmware::LinuxDirect
-            | Firmware::LinuxDirectBzImage
+            Firmware::LinuxDirect(None)
+            | Firmware::LinuxDirectBzImage(None)
             | Firmware::Pcat(_)
             | Firmware::Uefi(_)
-            | Firmware::OpenhclLinuxDirect
+            | Firmware::OpenhclLinuxDirect(None)
             | Firmware::OpenhclPcat(_) => None,
+            Firmware::LinuxDirect(Some(v))
+            | Firmware::LinuxDirectBzImage(Some(v))
+            | Firmware::OpenhclLinuxDirect(Some(v)) => Some(v.name_prefix()),
             Firmware::OpenhclUefi(opt, _) => opt.name_prefix(),
         };
 
@@ -224,11 +254,19 @@ impl ToTokens for FirmwareAndArch {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let arch = arch_to_tokens(self.arch);
         tokens.extend(match &self.firmware {
-            Firmware::LinuxDirect => {
+            Firmware::LinuxDirect(None) => {
                 quote!(::petri::Firmware::linux_direct(resolver, #arch))
             }
-            Firmware::LinuxDirectBzImage => {
+            Firmware::LinuxDirect(Some(v)) => {
+                let version = kernel_version_to_tokens(*v);
+                quote!(::petri::Firmware::linux_direct_with_version(resolver, #arch, #version))
+            }
+            Firmware::LinuxDirectBzImage(None) => {
                 quote!(::petri::Firmware::linux_direct_bzimage(resolver))
+            }
+            Firmware::LinuxDirectBzImage(Some(v)) => {
+                let version = kernel_version_to_tokens(*v);
+                quote!(::petri::Firmware::linux_direct_bzimage_with_version(resolver, #version))
             }
             Firmware::Pcat(guest) => {
                 quote!(::petri::Firmware::pcat(resolver, #guest))
@@ -236,7 +274,14 @@ impl ToTokens for FirmwareAndArch {
             Firmware::Uefi(guest) => {
                 quote!(::petri::Firmware::uefi(resolver, #arch, #guest))
             }
-            Firmware::OpenhclLinuxDirect => {
+            Firmware::OpenhclLinuxDirect(None) => {
+                quote!(::petri::Firmware::openhcl_linux_direct(resolver, #arch))
+            }
+            Firmware::OpenhclLinuxDirect(Some(v)) => {
+                // OpenhclLinuxDirect uses IGVM files and doesn't directly select kernel version.
+                // For now, kernel version selection for openhcl_linux_direct is a no-op — the
+                // IGVM file embeds the kernel. Pass through as the default.
+                let _ = v;
                 quote!(::petri::Firmware::openhcl_linux_direct(resolver, #arch))
             }
             Firmware::OpenhclPcat(guest) => {
@@ -405,10 +450,22 @@ impl Parse for Config {
         };
 
         let (arch, firmware) = match remainder {
-            "linux_direct_x64" => (MachineArch::X86_64, Firmware::LinuxDirect),
-            "linux_direct_bzimage_x64" => (MachineArch::X86_64, Firmware::LinuxDirectBzImage),
-            "linux_direct_aarch64" => (MachineArch::Aarch64, Firmware::LinuxDirect),
-            "openhcl_linux_direct_x64" => (MachineArch::X86_64, Firmware::OpenhclLinuxDirect),
+            "linux_direct_x64" => {
+                let kver = parse_linux_kernel_version(input)?;
+                (MachineArch::X86_64, Firmware::LinuxDirect(kver))
+            }
+            "linux_direct_bzimage_x64" => {
+                let kver = parse_linux_kernel_version(input)?;
+                (MachineArch::X86_64, Firmware::LinuxDirectBzImage(kver))
+            }
+            "linux_direct_aarch64" => {
+                let kver = parse_linux_kernel_version(input)?;
+                (MachineArch::Aarch64, Firmware::LinuxDirect(kver))
+            }
+            "openhcl_linux_direct_x64" => {
+                let kver = parse_linux_kernel_version(input)?;
+                (MachineArch::X86_64, Firmware::OpenhclLinuxDirect(kver))
+            }
             "pcat_x64" => (
                 MachineArch::X86_64,
                 Firmware::Pcat(parse_pcat_guest(input)?),
@@ -465,6 +522,25 @@ fn parse_uefi_guest(input: ParseStream<'_>) -> syn::Result<UefiGuest> {
     let parens;
     syn::parenthesized!(parens in input);
     parens.parse::<UefiGuest>()
+}
+
+/// Parse an optional parenthesized kernel version, e.g. `(kernel_6_1)`.
+///
+/// Returns `None` if no parenthesized group follows, allowing the default
+/// kernel to be used.
+fn parse_linux_kernel_version(input: ParseStream<'_>) -> syn::Result<Option<LinuxKernelVersion>> {
+    if input.peek(syn::token::Paren) {
+        let content;
+        syn::parenthesized!(content in input);
+        let word = content.parse::<Ident>()?;
+        match &*word.to_string() {
+            "kernel_6_1" => Ok(Some(LinuxKernelVersion::V6_1)),
+            "kernel_6_18" => Ok(Some(LinuxKernelVersion::V6_18)),
+            _ => Err(Error::new(word.span(), "unrecognized kernel version")),
+        }
+    } else {
+        Ok(None)
+    }
 }
 
 impl Parse for PcatGuest {
@@ -691,8 +767,11 @@ fn parse_extra_deps(input: ParseStream<'_>) -> syn::Result<Vec<Path>> {
 ///
 /// Valid configuration options are:
 /// - `{vmm}_linux_direct_{arch}`: Our provided Linux direct image
+/// - `{vmm}_linux_direct_{arch}(<kernel version>)`: Linux direct with a specific kernel version
 /// - `{vmm}_linux_direct_bzimage_x64`: Our provided Linux direct bzImage (compressed kernel, x86_64 only)
+/// - `{vmm}_linux_direct_bzimage_x64(<kernel version>)`: bzImage with a specific kernel version
 /// - `{vmm}_openhcl_linux_direct_{arch}`: Our provided Linux direct image with OpenHCL
+/// - `{vmm}_openhcl_linux_direct_{arch}(<kernel version>)`: OpenHCL Linux direct with a specific kernel version
 /// - `{vmm}_pcat_{arch}(<PCAT guest>)`: A Gen 1 configuration
 /// - `{vmm}_uefi_{arch}(<UEFI guest>)`: A Gen 2 configuration
 /// - `{vmm}_openhcl_pcat_{arch}(<PCAT guest>)`: A Gen 1 configuration with OpenHCL
@@ -738,6 +817,10 @@ fn parse_extra_deps(input: ParseStream<'_>) -> syn::Result<Vec<Path>> {
 /// - `vbs`: Use VBS isolation.
 /// - `snp`: Use SNP isolation.
 /// - `tdx`: Use TDX isolation.
+///
+/// Valid kernel version options are:
+/// - `kernel_6_1`: Linux 6.1 kernel
+/// - `kernel_6_18`: Linux 6.18 kernel
 ///
 /// Each configuration can be optionally followed by a square-bracketed, comma-separated
 /// list of additional artifacts required for that particular configuration.


### PR DESCRIPTION
Add infrastructure for tests to specify which Linux kernel version to use, enabling per-test kernel version pinning.

## Changes

- Add `LinuxDirectKernelVersion` enum to `petri_artifacts_vmm_test` with `V6_1` and `V6_18` variants
- Add version-specific artifact IDs for kernel and vmlinux (`LINUX_DIRECT_TEST_KERNEL_X64_6_1`, etc.)
- Add `linux_direct_with_version()` and `linux_direct_bzimage_with_version()` methods to petri VM builder
- Extend `#[vmm_test]` macro to accept parenthesized kernel version syntax: `linux_direct_x64(kernel_6_1)`
- Update flowey to download all registered kernel versions and place them at versioned paths
- Add `Linux6_18` variant to `LinuxTestKernelVersion` in flowey resolver

## Motivation

The upcoming openvmm-deps 0.3.0-33 release adds Linux 6.18 kernel support. Some tests (e.g., `pcie_devices`) cannot run on 6.18 due to a [known kernel bug](https://github.com/microsoft/openvmm/pull/3530#issuecomment-2920744319) in `mana_gd_probe`. This PR adds the ability to pin individual tests to a specific kernel version, so the default can be upgraded to 6.18 while problematic tests remain on 6.1.

A follow-up PR will flip the default kernel to 6.18 and pin `pcie_devices` to 6.1.

## Usage

Tests can now specify a kernel version in the `#[vmm_test]` attribute:

```rust
#[vmm_test(linux_direct_x64(kernel_6_1))]
async fn my_test(config: PetriVmBuilder<PetriVmmHvLite>) -> anyhow::Result<()> {
    // runs with 6.1 kernel specifically
}
```

Unversioned `linux_direct_x64` continues to use the default kernel version (currently 6.1).