### PR TITLE
crypto: add RSA-PSS verification and SHA-384 support

### DIFF
--- a/support/crypto/src/hashes.rs
+++ b/support/crypto/src/hashes.rs
@@ -14,6 +14,8 @@ pub enum HashAlgorithm {
     Sha1,
     /// SHA-256
     Sha256,
+    /// SHA-384
+    Sha384,
 }
 
 impl HashAlgorithm {
@@ -22,6 +24,7 @@ impl HashAlgorithm {
         match self {
             HashAlgorithm::Sha1 => symcrypt::hash::sha1(data).to_vec(),
             HashAlgorithm::Sha256 => symcrypt::hash::sha256(data).to_vec(),
+            HashAlgorithm::Sha384 => symcrypt::hash::sha384(data).to_vec(),
         }
     }
 
@@ -31,6 +34,7 @@ impl HashAlgorithm {
         match self {
             HashAlgorithm::Sha1 => sha1::Sha1::digest(data).to_vec(),
             HashAlgorithm::Sha256 => sha2::Sha256::digest(data).to_vec(),
+            HashAlgorithm::Sha384 => sha2::Sha384::digest(data).to_vec(),
         }
     }
 }
@@ -42,6 +46,7 @@ impl TryFrom<der::asn1::ObjectIdentifier> for HashAlgorithm {
     fn try_from(oid: der::asn1::ObjectIdentifier) -> Result<Self, Self::Error> {
         match oid {
             der::oid::db::rfc5912::SHA_256_WITH_RSA_ENCRYPTION => Ok(Self::Sha256),
+            der::oid::db::rfc5912::SHA_384_WITH_RSA_ENCRYPTION => Ok(Self::Sha384),
             der::oid::db::rfc5912::SHA_1_WITH_RSA_ENCRYPTION => Ok(Self::Sha1),
             _ => Err(der::ErrorKind::OidUnknown { oid }.to_error()),
         }
@@ -54,6 +59,7 @@ impl From<HashAlgorithm> for openssl::hash::MessageDigest {
         match hash_algorithm {
             HashAlgorithm::Sha1 => openssl::hash::MessageDigest::sha1(),
             HashAlgorithm::Sha256 => openssl::hash::MessageDigest::sha256(),
+            HashAlgorithm::Sha384 => openssl::hash::MessageDigest::sha384(),
         }
     }
 }
@@ -64,6 +70,7 @@ impl From<HashAlgorithm> for &'static openssl::md::MdRef {
         match hash_algorithm {
             HashAlgorithm::Sha1 => openssl::md::Md::sha1(),
             HashAlgorithm::Sha256 => openssl::md::Md::sha256(),
+            HashAlgorithm::Sha384 => openssl::md::Md::sha384(),
         }
     }
 }
@@ -74,6 +81,7 @@ impl From<HashAlgorithm> for symcrypt::hash::HashAlgorithm {
         match hash_algorithm {
             HashAlgorithm::Sha1 => symcrypt::hash::HashAlgorithm::Sha1,
             HashAlgorithm::Sha256 => symcrypt::hash::HashAlgorithm::Sha256,
+            HashAlgorithm::Sha384 => symcrypt::hash::HashAlgorithm::Sha384,
         }
     }
 }

--- a/support/crypto/src/rsa/mod.rs
+++ b/support/crypto/src/rsa/mod.rs
@@ -78,6 +78,18 @@ impl RsaKeyPair {
     ) -> Result<Vec<u8>, RsaError> {
         self.0.pkcs1_sign(data, hash_algorithm)
     }
+
+    /// Sign `data` using RSA-PSS (RSASSA-PSS) with the specified hash
+    /// algorithm. Uses MGF1 with the same hash and a salt length equal to
+    /// the hash output size, matching the convention used by COSE/JWS
+    /// (RFC 8230 section 2) and TLS 1.3.
+    pub fn pss_sign(
+        &self,
+        data: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<Vec<u8>, RsaError> {
+        self.0.pss_sign(data, hash_algorithm)
+    }
 }
 
 /// An RSA public key.
@@ -110,6 +122,21 @@ impl RsaPublicKey {
         hash_algorithm: HashAlgorithm,
     ) -> Result<bool, RsaError> {
         self.0.pkcs1_verify(message, signature, hash_algorithm)
+    }
+
+    /// Verify an RSA-PSS (RSASSA-PSS) signature with the specified hash
+    /// algorithm. Uses MGF1 with the same hash and a salt length equal to
+    /// the hash output size, matching the convention used by COSE/JWS
+    /// (RFC 8230 section 2) and TLS 1.3. Returns `Ok(true)` if the
+    /// signature is valid, `Ok(false)` if the signature is invalid, or an
+    /// error for other failures.
+    pub fn pss_verify(
+        &self,
+        message: &[u8],
+        signature: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<bool, RsaError> {
+        self.0.pss_verify(message, signature, hash_algorithm)
     }
 
     /// Returns the size of the RSA modulus in bytes.
@@ -159,7 +186,7 @@ mod tests {
 
     /// A tampered message must fail verification with `Ok(false)` (and
     /// must not panic or surface as `Err`). This guards against a backend
-    /// silently treating verification failures as internal errors —
+    /// silently treating verification failures as internal errors,
     /// which would prevent callers from distinguishing "bad signature"
     /// from "infrastructure failure".
     #[test]
@@ -219,5 +246,67 @@ mod tests {
             let pt = key.oaep_decrypt(&ct, alg).unwrap();
             assert_eq!(pt, payload);
         }
+    }
+
+    /// PSS sign/verify round-trip with SHA-384. Each signature contains
+    /// fresh random salt, so this also implicitly checks that the verifier
+    /// recovers the salt from the signature rather than requiring a fixed
+    /// value across backends.
+    ///
+    /// Uses a 3072-bit key to match the SHA-384 security level (NIST
+    /// SP 800-57: SHA-384 pairs with 3072-bit RSA at ~128-bit security).
+    #[test]
+    fn pss_sign_verify_roundtrip_sha384() {
+        let key = RsaKeyPair::generate(3072).unwrap();
+        let message = b"the message that needs to be hashed before signing";
+        let signature = key.pss_sign(message, HashAlgorithm::Sha384).unwrap();
+        let valid = key
+            .pss_verify(message, &signature, HashAlgorithm::Sha384)
+            .unwrap();
+        assert!(valid);
+    }
+
+    /// A tampered message must fail PSS verification with `Ok(false)`.
+    #[test]
+    fn pss_verify_rejects_tampered_message_sha384() {
+        let key = RsaKeyPair::generate(3072).unwrap();
+        let message = b"original message";
+        let signature = key.pss_sign(message, HashAlgorithm::Sha384).unwrap();
+        let tampered = b"tampered message";
+        let valid = key
+            .pss_verify(tampered, &signature, HashAlgorithm::Sha384)
+            .unwrap();
+        assert!(!valid);
+    }
+
+    /// A truncated PSS signature must be rejected with `Ok(false)`.
+    #[test]
+    fn pss_verify_rejects_truncated_signature_sha384() {
+        let key = RsaKeyPair::generate(3072).unwrap();
+        let message = b"original message";
+        let mut signature = key.pss_sign(message, HashAlgorithm::Sha384).unwrap();
+        signature.truncate(signature.len() - 1);
+        let valid = key
+            .pss_verify(message, &signature, HashAlgorithm::Sha384)
+            .unwrap();
+        assert!(!valid);
+    }
+
+    /// A PKCS#1 v1.5 signature must not verify as PSS (and vice versa);
+    /// the two padding schemes are not interchangeable on the wire.
+    #[test]
+    fn pss_and_pkcs1_signatures_are_not_interchangeable() {
+        let key = RsaKeyPair::generate(2048).unwrap();
+        let message = b"scheme-mismatch test";
+        let pkcs1_sig = key.pkcs1_sign(message, HashAlgorithm::Sha256).unwrap();
+        let pss_sig = key.pss_sign(message, HashAlgorithm::Sha256).unwrap();
+        let pkcs1_as_pss = key
+            .pss_verify(message, &pkcs1_sig, HashAlgorithm::Sha256)
+            .unwrap();
+        let pss_as_pkcs1 = key
+            .pkcs1_verify(message, &pss_sig, HashAlgorithm::Sha256)
+            .unwrap();
+        assert!(!pkcs1_as_pss);
+        assert!(!pss_as_pkcs1);
     }
 }

--- a/support/crypto/src/rsa/mod.rs
+++ b/support/crypto/src/rsa/mod.rs
@@ -253,11 +253,12 @@ mod tests {
     /// recovers the salt from the signature rather than requiring a fixed
     /// value across backends.
     ///
-    /// Uses a 3072-bit key to match the SHA-384 security level (NIST
-    /// SP 800-57: SHA-384 pairs with 3072-bit RSA at ~128-bit security).
+    /// Uses a 2048-bit key for test speed; SHA-384's matched-strength
+    /// key size is 3072 (NIST SP 800-57) but key generation in the
+    /// pure-Rust backend is too slow at that size for unit tests.
     #[test]
     fn pss_sign_verify_roundtrip_sha384() {
-        let key = RsaKeyPair::generate(3072).unwrap();
+        let key = RsaKeyPair::generate(2048).unwrap();
         let message = b"the message that needs to be hashed before signing";
         let signature = key.pss_sign(message, HashAlgorithm::Sha384).unwrap();
         let valid = key
@@ -269,7 +270,7 @@ mod tests {
     /// A tampered message must fail PSS verification with `Ok(false)`.
     #[test]
     fn pss_verify_rejects_tampered_message_sha384() {
-        let key = RsaKeyPair::generate(3072).unwrap();
+        let key = RsaKeyPair::generate(2048).unwrap();
         let message = b"original message";
         let signature = key.pss_sign(message, HashAlgorithm::Sha384).unwrap();
         let tampered = b"tampered message";
@@ -282,7 +283,7 @@ mod tests {
     /// A truncated PSS signature must be rejected with `Ok(false)`.
     #[test]
     fn pss_verify_rejects_truncated_signature_sha384() {
-        let key = RsaKeyPair::generate(3072).unwrap();
+        let key = RsaKeyPair::generate(2048).unwrap();
         let message = b"original message";
         let mut signature = key.pss_sign(message, HashAlgorithm::Sha384).unwrap();
         signature.truncate(signature.len() - 1);

--- a/support/crypto/src/rsa/ossl.rs
+++ b/support/crypto/src/rsa/ossl.rs
@@ -68,6 +68,26 @@ impl RsaKeyPairInner {
         signer.sign_to_vec().map_err(|e| err(e, "signer sign"))
     }
 
+    pub fn pss_sign(
+        &self,
+        data: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<Vec<u8>, RsaError> {
+        let mut signer = openssl::sign::Signer::new(hash_algorithm.into(), &self.0)
+            .map_err(|e| err(e, "creating signer"))?;
+        signer
+            .set_rsa_padding(openssl::rsa::Padding::PKCS1_PSS)
+            .map_err(|e| err(e, "setting RSA padding"))?;
+        signer
+            .set_rsa_mgf1_md(hash_algorithm.into())
+            .map_err(|e| err(e, "setting MGF1 hash"))?;
+        signer
+            .set_rsa_pss_saltlen(openssl::sign::RsaPssSaltlen::DIGEST_LENGTH)
+            .map_err(|e| err(e, "setting PSS salt length"))?;
+        signer.update(data).map_err(|e| err(e, "signer update"))?;
+        signer.sign_to_vec().map_err(|e| err(e, "signer sign"))
+    }
+
     pub(crate) fn as_pub(&self) -> &RsaPublicKeyInner {
         // SAFETY: PKey<Private> can be safely treated as PKey<Public> for read-only operations.
         unsafe { std::mem::transmute::<&RsaKeyPairInner, &RsaPublicKeyInner>(self) }
@@ -118,6 +138,31 @@ impl RsaPublicKeyInner {
         verifier
             .set_rsa_padding(openssl::rsa::Padding::PKCS1)
             .map_err(|e| err(e, "setting RSA padding"))?;
+        verifier
+            .update(message)
+            .map_err(|e| err(e, "verifier update"))?;
+        verifier
+            .verify(signature)
+            .map_err(|e| err(e, "verifier verify"))
+    }
+
+    pub fn pss_verify(
+        &self,
+        message: &[u8],
+        signature: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<bool, RsaError> {
+        let mut verifier = openssl::sign::Verifier::new(hash_algorithm.into(), &self.0)
+            .map_err(|e| err(e, "creating verifier"))?;
+        verifier
+            .set_rsa_padding(openssl::rsa::Padding::PKCS1_PSS)
+            .map_err(|e| err(e, "setting RSA padding"))?;
+        verifier
+            .set_rsa_mgf1_md(hash_algorithm.into())
+            .map_err(|e| err(e, "setting MGF1 hash"))?;
+        verifier
+            .set_rsa_pss_saltlen(openssl::sign::RsaPssSaltlen::DIGEST_LENGTH)
+            .map_err(|e| err(e, "setting PSS salt length"))?;
         verifier
             .update(message)
             .map_err(|e| err(e, "verifier update"))?;

--- a/support/crypto/src/rsa/rust.rs
+++ b/support/crypto/src/rsa/rust.rs
@@ -11,6 +11,7 @@ use getrandom::SysRng;
 use pkcs8::DecodePrivateKey;
 use rsa::Oaep;
 use rsa::Pkcs1v15Sign;
+use rsa::Pss;
 use rsa::RsaPrivateKey;
 use rsa::RsaPublicKey;
 use rsa::rand_core;
@@ -62,6 +63,10 @@ impl RsaKeyPairInner {
                 self.0
                     .decrypt_blinded(&mut rng(), Oaep::<sha2::Sha256>::new(), input)
             }
+            HashAlgorithm::Sha384 => {
+                self.0
+                    .decrypt_blinded(&mut rng(), Oaep::<sha2::Sha384>::new(), input)
+            }
         }
         .map_err(|e| RsaError(e, "OAEP decryption"))
     }
@@ -84,8 +89,39 @@ impl RsaKeyPairInner {
                 self.0
                     .sign_with_rng(&mut rng(), Pkcs1v15Sign::new::<sha2::Sha256>(), &data)
             }
+            HashAlgorithm::Sha384 => {
+                self.0
+                    .sign_with_rng(&mut rng(), Pkcs1v15Sign::new::<sha2::Sha384>(), &data)
+            }
         }
         .map_err(|e| RsaError(e, "PKCS#1 signing"))
+    }
+
+    pub fn pss_sign(
+        &self,
+        data: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<Vec<u8>, RsaError> {
+        // rsa's PSS signing expects a pre-hashed digest, just like the
+        // PKCS#1 v1.5 path above. `Pss::<H>::new()` defaults the salt
+        // length to the digest output size, matching the COSE/JWS
+        // convention (RFC 8230 section 2).
+        let data = hash_algorithm.hash(data);
+        match hash_algorithm {
+            HashAlgorithm::Sha1 => {
+                self.0
+                    .sign_with_rng(&mut rng(), Pss::<sha1::Sha1>::new(), &data)
+            }
+            HashAlgorithm::Sha256 => {
+                self.0
+                    .sign_with_rng(&mut rng(), Pss::<sha2::Sha256>::new(), &data)
+            }
+            HashAlgorithm::Sha384 => {
+                self.0
+                    .sign_with_rng(&mut rng(), Pss::<sha2::Sha384>::new(), &data)
+            }
+        }
+        .map_err(|e| RsaError(e, "PSS signing"))
     }
 
     pub(crate) fn as_pub(&self) -> &RsaPublicKeyInner {
@@ -117,6 +153,9 @@ impl RsaPublicKeyInner {
             HashAlgorithm::Sha256 => self
                 .0
                 .encrypt(&mut rng(), Oaep::<sha2::Sha256>::new(), input),
+            HashAlgorithm::Sha384 => self
+                .0
+                .encrypt(&mut rng(), Oaep::<sha2::Sha384>::new(), input),
         }
         .map_err(|e| RsaError(e, "OAEP encryption"))
     }
@@ -140,11 +179,38 @@ impl RsaPublicKeyInner {
                 self.0
                     .verify(Pkcs1v15Sign::new::<sha2::Sha256>(), &data, signature)
             }
+            HashAlgorithm::Sha384 => {
+                self.0
+                    .verify(Pkcs1v15Sign::new::<sha2::Sha384>(), &data, signature)
+            }
         };
         match result {
             Ok(()) => Ok(true),
             Err(rsa::Error::Verification) => Ok(false),
             Err(e) => Err(RsaError(e, "PKCS#1 signature verification")),
+        }
+    }
+
+    pub fn pss_verify(
+        &self,
+        data: &[u8],
+        signature: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<bool, RsaError> {
+        // PSS verification follows the same pre-hash convention as the
+        // PKCS#1 v1.5 path; `Pss::<H>::new()` uses a salt length equal
+        // to the digest output size (COSE/JWS convention, RFC 8230
+        // section 2).
+        let data = hash_algorithm.hash(data);
+        let result = match hash_algorithm {
+            HashAlgorithm::Sha1 => self.0.verify(Pss::<sha1::Sha1>::new(), &data, signature),
+            HashAlgorithm::Sha256 => self.0.verify(Pss::<sha2::Sha256>::new(), &data, signature),
+            HashAlgorithm::Sha384 => self.0.verify(Pss::<sha2::Sha384>::new(), &data, signature),
+        };
+        match result {
+            Ok(()) => Ok(true),
+            Err(rsa::Error::Verification) => Ok(false),
+            Err(e) => Err(RsaError(e, "PSS signature verification")),
         }
     }
 

--- a/support/crypto/src/rsa/symcrypt.rs
+++ b/support/crypto/src/rsa/symcrypt.rs
@@ -121,6 +121,21 @@ impl RsaKeyPairInner {
             .map_err(|e| err(e, "PKCS#1 signing"))
     }
 
+    pub fn pss_sign(
+        &self,
+        data: &[u8],
+        hash_algorithm: super::HashAlgorithm,
+    ) -> Result<Vec<u8>, RsaError> {
+        // SymCrypt's PSS signing expects a pre-hashed digest. Use a salt
+        // length equal to the hash output size, matching the COSE/JWS
+        // convention (RFC 8230 section 2).
+        let digest = hash_algorithm.hash(data);
+        let salt_length = digest.len();
+        self.0
+            .pss_sign(&digest, hash_algorithm.into(), salt_length)
+            .map_err(|e| err(e, "PSS signing"))
+    }
+
     pub(crate) fn as_pub(&self) -> &RsaPublicKeyInner {
         // SAFETY: RsaPublicKeyInner is just a wrapper around the same RsaKey.
         unsafe { std::mem::transmute::<&RsaKeyPairInner, &RsaPublicKeyInner>(self) }
@@ -165,7 +180,7 @@ impl RsaPublicKeyInner {
             // `SignatureVerificationFailure` is the expected error for an
             // invalid signature. `InvalidArgument` can also occur when the
             // signature bytes, interpreted as an integer, are >= the modulus
-            // or otherwise don't decode to a valid PKCS#1 v1.5 encoding —
+            // or otherwise don't decode to a valid PKCS#1 v1.5 encoding,
             // which happens probabilistically when verifying a signature
             // against the wrong public key. Both indicate "signature does
             // not verify", not a backend bug.
@@ -174,6 +189,31 @@ impl RsaPublicKeyInner {
                 | symcrypt::errors::SymCryptError::InvalidArgument,
             ) => Ok(false),
             Err(e) => Err(err(e, "PKCS#1 signature verification")),
+        }
+    }
+
+    pub fn pss_verify(
+        &self,
+        data: &[u8],
+        signature: &[u8],
+        hash_algorithm: super::HashAlgorithm,
+    ) -> Result<bool, RsaError> {
+        // SymCrypt's `pss_verify` expects the caller-supplied buffer to
+        // already be the hash digest of the message, and a salt length
+        // equal to the hash output size (COSE/JWS convention, RFC 8230
+        // section 2).
+        let digest = hash_algorithm.hash(data);
+        let salt_length = digest.len();
+        match self
+            .0
+            .pss_verify(&digest, signature, hash_algorithm.into(), salt_length)
+        {
+            Ok(()) => Ok(true),
+            Err(
+                symcrypt::errors::SymCryptError::SignatureVerificationFailure
+                | symcrypt::errors::SymCryptError::InvalidArgument,
+            ) => Ok(false),
+            Err(e) => Err(err(e, "PSS signature verification")),
         }
     }
 


### PR DESCRIPTION
Adds RSASSA-PSS sign/verify to the workspace crypto crate alongside the existing PKCS#1 v1.5 path, and extends HashAlgorithm with SHA-384 across all three backends (openssl, rust, symcrypt). PSS uses MGF1 with the same hash and a salt length equal to the hash output, matching the COSE/JWS convention from RFC 8230 §5.1; this is what COSE alg PS256/PS384/PS512 require.

Sha384 is also wired through the existing PKCS#1 v1.5 and OAEP paths in the rust backend for cross-backend symmetry (openssl and symcrypt already worked transparently via the HashAlgorithm conversion impls).

New tests cover PSS round-trip with SHA-384, tampered-message rejection, truncated-signature rejection, and that PKCS#1 v1.5 and PSS signatures are not interchangeable.