### PR TITLE
crypto: Add native windows and mac backends for RSA

### DIFF
--- a/support/crypto/Cargo.toml
+++ b/support/crypto/Cargo.toml
@@ -78,6 +78,16 @@ windows = { workspace = true, features = [
 ] }
 windows-result.workspace = true
 zerocopy.workspace = true
+# Used by the native BCrypt RSA backend to parse/encode PKCS#8 / PKCS#1.
+der.workspace = true
+pkcs1.workspace = true
+pkcs8 = { workspace = true, features = ["alloc"] }
+
+# Used by the native Security.framework RSA backend to parse/encode PKCS#8 / PKCS#1.
+[target.'cfg(target_os = "macos")'.dependencies]
+der.workspace = true
+pkcs1.workspace = true
+pkcs8 = { workspace = true, features = ["alloc"] }
 
 # Default to OpenSSL on Linux since there is no native backend available
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/support/crypto/src/aes_256_gcm/win.rs
+++ b/support/crypto/src/aes_256_gcm/win.rs
@@ -42,7 +42,7 @@ static AES_256_GCM: LazyLock<Result<AlgHandle, Aes256GcmError>> = LazyLock::new(
 });
 
 fn err(err: windows_result::Error, op: &'static str) -> Aes256GcmError {
-    Aes256GcmError(crate::BackendError(err, op))
+    Aes256GcmError(crate::BackendError::Bcrypt(err, op))
 }
 
 pub struct Aes256GcmInner {

--- a/support/crypto/src/hashes.rs
+++ b/support/crypto/src/hashes.rs
@@ -4,7 +4,6 @@
 //! Hash algorithms and related utilities.
 
 #![expect(deprecated)]
-#![cfg(any(openssl, rust, symcrypt))]
 
 /// Hash algorithm for RSA operations.
 #[derive(Debug, Clone, Copy)]
@@ -35,6 +34,123 @@ impl HashAlgorithm {
             HashAlgorithm::Sha1 => sha1::Sha1::digest(data).to_vec(),
             HashAlgorithm::Sha256 => sha2::Sha256::digest(data).to_vec(),
             HashAlgorithm::Sha384 => sha2::Sha384::digest(data).to_vec(),
+        }
+    }
+
+    #[cfg(all(native, windows))]
+    pub(crate) fn hash(self, data: &[u8]) -> Vec<u8> {
+        let mut out = vec![0u8; self.output_size()];
+        // SAFETY: alg is a static pseudo-handle valid for the process; the
+        // input and output slices are valid for the call. Status must be
+        // success because all inputs are known-good (fixed alg, fixed-size
+        // output buffer matching the digest size).
+        unsafe {
+            windows::Win32::Security::Cryptography::BCryptHash(
+                self.bcrypt_handle(),
+                None,
+                data,
+                &mut out,
+            )
+            .unwrap();
+        }
+        out
+    }
+
+    #[cfg(all(native, windows))]
+    pub(crate) fn bcrypt_handle(self) -> windows::Win32::Security::Cryptography::BCRYPT_ALG_HANDLE {
+        use windows::Win32::Security::Cryptography::*;
+        match self {
+            HashAlgorithm::Sha1 => BCRYPT_SHA1_ALG_HANDLE,
+            HashAlgorithm::Sha256 => BCRYPT_SHA256_ALG_HANDLE,
+            HashAlgorithm::Sha384 => BCRYPT_SHA384_ALG_HANDLE,
+        }
+    }
+
+    #[cfg(all(native, windows))]
+    pub(crate) fn bcrypt_alg_id(self) -> windows::core::PCWSTR {
+        use windows::Win32::Security::Cryptography::*;
+        match self {
+            HashAlgorithm::Sha1 => BCRYPT_SHA1_ALGORITHM,
+            HashAlgorithm::Sha256 => BCRYPT_SHA256_ALGORITHM,
+            HashAlgorithm::Sha384 => BCRYPT_SHA384_ALGORITHM,
+        }
+    }
+
+    #[cfg(all(native, windows))]
+    pub(crate) const fn output_size(self) -> usize {
+        match self {
+            HashAlgorithm::Sha1 => 20,
+            HashAlgorithm::Sha256 => 32,
+            HashAlgorithm::Sha384 => 48,
+        }
+    }
+
+    /// Returns the Security.framework `SecKeyAlgorithm` constant for
+    /// RSA PKCS#1 v1.5 message signing/verification with this hash.
+    #[cfg(all(native, target_os = "macos"))]
+    pub(crate) fn sec_key_alg_rsa_pkcs1(self) -> crate::mac::CFStringRef {
+        #[link(name = "Security", kind = "framework")]
+        unsafe extern "C" {
+            #[link_name = "kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA1"]
+            static SHA1: crate::mac::CFStringRef;
+            #[link_name = "kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA256"]
+            static SHA256: crate::mac::CFStringRef;
+            #[link_name = "kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA384"]
+            static SHA384: crate::mac::CFStringRef;
+        }
+        // SAFETY: extern statics are always valid.
+        unsafe {
+            match self {
+                HashAlgorithm::Sha1 => SHA1,
+                HashAlgorithm::Sha256 => SHA256,
+                HashAlgorithm::Sha384 => SHA384,
+            }
+        }
+    }
+
+    /// Returns the Security.framework `SecKeyAlgorithm` constant for
+    /// RSA-PSS message signing/verification with this hash.
+    #[cfg(all(native, target_os = "macos"))]
+    pub(crate) fn sec_key_alg_rsa_pss(self) -> crate::mac::CFStringRef {
+        #[link(name = "Security", kind = "framework")]
+        unsafe extern "C" {
+            #[link_name = "kSecKeyAlgorithmRSASignatureMessagePSSSHA1"]
+            static SHA1: crate::mac::CFStringRef;
+            #[link_name = "kSecKeyAlgorithmRSASignatureMessagePSSSHA256"]
+            static SHA256: crate::mac::CFStringRef;
+            #[link_name = "kSecKeyAlgorithmRSASignatureMessagePSSSHA384"]
+            static SHA384: crate::mac::CFStringRef;
+        }
+        // SAFETY: extern statics are always valid.
+        unsafe {
+            match self {
+                HashAlgorithm::Sha1 => SHA1,
+                HashAlgorithm::Sha256 => SHA256,
+                HashAlgorithm::Sha384 => SHA384,
+            }
+        }
+    }
+
+    /// Returns the Security.framework `SecKeyAlgorithm` constant for
+    /// RSA-OAEP encryption/decryption with this hash.
+    #[cfg(all(native, target_os = "macos"))]
+    pub(crate) fn sec_key_alg_rsa_oaep(self) -> crate::mac::CFStringRef {
+        #[link(name = "Security", kind = "framework")]
+        unsafe extern "C" {
+            #[link_name = "kSecKeyAlgorithmRSAEncryptionOAEPSHA1"]
+            static SHA1: crate::mac::CFStringRef;
+            #[link_name = "kSecKeyAlgorithmRSAEncryptionOAEPSHA256"]
+            static SHA256: crate::mac::CFStringRef;
+            #[link_name = "kSecKeyAlgorithmRSAEncryptionOAEPSHA384"]
+            static SHA384: crate::mac::CFStringRef;
+        }
+        // SAFETY: extern statics are always valid.
+        unsafe {
+            match self {
+                HashAlgorithm::Sha1 => SHA1,
+                HashAlgorithm::Sha256 => SHA256,
+                HashAlgorithm::Sha384 => SHA384,
+            }
         }
     }
 }

--- a/support/crypto/src/hashes.rs
+++ b/support/crypto/src/hashes.rs
@@ -40,8 +40,8 @@ impl HashAlgorithm {
     #[cfg(all(native, windows))]
     pub(crate) fn hash(self, data: &[u8]) -> Vec<u8> {
         let mut out = vec![0u8; self.output_size()];
-        // SAFETY: alg is a static pseudo-handle valid for the process; the
-        // input and output slices are valid for the call. Status must be
+        // SAFETY: the handle is a static pseudo-handle valid for the process;
+        // the input and output slices are valid for the call. Status must be
         // success because all inputs are known-good (fixed alg, fixed-size
         // output buffer matching the digest size).
         unsafe {

--- a/support/crypto/src/lib.rs
+++ b/support/crypto/src/lib.rs
@@ -26,7 +26,6 @@ pub mod xts_aes_256;
 
 mod hashes;
 
-#[cfg(any(openssl, rust, symcrypt))]
 pub use hashes::HashAlgorithm;
 
 pub(crate) mod mac;
@@ -43,8 +42,17 @@ pub(crate) struct BackendError(#[source] openssl::error::ErrorStack, &'static st
 /// operation being performed when the error occurred.
 #[cfg(all(native, windows))]
 #[derive(Clone, Debug, thiserror::Error)]
-#[error("windows crypto error during {1}")]
-pub(crate) struct BackendError(#[source] windows_result::Error, &'static str);
+pub(crate) enum BackendError {
+    /// An error from a BCrypt / CryptoAPI call.
+    #[error("windows crypto error during {1}")]
+    Bcrypt(#[source] windows_result::Error, &'static str),
+    /// An error from encoding or decoding PKCS#8.
+    #[error("PKCS#8 error during {1}")]
+    Pkcs8(#[source] pkcs8::Error, &'static str),
+    /// An error from DER encoding or decoding.
+    #[error("DER error during {1}")]
+    Der(#[source] der::Error, &'static str),
+}
 
 /// An error that occurred in the crypto backend, with a description of the
 /// operation being performed when the error occurred.
@@ -61,4 +69,21 @@ pub(crate) enum BackendError {
 }
 
 #[cfg(all(native, target_os = "macos"))]
-pub(crate) use mac::BackendError;
+#[derive(Clone, Debug, thiserror::Error)]
+pub(crate) enum BackendError {
+    /// An OSStatus error from a Security.framework or CoreFoundation API.
+    #[error("{1} returned a failure status code")]
+    OsStatus(#[source] mac::OsStatusCode, &'static str),
+    /// A Security.framework or CoreFoundation API returned a null pointer.
+    #[error("{0}: returned null")]
+    Null(&'static str),
+    /// A Security.framework API returned an error via CFErrorRef.
+    #[error("Security.framework error during {1}: {0}")]
+    Sec(String, &'static str),
+    /// An error from encoding or decoding PKCS#8.
+    #[error("PKCS#8 error during {1}")]
+    Pkcs8(#[source] pkcs8::Error, &'static str),
+    /// An error from DER encoding or decoding.
+    #[error("DER error during {1}")]
+    Der(#[source] der::Error, &'static str),
+}

--- a/support/crypto/src/mac.rs
+++ b/support/crypto/src/mac.rs
@@ -70,7 +70,6 @@ unsafe extern "C" {
 /// constructed directly from the return value of CF/Security APIs.
 pub(crate) struct CfHandle(pub(crate) CFTypeRef);
 
-
 impl Drop for CfHandle {
     fn drop(&mut self) {
         if !self.0.is_null() {

--- a/support/crypto/src/mac.rs
+++ b/support/crypto/src/mac.rs
@@ -70,11 +70,6 @@ unsafe extern "C" {
 /// constructed directly from the return value of CF/Security APIs.
 pub(crate) struct CfHandle(pub(crate) CFTypeRef);
 
-// SAFETY: Owned CF objects we use are read-only or internally synchronized,
-// so they are safe to move between threads.
-unsafe impl Send for CfHandle {}
-// SAFETY: see above.
-unsafe impl Sync for CfHandle {}
 
 impl Drop for CfHandle {
     fn drop(&mut self) {

--- a/support/crypto/src/mac.rs
+++ b/support/crypto/src/mac.rs
@@ -8,15 +8,32 @@
 use std::ffi::c_void;
 use std::fmt;
 
-type CFStringRef = *const c_void;
-type CFIndex = isize;
+pub(crate) type CFTypeRef = *const c_void;
+pub(crate) type CFAllocatorRef = *const c_void;
+pub(crate) type CFDataRef = *const c_void;
+pub(crate) type CFStringRef = *const c_void;
+pub(crate) type CFErrorRef = *const c_void;
+pub(crate) type CFArrayRef = *const c_void;
+pub(crate) type CFNumberRef = *const c_void;
+pub(crate) type CFDictionaryRef = *const c_void;
+pub(crate) type CFIndex = isize;
+
+pub(crate) type SecKeyRef = CFTypeRef;
 
 /// kCFStringEncodingUTF8
 const K_CF_STRING_ENCODING_UTF8: u32 = 0x08000100;
 
 #[link(name = "CoreFoundation", kind = "framework")]
 unsafe extern "C" {
-    fn CFRelease(cf: *const c_void);
+    pub(crate) static kCFAllocatorDefault: CFAllocatorRef;
+    pub(crate) fn CFRelease(cf: CFTypeRef);
+    pub(crate) fn CFDataCreate(
+        allocator: CFAllocatorRef,
+        bytes: *const u8,
+        length: CFIndex,
+    ) -> CFDataRef;
+    pub(crate) fn CFDataGetBytePtr(data: CFDataRef) -> *const u8;
+    pub(crate) fn CFDataGetLength(data: CFDataRef) -> CFIndex;
     fn CFStringGetLength(the_string: CFStringRef) -> CFIndex;
     fn CFStringGetCString(
         the_string: CFStringRef,
@@ -24,11 +41,184 @@ unsafe extern "C" {
         buffer_size: CFIndex,
         encoding: u32,
     ) -> u8;
+    fn CFErrorGetCode(err: CFErrorRef) -> CFIndex;
+    fn CFErrorCopyDescription(err: CFErrorRef) -> CFStringRef;
+    static kCFTypeDictionaryKeyCallBacks: c_void;
+    static kCFTypeDictionaryValueCallBacks: c_void;
+    fn CFNumberCreate(
+        allocator: CFAllocatorRef,
+        the_type: i32,
+        value_ptr: *const c_void,
+    ) -> CFNumberRef;
+    fn CFDictionaryCreate(
+        allocator: CFAllocatorRef,
+        keys: *const CFTypeRef,
+        values: *const CFTypeRef,
+        num_values: CFIndex,
+        key_callbacks: *const c_void,
+        value_callbacks: *const c_void,
+    ) -> CFDictionaryRef;
 }
 
 #[link(name = "Security", kind = "framework")]
 unsafe extern "C" {
     fn SecCopyErrorMessageString(status: OsStatusCode, reserved: *const c_void) -> CFStringRef;
+}
+
+/// RAII wrapper for any CoreFoundation type. Released with `CFRelease` on
+/// drop. Null pointers are tolerated (drop is a no-op) so this can be
+/// constructed directly from the return value of CF/Security APIs.
+pub(crate) struct CfHandle(pub(crate) CFTypeRef);
+
+// SAFETY: Owned CF objects we use are read-only or internally synchronized,
+// so they are safe to move between threads.
+unsafe impl Send for CfHandle {}
+// SAFETY: see above.
+unsafe impl Sync for CfHandle {}
+
+impl Drop for CfHandle {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            // SAFETY: pointer is a valid CF object that we own.
+            unsafe { CFRelease(self.0) };
+        }
+    }
+}
+
+/// Create an owned `CFData` from a byte slice, wrapped in a `CfHandle`.
+/// Returns `BackendError::Null` if CFDataCreate returns null.
+pub(crate) fn cf_data(bytes: &[u8], op: &'static str) -> Result<CfHandle, super::BackendError> {
+    // SAFETY: bytes pointer/length is valid; kCFAllocatorDefault is a
+    // valid CF allocator.
+    let data = unsafe { CFDataCreate(kCFAllocatorDefault, bytes.as_ptr(), bytes.len() as CFIndex) };
+    if data.is_null() {
+        return Err(super::BackendError::Null(op));
+    }
+    Ok(CfHandle(data))
+}
+
+/// Copy the bytes out of a `CFData` into a `Vec<u8>`.
+///
+/// # Safety
+///
+/// `data` must be a valid `CFDataRef`.
+pub(crate) unsafe fn cf_data_to_vec(data: CFDataRef) -> Vec<u8> {
+    // SAFETY: per caller contract.
+    let len = unsafe { CFDataGetLength(data) } as usize;
+    // SAFETY: per caller contract.
+    let ptr = unsafe { CFDataGetBytePtr(data) };
+    if ptr.is_null() || len == 0 {
+        return Vec::new();
+    }
+    // SAFETY: ptr is valid for `len` bytes per CFDataGetBytePtr contract.
+    unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec()
+}
+
+/// Copy a `CFString` into a Rust `String`, releasing the `CFString` once
+/// done. Null is treated as the empty string.
+///
+/// # Safety
+///
+/// `s` must be a valid owned `CFStringRef` (or null) returned by a
+/// CF/Security API.
+pub(crate) unsafe fn cf_string_to_string(s: CFStringRef) -> String {
+    if s.is_null() {
+        return String::new();
+    }
+    let _release = CfHandle(s);
+    // SAFETY: s is a valid non-null CFStringRef.
+    let len = unsafe { CFStringGetLength(s) };
+    let buf_size = len * 4 + 1;
+    let mut buf = vec![0u8; buf_size as usize];
+    // SAFETY: buf is sized as required.
+    let ok =
+        unsafe { CFStringGetCString(s, buf.as_mut_ptr(), buf_size, K_CF_STRING_ENCODING_UTF8) };
+    if ok == 0 {
+        return String::new();
+    }
+    let nul = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    String::from_utf8_lossy(&buf[..nul]).into_owned()
+}
+
+/// Build a `BackendError::Sec` from an owned `CFErrorRef`, releasing it.
+/// If `error` is null, returns a `BackendError::Null` for `op` instead.
+///
+/// # Safety
+///
+/// `error` must be a valid owned `CFErrorRef` (or null) returned by a
+/// CF/Security API.
+pub(crate) unsafe fn sec_err(error: CFErrorRef, op: &'static str) -> super::BackendError {
+    if error.is_null() {
+        return super::BackendError::Null(op);
+    }
+    let release = CfHandle(error);
+    // SAFETY: error is a valid CFErrorRef.
+    let code = unsafe { CFErrorGetCode(error) };
+    // SAFETY: error is valid; CFErrorCopyDescription returns an owned
+    // CFStringRef (or null) which cf_string_to_string handles.
+    let msg = unsafe { cf_string_to_string(CFErrorCopyDescription(error)) };
+    drop(release);
+    super::BackendError::Sec(format!("code {}: {}", code, msg), op)
+}
+
+/// Returns the CFError's numeric code, or `None` if `error` is null. Does
+/// not release `error`.
+///
+/// # Safety
+///
+/// `error` must be null or a valid `CFErrorRef`.
+pub(crate) unsafe fn cf_error_code(error: CFErrorRef) -> Option<CFIndex> {
+    if error.is_null() {
+        return None;
+    }
+    // SAFETY: per caller contract.
+    Some(unsafe { CFErrorGetCode(error) })
+}
+
+/// `kCFNumberIntType` — type tag for `CFNumberCreate` with a 32-bit value.
+const K_CF_NUMBER_INT_TYPE: i32 = 9;
+
+/// Create an owned `CFNumber` wrapping an `i32` value.
+pub(crate) fn cf_number(value: i32, op: &'static str) -> Result<CfHandle, super::BackendError> {
+    // SAFETY: value pointer is valid; kCFAllocatorDefault is valid.
+    let num = unsafe {
+        CFNumberCreate(
+            kCFAllocatorDefault,
+            K_CF_NUMBER_INT_TYPE,
+            std::ptr::from_ref(&value).cast(),
+        )
+    };
+    if num.is_null() {
+        return Err(super::BackendError::Null(op));
+    }
+    Ok(CfHandle(num))
+}
+
+/// Create an owned `CFDictionary` from `(key, value)` slices. Both keys
+/// and values must outlive the call; the dictionary takes its own
+/// references via `kCFTypeDictionary*CallBacks`.
+pub(crate) fn cf_dict(
+    pairs: &[(CFTypeRef, CFTypeRef)],
+    op: &'static str,
+) -> Result<CfHandle, super::BackendError> {
+    let keys: Vec<CFTypeRef> = pairs.iter().map(|(k, _)| *k).collect();
+    let values: Vec<CFTypeRef> = pairs.iter().map(|(_, v)| *v).collect();
+    // SAFETY: keys/values point to valid CF objects; callback tables are
+    // standard CF symbols.
+    let dict = unsafe {
+        CFDictionaryCreate(
+            kCFAllocatorDefault,
+            keys.as_ptr(),
+            values.as_ptr(),
+            pairs.len() as CFIndex,
+            std::ptr::from_ref(&kCFTypeDictionaryKeyCallBacks).cast(),
+            std::ptr::from_ref(&kCFTypeDictionaryValueCallBacks).cast(),
+        )
+    };
+    if dict.is_null() {
+        return Err(super::BackendError::Null(op));
+    }
+    Ok(CfHandle(dict))
 }
 
 /// An OSStatus code from a Security.framework or CoreFoundation API.
@@ -54,55 +244,14 @@ impl fmt::Display for OsStatusCode {
         if cf_str.is_null() {
             return write!(f, "OSStatus {}", self.0);
         }
-
-        // SAFETY: cf_str is a valid CFStringRef.
-        let len = unsafe { CFStringGetLength(cf_str) };
-        // UTF-8 can use up to 4 bytes per character; +1 for null terminator.
-        let buf_size = len * 4 + 1;
-        let mut buf = vec![0u8; buf_size as usize];
-        // SAFETY: cf_str is valid, buf is large enough.
-        let ok = unsafe {
-            CFStringGetCString(
-                cf_str,
-                buf.as_mut_ptr(),
-                buf_size,
-                K_CF_STRING_ENCODING_UTF8,
-            )
-        };
-        // SAFETY: cf_str is a non-null CFStringRef we must release.
-        unsafe { CFRelease(cf_str) };
-
-        if ok == 0 {
-            return write!(f, "OSStatus {}", self.0);
+        // SAFETY: cf_str is an owned non-null CFStringRef.
+        let msg = unsafe { cf_string_to_string(cf_str) };
+        if msg.is_empty() {
+            write!(f, "OSStatus {}", self.0)
+        } else {
+            write!(f, "OSStatus {}: {}", self.0, msg)
         }
-
-        let nul = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
-        let msg = std::str::from_utf8(&buf[..nul]).unwrap_or("");
-        write!(f, "OSStatus {}: {}", self.0, msg)
     }
 }
 
 impl std::error::Error for OsStatusCode {}
-
-/// An error that occurred in the crypto backend.
-#[derive(Clone, Debug, thiserror::Error)]
-#[error("{0}")]
-pub(crate) struct BackendError(BackendErrorKind);
-
-#[derive(Clone, Debug, thiserror::Error)]
-enum BackendErrorKind {
-    #[error("{1}: {0}")]
-    OsStatus(#[source] OsStatusCode, &'static str),
-    #[error("{0}: returned null")]
-    Null(&'static str),
-}
-
-impl BackendError {
-    pub(crate) fn os_status(code: OsStatusCode, op: &'static str) -> Self {
-        Self(BackendErrorKind::OsStatus(code, op))
-    }
-
-    pub(crate) fn null(op: &'static str) -> Self {
-        Self(BackendErrorKind::Null(op))
-    }
-}

--- a/support/crypto/src/pkcs7/mac.rs
+++ b/support/crypto/src/pkcs7/mac.rs
@@ -11,18 +11,8 @@
 #![expect(unsafe_code)]
 
 use super::*;
-use crate::mac::OsStatusCode;
-use std::ffi::c_void;
+use crate::mac::*;
 use std::ptr;
-
-// === Core Foundation FFI types ===
-
-type CFTypeRef = *const c_void;
-type CFAllocatorRef = *const c_void;
-type CFDataRef = *const c_void;
-type CFArrayRef = *const c_void;
-type CFErrorRef = *const c_void;
-type CFIndex = isize;
 
 // === Security FFI types ===
 
@@ -51,8 +41,6 @@ struct CFArrayCallBacks {
 #[link(name = "CoreFoundation", kind = "framework")]
 unsafe extern "C" {
     static kCFTypeArrayCallBacks: CFArrayCallBacks;
-    fn CFRelease(cf: CFTypeRef);
-    fn CFDataCreate(allocator: CFAllocatorRef, bytes: *const u8, length: CFIndex) -> CFDataRef;
     fn CFArrayCreate(
         allocator: CFAllocatorRef,
         values: *const CFTypeRef,
@@ -94,26 +82,14 @@ unsafe extern "C" {
     ) -> OsStatusCode;
 }
 
-/// RAII wrapper for any CoreFoundation type. Released with `CFRelease`.
-struct CfHandle(CFTypeRef);
-
-impl Drop for CfHandle {
-    fn drop(&mut self) {
-        if !self.0.is_null() {
-            // SAFETY: pointer is a valid CFTypeRef that we own.
-            unsafe { CFRelease(self.0) };
-        }
-    }
-}
-
 /// Create a Pkcs7Error from an OsStatusCode and operation description.
 fn os_err(status: OsStatusCode, op: &'static str) -> Pkcs7Error {
-    Pkcs7Error(crate::BackendError::os_status(status, op))
+    Pkcs7Error(crate::BackendError::OsStatus(status, op))
 }
 
 /// Create a Pkcs7Error for a null return with no OS error code.
 fn null_err(op: &'static str) -> Pkcs7Error {
-    Pkcs7Error(crate::BackendError::null(op))
+    Pkcs7Error(crate::BackendError::Null(op))
 }
 
 pub struct Pkcs7CertStoreInner {
@@ -130,21 +106,14 @@ impl Pkcs7CertStoreInner {
     }
 
     pub fn add_cert_der(&mut self, data: &[u8]) -> Result<(), Pkcs7Error> {
-        // SAFETY: CFDataCreate and SecCertificateCreateWithData are safe to
-        // call with valid byte slices. Both return owned CF objects.
-        unsafe {
-            let cf_data = CFDataCreate(ptr::null(), data.as_ptr(), data.len() as CFIndex);
-            if cf_data.is_null() {
-                return Err(null_err("create CFData for certificate"));
-            }
-            let _cf_data = CfHandle(cf_data);
-
-            let cert = SecCertificateCreateWithData(ptr::null(), cf_data);
-            if cert.is_null() {
-                return Err(null_err("create SecCertificate from DER"));
-            }
-            self.certs.push(CfHandle(cert));
+        let cf_data = cf_data(data, "create CFData for certificate").map_err(Pkcs7Error)?;
+        // SAFETY: cf_data wraps a valid CFDataRef; SecCertificateCreateWithData
+        // is safe with valid CFData input.
+        let cert = unsafe { SecCertificateCreateWithData(ptr::null(), cf_data.0) };
+        if cert.is_null() {
+            return Err(null_err("create SecCertificate from DER"));
         }
+        self.certs.push(CfHandle(cert));
         Ok(())
     }
 
@@ -198,21 +167,14 @@ impl Pkcs7SignedDataInner {
         signed_content: &[u8],
         uefi_mode: bool,
     ) -> Result<bool, Pkcs7Error> {
+        // Provide the detached content that was signed.
+        let content_data =
+            cf_data(signed_content, "create CFData for signed content").map_err(Pkcs7Error)?;
+
         // SAFETY: all CF/Security API calls use valid handles produced by
         // earlier successful calls. RAII wrappers ensure proper cleanup.
         unsafe {
-            // Provide the detached content that was signed.
-            let content_data = CFDataCreate(
-                ptr::null(),
-                signed_content.as_ptr(),
-                signed_content.len() as CFIndex,
-            );
-            if content_data.is_null() {
-                return Err(null_err("create CFData for signed content"));
-            }
-            let _content_data = CfHandle(content_data);
-
-            let status = CMSDecoderSetDetachedContent(self.decoder.0, content_data);
+            let status = CMSDecoderSetDetachedContent(self.decoder.0, content_data.0);
             if !status.success() {
                 return Err(os_err(status, "set detached content"));
             }

--- a/support/crypto/src/pkcs7/win.rs
+++ b/support/crypto/src/pkcs7/win.rs
@@ -10,7 +10,7 @@ use windows::Win32::Foundation::NTE_BAD_SIGNATURE;
 use windows::Win32::Security::Cryptography::*;
 
 fn err(e: windows_result::Error, op: &'static str) -> Pkcs7Error {
-    Pkcs7Error(crate::BackendError(e, op))
+    Pkcs7Error(crate::BackendError::Bcrypt(e, op))
 }
 
 /// RAII wrapper for HCERTSTORE.

--- a/support/crypto/src/rsa/mac.rs
+++ b/support/crypto/src/rsa/mac.rs
@@ -1,0 +1,435 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! RSA implementation using macOS Security.framework SecKey APIs.
+
+// UNSAFETY: calling Security.framework and CoreFoundation C APIs via FFI.
+#![expect(unsafe_code)]
+
+use super::RsaError;
+use crate::HashAlgorithm;
+use crate::mac::*;
+use der::Decode;
+use der::Encode;
+use std::ptr;
+
+/// errSecVerifyFailed — signature verification failed (i.e. signature is
+/// invalid). Other error codes are infrastructure failures.
+const ERR_SEC_VERIFY_FAILED: CFIndex = -67808;
+
+#[link(name = "Security", kind = "framework")]
+unsafe extern "C" {
+    static kSecAttrKeyType: CFStringRef;
+    static kSecAttrKeyTypeRSA: CFStringRef;
+    static kSecAttrKeySizeInBits: CFStringRef;
+    static kSecAttrKeyClass: CFStringRef;
+    static kSecAttrKeyClassPrivate: CFStringRef;
+    static kSecAttrKeyClassPublic: CFStringRef;
+
+    fn SecKeyCreateRandomKey(parameters: CFDictionaryRef, error: *mut CFErrorRef) -> SecKeyRef;
+    fn SecKeyCreateWithData(
+        key_data: CFDataRef,
+        attributes: CFDictionaryRef,
+        error: *mut CFErrorRef,
+    ) -> SecKeyRef;
+    fn SecKeyCopyPublicKey(key: SecKeyRef) -> SecKeyRef;
+    fn SecKeyCopyExternalRepresentation(key: SecKeyRef, error: *mut CFErrorRef) -> CFDataRef;
+    fn SecKeyGetBlockSize(key: SecKeyRef) -> usize;
+    fn SecKeyCreateSignature(
+        key: SecKeyRef,
+        algorithm: CFStringRef,
+        data_to_sign: CFDataRef,
+        error: *mut CFErrorRef,
+    ) -> CFDataRef;
+    fn SecKeyVerifySignature(
+        key: SecKeyRef,
+        algorithm: CFStringRef,
+        signed_data: CFDataRef,
+        signature: CFDataRef,
+        error: *mut CFErrorRef,
+    ) -> u8;
+    fn SecKeyCreateEncryptedData(
+        key: SecKeyRef,
+        algorithm: CFStringRef,
+        plaintext: CFDataRef,
+        error: *mut CFErrorRef,
+    ) -> CFDataRef;
+    fn SecKeyCreateDecryptedData(
+        key: SecKeyRef,
+        algorithm: CFStringRef,
+        ciphertext: CFDataRef,
+        error: *mut CFErrorRef,
+    ) -> CFDataRef;
+}
+
+fn der_err(e: der::Error, op: &'static str) -> RsaError {
+    RsaError(crate::BackendError::Der(e, op))
+}
+
+fn pkcs8_err(e: pkcs8::Error, op: &'static str) -> RsaError {
+    RsaError(crate::BackendError::Pkcs8(e, op))
+}
+
+fn null_err(op: &'static str) -> RsaError {
+    RsaError(crate::BackendError::Null(op))
+}
+
+/// Wrap a shared `crate::mac::cf_data` call with the RSA error type.
+fn rsa_cf_data(bytes: &[u8], op: &'static str) -> Result<CfHandle, RsaError> {
+    cf_data(bytes, op).map_err(RsaError)
+}
+
+/// Wrap `crate::mac::cf_number` with the RSA error type.
+fn rsa_cf_number(value: i32, op: &'static str) -> Result<CfHandle, RsaError> {
+    cf_number(value, op).map_err(RsaError)
+}
+
+/// Wrap `crate::mac::cf_dict` with the RSA error type.
+fn rsa_cf_dict(pairs: &[(CFTypeRef, CFTypeRef)], op: &'static str) -> Result<CfHandle, RsaError> {
+    cf_dict(pairs, op).map_err(RsaError)
+}
+
+/// Wrap `crate::mac::sec_err` with the RSA error type.
+///
+/// # Safety
+///
+/// Same as `crate::mac::sec_err`.
+unsafe fn rsa_sec_err(error: CFErrorRef, op: &'static str) -> RsaError {
+    // SAFETY: per caller contract.
+    RsaError(unsafe { sec_err(error, op) })
+}
+
+/// Build a PKCS#1 RSAPublicKey DER blob from (n, e).
+fn build_pkcs1_pub(n: &[u8], e: &[u8]) -> Result<Vec<u8>, RsaError> {
+    use der::asn1::UintRef;
+    let pk = pkcs1::RsaPublicKey {
+        modulus: UintRef::new(n).map_err(|e| der_err(e, "encoding modulus"))?,
+        public_exponent: UintRef::new(e).map_err(|e| der_err(e, "encoding e"))?,
+    };
+    pk.to_der()
+        .map_err(|e| der_err(e, "encoding PKCS#1 RSA public key"))
+}
+
+/// Parse a PKCS#1 RSAPublicKey DER blob into (n, e) byte vectors.
+fn parse_pkcs1_pub(der_bytes: &[u8]) -> Result<(Vec<u8>, Vec<u8>), RsaError> {
+    let pk = pkcs1::RsaPublicKey::from_der(der_bytes)
+        .map_err(|e| der_err(e, "parsing PKCS#1 RSA public key"))?;
+    Ok((
+        pk.modulus.as_bytes().to_vec(),
+        pk.public_exponent.as_bytes().to_vec(),
+    ))
+}
+
+/// Import an RSA private key from a PKCS#1 RSAPrivateKey DER blob.
+fn import_private(pkcs1_der: &[u8]) -> Result<CfHandle, RsaError> {
+    let key_data = rsa_cf_data(pkcs1_der, "create CFData for PKCS#1 RSA private key")?;
+    // SAFETY: kSecAttr* are valid CFStringRef extern statics.
+    let attrs = unsafe {
+        rsa_cf_dict(
+            &[
+                (kSecAttrKeyType, kSecAttrKeyTypeRSA),
+                (kSecAttrKeyClass, kSecAttrKeyClassPrivate),
+            ],
+            "create attrs for RSA private key import",
+        )?
+    };
+    let mut error: CFErrorRef = ptr::null();
+    // SAFETY: key_data and attrs are valid CF objects.
+    let key = unsafe { SecKeyCreateWithData(key_data.0, attrs.0, &mut error) };
+    if key.is_null() {
+        // SAFETY: error is either null or a valid CFErrorRef.
+        return Err(unsafe { rsa_sec_err(error, "import RSA private key") });
+    }
+    Ok(CfHandle(key))
+}
+
+/// Import an RSA public key from a PKCS#1 RSAPublicKey DER blob.
+fn import_public(pkcs1_der: &[u8]) -> Result<CfHandle, RsaError> {
+    let key_data = rsa_cf_data(pkcs1_der, "create CFData for PKCS#1 RSA public key")?;
+    // SAFETY: kSecAttr* are valid CFStringRef extern statics.
+    let attrs = unsafe {
+        rsa_cf_dict(
+            &[
+                (kSecAttrKeyType, kSecAttrKeyTypeRSA),
+                (kSecAttrKeyClass, kSecAttrKeyClassPublic),
+            ],
+            "create attrs for RSA public key import",
+        )?
+    };
+    let mut error: CFErrorRef = ptr::null();
+    // SAFETY: key_data and attrs are valid.
+    let key = unsafe { SecKeyCreateWithData(key_data.0, attrs.0, &mut error) };
+    if key.is_null() {
+        // SAFETY: error is null or valid.
+        return Err(unsafe { rsa_sec_err(error, "import RSA public key") });
+    }
+    Ok(CfHandle(key))
+}
+
+#[repr(transparent)]
+pub struct RsaKeyPairInner(CfHandle);
+
+#[repr(transparent)]
+pub struct RsaPublicKeyInner(CfHandle);
+
+impl RsaKeyPairInner {
+    pub fn generate(bits: u32) -> Result<Self, RsaError> {
+        let size = rsa_cf_number(bits as i32, "create CFNumber for key size")?;
+        // SAFETY: kSecAttr* are valid CFStringRef extern statics.
+        let params = unsafe {
+            rsa_cf_dict(
+                &[
+                    (kSecAttrKeyType, kSecAttrKeyTypeRSA),
+                    (kSecAttrKeySizeInBits, size.0),
+                ],
+                "create params for RSA key generation",
+            )?
+        };
+        let mut error: CFErrorRef = ptr::null();
+        // SAFETY: params is a valid CFDictionary.
+        let key = unsafe { SecKeyCreateRandomKey(params.0, &mut error) };
+        if key.is_null() {
+            // SAFETY: error is null or valid.
+            return Err(unsafe { rsa_sec_err(error, "generate RSA key") });
+        }
+        Ok(Self(CfHandle(key)))
+    }
+
+    pub fn from_pkcs8_der(der_bytes: &[u8]) -> Result<Self, RsaError> {
+        let pki = pkcs8::PrivateKeyInfoRef::from_der(der_bytes)
+            .map_err(|e| der_err(e, "parsing PKCS#8 DER"))?;
+        if pki.algorithm.oid != pkcs1::ALGORITHM_OID {
+            return Err(pkcs8_err(
+                pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid),
+                "PKCS#8 algorithm is not rsaEncryption",
+            ));
+        }
+        let handle = import_private(pki.private_key.as_bytes())?;
+        Ok(Self(handle))
+    }
+
+    #[cfg(any(test, feature = "test_helpers"))]
+    pub fn to_pkcs8_der(&self) -> Result<Vec<u8>, RsaError> {
+        use der::asn1::OctetString;
+        use pkcs8::spki::AlgorithmIdentifierOwned;
+
+        let mut error: CFErrorRef = ptr::null();
+        // SAFETY: self.0.0 is a valid SecKeyRef.
+        let data = unsafe { SecKeyCopyExternalRepresentation(self.0.0, &mut error) };
+        if data.is_null() {
+            // SAFETY: error is null or valid.
+            return Err(unsafe { rsa_sec_err(error, "export RSA private key") });
+        }
+        let data = CfHandle(data);
+        // SAFETY: data.0 is a valid CFDataRef.
+        let pkcs1_der = unsafe { cf_data_to_vec(data.0) };
+
+        let pki = pkcs8::PrivateKeyInfoOwned {
+            algorithm: AlgorithmIdentifierOwned {
+                oid: pkcs1::ALGORITHM_OID,
+                parameters: Some(der::Any::null()),
+            },
+            private_key: OctetString::new(pkcs1_der)
+                .map_err(|e| der_err(e, "wrapping PKCS#1 in OCTET STRING"))?,
+            public_key: None,
+        };
+        pki.to_der()
+            .map_err(|e| der_err(e, "encoding PKCS#8 PrivateKeyInfo"))
+    }
+
+    pub fn oaep_decrypt(
+        &self,
+        input: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<Vec<u8>, RsaError> {
+        let ct = rsa_cf_data(input, "create CFData")?;
+        let mut error: CFErrorRef = ptr::null();
+        // SAFETY: self.0.0 and ct.0 are valid.
+        let pt = unsafe {
+            SecKeyCreateDecryptedData(
+                self.0.0,
+                hash_algorithm.sec_key_alg_rsa_oaep(),
+                ct.0,
+                &mut error,
+            )
+        };
+        if pt.is_null() {
+            // SAFETY: error is null or valid.
+            return Err(unsafe { rsa_sec_err(error, "RSA-OAEP decrypt") });
+        }
+        let pt = CfHandle(pt);
+        // SAFETY: pt.0 is valid.
+        Ok(unsafe { cf_data_to_vec(pt.0) })
+    }
+
+    pub fn pkcs1_sign(
+        &self,
+        data: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<Vec<u8>, RsaError> {
+        sign(&self.0, hash_algorithm.sec_key_alg_rsa_pkcs1(), data)
+    }
+
+    pub fn pss_sign(
+        &self,
+        data: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<Vec<u8>, RsaError> {
+        sign(&self.0, hash_algorithm.sec_key_alg_rsa_pss(), data)
+    }
+
+    pub(crate) fn as_pub(&self) -> &RsaPublicKeyInner {
+        // SAFETY: both are #[repr(transparent)] over CfHandle. A SecKeyRef
+        // for a private key supports the SecKeyCopyPublicKey-style read
+        // path used by RsaPublicKeyInner methods.
+        unsafe { std::mem::transmute::<&RsaKeyPairInner, &RsaPublicKeyInner>(self) }
+    }
+}
+
+fn sign(key: &CfHandle, alg: CFStringRef, data: &[u8]) -> Result<Vec<u8>, RsaError> {
+    let data_cf = rsa_cf_data(data, "create CFData")?;
+    let mut error: CFErrorRef = ptr::null();
+    // SAFETY: key, alg, data_cf are valid.
+    let sig = unsafe { SecKeyCreateSignature(key.0, alg, data_cf.0, &mut error) };
+    if sig.is_null() {
+        // SAFETY: error is null or valid.
+        return Err(unsafe { rsa_sec_err(error, "RSA sign") });
+    }
+    let sig = CfHandle(sig);
+    // SAFETY: sig.0 valid.
+    Ok(unsafe { cf_data_to_vec(sig.0) })
+}
+
+fn verify(
+    key: &CfHandle,
+    alg: CFStringRef,
+    message: &[u8],
+    signature: &[u8],
+) -> Result<bool, RsaError> {
+    let msg = rsa_cf_data(message, "create CFData for message")?;
+    let sig = rsa_cf_data(signature, "create CFData for signature")?;
+    let mut error: CFErrorRef = ptr::null();
+    // SAFETY: all CF refs are valid.
+    let ok = unsafe { SecKeyVerifySignature(key.0, alg, msg.0, sig.0, &mut error) };
+    if ok != 0 {
+        return Ok(true);
+    }
+    // SAFETY: error is null or a valid CFErrorRef.
+    match unsafe { cf_error_code(error) } {
+        // Null error or errSecVerifyFailed both mean "bad signature" rather
+        // than an infrastructure failure.
+        None | Some(ERR_SEC_VERIFY_FAILED) => {
+            if !error.is_null() {
+                // SAFETY: error is a valid CFErrorRef we own.
+                unsafe { CFRelease(error) };
+            }
+            Ok(false)
+        }
+        // SAFETY: error is a valid CFErrorRef (sec_err takes ownership).
+        Some(_) => Err(unsafe { rsa_sec_err(error, "RSA verify") }),
+    }
+}
+
+impl RsaPublicKeyInner {
+    pub fn from_components(n: &[u8], e: &[u8]) -> Result<Self, RsaError> {
+        let der = build_pkcs1_pub(n, e)?;
+        Ok(Self(import_public(&der)?))
+    }
+
+    pub fn oaep_encrypt(
+        &self,
+        input: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<Vec<u8>, RsaError> {
+        let pub_key = self.public_key_handle()?;
+        let pt = rsa_cf_data(input, "create CFData")?;
+        let mut error: CFErrorRef = ptr::null();
+        // SAFETY: pub_key and pt valid.
+        let ct = unsafe {
+            SecKeyCreateEncryptedData(
+                pub_key.0,
+                hash_algorithm.sec_key_alg_rsa_oaep(),
+                pt.0,
+                &mut error,
+            )
+        };
+        if ct.is_null() {
+            // SAFETY: error is null or valid.
+            return Err(unsafe { rsa_sec_err(error, "RSA-OAEP encrypt") });
+        }
+        let ct = CfHandle(ct);
+        // SAFETY: ct.0 valid.
+        Ok(unsafe { cf_data_to_vec(ct.0) })
+    }
+
+    pub fn pkcs1_verify(
+        &self,
+        message: &[u8],
+        signature: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<bool, RsaError> {
+        let pub_key = self.public_key_handle()?;
+        verify(
+            &pub_key,
+            hash_algorithm.sec_key_alg_rsa_pkcs1(),
+            message,
+            signature,
+        )
+    }
+
+    pub fn pss_verify(
+        &self,
+        message: &[u8],
+        signature: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<bool, RsaError> {
+        let pub_key = self.public_key_handle()?;
+        verify(
+            &pub_key,
+            hash_algorithm.sec_key_alg_rsa_pss(),
+            message,
+            signature,
+        )
+    }
+
+    pub fn modulus_size(&self) -> usize {
+        // SAFETY: self.0.0 is a valid SecKeyRef.
+        unsafe { SecKeyGetBlockSize(self.0.0) }
+    }
+
+    pub fn modulus(&self) -> Vec<u8> {
+        self.export_components().map(|(n, _)| n).unwrap_or_default()
+    }
+
+    pub fn public_exponent(&self) -> Vec<u8> {
+        self.export_components().map(|(_, e)| e).unwrap_or_default()
+    }
+
+    /// Get a SecKeyRef for the public half of this key. For a key already
+    /// representing only the public half, this is just a retained copy.
+    fn public_key_handle(&self) -> Result<CfHandle, RsaError> {
+        // SAFETY: self.0.0 is a valid SecKeyRef.
+        let pk = unsafe { SecKeyCopyPublicKey(self.0.0) };
+        if pk.is_null() {
+            return Err(null_err("SecKeyCopyPublicKey"));
+        }
+        Ok(CfHandle(pk))
+    }
+
+    /// Export and parse the PKCS#1 RSAPublicKey representation, returning
+    /// `(modulus, public_exponent)`.
+    fn export_components(&self) -> Result<(Vec<u8>, Vec<u8>), RsaError> {
+        let pub_key = self.public_key_handle()?;
+        let mut error: CFErrorRef = ptr::null();
+        // SAFETY: pub_key.0 is valid.
+        let data = unsafe { SecKeyCopyExternalRepresentation(pub_key.0, &mut error) };
+        if data.is_null() {
+            // SAFETY: error is null or valid.
+            return Err(unsafe { rsa_sec_err(error, "export RSA public key") });
+        }
+        let data = CfHandle(data);
+        // SAFETY: data.0 is valid.
+        let der_bytes = unsafe { cf_data_to_vec(data.0) };
+        parse_pkcs1_pub(&der_bytes)
+    }
+}

--- a/support/crypto/src/rsa/mod.rs
+++ b/support/crypto/src/rsa/mod.rs
@@ -3,7 +3,13 @@
 
 //! RSA cryptographic operations.
 
-#![cfg(any(openssl, rust, symcrypt))]
+#![cfg(any(
+    openssl,
+    rust,
+    symcrypt,
+    all(native, windows),
+    all(native, target_os = "macos")
+))]
 
 #[cfg(openssl)]
 pub(crate) mod ossl;
@@ -20,12 +26,26 @@ pub(crate) mod symcrypt;
 #[cfg(symcrypt)]
 pub(crate) use symcrypt as sys;
 
+#[cfg(all(native, windows))]
+mod win;
+#[cfg(all(native, windows))]
+use win as sys;
+
+#[cfg(all(native, target_os = "macos"))]
+mod mac;
+#[cfg(all(native, target_os = "macos"))]
+use mac as sys;
+
 use crate::HashAlgorithm;
 use thiserror::Error;
 
 /// An error for RSA operations.
-// TODO: Make this clone once RustCrypto rsa::errors::Error is cloneable
-#[cfg(not(rust))]
+#[cfg(any(
+    openssl,
+    symcrypt,
+    all(native, windows),
+    all(native, target_os = "macos")
+))]
 #[derive(Debug, Error)]
 #[error("RSA error")]
 pub struct RsaError(#[source] pub(crate) super::BackendError);

--- a/support/crypto/src/rsa/win.rs
+++ b/support/crypto/src/rsa/win.rs
@@ -1,0 +1,580 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! RSA implementation using Windows BCrypt APIs.
+
+use super::RsaError;
+use crate::HashAlgorithm;
+use crate::win::KeyHandle;
+use der::Decode;
+#[cfg(any(test, feature = "test_helpers"))]
+use der::Encode;
+use std::ffi::c_void;
+use windows::Win32::Foundation::STATUS_INVALID_PARAMETER;
+use windows::Win32::Foundation::STATUS_INVALID_SIGNATURE;
+use windows::Win32::Security::Cryptography::BCRYPT_FLAGS;
+use windows::Win32::Security::Cryptography::BCRYPT_KEY_HANDLE;
+use windows::Win32::Security::Cryptography::BCRYPT_OAEP_PADDING_INFO;
+use windows::Win32::Security::Cryptography::BCRYPT_PAD_OAEP;
+use windows::Win32::Security::Cryptography::BCRYPT_PAD_PKCS1;
+use windows::Win32::Security::Cryptography::BCRYPT_PAD_PSS;
+use windows::Win32::Security::Cryptography::BCRYPT_PKCS1_PADDING_INFO;
+use windows::Win32::Security::Cryptography::BCRYPT_PSS_PADDING_INFO;
+use windows::Win32::Security::Cryptography::BCRYPT_RSA_ALG_HANDLE;
+use windows::Win32::Security::Cryptography::BCRYPT_RSAFULLPRIVATE_BLOB;
+use windows::Win32::Security::Cryptography::BCRYPT_RSAFULLPRIVATE_MAGIC;
+use windows::Win32::Security::Cryptography::BCRYPT_RSAKEY_BLOB;
+use windows::Win32::Security::Cryptography::BCRYPT_RSAPUBLIC_BLOB;
+use windows::Win32::Security::Cryptography::BCRYPT_RSAPUBLIC_MAGIC;
+
+fn err(err: windows_result::Error, op: &'static str) -> RsaError {
+    RsaError(crate::BackendError::Bcrypt(err, op))
+}
+
+fn der_err(e: der::Error, op: &'static str) -> RsaError {
+    RsaError(crate::BackendError::Der(e, op))
+}
+
+fn pkcs8_err(e: pkcs8::Error, op: &'static str) -> RsaError {
+    RsaError(crate::BackendError::Pkcs8(e, op))
+}
+
+#[repr(transparent)]
+pub struct RsaKeyPairInner(KeyHandle);
+
+#[repr(transparent)]
+pub struct RsaPublicKeyInner(KeyHandle);
+
+/// Left-pads `src` with leading zero bytes so the result is `len` bytes long.
+/// Panics if `src.len() > len`.
+fn left_pad(src: &[u8], len: usize) -> Vec<u8> {
+    assert!(src.len() <= len);
+    let mut out = vec![0u8; len];
+    out[len - src.len()..].copy_from_slice(src);
+    out
+}
+
+/// Bit length of a non-negative big-endian integer.
+fn bit_length(bytes: &[u8]) -> u32 {
+    for (i, &b) in bytes.iter().enumerate() {
+        if b != 0 {
+            return ((bytes.len() - i) as u32) * 8 - b.leading_zeros();
+        }
+    }
+    0
+}
+
+/// Build a BCRYPT_RSAFULLPRIVATE_BLOB from PKCS#1 RSA private key components.
+fn build_fullprivate_blob(key: &pkcs1::RsaPrivateKey<'_>) -> Vec<u8> {
+    let n = key.modulus.as_bytes();
+    let e = key.public_exponent.as_bytes();
+    let d = key.private_exponent.as_bytes();
+    let p = key.prime1.as_bytes();
+    let q = key.prime2.as_bytes();
+    let dp = key.exponent1.as_bytes();
+    let dq = key.exponent2.as_bytes();
+    let qinv = key.coefficient.as_bytes();
+
+    let cb_modulus = n.len().max(d.len());
+    let cb_prime1 = p.len().max(dp.len()).max(qinv.len());
+    let cb_prime2 = q.len().max(dq.len());
+    let cb_public_exp = e.len();
+
+    let header = BCRYPT_RSAKEY_BLOB {
+        Magic: BCRYPT_RSAFULLPRIVATE_MAGIC,
+        BitLength: bit_length(n),
+        cbPublicExp: cb_public_exp as u32,
+        cbModulus: cb_modulus as u32,
+        cbPrime1: cb_prime1 as u32,
+        cbPrime2: cb_prime2 as u32,
+    };
+
+    let total = size_of::<BCRYPT_RSAKEY_BLOB>()
+        + cb_public_exp
+        + cb_modulus
+        + cb_prime1 * 3
+        + cb_prime2 * 2
+        + cb_modulus;
+    let mut out = Vec::with_capacity(total);
+    out.extend_from_slice(header.as_bytes());
+    out.extend_from_slice(&left_pad(e, cb_public_exp));
+    out.extend_from_slice(&left_pad(n, cb_modulus));
+    out.extend_from_slice(&left_pad(p, cb_prime1));
+    out.extend_from_slice(&left_pad(q, cb_prime2));
+    out.extend_from_slice(&left_pad(dp, cb_prime1));
+    out.extend_from_slice(&left_pad(dq, cb_prime2));
+    out.extend_from_slice(&left_pad(qinv, cb_prime1));
+    out.extend_from_slice(&left_pad(d, cb_modulus));
+    out
+}
+
+/// SAFETY: zerocopy IntoBytes-compatible because BCRYPT_RSAKEY_BLOB is
+/// `#[repr(C)]` with all-integer fields. We can't derive `IntoBytes` on a
+/// foreign type, so write a small helper.
+trait HeaderBytes {
+    fn as_bytes(&self) -> &[u8];
+}
+impl HeaderBytes for BCRYPT_RSAKEY_BLOB {
+    fn as_bytes(&self) -> &[u8] {
+        // SAFETY: BCRYPT_RSAKEY_BLOB is #[repr(C)] and contains only POD u32
+        // fields, so any byte pattern is valid.
+        unsafe {
+            std::slice::from_raw_parts(
+                std::ptr::from_ref(self).cast::<u8>(),
+                size_of::<BCRYPT_RSAKEY_BLOB>(),
+            )
+        }
+    }
+}
+
+/// Parse a BCRYPT_RSAFULLPRIVATE_BLOB or BCRYPT_RSAPUBLIC_BLOB into its
+/// big-endian component byte ranges.
+struct PublicComponents<'a> {
+    modulus: &'a [u8],
+    public_exponent: &'a [u8],
+}
+
+fn parse_public_components(blob: &[u8]) -> PublicComponents<'_> {
+    assert!(blob.len() >= size_of::<BCRYPT_RSAKEY_BLOB>());
+    let header_ptr = blob.as_ptr().cast::<BCRYPT_RSAKEY_BLOB>();
+    // SAFETY: blob is at least header-sized; header is POD.
+    let header = unsafe { std::ptr::read_unaligned(header_ptr) };
+    let off = size_of::<BCRYPT_RSAKEY_BLOB>();
+    let cb_e = header.cbPublicExp as usize;
+    let cb_n = header.cbModulus as usize;
+    PublicComponents {
+        public_exponent: &blob[off..off + cb_e],
+        modulus: &blob[off + cb_e..off + cb_e + cb_n],
+    }
+}
+
+/// Export a BCrypt key as the given blob type.
+fn export_key(key: &KeyHandle, blob_type: windows::core::PCWSTR) -> Result<Vec<u8>, RsaError> {
+    let mut needed: u32 = 0;
+    // SAFETY: handle is valid; first call queries needed size.
+    unsafe {
+        windows::Win32::Security::Cryptography::BCryptExportKey(
+            key.0,
+            None,
+            blob_type,
+            None,
+            &mut needed,
+            0,
+        )
+    }
+    .ok()
+    .map_err(|e| err(e, "querying export size"))?;
+    let mut out = vec![0u8; needed as usize];
+    // SAFETY: out is sized per the previous query.
+    unsafe {
+        windows::Win32::Security::Cryptography::BCryptExportKey(
+            key.0,
+            None,
+            blob_type,
+            Some(&mut out),
+            &mut needed,
+            0,
+        )
+    }
+    .ok()
+    .map_err(|e| err(e, "exporting key"))?;
+    out.truncate(needed as usize);
+    Ok(out)
+}
+
+/// Import a key blob into a BCrypt key handle.
+fn import_key(blob: &[u8], blob_type: windows::core::PCWSTR) -> Result<KeyHandle, RsaError> {
+    let mut handle = BCRYPT_KEY_HANDLE::default();
+    // SAFETY: BCRYPT_RSA_ALG_HANDLE is a static pseudo-handle; blob is a
+    // valid byte slice.
+    unsafe {
+        windows::Win32::Security::Cryptography::BCryptImportKeyPair(
+            BCRYPT_RSA_ALG_HANDLE,
+            None,
+            blob_type,
+            &mut handle,
+            blob,
+            0,
+        )
+    }
+    .ok()
+    .map_err(|e| err(e, "importing key"))?;
+    Ok(KeyHandle(handle))
+}
+
+impl RsaKeyPairInner {
+    pub fn generate(bits: u32) -> Result<Self, RsaError> {
+        let mut handle = BCRYPT_KEY_HANDLE::default();
+        // SAFETY: BCRYPT_RSA_ALG_HANDLE is a static pseudo-handle valid for
+        // the lifetime of the process.
+        unsafe {
+            windows::Win32::Security::Cryptography::BCryptGenerateKeyPair(
+                BCRYPT_RSA_ALG_HANDLE,
+                &mut handle,
+                bits,
+                0,
+            )
+        }
+        .ok()
+        .map_err(|e| err(e, "generating RSA key"))?;
+        let key = KeyHandle(handle);
+        // SAFETY: handle is valid.
+        unsafe { windows::Win32::Security::Cryptography::BCryptFinalizeKeyPair(key.0, 0) }
+            .ok()
+            .map_err(|e| err(e, "finalizing RSA key"))?;
+        Ok(Self(key))
+    }
+
+    pub fn from_pkcs8_der(der_bytes: &[u8]) -> Result<Self, RsaError> {
+        let pki = pkcs8::PrivateKeyInfoRef::from_der(der_bytes)
+            .map_err(|e| der_err(e, "parsing PKCS#8 DER"))?;
+        if pki.algorithm.oid != pkcs1::ALGORITHM_OID {
+            return Err(pkcs8_err(
+                pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid),
+                "PKCS#8 algorithm is not rsaEncryption",
+            ));
+        }
+        let key = pkcs1::RsaPrivateKey::from_der(pki.private_key.as_bytes())
+            .map_err(|e| der_err(e, "parsing PKCS#1 RSA private key"))?;
+        if key.other_prime_infos.is_some() {
+            return Err(pkcs8_err(
+                pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid),
+                "multiprime RSA keys not supported",
+            ));
+        }
+        let blob = build_fullprivate_blob(&key);
+        let handle = import_key(&blob, BCRYPT_RSAFULLPRIVATE_BLOB)?;
+        Ok(Self(handle))
+    }
+
+    #[cfg(any(test, feature = "test_helpers"))]
+    pub fn to_pkcs8_der(&self) -> Result<Vec<u8>, RsaError> {
+        use der::asn1::OctetString;
+        use der::asn1::UintRef;
+        use pkcs8::spki::AlgorithmIdentifierOwned;
+
+        let blob = export_key(&self.0, BCRYPT_RSAFULLPRIVATE_BLOB)?;
+        let header_ptr = blob.as_ptr().cast::<BCRYPT_RSAKEY_BLOB>();
+        // SAFETY: blob is at least header-sized and header is POD.
+        let header = unsafe { std::ptr::read_unaligned(header_ptr) };
+        let mut off = size_of::<BCRYPT_RSAKEY_BLOB>();
+        let cb_e = header.cbPublicExp as usize;
+        let cb_n = header.cbModulus as usize;
+        let cb_p = header.cbPrime1 as usize;
+        let cb_q = header.cbPrime2 as usize;
+        let take = |off: &mut usize, n: usize| {
+            let s = &blob[*off..*off + n];
+            *off += n;
+            s
+        };
+        let e_bytes = take(&mut off, cb_e);
+        let n_bytes = take(&mut off, cb_n);
+        let p_bytes = take(&mut off, cb_p);
+        let q_bytes = take(&mut off, cb_q);
+        let dp_bytes = take(&mut off, cb_p);
+        let dq_bytes = take(&mut off, cb_q);
+        let qinv_bytes = take(&mut off, cb_p);
+        let d_bytes = take(&mut off, cb_n);
+
+        let pk = pkcs1::RsaPrivateKey {
+            modulus: UintRef::new(n_bytes).map_err(|e| der_err(e, "encoding modulus"))?,
+            public_exponent: UintRef::new(e_bytes).map_err(|e| der_err(e, "encoding e"))?,
+            private_exponent: UintRef::new(d_bytes).map_err(|e| der_err(e, "encoding d"))?,
+            prime1: UintRef::new(p_bytes).map_err(|e| der_err(e, "encoding p"))?,
+            prime2: UintRef::new(q_bytes).map_err(|e| der_err(e, "encoding q"))?,
+            exponent1: UintRef::new(dp_bytes).map_err(|e| der_err(e, "encoding dp"))?,
+            exponent2: UintRef::new(dq_bytes).map_err(|e| der_err(e, "encoding dq"))?,
+            coefficient: UintRef::new(qinv_bytes).map_err(|e| der_err(e, "encoding qinv"))?,
+            other_prime_infos: None,
+        };
+        let pkcs1_der = pk
+            .to_der()
+            .map_err(|e| der_err(e, "encoding PKCS#1 RSA private key"))?;
+
+        let pki = pkcs8::PrivateKeyInfoOwned {
+            algorithm: AlgorithmIdentifierOwned {
+                oid: pkcs1::ALGORITHM_OID,
+                parameters: Some(der::Any::null()),
+            },
+            private_key: OctetString::new(pkcs1_der)
+                .map_err(|e| der_err(e, "wrapping PKCS#1 in OCTET STRING"))?,
+            public_key: None,
+        };
+        pki.to_der()
+            .map_err(|e| der_err(e, "encoding PKCS#8 PrivateKeyInfo"))
+    }
+
+    pub fn oaep_decrypt(
+        &self,
+        input: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<Vec<u8>, RsaError> {
+        let alg_id = hash_algorithm.bcrypt_alg_id();
+        let pad = BCRYPT_OAEP_PADDING_INFO {
+            pszAlgId: alg_id,
+            pbLabel: std::ptr::null_mut(),
+            cbLabel: 0,
+        };
+        let pad_ptr: *const c_void = std::ptr::from_ref(&pad).cast();
+        let mut needed: u32 = 0;
+        // SAFETY: handle is valid; first call queries needed size.
+        unsafe {
+            windows::Win32::Security::Cryptography::BCryptDecrypt(
+                self.0.0,
+                Some(input),
+                Some(pad_ptr),
+                None,
+                None,
+                &mut needed,
+                BCRYPT_PAD_OAEP,
+            )
+        }
+        .ok()
+        .map_err(|e| err(e, "querying OAEP decrypt size"))?;
+        let mut out = vec![0u8; needed as usize];
+        // SAFETY: output buffer is sized to needed.
+        unsafe {
+            windows::Win32::Security::Cryptography::BCryptDecrypt(
+                self.0.0,
+                Some(input),
+                Some(pad_ptr),
+                None,
+                Some(&mut out),
+                &mut needed,
+                BCRYPT_PAD_OAEP,
+            )
+        }
+        .ok()
+        .map_err(|e| err(e, "RSA-OAEP decrypt"))?;
+        out.truncate(needed as usize);
+        Ok(out)
+    }
+
+    pub fn pkcs1_sign(
+        &self,
+        data: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<Vec<u8>, RsaError> {
+        let digest = hash_algorithm.hash(data);
+        let pad = BCRYPT_PKCS1_PADDING_INFO {
+            pszAlgId: hash_algorithm.bcrypt_alg_id(),
+        };
+        sign_hash(
+            &self.0,
+            &digest,
+            std::ptr::from_ref(&pad).cast(),
+            BCRYPT_PAD_PKCS1,
+        )
+    }
+
+    pub fn pss_sign(
+        &self,
+        data: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<Vec<u8>, RsaError> {
+        let digest = hash_algorithm.hash(data);
+        let pad = BCRYPT_PSS_PADDING_INFO {
+            pszAlgId: hash_algorithm.bcrypt_alg_id(),
+            cbSalt: hash_algorithm.output_size() as u32,
+        };
+        sign_hash(
+            &self.0,
+            &digest,
+            std::ptr::from_ref(&pad).cast(),
+            BCRYPT_PAD_PSS,
+        )
+    }
+
+    pub(crate) fn as_pub(&self) -> &RsaPublicKeyInner {
+        // SAFETY: both are #[repr(transparent)] over KeyHandle; a private
+        // key handle is valid for any public-key operation.
+        unsafe { std::mem::transmute::<&RsaKeyPairInner, &RsaPublicKeyInner>(self) }
+    }
+}
+
+fn sign_hash(
+    key: &KeyHandle,
+    digest: &[u8],
+    pad_info: *const c_void,
+    flags: BCRYPT_FLAGS,
+) -> Result<Vec<u8>, RsaError> {
+    let mut needed: u32 = 0;
+    // SAFETY: handle and digest valid; first call queries needed size.
+    unsafe {
+        windows::Win32::Security::Cryptography::BCryptSignHash(
+            key.0,
+            Some(pad_info),
+            digest,
+            None,
+            &mut needed,
+            flags,
+        )
+    }
+    .ok()
+    .map_err(|e| err(e, "querying signature size"))?;
+    let mut sig = vec![0u8; needed as usize];
+    // SAFETY: sig is sized per query.
+    unsafe {
+        windows::Win32::Security::Cryptography::BCryptSignHash(
+            key.0,
+            Some(pad_info),
+            digest,
+            Some(&mut sig),
+            &mut needed,
+            flags,
+        )
+    }
+    .ok()
+    .map_err(|e| err(e, "signing hash"))?;
+    sig.truncate(needed as usize);
+    Ok(sig)
+}
+
+fn verify_hash(
+    key: &KeyHandle,
+    digest: &[u8],
+    signature: &[u8],
+    pad_info: *const c_void,
+    flags: BCRYPT_FLAGS,
+) -> Result<bool, RsaError> {
+    // SAFETY: all pointers/handles are valid for the call.
+    let status = unsafe {
+        windows::Win32::Security::Cryptography::BCryptVerifySignature(
+            key.0,
+            Some(pad_info),
+            digest,
+            signature,
+            flags,
+        )
+    };
+    if status == STATUS_INVALID_SIGNATURE || status == STATUS_INVALID_PARAMETER {
+        // STATUS_INVALID_PARAMETER is what BCrypt returns when the
+        // signature bytes don't decode to a valid encoded message (e.g.
+        // wrong length, or as an integer >= modulus). Treat that as
+        // "bad signature" rather than an infrastructure error, matching
+        // the symcrypt backend.
+        return Ok(false);
+    }
+    status.ok().map_err(|e| err(e, "verifying signature"))?;
+    Ok(true)
+}
+
+impl RsaPublicKeyInner {
+    pub fn from_components(n: &[u8], e: &[u8]) -> Result<Self, RsaError> {
+        let cb_n = n.len();
+        let cb_e = e.len();
+        let header = BCRYPT_RSAKEY_BLOB {
+            Magic: BCRYPT_RSAPUBLIC_MAGIC,
+            BitLength: bit_length(n),
+            cbPublicExp: cb_e as u32,
+            cbModulus: cb_n as u32,
+            cbPrime1: 0,
+            cbPrime2: 0,
+        };
+        let mut blob = Vec::with_capacity(size_of::<BCRYPT_RSAKEY_BLOB>() + cb_e + cb_n);
+        blob.extend_from_slice(header.as_bytes());
+        blob.extend_from_slice(e);
+        blob.extend_from_slice(n);
+        let handle = import_key(&blob, BCRYPT_RSAPUBLIC_BLOB)?;
+        Ok(Self(handle))
+    }
+
+    pub fn oaep_encrypt(
+        &self,
+        input: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<Vec<u8>, RsaError> {
+        let alg_id = hash_algorithm.bcrypt_alg_id();
+        let pad = BCRYPT_OAEP_PADDING_INFO {
+            pszAlgId: alg_id,
+            pbLabel: std::ptr::null_mut(),
+            cbLabel: 0,
+        };
+        let pad_ptr: *const c_void = std::ptr::from_ref(&pad).cast();
+        let mut needed: u32 = 0;
+        // SAFETY: handle valid; first call queries needed size.
+        unsafe {
+            windows::Win32::Security::Cryptography::BCryptEncrypt(
+                self.0.0,
+                Some(input),
+                Some(pad_ptr),
+                None,
+                None,
+                &mut needed,
+                BCRYPT_PAD_OAEP,
+            )
+        }
+        .ok()
+        .map_err(|e| err(e, "querying OAEP encrypt size"))?;
+        let mut out = vec![0u8; needed as usize];
+        // SAFETY: output sized to needed.
+        unsafe {
+            windows::Win32::Security::Cryptography::BCryptEncrypt(
+                self.0.0,
+                Some(input),
+                Some(pad_ptr),
+                None,
+                Some(&mut out),
+                &mut needed,
+                BCRYPT_PAD_OAEP,
+            )
+        }
+        .ok()
+        .map_err(|e| err(e, "RSA-OAEP encrypt"))?;
+        out.truncate(needed as usize);
+        Ok(out)
+    }
+
+    pub fn pkcs1_verify(
+        &self,
+        message: &[u8],
+        signature: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<bool, RsaError> {
+        let digest = hash_algorithm.hash(message);
+        let pad = BCRYPT_PKCS1_PADDING_INFO {
+            pszAlgId: hash_algorithm.bcrypt_alg_id(),
+        };
+        verify_hash(
+            &self.0,
+            &digest,
+            signature,
+            std::ptr::from_ref(&pad).cast(),
+            BCRYPT_PAD_PKCS1,
+        )
+    }
+
+    pub fn pss_verify(
+        &self,
+        message: &[u8],
+        signature: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<bool, RsaError> {
+        let digest = hash_algorithm.hash(message);
+        let pad = BCRYPT_PSS_PADDING_INFO {
+            pszAlgId: hash_algorithm.bcrypt_alg_id(),
+            cbSalt: hash_algorithm.output_size() as u32,
+        };
+        verify_hash(
+            &self.0,
+            &digest,
+            signature,
+            std::ptr::from_ref(&pad).cast(),
+            BCRYPT_PAD_PSS,
+        )
+    }
+
+    pub fn modulus_size(&self) -> usize {
+        self.modulus().len()
+    }
+
+    pub fn modulus(&self) -> Vec<u8> {
+        let blob = export_key(&self.0, BCRYPT_RSAPUBLIC_BLOB).unwrap();
+        parse_public_components(&blob).modulus.to_vec()
+    }
+
+    pub fn public_exponent(&self) -> Vec<u8> {
+        let blob = export_key(&self.0, BCRYPT_RSAPUBLIC_BLOB).unwrap();
+        parse_public_components(&blob).public_exponent.to_vec()
+    }
+}

--- a/support/crypto/src/xts_aes_256/win.rs
+++ b/support/crypto/src/xts_aes_256/win.rs
@@ -28,7 +28,7 @@ static XTS_AES_256: LazyLock<Result<AlgHandle, XtsAes256Error>> = LazyLock::new(
 });
 
 fn err(err: windows_result::Error, op: &'static str) -> XtsAes256Error {
-    XtsAes256Error(crate::BackendError(err, op))
+    XtsAes256Error(crate::BackendError::Bcrypt(err, op))
 }
 
 pub struct XtsAes256Inner {


### PR DESCRIPTION
Also includes some small tweaks and cleanups to other windows and mac backends. These will be used to support the upcoming generic PKCS#7 validation, which will be completely replacing their current implementations.