### PR TITLE
consomme: make per-connection TCP buffer sizes configurable

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -33,6 +33,9 @@ mod windows;
 /// Standard DNS port number.
 const DNS_PORT: u16 = 53;
 
+/// Default per-connection TCP ring buffer size in bytes.
+const DEFAULT_TCP_BUFFER_SIZE: usize = 256 * 1024;
+
 use inspect::Inspect;
 use inspect::InspectMut;
 use pal_async::driver::Driver;
@@ -144,6 +147,14 @@ pub struct ConsommeParams {
     /// routable IPv6 address.
     #[inspect(display)]
     pub skip_ipv6_checks: bool,
+    /// Per-connection TCP receive ring buffer size (guest-to-host). Clamped
+    /// and rounded to a power of two in [16 KiB, 4 MiB]. Takes effect for
+    /// new connections only.
+    pub tcp_rx_buffer_size: usize,
+    /// Per-connection TCP transmit ring buffer size (host-to-guest). Clamped
+    /// and rounded to a power of two in [16 KiB, 4 MiB]. Takes effect for
+    /// new connections only.
+    pub tcp_tx_buffer_size: usize,
 }
 
 /// An error indicating that the CIDR is invalid.
@@ -177,6 +188,8 @@ impl ConsommeParams {
             // Per RFC 4787, UDP NAT bindings, by default, should timeout after 5 minutes, but can be configured.
             udp_timeout: Duration::from_secs(300),
             skip_ipv6_checks: false,
+            tcp_rx_buffer_size: DEFAULT_TCP_BUFFER_SIZE,
+            tcp_tx_buffer_size: DEFAULT_TCP_BUFFER_SIZE,
         })
     }
 
@@ -669,13 +682,15 @@ impl Consomme {
                 }
             };
         let timeout = params.udp_timeout;
+        let tcp_rx_buffer_size = params.tcp_rx_buffer_size;
+        let tcp_tx_buffer_size = params.tcp_tx_buffer_size;
         Self {
             state: ConsommeState {
                 params,
                 buffer: Box::new([0; 65536]),
                 local_addr_map: local_addr_map::LocalAddrMap::new(),
             },
-            tcp: tcp::Tcp::new(),
+            tcp: tcp::Tcp::new(tcp_rx_buffer_size, tcp_tx_buffer_size),
             udp: udp::Udp::new(timeout),
             icmp: icmp::Icmp::new(),
             dns,

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -148,12 +148,14 @@ pub struct ConsommeParams {
     #[inspect(display)]
     pub skip_ipv6_checks: bool,
     /// Per-connection TCP receive ring buffer size (guest-to-host). Clamped
-    /// and rounded to a power of two in [16 KiB, 4 MiB]. Takes effect for
-    /// new connections only.
+    /// and rounded to a power of two in [16 KiB, 4 MiB]. Read only when the
+    /// connection's `Consomme` is constructed via [`Consomme::new`]; runtime
+    /// updates through [`Consomme::params_mut`] are ignored.
     pub tcp_rx_buffer_size: usize,
     /// Per-connection TCP transmit ring buffer size (host-to-guest). Clamped
-    /// and rounded to a power of two in [16 KiB, 4 MiB]. Takes effect for
-    /// new connections only.
+    /// and rounded to a power of two in [16 KiB, 4 MiB]. Read only when the
+    /// connection's `Consomme` is constructed via [`Consomme::new`]; runtime
+    /// updates through [`Consomme::params_mut`] are ignored.
     pub tcp_tx_buffer_size: usize,
 }
 

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -117,13 +117,13 @@ pub enum TcpError {
 }
 
 impl Tcp {
-    pub fn new() -> Self {
+    pub fn new(rx_buffer_size: usize, tx_buffer_size: usize) -> Self {
         Self {
             connections: HashMap::new(),
             listeners: HashMap::new(),
             connection_params: ConnectionParams {
-                rx_buffer_size: 256 * 1024,
-                tx_buffer_size: 256 * 1024,
+                rx_buffer_size,
+                tx_buffer_size,
             },
             aggregate_stats: TcpAggregateStats::default(),
         }


### PR DESCRIPTION
The hardcoded 256 KiB per-connection rx/tx ring buffers in consomme cap TCP throughput at roughly 2 Gbps on paths whose bandwidth-delay product exceeds the buffer size.

Expose `tcp_rx_buffer_size` and `tcp_tx_buffer_size` on `ConsommeParams` so embedders can pick a value appropriate for their workload. The default remains 256 KiB, preserving existing behavior.

### Testing

- `cargo build --release`
- `cargo clippy --release -p consomme -p net_consomme --all-targets`
- `cargo nextest run -p consomme` (55/55 pass)
- `cargo doc --no-deps -p consomme -p net_consomme`
- `cargo xtask fmt --fix`

Empirically, raising the per-connection buffers to 1 MiB took `iperf3` throughput across consomme from ~514 Mbps to roughly 3-4 Gbps in the host-to-guest direction. A follow-up will add autotuning so the default can grow without a fixed per-connection memory cost.