### PR TITLE
Repo: Fix lints from Rust 1.96

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
@@ -126,8 +126,7 @@ impl SimpleFlowNode for Node {
                     if let Some(dbg) = built_openvmm_hcl.dbg {
                         fs_err::copy(dbg, path.join("openvmm_hcl.dbg"))?;
                     }
-                    Ok(path
-                        .absolute()?
+                    Ok(std::path::absolute(path)?
                         .into_os_string()
                         .into_string()
                         .ok()

--- a/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
+++ b/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
@@ -197,7 +197,7 @@ impl SimpleFlowNode for Node {
                     if windows_via_wsl2 {
                         Ok(flowey_lib_common::_util::wslpath::linux_to_win(rt, path))
                     } else {
-                        path.absolute()
+                        std::path::absolute(path)
                             .with_context(|| format!("invalid path {}", path.display()))
                     }
                 };

--- a/vm/devices/net/net_consomme/consomme/src/dns_resolver/dns_tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/dns_resolver/dns_tcp.rs
@@ -339,11 +339,6 @@ mod tests {
         ]
     }
 
-    struct NoopWaker;
-    impl std::task::Wake for NoopWaker {
-        fn wake(self: Arc<Self>) {}
-    }
-
     #[test]
     fn single_query_response() {
         let mut dns = DnsResolver::new_for_test(Arc::new(EchoBackend));
@@ -355,8 +350,7 @@ mod tests {
         let consumed = handler.ingest(&[&msg], &mut dns).unwrap();
         assert_eq!(consumed, msg.len());
 
-        let waker = std::task::Waker::from(Arc::new(NoopWaker));
-        let mut cx = Context::from_waker(&waker);
+        let mut cx = Context::from_waker(std::task::Waker::noop());
 
         let mut buf = vec![0u8; 256];
         match handler.poll_read(&mut cx, &mut [IoSliceMut::new(&mut buf)], &mut dns) {
@@ -385,8 +379,7 @@ mod tests {
         let consumed = handler.ingest(&[&msg[..2]], &mut dns).unwrap();
         assert_eq!(consumed, 2);
 
-        let waker = std::task::Waker::from(Arc::new(NoopWaker));
-        let mut cx = Context::from_waker(&waker);
+        let mut cx = Context::from_waker(std::task::Waker::noop());
         let mut buf = vec![0u8; 256];
         assert!(matches!(
             handler.poll_read(&mut cx, &mut [IoSliceMut::new(&mut buf)], &mut dns),
@@ -421,8 +414,7 @@ mod tests {
         let consumed = handler.ingest(&[&combined], &mut dns).unwrap();
         assert_eq!(consumed, make_tcp_dns_message(&q1).len());
 
-        let waker = std::task::Waker::from(Arc::new(NoopWaker));
-        let mut cx = Context::from_waker(&waker);
+        let mut cx = Context::from_waker(std::task::Waker::noop());
 
         // Drain the first response.
         let mut buf = vec![0u8; 256];
@@ -454,8 +446,7 @@ mod tests {
             .ingest(&[&make_tcp_dns_message(&query)], &mut dns)
             .unwrap();
 
-        let waker = std::task::Waker::from(Arc::new(NoopWaker));
-        let mut cx = Context::from_waker(&waker);
+        let mut cx = Context::from_waker(std::task::Waker::noop());
 
         // Drain the response.
         let mut buf = vec![0u8; 256];


### PR DESCRIPTION
We won't be updating to 1.96 for some time, but we can at least fix these up.