### PR TITLE
sidecar: restore shared CR2 and FX state on VTL transition

### DIFF
--- a/openhcl/sidecar/src/arch/x86_64/vp.rs
+++ b/openhcl/sidecar/src/arch/x86_64/vp.rs
@@ -292,8 +292,11 @@ fn run_vp_once(command_page: &mut CommandPage) -> Result<bool, ()> {
     // SAFETY: no safety requirements for this hypercall.
     unsafe {
         core::arch::asm! {
+            "fxrstor fs:[0x80]",
             "push rbp",
             "push rbx",
+            "mov rbx, fs:[0x20]",
+            "mov cr2, rbx",
             "mov rbp, fs:[0x28]",
             "mov rbx, fs:[0x18]",
             "call rax",

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -1089,10 +1089,10 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
     }
 
     fn set_gp(&mut self, reg: x86emu::Gp, v: u64) {
-        if reg == x86emu::Gp::RSP {
-            self.cache.rsp = v;
+        match reg {
+            x86emu::Gp::RSP => self.cache.rsp = v,
+            _ => self.vp.runner.cpu_context_mut().gps[reg as usize] = v,
         }
-        self.vp.runner.cpu_context_mut().gps[reg as usize] = v;
     }
 
     fn xmm(&mut self, index: usize) -> u128 {


### PR DESCRIPTION
Restore the shared CR2 register and FX state to the saved values before transitioning to a lower VTL. This matches the rest of the shared registers already properly saved/restored.

Clean CP of #3584 plus targeted port of simple fix to not overwrite CR2 with RSP