### PR TITLE
openvmm_core: pre-assign PCI resources for UEFI boot

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -3130,11 +3130,17 @@ impl LoadedVm {
         true
     }
 
-    /// Assign PCI bus numbers and BAR addresses for Linux direct boot.
+    /// Assign PCI bus numbers and BAR addresses for all boot modes.
     ///
-    /// UEFI and PCAT firmware perform their own PCI enumeration, so this
-    /// is only needed when booting without firmware. This is called after
-    /// `load_firmware` on both initial boot and reset.
+    /// This pre-programs PCI config space (bus numbers, bridge windows,
+    /// BAR addresses) before the guest starts. For UEFI, the firmware
+    /// is told via a config flag to skip its own PCI enumeration and
+    /// use the pre-assigned resources. For Linux direct boot, this is
+    /// required since there is no firmware to do PCI enumeration.
+    ///
+    /// This must only be called on clean boot or reset, not on
+    /// snapshot restore (where config space is already populated from
+    /// saved state).
     ///
     /// Config space accesses go through device state units (via the ECAM
     /// MMIO path), so devices must be running. This method temporarily
@@ -3142,9 +3148,7 @@ impl LoadedVm {
     /// then stops state units again. The caller is responsible for
     /// resuming normally afterward.
     async fn assign_pci_resources(&mut self) -> anyhow::Result<()> {
-        if !matches!(self.inner.load_mode, LoadMode::Linux { .. })
-            || self.inner.pcie_host_bridges.is_empty()
-        {
+        if self.inner.pcie_host_bridges.is_empty() {
             return Ok(());
         }
 

--- a/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
@@ -139,7 +139,8 @@ pub fn load_uefi(params: &LoadUefiParams<'_>) -> Result<Vec<Register>, Error> {
             },
         )
         .with_default_boot_always_attempt(settings.default_boot_always_attempt)
-        .with_vmbus_disabled(!settings.vmbus);
+        .with_vmbus_disabled(!settings.vmbus)
+        .with_pci_resources_pre_assigned(true);
 
     let mut cfg = config::Blob::new();
     cfg.add(&config::BiosInformation {

--- a/vm/loader/src/uefi/config.rs
+++ b/vm/loader/src/uefi/config.rs
@@ -325,8 +325,9 @@ pub struct Flags {
     pub mtrrs_initialized_at_load: bool,
     pub hv_sint_enabled: bool,
     pub vmbus_disabled: bool,
+    pub pci_resources_pre_assigned: bool,
 
-    #[bits(33)]
+    #[bits(32)]
     _reserved: u64,
 }
 


### PR DESCRIPTION
Currently, PCI bus numbers and BAR addresses are only pre-programmed into config space for Linux direct boot, since UEFI firmware performs its own PCI enumeration. This changes the behavior to pre-assign PCI resources for all boot modes.

For UEFI, a new `pci_resources_pre_assigned` config flag tells the firmware to skip its own PCI enumeration and use the pre-assigned resources instead. The `assign_pci_resources` method now runs unconditionally whenever PCIe host bridges are present, rather than only for Linux direct boot.