### PR TITLE
pal_async: add async process wait primitives

### DIFF
--- a/support/mesh/mesh_process/src/lib.rs
+++ b/support/mesh/mesh_process/src/lib.rs
@@ -59,7 +59,6 @@ use std::os::windows::prelude::*;
 use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::thread;
 use tracing::Instrument;
 use tracing::instrument;
 use unicycle::FuturesUnordered;
@@ -388,7 +387,7 @@ struct MeshInner {
     requests: mesh::Receiver<MeshRequest>,
     hosts: Slab<MeshHostInner>,
     /// Handles for spawned host processes.
-    waiters: FuturesUnordered<OneshotReceiver<usize>>,
+    waiters: FuturesUnordered<Task<usize>>,
     /// Mesh node for host process communication.
     node: IpcNode,
     /// IO driver for the mesh node, used for listener accept loops,
@@ -675,7 +674,7 @@ impl MeshInner {
         loop {
             let event = futures::select! { // merge semantics
                 request = self.requests.select_next_some() => Event::Request(request),
-                n = self.waiters.select_next_some() => Event::Done(n.unwrap()),
+                n = self.waiters.select_next_some() => Event::Done(n),
                 complete => break,
             };
 
@@ -841,7 +840,7 @@ impl MeshInner {
         let name = config.name.clone();
 
         #[cfg(windows)]
-        let wait = {
+        let child = {
             let (invitation, handle) = self.node.invite(recv).context("mesh node invite error")?;
             node_id = invitation.node_id();
             let (credentials, directory) = invitation.into_parts();
@@ -885,24 +884,18 @@ impl MeshInner {
 
             // Launch the child process on a separate thread to isolate
             // the CreateProcess call from other IO pools.
-            let child = thread::scope(|s| s.spawn(|| builder.spawn()).join().unwrap())
+            let child = std::thread::scope(|s| s.spawn(|| builder.spawn()).join().unwrap())
                 .context("failed to launch mesh process")?;
             // Wait for the child to connect to the mesh. TODO: timeout
             handle.await;
             pid = child.id() as i32;
             tracing::Span::current().record("pid", pid);
-            move || {
-                child.wait();
-                let code = child.exit_code();
-                if code == 0 {
-                    tracing::info!(pid, name = name.as_str(), "mesh child exited successfully");
-                } else {
-                    tracing::error!(pid, name = name.as_str(), code, "mesh child abnormal exit");
-                }
-            }
+
+            pal_async::windows::PolledProcess::new(&self.node_driver, child)
+                .context("failed to create process wait")?
         };
         #[cfg(unix)]
-        let mut wait = {
+        let child = {
             use pal::unix::process;
 
             let invitation = self
@@ -946,26 +939,14 @@ impl MeshInner {
 
             // Launch the child process on a separate thread to isolate
             // the fork() call from other IO pools.
-            let mut child = thread::scope(|s| s.spawn(|| command.spawn()).join().unwrap())
+            let child = std::thread::scope(|s| s.spawn(|| command.spawn()).join().unwrap())
                 .context("failed to launch mesh process")?;
             pid = child.id();
             tracing::Span::current().record("pid", pid);
-            move || {
-                let exit_status = child.wait().expect("mesh child wait failure");
-                if let Some(0) = exit_status.code() {
-                    tracing::info!(pid, name = name.as_str(), "mesh child exited successfully");
-                } else {
-                    tracing::error!(
-                        pid,
-                        name = name.as_str(),
-                        %exit_status,
-                        "mesh child abnormal exit"
-                    );
-                }
-            }
-        };
 
-        let (wait_send, wait_recv) = mesh::oneshot();
+            pal_async::process::PolledChild::<process::Child>::new(&self.node_driver, child)
+                .context("failed to create process wait")?
+        };
 
         let id = self.hosts.insert(MeshHostInner {
             name: config.name,
@@ -974,16 +955,59 @@ impl MeshInner {
             send: request_send,
         });
 
-        thread::Builder::new()
-            .name(format!("wait-mesh-child-{}", pid))
-            .spawn(move || {
-                wait();
-                wait_send.send(id);
-            })
-            .unwrap();
+        let task = self
+            .node_driver
+            .spawn(format!("wait-mesh-child-{}", pid), async move {
+                wait_mesh_child(child, &name, pid).await;
+                id
+            });
 
-        self.waiters.push(wait_recv);
+        self.waiters.push(task);
         Ok(pid)
+    }
+}
+
+#[cfg(windows)]
+async fn wait_mesh_child(mut child: pal_async::windows::PolledProcess, name: &str, pid: i32) {
+    match child.wait().await {
+        Ok(0) => {
+            tracing::info!(pid, name, "mesh child exited successfully");
+        }
+        Ok(code) => {
+            tracing::error!(pid, name, code, "mesh child abnormal exit");
+        }
+        Err(e) => {
+            tracing::error!(
+                pid,
+                name,
+                error = &e as &dyn std::error::Error,
+                "mesh child wait failed"
+            );
+        }
+    }
+}
+
+#[cfg(unix)]
+async fn wait_mesh_child(
+    mut child: pal_async::process::PolledChild<pal::unix::process::Child>,
+    name: &str,
+    pid: i32,
+) {
+    match child.wait().await {
+        Ok(status) if status.code() == Some(0) => {
+            tracing::info!(pid, name, "mesh child exited successfully");
+        }
+        Ok(exit_status) => {
+            tracing::error!(pid, name, %exit_status, "mesh child abnormal exit");
+        }
+        Err(e) => {
+            tracing::error!(
+                pid,
+                name,
+                error = &e as &dyn std::error::Error,
+                "mesh child wait failed"
+            );
+        }
     }
 }
 

--- a/support/mesh/mesh_process/src/lib.rs
+++ b/support/mesh/mesh_process/src/lib.rs
@@ -892,7 +892,7 @@ impl MeshInner {
             tracing::Span::current().record("pid", pid);
 
             pal_async::windows::PolledProcess::new(&self.node_driver, child)
-                .context("failed to create process wait")?
+                .expect("failed to create process wait")
         };
         #[cfg(unix)]
         let child = {
@@ -945,7 +945,7 @@ impl MeshInner {
             tracing::Span::current().record("pid", pid);
 
             pal_async::process::PolledChild::<process::Child>::new(&self.node_driver, child)
-                .context("failed to create process wait")?
+                .expect("failed to create process wait")
         };
 
         let id = self.hosts.insert(MeshHostInner {

--- a/support/pal/pal_async/src/driver.rs
+++ b/support/pal/pal_async/src/driver.rs
@@ -12,6 +12,10 @@ use crate::fd::FdReadyDriver;
 use crate::fd::PollFdReady;
 #[cfg(target_os = "linux")]
 use crate::io_uring::IoUringDriver;
+#[cfg(target_os = "macos")]
+use crate::process::macos::PollProcessWait;
+#[cfg(target_os = "macos")]
+use crate::process::macos::ProcessWaitDriver;
 use crate::socket::PollSocketReady;
 use crate::socket::SocketReadyDriver;
 #[cfg(windows)]
@@ -63,6 +67,10 @@ pub trait Driver: 'static + Send + Sync {
     /// [`MAXIMUM_WAIT_READ_SIZE`](super::wait::MAXIMUM_WAIT_READ_SIZE) bytes.
     #[cfg(unix)]
     fn new_dyn_wait(&self, fd: RawFd, read_size: usize) -> io::Result<PollImpl<dyn PollWait>>;
+
+    /// Creates a new process wait from a process ID.
+    #[cfg(target_os = "macos")]
+    fn new_dyn_process_wait(&self, pid: i32) -> io::Result<PollImpl<dyn PollProcessWait>>;
 
     /// Creates a new overlapped file handler.
     ///
@@ -130,10 +138,17 @@ pub trait Driver: 'static + Send + Sync {
     ) -> std::pin::Pin<Box<dyn Future<Output = io::Result<i32>> + Send + '_>>;
 }
 
-#[cfg(all(unix, not(target_os = "linux")))]
+#[cfg(target_os = "macos")]
 impl<T> Driver for T
 where
-    T: 'static + Send + Sync + FdReadyDriver + TimerDriver + SocketReadyDriver + WaitDriver,
+    T: 'static
+        + Send
+        + Sync
+        + FdReadyDriver
+        + TimerDriver
+        + SocketReadyDriver
+        + WaitDriver
+        + ProcessWaitDriver,
 {
     fn new_dyn_timer(&self) -> PollImpl<dyn PollTimer> {
         smallbox::smallbox!(self.new_timer())
@@ -149,6 +164,10 @@ where
 
     fn new_dyn_wait(&self, fd: RawFd, read_size: usize) -> io::Result<PollImpl<dyn PollWait>> {
         Ok(smallbox::smallbox!(self.new_wait(fd, read_size)?))
+    }
+
+    fn new_dyn_process_wait(&self, pid: i32) -> io::Result<PollImpl<dyn PollProcessWait>> {
+        Ok(smallbox::smallbox!(self.new_process_wait_pid(pid)?))
     }
 }
 
@@ -251,6 +270,11 @@ impl Driver for Box<dyn Driver> {
         self.as_ref().new_dyn_wait(fd, read_size)
     }
 
+    #[cfg(target_os = "macos")]
+    fn new_dyn_process_wait(&self, pid: i32) -> io::Result<PollImpl<dyn PollProcessWait>> {
+        self.as_ref().new_dyn_process_wait(pid)
+    }
+
     #[cfg(target_os = "linux")]
     fn io_uring_probe(&self, opcode: u8) -> bool {
         self.as_ref().io_uring_probe(opcode)
@@ -305,6 +329,11 @@ impl Driver for Arc<dyn Driver> {
 
     fn new_dyn_wait(&self, fd: RawFd, read_size: usize) -> io::Result<PollImpl<dyn PollWait>> {
         self.as_ref().new_dyn_wait(fd, read_size)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn new_dyn_process_wait(&self, pid: i32) -> io::Result<PollImpl<dyn PollProcessWait>> {
+        self.as_ref().new_dyn_process_wait(pid)
     }
 
     #[cfg(target_os = "linux")]

--- a/support/pal/pal_async/src/executor_tests.rs
+++ b/support/pal/pal_async/src/executor_tests.rs
@@ -201,7 +201,7 @@ pub async fn socket_tests(driver: impl Driver) {
 }
 
 /// Runs process wait tests.
-#[cfg(any(target_os = "linux", windows))]
+#[cfg(any(target_os = "linux", target_os = "macos", windows))]
 pub async fn process_tests(driver: impl crate::process::DynProcessWaitDriver) {
     use crate::process::PolledChild;
     type StdPolledChild = PolledChild<std::process::Child>;
@@ -209,7 +209,7 @@ pub async fn process_tests(driver: impl crate::process::DynProcessWaitDriver) {
     fn success_command() -> std::process::Command {
         #[cfg(unix)]
         {
-            std::process::Command::new("/bin/true")
+            std::process::Command::new("true")
         }
         #[cfg(windows)]
         {
@@ -222,7 +222,7 @@ pub async fn process_tests(driver: impl crate::process::DynProcessWaitDriver) {
     fn failure_command() -> std::process::Command {
         #[cfg(unix)]
         {
-            std::process::Command::new("/bin/false")
+            std::process::Command::new("false")
         }
         #[cfg(windows)]
         {
@@ -295,6 +295,28 @@ pub async fn process_tests(driver: impl crate::process::DynProcessWaitDriver) {
         let status2 = polled.get_mut().try_wait().unwrap();
         assert!(status2.is_some());
         assert!(status2.unwrap().success());
+    }
+
+    // already-exited child completes immediately
+    {
+        let mut child = success_command().spawn().unwrap();
+        child.wait().unwrap(); // reap synchronously first
+        let mut polled = StdPolledChild::new(&driver, child).unwrap();
+        let status = polled.wait().await.unwrap();
+        assert!(status.success());
+    }
+
+    // dropping a pending PolledChild does not reap or kill the child
+    {
+        let child = long_running_command().spawn().unwrap();
+        let polled = StdPolledChild::new(&driver, child).unwrap();
+        // Drop the PolledChild while the child is still running.
+        let mut child = polled.into_inner();
+        // The child should still be alive — try_wait should return None.
+        let status = child.try_wait().unwrap();
+        assert!(status.is_none(), "child was reaped or killed by drop");
+        child.kill().unwrap();
+        child.wait().unwrap();
     }
 }
 

--- a/support/pal/pal_async/src/executor_tests.rs
+++ b/support/pal/pal_async/src/executor_tests.rs
@@ -201,14 +201,57 @@ pub async fn socket_tests(driver: impl Driver) {
 }
 
 /// Runs process wait tests.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", windows))]
 pub async fn process_tests(driver: impl crate::process::DynProcessWaitDriver) {
     use crate::process::PolledChild;
     type StdPolledChild = PolledChild<std::process::Child>;
 
+    fn success_command() -> std::process::Command {
+        #[cfg(unix)]
+        {
+            std::process::Command::new("/bin/true")
+        }
+        #[cfg(windows)]
+        {
+            let mut cmd = std::process::Command::new("cmd.exe");
+            cmd.args(["/c", "exit", "0"]);
+            cmd
+        }
+    }
+
+    fn failure_command() -> std::process::Command {
+        #[cfg(unix)]
+        {
+            std::process::Command::new("/bin/false")
+        }
+        #[cfg(windows)]
+        {
+            let mut cmd = std::process::Command::new("cmd.exe");
+            cmd.args(["/c", "exit", "1"]);
+            cmd
+        }
+    }
+
+    fn long_running_command() -> std::process::Command {
+        #[cfg(unix)]
+        {
+            let mut cmd = std::process::Command::new("sleep");
+            cmd.arg("60");
+            cmd
+        }
+        #[cfg(windows)]
+        {
+            let mut cmd = std::process::Command::new("ping");
+            cmd.args(["-n", "60", "127.0.0.1"])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null());
+            cmd
+        }
+    }
+
     // std child exits successfully
     {
-        let child = std::process::Command::new("/bin/true").spawn().unwrap();
+        let child = success_command().spawn().unwrap();
         let mut polled = StdPolledChild::new(&driver, child).unwrap();
         let status = polled.wait().await.unwrap();
         assert!(status.success());
@@ -216,7 +259,7 @@ pub async fn process_tests(driver: impl crate::process::DynProcessWaitDriver) {
 
     // std child exits with nonzero status
     {
-        let child = std::process::Command::new("/bin/false").spawn().unwrap();
+        let child = failure_command().spawn().unwrap();
         let mut polled = StdPolledChild::new(&driver, child).unwrap();
         let status = polled.wait().await.unwrap();
         assert!(!status.success());
@@ -224,10 +267,7 @@ pub async fn process_tests(driver: impl crate::process::DynProcessWaitDriver) {
 
     // wait remains pending while child is still running
     {
-        let child = std::process::Command::new("sleep")
-            .arg("60")
-            .spawn()
-            .unwrap();
+        let child = long_running_command().spawn().unwrap();
         let mut polled = StdPolledChild::new(&driver, child).unwrap();
         let pending = poll_fn(|cx| Poll::Ready(polled.poll_wait(cx))).await;
         assert!(pending.is_pending());
@@ -238,10 +278,7 @@ pub async fn process_tests(driver: impl crate::process::DynProcessWaitDriver) {
 
     // into_inner returns a usable child
     {
-        let child = std::process::Command::new("sleep")
-            .arg("60")
-            .spawn()
-            .unwrap();
+        let child = long_running_command().spawn().unwrap();
         let polled = StdPolledChild::new(&driver, child).unwrap();
         let mut child = polled.into_inner();
         child.kill().unwrap();
@@ -251,7 +288,7 @@ pub async fn process_tests(driver: impl crate::process::DynProcessWaitDriver) {
 
     // after async wait, try_wait observes the cached status
     {
-        let child = std::process::Command::new("/bin/true").spawn().unwrap();
+        let child = success_command().spawn().unwrap();
         let mut polled = StdPolledChild::new(&driver, child).unwrap();
         let status = polled.wait().await.unwrap();
         assert!(status.success());

--- a/support/pal/pal_async/src/executor_tests.rs
+++ b/support/pal/pal_async/src/executor_tests.rs
@@ -202,7 +202,7 @@ pub async fn socket_tests(driver: impl Driver) {
 
 /// Runs process wait tests.
 #[cfg(any(target_os = "linux", target_os = "macos", windows))]
-pub async fn process_tests(driver: impl crate::process::DynProcessWaitDriver) {
+pub async fn process_tests(driver: impl Driver) {
     use crate::process::PolledChild;
     type StdPolledChild = PolledChild<std::process::Child>;
 

--- a/support/pal/pal_async/src/executor_tests.rs
+++ b/support/pal/pal_async/src/executor_tests.rs
@@ -206,6 +206,14 @@ pub async fn process_tests(driver: impl Driver) {
     use crate::process::PolledChild;
     type StdPolledChild = PolledChild<std::process::Child>;
 
+    #[cfg(windows)]
+    fn cmd() -> std::process::Command {
+        let mut cmd = std::process::Command::new("cmd.exe");
+        // Avoid complaints about running in a UNC path for WSL.
+        cmd.current_dir(std::env::var_os("WINDIR").unwrap());
+        cmd
+    }
+
     fn success_command() -> std::process::Command {
         #[cfg(unix)]
         {
@@ -213,7 +221,7 @@ pub async fn process_tests(driver: impl Driver) {
         }
         #[cfg(windows)]
         {
-            let mut cmd = std::process::Command::new("cmd.exe");
+            let mut cmd = cmd();
             cmd.args(["/c", "exit", "0"]);
             cmd
         }
@@ -226,7 +234,7 @@ pub async fn process_tests(driver: impl Driver) {
         }
         #[cfg(windows)]
         {
-            let mut cmd = std::process::Command::new("cmd.exe");
+            let mut cmd = cmd();
             cmd.args(["/c", "exit", "1"]);
             cmd
         }
@@ -241,10 +249,9 @@ pub async fn process_tests(driver: impl Driver) {
         }
         #[cfg(windows)]
         {
-            let mut cmd = std::process::Command::new("ping");
-            cmd.args(["-n", "60", "127.0.0.1"])
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null());
+            let mut cmd = cmd();
+            cmd.args(["/c", "pause"])
+                .stdout(std::process::Stdio::null());
             cmd
         }
     }
@@ -317,6 +324,89 @@ pub async fn process_tests(driver: impl Driver) {
         assert!(status.is_none(), "child was reaped or killed by drop");
         child.kill().unwrap();
         child.wait().unwrap();
+    }
+
+    // --- pal::unix::process::Child tests ---
+    #[cfg(unix)]
+    {
+        type PalChild = PolledChild<pal::unix::process::Child>;
+
+        fn pal_success_child() -> pal::unix::process::Child {
+            pal::unix::process::Builder::new("/usr/bin/true")
+                .spawn()
+                .unwrap()
+        }
+
+        fn pal_failure_child() -> pal::unix::process::Child {
+            pal::unix::process::Builder::new("/usr/bin/false")
+                .spawn()
+                .unwrap()
+        }
+
+        // pal child exits successfully
+        {
+            let child = pal_success_child();
+            let mut polled = PalChild::new(&driver, child).unwrap();
+            let status = polled.wait().await.unwrap();
+            assert!(status.success());
+        }
+
+        // pal child exits with failure
+        {
+            let child = pal_failure_child();
+            let mut polled = PalChild::new(&driver, child).unwrap();
+            let status = polled.wait().await.unwrap();
+            assert!(!status.success());
+        }
+
+        // after async wait, try_wait observes the cached status
+        {
+            let child = pal_success_child();
+            let mut polled = PalChild::new(&driver, child).unwrap();
+            let status = polled.wait().await.unwrap();
+            assert!(status.success());
+            let status2 = polled.get_mut().try_wait().unwrap();
+            assert!(status2.is_some());
+            assert!(status2.unwrap().success());
+        }
+    }
+
+    // --- pal::windows::Process tests (via PolledProcess) ---
+    #[cfg(windows)]
+    {
+        use crate::windows::PolledProcess;
+        use std::os::windows::io::OwnedHandle;
+
+        // PolledProcess exits successfully
+        {
+            let std_child = success_command().spawn().unwrap();
+            let handle = OwnedHandle::from(std_child);
+            let process = pal::windows::Process::from(handle);
+            let mut polled = PolledProcess::new(&driver, process).unwrap();
+            let exit_code = polled.wait().await.unwrap();
+            assert_eq!(exit_code, 0);
+        }
+
+        // PolledProcess exits with nonzero code
+        {
+            let std_child = failure_command().spawn().unwrap();
+            let handle = OwnedHandle::from(std_child);
+            let process = pal::windows::Process::from(handle);
+            let mut polled = PolledProcess::new(&driver, process).unwrap();
+            let exit_code = polled.wait().await.unwrap();
+            assert_ne!(exit_code, 0);
+        }
+
+        // PolledProcess kill + wait
+        {
+            let std_child = long_running_command().spawn().unwrap();
+            let handle = OwnedHandle::from(std_child);
+            let process = pal::windows::Process::from(handle);
+            let mut polled = PolledProcess::new(&driver, process).unwrap();
+            polled.get().kill(42).unwrap();
+            let exit_code = polled.wait().await.unwrap();
+            assert_eq!(exit_code, 42);
+        }
     }
 }
 

--- a/support/pal/pal_async/src/executor_tests.rs
+++ b/support/pal/pal_async/src/executor_tests.rs
@@ -200,6 +200,67 @@ pub async fn socket_tests(driver: impl Driver) {
     }
 }
 
+/// Runs process wait tests.
+#[cfg(target_os = "linux")]
+pub async fn process_tests(driver: impl crate::process::DynProcessWaitDriver) {
+    use crate::process::PolledChild;
+    type StdPolledChild = PolledChild<std::process::Child>;
+
+    // std child exits successfully
+    {
+        let child = std::process::Command::new("/bin/true").spawn().unwrap();
+        let mut polled = StdPolledChild::new(&driver, child).unwrap();
+        let status = polled.wait().await.unwrap();
+        assert!(status.success());
+    }
+
+    // std child exits with nonzero status
+    {
+        let child = std::process::Command::new("/bin/false").spawn().unwrap();
+        let mut polled = StdPolledChild::new(&driver, child).unwrap();
+        let status = polled.wait().await.unwrap();
+        assert!(!status.success());
+    }
+
+    // wait remains pending while child is still running
+    {
+        let child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .unwrap();
+        let mut polled = StdPolledChild::new(&driver, child).unwrap();
+        let pending = poll_fn(|cx| Poll::Ready(polled.poll_wait(cx))).await;
+        assert!(pending.is_pending());
+        polled.get_mut().kill().unwrap();
+        let status = polled.wait().await.unwrap();
+        assert!(!status.success());
+    }
+
+    // into_inner returns a usable child
+    {
+        let child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .unwrap();
+        let polled = StdPolledChild::new(&driver, child).unwrap();
+        let mut child = polled.into_inner();
+        child.kill().unwrap();
+        let status = child.wait().unwrap();
+        assert!(!status.success());
+    }
+
+    // after async wait, try_wait observes the cached status
+    {
+        let child = std::process::Command::new("/bin/true").spawn().unwrap();
+        let mut polled = StdPolledChild::new(&driver, child).unwrap();
+        let status = polled.wait().await.unwrap();
+        assert!(status.success());
+        let status2 = polled.get_mut().try_wait().unwrap();
+        assert!(status2.is_some());
+        assert!(status2.unwrap().success());
+    }
+}
+
 #[cfg(target_os = "linux")]
 pub mod io_uring_tests {
     //! io-uring submission tests.

--- a/support/pal/pal_async/src/lib.rs
+++ b/support/pal/pal_async/src/lib.rs
@@ -37,6 +37,7 @@ pub mod windows {
     pub use super::sys::iocp::IocpPool;
     pub use super::sys::overlapped;
     pub use super::sys::pipe;
+    pub use super::sys::process::PolledProcess;
     pub use super::sys::tp::TpPool;
 }
 

--- a/support/pal/pal_async/src/lib.rs
+++ b/support/pal/pal_async/src/lib.rs
@@ -13,6 +13,7 @@ pub mod interest;
 pub mod io_uring;
 pub mod local;
 pub mod pipe;
+pub mod process;
 pub mod socket;
 pub mod timer;
 pub mod wait;

--- a/support/pal/pal_async/src/lib.rs
+++ b/support/pal/pal_async/src/lib.rs
@@ -37,8 +37,8 @@ pub mod windows {
     pub use super::sys::iocp::IocpPool;
     pub use super::sys::overlapped;
     pub use super::sys::pipe;
-    pub use super::sys::process::PolledProcess;
     pub use super::sys::tp::TpPool;
+    pub use crate::process::PolledProcess;
 }
 
 /// Unix-specific async functionality.

--- a/support/pal/pal_async/src/process.rs
+++ b/support/pal/pal_async/src/process.rs
@@ -4,121 +4,40 @@
 //! Process wait functionality.
 //!
 //! Provides async primitives for waiting on child process exit without
-//! consuming the child object. The low-level [`ProcessWaitDriver`] and
-//! [`PollProcessWait`] traits define a platform-specific wait source, while
-//! the high-level [`PolledChild`] wrapper owns a child process and provides a
-//! futures-based `wait()` method.
-//!
-//! [`ProcessWaitDriver`] is an extension trait, not part of [`Driver`]. On
-//! Linux it is blanket-implemented for all `FdReadyDriver` types via pidfd
-//! polling. On Windows it is blanket-implemented for all `WaitDriver` types.
-//! Platform-specific driver implementations live in the `unix` and
-//! `windows` backend modules.
+//! consuming the child object. On Linux and Windows, [`PolledChild`]
+//! constructs the wait directly from existing [`Driver`]
+//! primitives (fd readiness and waitable handles). On macOS,
+//! `Driver::new_dyn_process_wait` dispatches to the kqueue `EVFILT_PROC`
+//! mechanism via the `ProcessWaitDriver` trait.
 
 use crate::driver::Driver;
-use crate::driver::PollImpl;
 use std::future::Future;
 use std::future::poll_fn;
 use std::io;
 #[cfg(target_os = "linux")]
 use std::os::fd::OwnedFd;
-#[cfg(windows)]
-use std::os::windows::prelude::*;
 use std::task::Context;
 use std::task::Poll;
 
-/// A trait for driving process exit waits.
-///
-/// This is an extension trait, not part of [`Driver`]. Not all executors
-/// support process waits on all platforms.
-pub trait ProcessWaitDriver: Unpin {
-    /// The process wait object.
-    type ProcessWait: 'static + PollProcessWait;
-
-    /// Creates a new process wait from a waitable process handle.
-    #[cfg(windows)]
-    fn new_process_wait_handle(&self, handle: RawHandle) -> io::Result<Self::ProcessWait>;
-
-    /// Creates a new process wait from a pidfd.
-    #[cfg(target_os = "linux")]
-    fn new_process_wait_pidfd(&self, pidfd: RawFd) -> io::Result<Self::ProcessWait>;
-
-    /// Creates a new process wait from a process ID.
-    #[cfg(target_os = "macos")]
-    fn new_process_wait_pid(&self, pid: libc::pid_t) -> io::Result<Self::ProcessWait>;
+/// macOS-specific process wait types.
+#[cfg(target_os = "macos")]
+pub mod macos {
+    pub use crate::sys::process::macos::NoProcessWait;
+    pub use crate::sys::process::macos::PollProcessWait;
+    pub use crate::sys::process::macos::ProcessWaitDriver;
+    pub use crate::sys::process::macos::ProcessWaitImpl;
 }
-
-/// A trait for polling process exit.
-///
-/// Implementations must not reap the child process and must not consume a
-/// signal by reading from a pidfd or other process wait source. The caller
-/// is responsible for obtaining the exit status through the child object's
-/// native API after this poll returns [`Poll::Ready`].
-pub trait PollProcessWait: Unpin + Send + Sync {
-    /// Polls until the process exit wait source is signaled.
-    fn poll_process_exit(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>>;
-}
-
-impl std::fmt::Debug for dyn PollProcessWait {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.pad("PollProcessWait")
-    }
-}
-
-/// A type-erased process wait implementation.
-pub type ProcessWaitImpl = PollImpl<dyn PollProcessWait>;
-
-/// Extension trait for drivers that support type-erased process waits.
-///
-/// A blanket implementation is provided for any `T: Driver +
-/// ProcessWaitDriver`. Call sites that only hold `&dyn Driver` cannot use
-/// this trait directly.
-pub trait DynProcessWaitDriver: Driver {
-    /// Creates a new type-erased process wait from a waitable process handle.
-    #[cfg(windows)]
-    fn new_dyn_process_wait_handle(&self, handle: RawHandle) -> io::Result<ProcessWaitImpl>;
-
-    /// Creates a new type-erased process wait from a pidfd.
-    #[cfg(target_os = "linux")]
-    fn new_dyn_process_wait_pidfd(&self, pidfd: RawFd) -> io::Result<ProcessWaitImpl>;
-
-    /// Creates a new type-erased process wait from a process ID.
-    #[cfg(target_os = "macos")]
-    fn new_dyn_process_wait_pid(&self, pid: libc::pid_t) -> io::Result<ProcessWaitImpl>;
-}
-
-impl<T: Driver + ProcessWaitDriver> DynProcessWaitDriver for T {
-    #[cfg(windows)]
-    fn new_dyn_process_wait_handle(&self, handle: RawHandle) -> io::Result<ProcessWaitImpl> {
-        Ok(smallbox::smallbox!(self.new_process_wait_handle(handle)?))
-    }
-
-    #[cfg(target_os = "linux")]
-    fn new_dyn_process_wait_pidfd(&self, pidfd: RawFd) -> io::Result<ProcessWaitImpl> {
-        Ok(smallbox::smallbox!(self.new_process_wait_pidfd(pidfd)?))
-    }
-
-    #[cfg(target_os = "macos")]
-    fn new_dyn_process_wait_pid(&self, pid: libc::pid_t) -> io::Result<ProcessWaitImpl> {
-        Ok(smallbox::smallbox!(self.new_process_wait_pid(pid)?))
-    }
-}
-
-// --- High-level PolledChild wrapper ---
 
 /// An owned child process with an asynchronous exit wait.
 ///
-/// The `wait` field is declared before `child` so that the backend wait
+/// The wait field is declared before `child` so that the backend wait
 /// registration is dropped before the child's underlying handle or fd.
-///
-/// Platform-specific constructors are provided in the `unix` and `windows`
-/// backend modules.
 pub struct PolledChild<C> {
-    pub(crate) wait: Option<ProcessWaitImpl>,
+    wait: Option<crate::sys::process::WaitInner>,
     #[cfg(target_os = "linux")]
     #[expect(dead_code)] // Held for drop ordering; keeps the fd alive.
-    pub(crate) owned_pidfd: Option<OwnedFd>,
-    pub(crate) child: C,
+    owned_pidfd: Option<OwnedFd>,
+    child: C,
 }
 
 impl<C> PolledChild<C> {
@@ -138,16 +57,32 @@ impl<C> PolledChild<C> {
     }
 }
 
-// --- PolledChild<std::process::Child> polling ---
+// --- std::process::Child ---
 
 impl PolledChild<std::process::Child> {
+    /// Creates a new `PolledChild` wrapping a [`std::process::Child`].
+    pub fn new(
+        driver: &(impl ?Sized + Driver),
+        mut child: std::process::Child,
+    ) -> io::Result<Self> {
+        // Guard against pid reuse: std::process::Child identifies the process
+        // by pid, which the OS can recycle after the child is reaped. If the
+        // caller already called wait(), pidfd_open or EVFILT_PROC could
+        // silently attach to an unrelated process. Check try_wait() first so
+        // we never touch the pid of a reaped child.
+        if let Some(_status) = child.try_wait()? {
+            return Ok(Self::exited(child));
+        }
+        Self::new_inner(driver, child)
+    }
+
     /// Polls for the child process to exit.
     pub fn poll_wait(
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<std::process::ExitStatus>> {
         if let Some(wait) = &mut self.wait {
-            match wait.poll_process_exit(cx) {
+            match wait.poll_exit(cx) {
                 Poll::Ready(Ok(())) => {}
                 Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
                 Poll::Pending => return Poll::Pending,
@@ -170,5 +105,239 @@ impl PolledChild<std::process::Child> {
         &mut self,
     ) -> impl '_ + Unpin + Future<Output = io::Result<std::process::ExitStatus>> {
         poll_fn(move |cx| self.poll_wait(cx))
+    }
+}
+
+// --- pal::unix::process::Child ---
+
+#[cfg(unix)]
+impl PolledChild<pal::unix::process::Child> {
+    /// Creates a new `PolledChild` wrapping a [`pal::unix::process::Child`].
+    pub fn new(
+        driver: &(impl ?Sized + Driver),
+        mut child: pal::unix::process::Child,
+    ) -> io::Result<Self> {
+        // macOS uses EVFILT_PROC which takes a pid, so we need the same
+        // pid-reuse guard as std::process::Child above. Linux doesn't need
+        // this: pal::unix::process::Child owns a pidfd, which is a stable
+        // kernel reference that cannot be confused with another process.
+        if cfg!(target_os = "macos") && child.try_wait()?.is_some() {
+            return Ok(Self::exited(child));
+        }
+        Self::new_inner(driver, child)
+    }
+
+    /// Polls for the child process to exit.
+    pub fn poll_wait(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<std::process::ExitStatus>> {
+        if let Some(wait) = &mut self.wait {
+            match wait.poll_exit(cx) {
+                Poll::Ready(Ok(())) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        match self.child.try_wait() {
+            Ok(Some(status)) => Poll::Ready(Ok(status)),
+            Ok(None) => {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            Err(e) => Poll::Ready(Err(e)),
+        }
+    }
+
+    /// Waits for the child process to exit.
+    pub fn wait(
+        &mut self,
+    ) -> impl '_ + Unpin + Future<Output = io::Result<std::process::ExitStatus>> {
+        poll_fn(move |cx| self.poll_wait(cx))
+    }
+}
+
+// --- pal::windows::Process ---
+
+/// An owned process handle with an asynchronous exit wait.
+///
+/// Unlike [`PolledChild`], this type wraps a cloneable process handle
+/// (not a child with cached exit status). The exit code is returned
+/// as a `u32` matching the API of [`pal::windows::Process`].
+///
+/// The `wait` field is declared before `process` so that the backend
+/// wait registration is dropped before the process handle.
+#[cfg(windows)]
+pub struct PolledProcess {
+    wait: Option<crate::sys::process::WaitInner>,
+    process: pal::windows::Process,
+}
+
+#[cfg(windows)]
+impl PolledProcess {
+    /// Creates a new `PolledProcess` wrapping a [`pal::windows::Process`].
+    ///
+    /// Waits on the process handle to detect exit.
+    pub fn new(
+        driver: &(impl ?Sized + Driver),
+        process: pal::windows::Process,
+    ) -> io::Result<Self> {
+        use crate::sys::process::HandleProcessWait;
+        use std::os::windows::prelude::*;
+
+        let handle = process.as_handle().as_raw_handle();
+        let wait = driver.new_dyn_wait(handle)?;
+        Ok(Self {
+            wait: Some(HandleProcessWait::new(wait)),
+            process,
+        })
+    }
+
+    /// Returns the inner process, dropping the wait registration.
+    pub fn into_inner(self) -> pal::windows::Process {
+        self.process
+    }
+
+    /// Gets a reference to the inner process.
+    pub fn get(&self) -> &pal::windows::Process {
+        &self.process
+    }
+
+    /// Polls for the process to exit, returning its exit code.
+    pub fn poll_wait(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<u32>> {
+        if let Some(wait) = &mut self.wait {
+            match wait.poll_exit(cx) {
+                Poll::Ready(Ok(())) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        Poll::Ready(Ok(self.process.exit_code()))
+    }
+
+    /// Waits for the process to exit, returning its exit code.
+    pub fn wait(&mut self) -> impl '_ + Unpin + Future<Output = io::Result<u32>> {
+        poll_fn(move |cx| self.poll_wait(cx))
+    }
+}
+
+// --- Platform-specific construction helpers ---
+
+/// Helper to create a `PolledChild` for an already-exited child.
+impl<C> PolledChild<C> {
+    fn exited(child: C) -> Self {
+        Self {
+            wait: None,
+            #[cfg(target_os = "linux")]
+            owned_pidfd: None,
+            child,
+        }
+    }
+}
+
+/// Linux: open a pidfd and poll fd readiness.
+#[cfg(target_os = "linux")]
+mod linux {
+    // UNSAFETY: Needed for the pidfd_open syscall.
+    #![expect(unsafe_code)]
+
+    use super::*;
+    use crate::sys::process::FdProcessWait;
+    use std::os::unix::prelude::*;
+
+    /// Opens a pidfd for an existing process.
+    fn pidfd_open(pid: i32) -> io::Result<OwnedFd> {
+        // SAFETY: pidfd_open is a simple syscall that creates a new file
+        // descriptor for monitoring the given pid.
+        let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0 as libc::c_int) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: pidfd_open returned a valid file descriptor on success.
+        Ok(unsafe { OwnedFd::from_raw_fd(fd as RawFd) })
+    }
+
+    impl PolledChild<std::process::Child> {
+        pub(super) fn new_inner(
+            driver: &(impl ?Sized + Driver),
+            child: std::process::Child,
+        ) -> io::Result<Self> {
+            let pidfd = pidfd_open(child.id() as i32)?;
+            let fd_ready = driver.new_dyn_fd_ready(pidfd.as_fd().as_raw_fd())?;
+            Ok(Self {
+                wait: Some(FdProcessWait::new(fd_ready)),
+                owned_pidfd: Some(pidfd),
+                child,
+            })
+        }
+    }
+
+    impl PolledChild<pal::unix::process::Child> {
+        pub(super) fn new_inner(
+            driver: &(impl ?Sized + Driver),
+            child: pal::unix::process::Child,
+        ) -> io::Result<Self> {
+            let fd_ready = driver.new_dyn_fd_ready(child.as_fd().as_raw_fd())?;
+            Ok(Self {
+                wait: Some(FdProcessWait::new(fd_ready)),
+                owned_pidfd: None,
+                child,
+            })
+        }
+    }
+}
+
+/// macOS: use kqueue EVFILT_PROC via `Driver::new_dyn_process_wait`.
+#[cfg(target_os = "macos")]
+mod macos_impl {
+    use super::*;
+    use crate::sys::process::WaitInner;
+
+    impl PolledChild<std::process::Child> {
+        pub(super) fn new_inner(
+            driver: &(impl ?Sized + Driver),
+            child: std::process::Child,
+        ) -> io::Result<Self> {
+            let wait = driver.new_dyn_process_wait(child.id() as i32)?;
+            Ok(Self {
+                wait: Some(WaitInner::new(wait)),
+                child,
+            })
+        }
+    }
+
+    impl PolledChild<pal::unix::process::Child> {
+        pub(super) fn new_inner(
+            driver: &(impl ?Sized + Driver),
+            child: pal::unix::process::Child,
+        ) -> io::Result<Self> {
+            let wait = driver.new_dyn_process_wait(child.id() as i32)?;
+            Ok(Self {
+                wait: Some(WaitInner::new(wait)),
+                child,
+            })
+        }
+    }
+}
+
+/// Windows: wait on process handle via `Driver::new_dyn_wait`.
+#[cfg(windows)]
+mod windows {
+    use super::*;
+    use crate::sys::process::HandleProcessWait;
+    use std::os::windows::prelude::*;
+
+    impl PolledChild<std::process::Child> {
+        pub(super) fn new_inner(
+            driver: &(impl ?Sized + Driver),
+            child: std::process::Child,
+        ) -> io::Result<Self> {
+            let handle = child.as_handle().as_raw_handle();
+            let wait = driver.new_dyn_wait(handle)?;
+            Ok(Self {
+                wait: Some(HandleProcessWait::new(wait)),
+                child,
+            })
+        }
     }
 }

--- a/support/pal/pal_async/src/process.rs
+++ b/support/pal/pal_async/src/process.rs
@@ -35,9 +35,9 @@ pub mod macos {
 /// registration is dropped before the child's underlying handle or fd.
 pub struct PolledChild<C> {
     wait: Option<crate::sys::process::WaitInner>,
+    // Drop order: after `wait`, which may have a RawFd copy of this.
     #[cfg(target_os = "linux")]
-    #[expect(dead_code)] // Held for drop ordering; keeps the fd alive.
-    owned_pidfd: Option<OwnedFd>,
+    _owned_pidfd: Option<OwnedFd>,
     child: C,
 }
 
@@ -193,7 +193,7 @@ impl<C> PolledChild<C> {
         Self {
             wait: None,
             #[cfg(target_os = "linux")]
-            owned_pidfd: None,
+            _owned_pidfd: None,
             child,
         }
     }
@@ -235,7 +235,7 @@ mod linux {
             let fd_ready = driver.new_dyn_fd_ready(pidfd.as_fd().as_raw_fd())?;
             Ok(Self {
                 wait: Some(FdProcessWait::new(fd_ready)),
-                owned_pidfd: Some(pidfd),
+                _owned_pidfd: Some(pidfd),
                 child,
             })
         }
@@ -249,7 +249,7 @@ mod linux {
             let fd_ready = driver.new_dyn_fd_ready(child.as_fd().as_raw_fd())?;
             Ok(Self {
                 wait: Some(FdProcessWait::new(fd_ready)),
-                owned_pidfd: None,
+                _owned_pidfd: None,
                 child,
             })
         }

--- a/support/pal/pal_async/src/process.rs
+++ b/support/pal/pal_async/src/process.rs
@@ -206,7 +206,7 @@ mod linux {
     #![expect(unsafe_code)]
 
     use super::*;
-    use crate::sys::process::FdProcessWait;
+    use crate::sys::process::linux::FdProcessWait;
     use std::os::unix::prelude::*;
 
     /// Opens a pidfd for an existing process.

--- a/support/pal/pal_async/src/process.rs
+++ b/support/pal/pal_async/src/process.rs
@@ -22,8 +22,6 @@ use std::future::poll_fn;
 use std::io;
 #[cfg(target_os = "linux")]
 use std::os::fd::OwnedFd;
-#[cfg(unix)]
-use std::os::unix::prelude::*;
 #[cfg(windows)]
 use std::os::windows::prelude::*;
 use std::task::Context;

--- a/support/pal/pal_async/src/process.rs
+++ b/support/pal/pal_async/src/process.rs
@@ -185,10 +185,9 @@ impl PolledProcess {
     }
 }
 
-// --- Platform-specific construction helpers ---
-
-/// Helper to create a `PolledChild` for an already-exited child.
 impl<C> PolledChild<C> {
+    #[cfg_attr(windows, expect(dead_code))]
+    /// Creates a `PolledChild` for an already-exited child.
     fn exited(child: C) -> Self {
         Self {
             wait: None,

--- a/support/pal/pal_async/src/process.rs
+++ b/support/pal/pal_async/src/process.rs
@@ -10,8 +10,9 @@
 //! futures-based `wait()` method.
 //!
 //! [`ProcessWaitDriver`] is an extension trait, not part of [`Driver`]. On
-//! Linux it is blanket-implemented for all [`FdReadyDriver`] types via pidfd
-//! polling. Platform-specific driver implementations live in the `unix` and
+//! Linux it is blanket-implemented for all `FdReadyDriver` types via pidfd
+//! polling. On Windows it is blanket-implemented for all `WaitDriver` types.
+//! Platform-specific driver implementations live in the `unix` and
 //! `windows` backend modules.
 
 use crate::driver::Driver;

--- a/support/pal/pal_async/src/process.rs
+++ b/support/pal/pal_async/src/process.rs
@@ -289,7 +289,7 @@ mod macos_impl {
             if child.try_wait()?.is_some() {
                 return Ok(Self::exited(child));
             }
-            let wait = driver.new_dyn_process_wait(child.id() as i32)?;
+            let wait = driver.new_dyn_process_wait(child.id())?;
             Ok(Self {
                 wait: Some(WaitInner::new(wait)),
                 child,

--- a/support/pal/pal_async/src/process.rs
+++ b/support/pal/pal_async/src/process.rs
@@ -18,6 +18,7 @@ use std::io;
 use std::os::fd::OwnedFd;
 use std::task::Context;
 use std::task::Poll;
+use std::task::ready;
 
 /// macOS-specific process wait types.
 #[cfg(target_os = "macos")]
@@ -57,22 +58,26 @@ impl<C> PolledChild<C> {
     }
 }
 
+/// Polls the wait backend for process exit, then calls `try_wait`.
+///
+/// This is the shared implementation of `PolledChild::poll_wait` for all
+/// child-process types.
+fn poll_child_exit(
+    cx: &mut Context<'_>,
+    wait: &mut Option<crate::sys::process::WaitInner>,
+    mut try_wait: impl FnMut() -> io::Result<Option<std::process::ExitStatus>>,
+) -> Poll<io::Result<std::process::ExitStatus>> {
+    if let Some(w) = wait {
+        ready!(w.poll_exit(cx))?;
+    }
+    Ok(try_wait()?.expect("wait backend signaled readiness but process has not exited")).into()
+}
+
 // --- std::process::Child ---
 
 impl PolledChild<std::process::Child> {
     /// Creates a new `PolledChild` wrapping a [`std::process::Child`].
-    pub fn new(
-        driver: &(impl ?Sized + Driver),
-        mut child: std::process::Child,
-    ) -> io::Result<Self> {
-        // Guard against pid reuse: std::process::Child identifies the process
-        // by pid, which the OS can recycle after the child is reaped. If the
-        // caller already called wait(), pidfd_open or EVFILT_PROC could
-        // silently attach to an unrelated process. Check try_wait() first so
-        // we never touch the pid of a reaped child.
-        if let Some(_status) = child.try_wait()? {
-            return Ok(Self::exited(child));
-        }
+    pub fn new(driver: &(impl ?Sized + Driver), child: std::process::Child) -> io::Result<Self> {
         Self::new_inner(driver, child)
     }
 
@@ -81,23 +86,7 @@ impl PolledChild<std::process::Child> {
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<std::process::ExitStatus>> {
-        if let Some(wait) = &mut self.wait {
-            match wait.poll_exit(cx) {
-                Poll::Ready(Ok(())) => {}
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                Poll::Pending => return Poll::Pending,
-            }
-        }
-        match self.child.try_wait() {
-            Ok(Some(status)) => Poll::Ready(Ok(status)),
-            Ok(None) => {
-                // Spurious readiness. Wake to retry without waiting for
-                // another fd readiness edge (the signaled state is cached).
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
-            Err(e) => Poll::Ready(Err(e)),
-        }
+        poll_child_exit(cx, &mut self.wait, || self.child.try_wait())
     }
 
     /// Waits for the child process to exit.
@@ -115,15 +104,8 @@ impl PolledChild<pal::unix::process::Child> {
     /// Creates a new `PolledChild` wrapping a [`pal::unix::process::Child`].
     pub fn new(
         driver: &(impl ?Sized + Driver),
-        mut child: pal::unix::process::Child,
+        child: pal::unix::process::Child,
     ) -> io::Result<Self> {
-        // macOS uses EVFILT_PROC which takes a pid, so we need the same
-        // pid-reuse guard as std::process::Child above. Linux doesn't need
-        // this: pal::unix::process::Child owns a pidfd, which is a stable
-        // kernel reference that cannot be confused with another process.
-        if cfg!(target_os = "macos") && child.try_wait()?.is_some() {
-            return Ok(Self::exited(child));
-        }
         Self::new_inner(driver, child)
     }
 
@@ -132,21 +114,7 @@ impl PolledChild<pal::unix::process::Child> {
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<std::process::ExitStatus>> {
-        if let Some(wait) = &mut self.wait {
-            match wait.poll_exit(cx) {
-                Poll::Ready(Ok(())) => {}
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                Poll::Pending => return Poll::Pending,
-            }
-        }
-        match self.child.try_wait() {
-            Ok(Some(status)) => Poll::Ready(Ok(status)),
-            Ok(None) => {
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
-            Err(e) => Poll::Ready(Err(e)),
-        }
+        poll_child_exit(cx, &mut self.wait, || self.child.try_wait())
     }
 
     /// Waits for the child process to exit.
@@ -206,11 +174,7 @@ impl PolledProcess {
     /// Polls for the process to exit, returning its exit code.
     pub fn poll_wait(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<u32>> {
         if let Some(wait) = &mut self.wait {
-            match wait.poll_exit(cx) {
-                Poll::Ready(Ok(())) => {}
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                Poll::Pending => return Poll::Pending,
-            }
+            ready!(wait.poll_exit(cx))?;
         }
         Poll::Ready(Ok(self.process.exit_code()))
     }
@@ -260,8 +224,13 @@ mod linux {
     impl PolledChild<std::process::Child> {
         pub(super) fn new_inner(
             driver: &(impl ?Sized + Driver),
-            child: std::process::Child,
+            mut child: std::process::Child,
         ) -> io::Result<Self> {
+            // If the caller already reaped the child, don't try to register
+            // notifications on its pid.
+            if child.try_wait()?.is_some() {
+                return Ok(Self::exited(child));
+            }
             let pidfd = pidfd_open(child.id() as i32)?;
             let fd_ready = driver.new_dyn_fd_ready(pidfd.as_fd().as_raw_fd())?;
             Ok(Self {
@@ -296,8 +265,13 @@ mod macos_impl {
     impl PolledChild<std::process::Child> {
         pub(super) fn new_inner(
             driver: &(impl ?Sized + Driver),
-            child: std::process::Child,
+            mut child: std::process::Child,
         ) -> io::Result<Self> {
+            // If the caller already reaped the child, don't try to register
+            // notifications on its pid.
+            if child.try_wait()?.is_some() {
+                return Ok(Self::exited(child));
+            }
             let wait = driver.new_dyn_process_wait(child.id() as i32)?;
             Ok(Self {
                 wait: Some(WaitInner::new(wait)),
@@ -309,8 +283,13 @@ mod macos_impl {
     impl PolledChild<pal::unix::process::Child> {
         pub(super) fn new_inner(
             driver: &(impl ?Sized + Driver),
-            child: pal::unix::process::Child,
+            mut child: pal::unix::process::Child,
         ) -> io::Result<Self> {
+            // If the caller already reaped the child, don't try to register
+            // notifications on its pid.
+            if child.try_wait()?.is_some() {
+                return Ok(Self::exited(child));
+            }
             let wait = driver.new_dyn_process_wait(child.id() as i32)?;
             Ok(Self {
                 wait: Some(WaitInner::new(wait)),

--- a/support/pal/pal_async/src/process.rs
+++ b/support/pal/pal_async/src/process.rs
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Process wait functionality.
+//!
+//! Provides async primitives for waiting on child process exit without
+//! consuming the child object. The low-level [`ProcessWaitDriver`] and
+//! [`PollProcessWait`] traits define a platform-specific wait source, while
+//! the high-level [`PolledChild`] wrapper owns a child process and provides a
+//! futures-based `wait()` method.
+//!
+//! [`ProcessWaitDriver`] is an extension trait, not part of [`Driver`]. On
+//! Linux it is blanket-implemented for all [`FdReadyDriver`] types via pidfd
+//! polling. Platform-specific driver implementations live in the `unix` and
+//! `windows` backend modules.
+
+use crate::driver::Driver;
+use crate::driver::PollImpl;
+use std::future::Future;
+use std::future::poll_fn;
+use std::io;
+#[cfg(target_os = "linux")]
+use std::os::fd::OwnedFd;
+#[cfg(unix)]
+use std::os::unix::prelude::*;
+#[cfg(windows)]
+use std::os::windows::prelude::*;
+use std::task::Context;
+use std::task::Poll;
+
+/// A trait for driving process exit waits.
+///
+/// This is an extension trait, not part of [`Driver`]. Not all executors
+/// support process waits on all platforms.
+pub trait ProcessWaitDriver: Unpin {
+    /// The process wait object.
+    type ProcessWait: 'static + PollProcessWait;
+
+    /// Creates a new process wait from a waitable process handle.
+    #[cfg(windows)]
+    fn new_process_wait_handle(&self, handle: RawHandle) -> io::Result<Self::ProcessWait>;
+
+    /// Creates a new process wait from a pidfd.
+    #[cfg(target_os = "linux")]
+    fn new_process_wait_pidfd(&self, pidfd: RawFd) -> io::Result<Self::ProcessWait>;
+
+    /// Creates a new process wait from a process ID.
+    #[cfg(target_os = "macos")]
+    fn new_process_wait_pid(&self, pid: libc::pid_t) -> io::Result<Self::ProcessWait>;
+}
+
+/// A trait for polling process exit.
+///
+/// Implementations must not reap the child process and must not consume a
+/// signal by reading from a pidfd or other process wait source. The caller
+/// is responsible for obtaining the exit status through the child object's
+/// native API after this poll returns [`Poll::Ready`].
+pub trait PollProcessWait: Unpin + Send + Sync {
+    /// Polls until the process exit wait source is signaled.
+    fn poll_process_exit(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>>;
+}
+
+impl std::fmt::Debug for dyn PollProcessWait {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.pad("PollProcessWait")
+    }
+}
+
+/// A type-erased process wait implementation.
+pub type ProcessWaitImpl = PollImpl<dyn PollProcessWait>;
+
+/// Extension trait for drivers that support type-erased process waits.
+///
+/// A blanket implementation is provided for any `T: Driver +
+/// ProcessWaitDriver`. Call sites that only hold `&dyn Driver` cannot use
+/// this trait directly.
+pub trait DynProcessWaitDriver: Driver {
+    /// Creates a new type-erased process wait from a waitable process handle.
+    #[cfg(windows)]
+    fn new_dyn_process_wait_handle(&self, handle: RawHandle) -> io::Result<ProcessWaitImpl>;
+
+    /// Creates a new type-erased process wait from a pidfd.
+    #[cfg(target_os = "linux")]
+    fn new_dyn_process_wait_pidfd(&self, pidfd: RawFd) -> io::Result<ProcessWaitImpl>;
+
+    /// Creates a new type-erased process wait from a process ID.
+    #[cfg(target_os = "macos")]
+    fn new_dyn_process_wait_pid(&self, pid: libc::pid_t) -> io::Result<ProcessWaitImpl>;
+}
+
+impl<T: Driver + ProcessWaitDriver> DynProcessWaitDriver for T {
+    #[cfg(windows)]
+    fn new_dyn_process_wait_handle(&self, handle: RawHandle) -> io::Result<ProcessWaitImpl> {
+        Ok(smallbox::smallbox!(self.new_process_wait_handle(handle)?))
+    }
+
+    #[cfg(target_os = "linux")]
+    fn new_dyn_process_wait_pidfd(&self, pidfd: RawFd) -> io::Result<ProcessWaitImpl> {
+        Ok(smallbox::smallbox!(self.new_process_wait_pidfd(pidfd)?))
+    }
+
+    #[cfg(target_os = "macos")]
+    fn new_dyn_process_wait_pid(&self, pid: libc::pid_t) -> io::Result<ProcessWaitImpl> {
+        Ok(smallbox::smallbox!(self.new_process_wait_pid(pid)?))
+    }
+}
+
+// --- High-level PolledChild wrapper ---
+
+/// An owned child process with an asynchronous exit wait.
+///
+/// The `wait` field is declared before `child` so that the backend wait
+/// registration is dropped before the child's underlying handle or fd.
+///
+/// Platform-specific constructors are provided in the `unix` and `windows`
+/// backend modules.
+pub struct PolledChild<C> {
+    pub(crate) wait: Option<ProcessWaitImpl>,
+    #[cfg(target_os = "linux")]
+    #[expect(dead_code)] // Held for drop ordering; keeps the fd alive.
+    pub(crate) owned_pidfd: Option<OwnedFd>,
+    pub(crate) child: C,
+}
+
+impl<C> PolledChild<C> {
+    /// Returns the inner child, dropping the wait registration.
+    pub fn into_inner(self) -> C {
+        self.child
+    }
+
+    /// Gets a reference to the inner child.
+    pub fn get(&self) -> &C {
+        &self.child
+    }
+
+    /// Gets a mutable reference to the inner child.
+    pub fn get_mut(&mut self) -> &mut C {
+        &mut self.child
+    }
+}
+
+// --- PolledChild<std::process::Child> polling ---
+
+impl PolledChild<std::process::Child> {
+    /// Polls for the child process to exit.
+    pub fn poll_wait(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<std::process::ExitStatus>> {
+        if let Some(wait) = &mut self.wait {
+            match wait.poll_process_exit(cx) {
+                Poll::Ready(Ok(())) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        match self.child.try_wait() {
+            Ok(Some(status)) => Poll::Ready(Ok(status)),
+            Ok(None) => {
+                // Spurious readiness. Wake to retry without waiting for
+                // another fd readiness edge (the signaled state is cached).
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            Err(e) => Poll::Ready(Err(e)),
+        }
+    }
+
+    /// Waits for the child process to exit.
+    pub fn wait(
+        &mut self,
+    ) -> impl '_ + Unpin + Future<Output = io::Result<std::process::ExitStatus>> {
+        poll_fn(move |cx| self.poll_wait(cx))
+    }
+}

--- a/support/pal/pal_async/src/unix/epoll.rs
+++ b/support/pal/pal_async/src/unix/epoll.rs
@@ -548,6 +548,11 @@ mod tests {
     }
 
     #[test]
+    fn process_works() {
+        EpollPool::run_with(executor_tests::process_tests)
+    }
+
+    #[test]
     fn uring_works() {
         EpollPool::run_with(executor_tests::io_uring_tests::uring_tests)
     }

--- a/support/pal/pal_async/src/unix/kqueue.rs
+++ b/support/pal/pal_async/src/unix/kqueue.rs
@@ -12,8 +12,8 @@ use crate::interest::PollInterestSet;
 use crate::io_pool::IoBackend;
 use crate::io_pool::IoDriver;
 use crate::io_pool::IoPool;
-use crate::process::PollProcessWait;
-use crate::process::ProcessWaitDriver;
+use crate::process::macos::PollProcessWait;
+use crate::process::macos::ProcessWaitDriver;
 use crate::timer::Instant;
 use crate::timer::PollTimer;
 use crate::timer::TimerDriver;
@@ -513,11 +513,7 @@ impl ProcessWaitOp {
 pub struct ProcessWait {
     op: Arc<ProcessWaitOp>,
     kqueue: Arc<KqueueBackend>,
-    pid: libc::pid_t,
-    /// Whether kqueue registration was issued (and thus needs `EV_DELETE`
-    /// on drop). One-shot events auto-remove after delivery, but if the
-    /// event hasn't fired yet we must clean up.
-    registered: bool,
+    pid: i32,
 }
 
 impl PollProcessWait for ProcessWait {
@@ -533,21 +529,19 @@ impl PollProcessWait for ProcessWait {
 
 impl Drop for ProcessWait {
     fn drop(&mut self) {
-        if self.registered {
-            // Try to remove the one-shot event. If the process already
-            // exited, the event was already delivered and auto-removed, so
-            // ENOENT is expected.
-            let _ = self.kqueue.kqfd.run(
-                &[libc::kevent64_s {
-                    ident: self.pid as u64,
-                    filter: libc::EVFILT_PROC,
-                    flags: libc::EV_DELETE,
-                    ..empty_event()
-                }],
-                &mut [],
-                Some(&zero_timespec()),
-            );
-        }
+        // Try to remove the one-shot event. If the process already
+        // exited, the event was already delivered and auto-removed, so
+        // ENOENT is expected.
+        let _ = self.kqueue.kqfd.run(
+            &[libc::kevent64_s {
+                ident: self.pid as u64,
+                filter: libc::EVFILT_PROC,
+                flags: libc::EV_DELETE,
+                ..empty_event()
+            }],
+            &mut [],
+            Some(&zero_timespec()),
+        );
 
         // SAFETY: Reclaiming the reference added in new_process_wait_pid.
         let op = unsafe { Arc::from_raw(Arc::as_ptr(&self.op)) };
@@ -565,7 +559,7 @@ impl Drop for ProcessWait {
 impl ProcessWaitDriver for KqueueDriver {
     type ProcessWait = ProcessWait;
 
-    fn new_process_wait_pid(&self, pid: libc::pid_t) -> io::Result<Self::ProcessWait> {
+    fn new_process_wait_pid(&self, pid: i32) -> io::Result<Self::ProcessWait> {
         let op = Arc::new(ProcessWaitOp {
             inner: Mutex::new(ProcessWaitInner {
                 signaled: false,
@@ -573,7 +567,7 @@ impl ProcessWaitDriver for KqueueDriver {
             }),
         });
         let udata = Arc::as_ptr(&op) as usize as u64;
-        let result = self.inner.kqfd.run(
+        self.inner.kqfd.run(
             &[libc::kevent64_s {
                 ident: pid as u64,
                 filter: libc::EVFILT_PROC,
@@ -584,18 +578,7 @@ impl ProcessWaitDriver for KqueueDriver {
             }],
             &mut [],
             Some(&zero_timespec()),
-        );
-
-        let registered = match result {
-            Ok(_) => true,
-            Err(e) if e.0 == libc::ESRCH => {
-                // Process already exited. Mark as signaled so poll_process_exit
-                // returns immediately.
-                op.inner.lock().signaled = true;
-                false
-            }
-            Err(e) => return Err(e.into()),
-        };
+        )?;
 
         // Add reference owned by the kqueue event, reclaimed in drop.
         let _ = Arc::into_raw(op.clone());
@@ -604,7 +587,6 @@ impl ProcessWaitDriver for KqueueDriver {
             op,
             kqueue: self.inner.clone(),
             pid,
-            registered,
         })
     }
 }

--- a/support/pal/pal_async/src/unix/kqueue.rs
+++ b/support/pal/pal_async/src/unix/kqueue.rs
@@ -12,6 +12,8 @@ use crate::interest::PollInterestSet;
 use crate::io_pool::IoBackend;
 use crate::io_pool::IoDriver;
 use crate::io_pool::IoPool;
+use crate::process::PollProcessWait;
+use crate::process::ProcessWaitDriver;
 use crate::timer::Instant;
 use crate::timer::PollTimer;
 use crate::timer::TimerDriver;
@@ -58,6 +60,7 @@ impl Default for KqueueBackend {
                 state: PoolState::Running,
                 timers: TimerQueue::default(),
                 fd_ready_to_delete: Vec::new(),
+                process_ops_to_delete: Vec::new(),
             }),
         }
     }
@@ -68,6 +71,7 @@ struct KqueueState {
     state: PoolState,
     timers: TimerQueue,
     fd_ready_to_delete: Vec<Arc<FdReadyOp>>,
+    process_ops_to_delete: Vec<Arc<ProcessWaitOp>>,
 }
 
 #[derive(Debug)]
@@ -163,7 +167,8 @@ impl IoBackend for KqueueBackend {
         let waker = waker_ref(self);
         let mut cx = Context::from_waker(&waker);
 
-        let mut to_delete: Vec<_> = Vec::new();
+        let mut to_delete: Vec<Arc<FdReadyOp>> = Vec::new();
+        let mut proc_to_delete: Vec<Arc<ProcessWaitOp>> = Vec::new();
         let mut wakers = WakerList::default();
 
         let mut state = self.state.lock();
@@ -176,6 +181,7 @@ impl IoBackend for KqueueBackend {
 
             wakers.wake();
             to_delete.clear();
+            proc_to_delete.clear();
 
             match fut.poll_unpin(&mut cx) {
                 Poll::Ready(r) => break r,
@@ -183,8 +189,9 @@ impl IoBackend for KqueueBackend {
             }
 
             state = self.state.lock();
-            // This list is only populated while in the Sleeping state.
+            // These lists are only populated while in the Sleeping state.
             assert!(state.fd_ready_to_delete.is_empty());
+            assert!(state.process_ops_to_delete.is_empty());
 
             if state.state.can_sleep() {
                 let deadline = state.timers.next_deadline();
@@ -244,14 +251,23 @@ impl IoBackend for KqueueBackend {
                             };
                             op.wake_ready(revents, &mut wakers);
                         }
+                        libc::EVFILT_PROC => {
+                            // SAFETY: the operation context is still alive.
+                            // If the ProcessWait was dropped, the op will be
+                            // in process_ops_to_delete. The event is one-shot
+                            // so no further events will arrive for this pid.
+                            let op = unsafe { &*(event.udata as usize as *const ProcessWaitOp) };
+                            op.wake_signaled(&mut wakers);
+                        }
                         _ => unreachable!(),
                     }
                 }
 
                 state = self.state.lock();
 
-                // Free any FdReadyOp objects that were deleted while in the kevent64 call.
+                // Free any op objects that were deleted while in the kevent64 call.
                 to_delete.append(&mut state.fd_ready_to_delete);
+                proc_to_delete.append(&mut state.process_ops_to_delete);
             }
         }
     }
@@ -469,6 +485,130 @@ impl WaitDriver for KqueueDriver {
     }
 }
 
+// --- Process wait support via EVFILT_PROC ---
+
+#[derive(Debug)]
+struct ProcessWaitOp {
+    inner: Mutex<ProcessWaitInner>,
+}
+
+#[derive(Debug)]
+struct ProcessWaitInner {
+    signaled: bool,
+    waker: Option<std::task::Waker>,
+}
+
+impl ProcessWaitOp {
+    fn wake_signaled(&self, wakers: &mut WakerList) {
+        let mut inner = self.inner.lock();
+        inner.signaled = true;
+        if let Some(waker) = inner.waker.take() {
+            wakers.push(waker);
+        }
+    }
+}
+
+/// A process wait implementation backed by kqueue `EVFILT_PROC`.
+#[derive(Debug)]
+pub struct ProcessWait {
+    op: Arc<ProcessWaitOp>,
+    kqueue: Arc<KqueueBackend>,
+    pid: libc::pid_t,
+    /// Whether kqueue registration was issued (and thus needs `EV_DELETE`
+    /// on drop). One-shot events auto-remove after delivery, but if the
+    /// event hasn't fired yet we must clean up.
+    registered: bool,
+}
+
+impl PollProcessWait for ProcessWait {
+    fn poll_process_exit(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let mut inner = self.op.inner.lock();
+        if inner.signaled {
+            return Poll::Ready(Ok(()));
+        }
+        inner.waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+impl Drop for ProcessWait {
+    fn drop(&mut self) {
+        if self.registered {
+            // Try to remove the one-shot event. If the process already
+            // exited, the event was already delivered and auto-removed, so
+            // ENOENT is expected.
+            let _ = self.kqueue.kqfd.run(
+                &[libc::kevent64_s {
+                    ident: self.pid as u64,
+                    filter: libc::EVFILT_PROC,
+                    flags: libc::EV_DELETE,
+                    ..empty_event()
+                }],
+                &mut [],
+                Some(&zero_timespec()),
+            );
+        }
+
+        // SAFETY: Reclaiming the reference added in new_process_wait_pid.
+        let op = unsafe { Arc::from_raw(Arc::as_ptr(&self.op)) };
+        let mut state = self.kqueue.state.lock();
+        if state.state.is_referencing_ops() {
+            state.process_ops_to_delete.push(op);
+            if state.state.wake() {
+                drop(state);
+                self.kqueue.post_user_event();
+            }
+        }
+    }
+}
+
+impl ProcessWaitDriver for KqueueDriver {
+    type ProcessWait = ProcessWait;
+
+    fn new_process_wait_pid(&self, pid: libc::pid_t) -> io::Result<Self::ProcessWait> {
+        let op = Arc::new(ProcessWaitOp {
+            inner: Mutex::new(ProcessWaitInner {
+                signaled: false,
+                waker: None,
+            }),
+        });
+        let udata = Arc::as_ptr(&op) as usize as u64;
+        let result = self.inner.kqfd.run(
+            &[libc::kevent64_s {
+                ident: pid as u64,
+                filter: libc::EVFILT_PROC,
+                flags: libc::EV_ADD | libc::EV_ONESHOT,
+                fflags: libc::NOTE_EXIT,
+                udata,
+                ..empty_event()
+            }],
+            &mut [],
+            Some(&zero_timespec()),
+        );
+
+        let registered = match result {
+            Ok(_) => true,
+            Err(e) if e.0 == libc::ESRCH => {
+                // Process already exited. Mark as signaled so poll_process_exit
+                // returns immediately.
+                op.inner.lock().signaled = true;
+                false
+            }
+            Err(e) => return Err(e.into()),
+        };
+
+        // Add reference owned by the kqueue event, reclaimed in drop.
+        let _ = Arc::into_raw(op.clone());
+
+        Ok(ProcessWait {
+            op,
+            kqueue: self.inner.clone(),
+            pid,
+            registered,
+        })
+    }
+}
+
 impl TimerDriver for KqueueDriver {
     type Timer = Timer;
 
@@ -551,5 +691,10 @@ mod tests {
     #[test]
     fn socket_works() {
         KqueuePool::run_with(executor_tests::socket_tests)
+    }
+
+    #[test]
+    fn process_works() {
+        KqueuePool::run_with(executor_tests::process_tests)
     }
 }

--- a/support/pal/pal_async/src/unix/kqueue.rs
+++ b/support/pal/pal_async/src/unix/kqueue.rs
@@ -531,8 +531,9 @@ impl Drop for ProcessWait {
     fn drop(&mut self) {
         // Try to remove the one-shot event. If the process already
         // exited, the event was already delivered and auto-removed, so
-        // ENOENT is expected.
-        let _ = self.kqueue.kqfd.run(
+        // ENOENT is expected. ESRCH can also occur if the process has
+        // been reaped.
+        match self.kqueue.kqfd.run(
             &[libc::kevent64_s {
                 ident: self.pid as u64,
                 filter: libc::EVFILT_PROC,
@@ -541,7 +542,10 @@ impl Drop for ProcessWait {
             }],
             &mut [],
             Some(&zero_timespec()),
-        );
+        ) {
+            Ok(_) | Err(Errno(libc::ENOENT)) | Err(Errno(libc::ESRCH)) => {}
+            Err(err) => panic!("kevent64 unexpectedly failed: {err:?}"),
+        }
 
         // SAFETY: Reclaiming the reference added in new_process_wait_pid.
         let op = unsafe { Arc::from_raw(Arc::as_ptr(&self.op)) };

--- a/support/pal/pal_async/src/unix/local.rs
+++ b/support/pal/pal_async/src/unix/local.rs
@@ -209,6 +209,15 @@ impl WaitDriver for LocalDriver {
     }
 }
 
+#[cfg(target_os = "macos")]
+impl crate::process::macos::ProcessWaitDriver for LocalDriver {
+    type ProcessWait = crate::process::macos::NoProcessWait;
+
+    fn new_process_wait_pid(&self, _pid: i32) -> io::Result<Self::ProcessWait> {
+        Err(io::ErrorKind::Unsupported.into())
+    }
+}
+
 #[cfg(target_os = "linux")]
 impl crate::io_uring::IoUringDriver for LocalDriver {
     type Submitter = crate::io_uring::NoIoUring;

--- a/support/pal/pal_async/src/unix/mod.rs
+++ b/support/pal/pal_async/src/unix/mod.rs
@@ -11,6 +11,8 @@ use cfg_if::cfg_if;
 
 pub mod local;
 pub mod pipe;
+#[cfg(target_os = "linux")]
+pub mod process;
 pub mod wait;
 
 cfg_if! {

--- a/support/pal/pal_async/src/unix/mod.rs
+++ b/support/pal/pal_async/src/unix/mod.rs
@@ -11,7 +11,6 @@ use cfg_if::cfg_if;
 
 pub mod local;
 pub mod pipe;
-#[cfg(target_os = "linux")]
 pub mod process;
 pub mod wait;
 

--- a/support/pal/pal_async/src/unix/process.rs
+++ b/support/pal/pal_async/src/unix/process.rs
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Unix process wait implementations.
+
+// UNSAFETY: Needed for the pidfd_open syscall.
+#![expect(unsafe_code)]
+
+use crate::fd::FdReadyDriver;
+use crate::fd::PollFdReady;
+use crate::interest::InterestSlot;
+use crate::interest::PollEvents;
+use crate::process::DynProcessWaitDriver;
+use crate::process::PollProcessWait;
+use crate::process::PolledChild;
+use crate::process::ProcessWaitDriver;
+use std::future::Future;
+use std::future::poll_fn;
+use std::io;
+use std::os::fd::OwnedFd;
+use std::os::unix::prelude::*;
+use std::task::Context;
+use std::task::Poll;
+
+/// A process wait implementation backed by pidfd readiness polling.
+///
+/// Caches the signaled state so that subsequent polls return immediately
+/// without relying on another epoll edge.
+pub struct PidFdProcessWait<F> {
+    fd_ready: F,
+    signaled: bool,
+}
+
+impl<F: PollFdReady> PollProcessWait for PidFdProcessWait<F> {
+    fn poll_process_exit(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if self.signaled {
+            return Poll::Ready(Ok(()));
+        }
+        match self
+            .fd_ready
+            .poll_fd_ready(cx, InterestSlot::Read, PollEvents::IN)
+        {
+            Poll::Ready(_) => {
+                self.signaled = true;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<T: FdReadyDriver> ProcessWaitDriver for T {
+    type ProcessWait = PidFdProcessWait<T::FdReady>;
+
+    fn new_process_wait_pidfd(&self, pidfd: RawFd) -> io::Result<Self::ProcessWait> {
+        let fd_ready = self.new_fd_ready(pidfd)?;
+        Ok(PidFdProcessWait {
+            fd_ready,
+            signaled: false,
+        })
+    }
+}
+
+/// Opens a pidfd for an existing process.
+fn pidfd_open(pid: i32) -> io::Result<OwnedFd> {
+    // SAFETY: pidfd_open is a simple syscall that creates a new file
+    // descriptor for monitoring the given pid.
+    let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0 as libc::c_int) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: pidfd_open returned a valid file descriptor on success.
+    Ok(unsafe { OwnedFd::from_raw_fd(fd as RawFd) })
+}
+
+// --- PolledChild<std::process::Child> construction (Linux) ---
+
+impl PolledChild<std::process::Child> {
+    /// Creates a new `PolledChild` wrapping a [`std::process::Child`].
+    ///
+    /// Opens a pidfd for the child process to poll for exit.
+    pub fn new(
+        driver: &(impl ?Sized + DynProcessWaitDriver),
+        child: std::process::Child,
+    ) -> io::Result<Self> {
+        let pidfd = pidfd_open(child.id() as i32)?;
+        let wait = driver.new_dyn_process_wait_pidfd(pidfd.as_fd().as_raw_fd())?;
+        Ok(Self {
+            wait: Some(wait),
+            owned_pidfd: Some(pidfd),
+            child,
+        })
+    }
+}
+
+// --- PolledChild<pal::unix::process::Child> ---
+
+impl PolledChild<pal::unix::process::Child> {
+    /// Creates a new `PolledChild` wrapping a [`pal::unix::process::Child`].
+    ///
+    /// Uses the child's existing pidfd to poll for exit.
+    pub fn new(
+        driver: &(impl ?Sized + DynProcessWaitDriver),
+        child: pal::unix::process::Child,
+    ) -> io::Result<Self> {
+        let wait = driver.new_dyn_process_wait_pidfd(child.as_fd().as_raw_fd())?;
+        Ok(Self {
+            wait: Some(wait),
+            owned_pidfd: None,
+            child,
+        })
+    }
+
+    /// Polls for the child process to exit.
+    pub fn poll_wait(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<std::process::ExitStatus>> {
+        if let Some(wait) = &mut self.wait {
+            match wait.poll_process_exit(cx) {
+                Poll::Ready(Ok(())) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        match self.child.try_wait() {
+            Ok(Some(status)) => Poll::Ready(Ok(status)),
+            Ok(None) => {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            Err(e) => Poll::Ready(Err(e)),
+        }
+    }
+
+    /// Waits for the child process to exit.
+    pub fn wait(
+        &mut self,
+    ) -> impl '_ + Unpin + Future<Output = io::Result<std::process::ExitStatus>> {
+        poll_fn(move |cx| self.poll_wait(cx))
+    }
+}

--- a/support/pal/pal_async/src/unix/process/linux.rs
+++ b/support/pal/pal_async/src/unix/process/linux.rs
@@ -1,36 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Linux process wait implementations using pidfds.
+//! Linux low-level process wait implementation using pidfd readiness.
 
-// UNSAFETY: Needed for the pidfd_open syscall.
-#![expect(unsafe_code)]
-
-use crate::fd::FdReadyDriver;
+use crate::driver::PollImpl;
 use crate::fd::PollFdReady;
 use crate::interest::InterestSlot;
 use crate::interest::PollEvents;
-use crate::process::DynProcessWaitDriver;
-use crate::process::PollProcessWait;
-use crate::process::PolledChild;
-use crate::process::ProcessWaitDriver;
 use std::io;
-use std::os::fd::OwnedFd;
-use std::os::unix::prelude::*;
 use std::task::Context;
 use std::task::Poll;
 
-/// A process wait implementation backed by pidfd readiness polling.
+/// Process wait backed by pidfd readiness polling.
 ///
 /// Caches the signaled state so that subsequent polls return immediately
 /// without relying on another epoll edge.
-pub struct PidFdProcessWait<F> {
-    fd_ready: F,
+pub(crate) struct FdProcessWait {
+    fd_ready: PollImpl<dyn PollFdReady>,
     signaled: bool,
 }
 
-impl<F: PollFdReady> PollProcessWait for PidFdProcessWait<F> {
-    fn poll_process_exit(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+impl FdProcessWait {
+    pub(crate) fn new(fd_ready: PollImpl<dyn PollFdReady>) -> Self {
+        Self {
+            fd_ready,
+            signaled: false,
+        }
+    }
+
+    pub(crate) fn poll_exit(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         if self.signaled {
             return Poll::Ready(Ok(()));
         }
@@ -47,61 +45,5 @@ impl<F: PollFdReady> PollProcessWait for PidFdProcessWait<F> {
     }
 }
 
-impl<T: FdReadyDriver> ProcessWaitDriver for T {
-    type ProcessWait = PidFdProcessWait<T::FdReady>;
-
-    fn new_process_wait_pidfd(&self, pidfd: RawFd) -> io::Result<Self::ProcessWait> {
-        let fd_ready = self.new_fd_ready(pidfd)?;
-        Ok(PidFdProcessWait {
-            fd_ready,
-            signaled: false,
-        })
-    }
-}
-
-/// Opens a pidfd for an existing process.
-fn pidfd_open(pid: i32) -> io::Result<OwnedFd> {
-    // SAFETY: pidfd_open is a simple syscall that creates a new file
-    // descriptor for monitoring the given pid.
-    let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0 as libc::c_int) };
-    if fd < 0 {
-        return Err(io::Error::last_os_error());
-    }
-    // SAFETY: pidfd_open returned a valid file descriptor on success.
-    Ok(unsafe { OwnedFd::from_raw_fd(fd as RawFd) })
-}
-
-impl PolledChild<std::process::Child> {
-    /// Creates a new `PolledChild` wrapping a [`std::process::Child`].
-    ///
-    /// Opens a pidfd for the child process to poll for exit.
-    pub fn new(
-        driver: &(impl ?Sized + DynProcessWaitDriver),
-        child: std::process::Child,
-    ) -> io::Result<Self> {
-        let pidfd = pidfd_open(child.id() as i32)?;
-        let wait = driver.new_dyn_process_wait_pidfd(pidfd.as_fd().as_raw_fd())?;
-        Ok(Self {
-            wait: Some(wait),
-            owned_pidfd: Some(pidfd),
-            child,
-        })
-    }
-}
-
-impl PolledChild<pal::unix::process::Child> {
-    /// Creates a new `PolledChild` wrapping a [`pal::unix::process::Child`].
-    ///
-    /// Uses the child's existing pidfd to poll for exit.
-    pub fn new(
-        driver: &(impl ?Sized + DynProcessWaitDriver),
-        child: pal::unix::process::Child,
-    ) -> io::Result<Self> {
-        let wait = driver.new_dyn_process_wait_pidfd(child.as_fd().as_raw_fd())?;
-        Ok(Self {
-            wait: Some(wait),
-            owned_pidfd: None,
-            child,
-        })
-    }
-}
+/// The platform wait type stored inside [`PolledChild`](crate::process::PolledChild).
+pub(crate) type WaitInner = FdProcessWait;

--- a/support/pal/pal_async/src/unix/process/linux.rs
+++ b/support/pal/pal_async/src/unix/process/linux.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Unix process wait implementations.
+//! Linux process wait implementations using pidfds.
 
 // UNSAFETY: Needed for the pidfd_open syscall.
 #![expect(unsafe_code)]
@@ -14,8 +14,6 @@ use crate::process::DynProcessWaitDriver;
 use crate::process::PollProcessWait;
 use crate::process::PolledChild;
 use crate::process::ProcessWaitDriver;
-use std::future::Future;
-use std::future::poll_fn;
 use std::io;
 use std::os::fd::OwnedFd;
 use std::os::unix::prelude::*;
@@ -73,8 +71,6 @@ fn pidfd_open(pid: i32) -> io::Result<OwnedFd> {
     Ok(unsafe { OwnedFd::from_raw_fd(fd as RawFd) })
 }
 
-// --- PolledChild<std::process::Child> construction (Linux) ---
-
 impl PolledChild<std::process::Child> {
     /// Creates a new `PolledChild` wrapping a [`std::process::Child`].
     ///
@@ -93,8 +89,6 @@ impl PolledChild<std::process::Child> {
     }
 }
 
-// --- PolledChild<pal::unix::process::Child> ---
-
 impl PolledChild<pal::unix::process::Child> {
     /// Creates a new `PolledChild` wrapping a [`pal::unix::process::Child`].
     ///
@@ -109,34 +103,5 @@ impl PolledChild<pal::unix::process::Child> {
             owned_pidfd: None,
             child,
         })
-    }
-
-    /// Polls for the child process to exit.
-    pub fn poll_wait(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<io::Result<std::process::ExitStatus>> {
-        if let Some(wait) = &mut self.wait {
-            match wait.poll_process_exit(cx) {
-                Poll::Ready(Ok(())) => {}
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                Poll::Pending => return Poll::Pending,
-            }
-        }
-        match self.child.try_wait() {
-            Ok(Some(status)) => Poll::Ready(Ok(status)),
-            Ok(None) => {
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
-            Err(e) => Poll::Ready(Err(e)),
-        }
-    }
-
-    /// Waits for the child process to exit.
-    pub fn wait(
-        &mut self,
-    ) -> impl '_ + Unpin + Future<Output = io::Result<std::process::ExitStatus>> {
-        poll_fn(move |cx| self.poll_wait(cx))
     }
 }

--- a/support/pal/pal_async/src/unix/process/macos.rs
+++ b/support/pal/pal_async/src/unix/process/macos.rs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! macOS process wait implementations using kqueue `EVFILT_PROC`.
+
+use crate::process::DynProcessWaitDriver;
+use crate::process::PolledChild;
+use std::io;
+
+impl PolledChild<std::process::Child> {
+    /// Creates a new `PolledChild` wrapping a [`std::process::Child`].
+    ///
+    /// Uses kqueue `EVFILT_PROC` to poll for exit. If the child has
+    /// already exited, the wait completes without a kqueue registration.
+    pub fn new(
+        driver: &(impl ?Sized + DynProcessWaitDriver),
+        mut child: std::process::Child,
+    ) -> io::Result<Self> {
+        // Check if the child has already exited before registering.
+        if let Some(_status) = child.try_wait()? {
+            return Ok(Self { wait: None, child });
+        }
+        let wait = driver.new_dyn_process_wait_pid(child.id() as libc::pid_t)?;
+        Ok(Self {
+            wait: Some(wait),
+            child,
+        })
+    }
+}
+
+impl PolledChild<pal::unix::process::Child> {
+    /// Creates a new `PolledChild` wrapping a [`pal::unix::process::Child`].
+    ///
+    /// Uses kqueue `EVFILT_PROC` to poll for exit. If the child has
+    /// already exited, the wait completes without a kqueue registration.
+    pub fn new(
+        driver: &(impl ?Sized + DynProcessWaitDriver),
+        mut child: pal::unix::process::Child,
+    ) -> io::Result<Self> {
+        if let Some(_status) = child.try_wait()? {
+            return Ok(Self { wait: None, child });
+        }
+        let wait = driver.new_dyn_process_wait_pid(child.id() as libc::pid_t)?;
+        Ok(Self {
+            wait: Some(wait),
+            child,
+        })
+    }
+}

--- a/support/pal/pal_async/src/unix/process/macos.rs
+++ b/support/pal/pal_async/src/unix/process/macos.rs
@@ -30,12 +30,6 @@ pub trait PollProcessWait: Unpin + Send + Sync {
     fn poll_process_exit(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>>;
 }
 
-impl std::fmt::Debug for dyn PollProcessWait {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.pad("PollProcessWait")
-    }
-}
-
 /// A [`PollProcessWait`] implementation that is never constructed.
 ///
 /// Used by drivers that do not support process waits (e.g., `LocalDriver`).

--- a/support/pal/pal_async/src/unix/process/macos.rs
+++ b/support/pal/pal_async/src/unix/process/macos.rs
@@ -1,49 +1,68 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! macOS process wait implementations using kqueue `EVFILT_PROC`.
+//! macOS low-level process wait implementation using kqueue `EVFILT_PROC`.
 
-use crate::process::DynProcessWaitDriver;
-use crate::process::PolledChild;
+use crate::driver::PollImpl;
 use std::io;
+use std::task::Context;
+use std::task::Poll;
 
-impl PolledChild<std::process::Child> {
-    /// Creates a new `PolledChild` wrapping a [`std::process::Child`].
-    ///
-    /// Uses kqueue `EVFILT_PROC` to poll for exit. If the child has
-    /// already exited, the wait completes without a kqueue registration.
-    pub fn new(
-        driver: &(impl ?Sized + DynProcessWaitDriver),
-        mut child: std::process::Child,
-    ) -> io::Result<Self> {
-        // Check if the child has already exited before registering.
-        if let Some(_status) = child.try_wait()? {
-            return Ok(Self { wait: None, child });
-        }
-        let wait = driver.new_dyn_process_wait_pid(child.id() as libc::pid_t)?;
-        Ok(Self {
-            wait: Some(wait),
-            child,
-        })
+/// A trait for driving process exit waits on macOS.
+///
+/// Kqueue `EVFILT_PROC` is a fundamentally different mechanism from fd
+/// readiness or waitable handles, so macOS needs its own driver trait.
+pub trait ProcessWaitDriver: Unpin {
+    /// The process wait object.
+    type ProcessWait: 'static + PollProcessWait;
+
+    /// Creates a new process wait from a process ID.
+    fn new_process_wait_pid(&self, pid: i32) -> io::Result<Self::ProcessWait>;
+}
+
+/// A trait for polling process exit.
+///
+/// Implementations must not reap the child process. The caller is responsible
+/// for obtaining the exit status through the child object's native API after
+/// this poll returns [`Poll::Ready`].
+pub trait PollProcessWait: Unpin + Send + Sync {
+    /// Polls until the process exit wait source is signaled.
+    fn poll_process_exit(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>>;
+}
+
+impl std::fmt::Debug for dyn PollProcessWait {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.pad("PollProcessWait")
     }
 }
 
-impl PolledChild<pal::unix::process::Child> {
-    /// Creates a new `PolledChild` wrapping a [`pal::unix::process::Child`].
-    ///
-    /// Uses kqueue `EVFILT_PROC` to poll for exit. If the child has
-    /// already exited, the wait completes without a kqueue registration.
-    pub fn new(
-        driver: &(impl ?Sized + DynProcessWaitDriver),
-        mut child: pal::unix::process::Child,
-    ) -> io::Result<Self> {
-        if let Some(_status) = child.try_wait()? {
-            return Ok(Self { wait: None, child });
-        }
-        let wait = driver.new_dyn_process_wait_pid(child.id() as libc::pid_t)?;
-        Ok(Self {
-            wait: Some(wait),
-            child,
-        })
+/// A [`PollProcessWait`] implementation that is never constructed.
+///
+/// Used by drivers that do not support process waits (e.g., `LocalDriver`).
+/// The constructor returns an error, so `poll_process_exit` is unreachable.
+pub enum NoProcessWait {}
+
+impl PollProcessWait for NoProcessWait {
+    fn poll_process_exit(&mut self, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match *self {}
+    }
+}
+
+/// A type-erased process wait implementation.
+pub type ProcessWaitImpl = PollImpl<dyn PollProcessWait>;
+
+/// The platform wait type stored inside [`PolledChild`](crate::process::PolledChild).
+///
+/// Wraps the type-erased [`ProcessWaitImpl`] and provides a `poll_exit`
+/// method matching the interface used by other platforms.
+pub(crate) struct WaitInner(ProcessWaitImpl);
+
+impl WaitInner {
+    pub(crate) fn new(inner: ProcessWaitImpl) -> Self {
+        Self(inner)
+    }
+
+    pub(crate) fn poll_exit(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.0.poll_process_exit(cx)
     }
 }

--- a/support/pal/pal_async/src/unix/process/mod.rs
+++ b/support/pal/pal_async/src/unix/process/mod.rs
@@ -6,42 +6,11 @@
 #[cfg(target_os = "linux")]
 mod linux;
 #[cfg(target_os = "macos")]
-mod macos;
+pub mod macos;
 
-use crate::process::PolledChild;
-use std::future::Future;
-use std::future::poll_fn;
-use std::io;
-use std::task::Context;
-use std::task::Poll;
-
-impl PolledChild<pal::unix::process::Child> {
-    /// Polls for the child process to exit.
-    pub fn poll_wait(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<io::Result<std::process::ExitStatus>> {
-        if let Some(wait) = &mut self.wait {
-            match wait.poll_process_exit(cx) {
-                Poll::Ready(Ok(())) => {}
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                Poll::Pending => return Poll::Pending,
-            }
-        }
-        match self.child.try_wait() {
-            Ok(Some(status)) => Poll::Ready(Ok(status)),
-            Ok(None) => {
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
-            Err(e) => Poll::Ready(Err(e)),
-        }
-    }
-
-    /// Waits for the child process to exit.
-    pub fn wait(
-        &mut self,
-    ) -> impl '_ + Unpin + Future<Output = io::Result<std::process::ExitStatus>> {
-        poll_fn(move |cx| self.poll_wait(cx))
-    }
-}
+#[cfg(target_os = "linux")]
+pub(crate) use linux::FdProcessWait;
+#[cfg(target_os = "linux")]
+pub(crate) use linux::WaitInner;
+#[cfg(target_os = "macos")]
+pub(crate) use macos::WaitInner;

--- a/support/pal/pal_async/src/unix/process/mod.rs
+++ b/support/pal/pal_async/src/unix/process/mod.rs
@@ -4,12 +4,10 @@
 //! Unix process wait implementations.
 
 #[cfg(target_os = "linux")]
-mod linux;
+pub mod linux;
 #[cfg(target_os = "macos")]
 pub mod macos;
 
-#[cfg(target_os = "linux")]
-pub(crate) use linux::FdProcessWait;
 #[cfg(target_os = "linux")]
 pub(crate) use linux::WaitInner;
 #[cfg(target_os = "macos")]

--- a/support/pal/pal_async/src/unix/process/mod.rs
+++ b/support/pal/pal_async/src/unix/process/mod.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Unix process wait implementations.
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
+
+use crate::process::PolledChild;
+use std::future::Future;
+use std::future::poll_fn;
+use std::io;
+use std::task::Context;
+use std::task::Poll;
+
+impl PolledChild<pal::unix::process::Child> {
+    /// Polls for the child process to exit.
+    pub fn poll_wait(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<std::process::ExitStatus>> {
+        if let Some(wait) = &mut self.wait {
+            match wait.poll_process_exit(cx) {
+                Poll::Ready(Ok(())) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        match self.child.try_wait() {
+            Ok(Some(status)) => Poll::Ready(Ok(status)),
+            Ok(None) => {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            Err(e) => Poll::Ready(Err(e)),
+        }
+    }
+
+    /// Waits for the child process to exit.
+    pub fn wait(
+        &mut self,
+    ) -> impl '_ + Unpin + Future<Output = io::Result<std::process::ExitStatus>> {
+        poll_fn(move |cx| self.poll_wait(cx))
+    }
+}

--- a/support/pal/pal_async/src/waker.rs
+++ b/support/pal/pal_async/src/waker.rs
@@ -18,10 +18,7 @@ impl WakerList {
         }
     }
 
-    #[cfg_attr(
-        not(any(windows, target_os = "linux", target_os = "macos")),
-        expect(dead_code)
-    )]
+    /// Pushes a waker onto the list.
     pub fn push(&mut self, waker: Waker) {
         self.0.push(waker);
     }

--- a/support/pal/pal_async/src/waker.rs
+++ b/support/pal/pal_async/src/waker.rs
@@ -18,7 +18,10 @@ impl WakerList {
         }
     }
 
-    #[cfg_attr(not(any(windows, target_os = "linux")), expect(dead_code))]
+    #[cfg_attr(
+        not(any(windows, target_os = "linux", target_os = "macos")),
+        expect(dead_code)
+    )]
     pub fn push(&mut self, waker: Waker) {
         self.0.push(waker);
     }

--- a/support/pal/pal_async/src/windows/iocp.rs
+++ b/support/pal/pal_async/src/windows/iocp.rs
@@ -614,4 +614,9 @@ mod tests {
     fn overlapped_file_works() {
         IocpPool::run_with(executor_tests::windows::overlapped_file_tests)
     }
+
+    #[test]
+    fn process_works() {
+        IocpPool::run_with(executor_tests::process_tests)
+    }
 }

--- a/support/pal/pal_async/src/windows/mod.rs
+++ b/support/pal/pal_async/src/windows/mod.rs
@@ -11,6 +11,7 @@ pub mod iocp;
 pub mod local;
 pub mod overlapped;
 pub mod pipe;
+pub mod process;
 mod socket;
 pub mod tp;
 

--- a/support/pal/pal_async/src/windows/process.rs
+++ b/support/pal/pal_async/src/windows/process.rs
@@ -1,38 +1,31 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Windows process wait implementations.
-//!
-//! Implements [`ProcessWaitDriver`] for all [`WaitDriver`] types by wrapping
-//! the existing waitable-handle infrastructure. Process handles are waitable
-//! on Windows and become signaled when the process exits.
+//! Windows low-level process wait implementation using waitable handles.
 
-use crate::process::DynProcessWaitDriver;
-use crate::process::PollProcessWait;
-use crate::process::PolledChild;
-use crate::process::ProcessWaitDriver;
-use crate::process::ProcessWaitImpl;
+use crate::driver::PollImpl;
 use crate::wait::PollWait;
-use crate::wait::WaitDriver;
-use std::future::Future;
-use std::future::poll_fn;
 use std::io;
-use std::os::windows::prelude::*;
 use std::task::Context;
 use std::task::Poll;
 
-/// A process wait implementation backed by a waitable process handle.
+/// Process wait backed by a waitable process handle.
 ///
-/// Delegates to the underlying [`PollWait`] implementation and caches
-/// the signaled state so that subsequent polls return immediately
-/// without re-registering with the OS.
-pub struct HandleProcessWait<W> {
-    wait: W,
+/// Caches the signaled state so that subsequent polls return immediately.
+pub(crate) struct HandleProcessWait {
+    wait: PollImpl<dyn PollWait>,
     signaled: bool,
 }
 
-impl<W: PollWait> PollProcessWait for HandleProcessWait<W> {
-    fn poll_process_exit(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+impl HandleProcessWait {
+    pub(crate) fn new(wait: PollImpl<dyn PollWait>) -> Self {
+        Self {
+            wait,
+            signaled: false,
+        }
+    }
+
+    pub(crate) fn poll_exit(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         if self.signaled {
             return Poll::Ready(Ok(()));
         }
@@ -46,92 +39,5 @@ impl<W: PollWait> PollProcessWait for HandleProcessWait<W> {
     }
 }
 
-impl<T: WaitDriver> ProcessWaitDriver for T {
-    type ProcessWait = HandleProcessWait<T::Wait>;
-
-    fn new_process_wait_handle(&self, handle: RawHandle) -> io::Result<Self::ProcessWait> {
-        let wait = self.new_wait(handle)?;
-        Ok(HandleProcessWait {
-            wait,
-            signaled: false,
-        })
-    }
-}
-
-// --- PolledChild<std::process::Child> construction (Windows) ---
-
-impl PolledChild<std::process::Child> {
-    /// Creates a new `PolledChild` wrapping a [`std::process::Child`].
-    ///
-    /// Waits on the child's process handle to detect exit.
-    pub fn new(
-        driver: &(impl ?Sized + DynProcessWaitDriver),
-        child: std::process::Child,
-    ) -> io::Result<Self> {
-        let handle = child.as_handle().as_raw_handle();
-        let wait = driver.new_dyn_process_wait_handle(handle)?;
-        Ok(Self {
-            wait: Some(wait),
-            child,
-        })
-    }
-}
-
-// --- PolledProcess for pal::windows::Process ---
-
-/// An owned process handle with an asynchronous exit wait.
-///
-/// Unlike [`PolledChild`], this type wraps a cloneable process handle
-/// (not a child with cached exit status). The exit code is returned
-/// as a `u32` matching the API of [`pal::windows::Process`].
-///
-/// The `wait` field is declared before `process` so that the backend
-/// wait registration is dropped before the process handle.
-pub struct PolledProcess {
-    wait: Option<ProcessWaitImpl>,
-    process: pal::windows::Process,
-}
-
-impl PolledProcess {
-    /// Creates a new `PolledProcess` wrapping a [`pal::windows::Process`].
-    ///
-    /// Waits on the process handle to detect exit.
-    pub fn new(
-        driver: &(impl ?Sized + DynProcessWaitDriver),
-        process: pal::windows::Process,
-    ) -> io::Result<Self> {
-        let handle = process.as_handle().as_raw_handle();
-        let wait = driver.new_dyn_process_wait_handle(handle)?;
-        Ok(Self {
-            wait: Some(wait),
-            process,
-        })
-    }
-
-    /// Returns the inner process, dropping the wait registration.
-    pub fn into_inner(self) -> pal::windows::Process {
-        self.process
-    }
-
-    /// Gets a reference to the inner process.
-    pub fn get(&self) -> &pal::windows::Process {
-        &self.process
-    }
-
-    /// Polls for the process to exit, returning its exit code.
-    pub fn poll_wait(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<u32>> {
-        if let Some(wait) = &mut self.wait {
-            match wait.poll_process_exit(cx) {
-                Poll::Ready(Ok(())) => {}
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                Poll::Pending => return Poll::Pending,
-            }
-        }
-        Poll::Ready(Ok(self.process.exit_code()))
-    }
-
-    /// Waits for the process to exit, returning its exit code.
-    pub fn wait(&mut self) -> impl '_ + Unpin + Future<Output = io::Result<u32>> {
-        poll_fn(move |cx| self.poll_wait(cx))
-    }
-}
+/// The platform wait type stored inside [`PolledChild`](crate::process::PolledChild).
+pub(crate) type WaitInner = HandleProcessWait;

--- a/support/pal/pal_async/src/windows/process.rs
+++ b/support/pal/pal_async/src/windows/process.rs
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Windows process wait implementations.
+//!
+//! Implements [`ProcessWaitDriver`] for all [`WaitDriver`] types by wrapping
+//! the existing waitable-handle infrastructure. Process handles are waitable
+//! on Windows and become signaled when the process exits.
+
+use crate::process::DynProcessWaitDriver;
+use crate::process::PollProcessWait;
+use crate::process::PolledChild;
+use crate::process::ProcessWaitDriver;
+use crate::process::ProcessWaitImpl;
+use crate::wait::PollWait;
+use crate::wait::WaitDriver;
+use std::future::Future;
+use std::future::poll_fn;
+use std::io;
+use std::os::windows::prelude::*;
+use std::task::Context;
+use std::task::Poll;
+
+/// A process wait implementation backed by a waitable process handle.
+///
+/// Delegates to the underlying [`PollWait`] implementation and caches
+/// the signaled state so that subsequent polls return immediately
+/// without re-registering with the OS.
+pub struct HandleProcessWait<W> {
+    wait: W,
+    signaled: bool,
+}
+
+impl<W: PollWait> PollProcessWait for HandleProcessWait<W> {
+    fn poll_process_exit(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if self.signaled {
+            return Poll::Ready(Ok(()));
+        }
+        match self.wait.poll_wait(cx) {
+            Poll::Ready(result) => {
+                self.signaled = true;
+                Poll::Ready(result)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<T: WaitDriver> ProcessWaitDriver for T {
+    type ProcessWait = HandleProcessWait<T::Wait>;
+
+    fn new_process_wait_handle(&self, handle: RawHandle) -> io::Result<Self::ProcessWait> {
+        let wait = self.new_wait(handle)?;
+        Ok(HandleProcessWait {
+            wait,
+            signaled: false,
+        })
+    }
+}
+
+// --- PolledChild<std::process::Child> construction (Windows) ---
+
+impl PolledChild<std::process::Child> {
+    /// Creates a new `PolledChild` wrapping a [`std::process::Child`].
+    ///
+    /// Waits on the child's process handle to detect exit.
+    pub fn new(
+        driver: &(impl ?Sized + DynProcessWaitDriver),
+        child: std::process::Child,
+    ) -> io::Result<Self> {
+        let handle = child.as_handle().as_raw_handle();
+        let wait = driver.new_dyn_process_wait_handle(handle)?;
+        Ok(Self {
+            wait: Some(wait),
+            child,
+        })
+    }
+}
+
+// --- PolledProcess for pal::windows::Process ---
+
+/// An owned process handle with an asynchronous exit wait.
+///
+/// Unlike [`PolledChild`], this type wraps a cloneable process handle
+/// (not a child with cached exit status). The exit code is returned
+/// as a `u32` matching the API of [`pal::windows::Process`].
+///
+/// The `wait` field is declared before `process` so that the backend
+/// wait registration is dropped before the process handle.
+pub struct PolledProcess {
+    wait: Option<ProcessWaitImpl>,
+    process: pal::windows::Process,
+}
+
+impl PolledProcess {
+    /// Creates a new `PolledProcess` wrapping a [`pal::windows::Process`].
+    ///
+    /// Waits on the process handle to detect exit.
+    pub fn new(
+        driver: &(impl ?Sized + DynProcessWaitDriver),
+        process: pal::windows::Process,
+    ) -> io::Result<Self> {
+        let handle = process.as_handle().as_raw_handle();
+        let wait = driver.new_dyn_process_wait_handle(handle)?;
+        Ok(Self {
+            wait: Some(wait),
+            process,
+        })
+    }
+
+    /// Returns the inner process, dropping the wait registration.
+    pub fn into_inner(self) -> pal::windows::Process {
+        self.process
+    }
+
+    /// Gets a reference to the inner process.
+    pub fn get(&self) -> &pal::windows::Process {
+        &self.process
+    }
+
+    /// Polls for the process to exit, returning its exit code.
+    pub fn poll_wait(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<u32>> {
+        if let Some(wait) = &mut self.wait {
+            match wait.poll_process_exit(cx) {
+                Poll::Ready(Ok(())) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        Poll::Ready(Ok(self.process.exit_code()))
+    }
+
+    /// Waits for the process to exit, returning its exit code.
+    pub fn wait(&mut self) -> impl '_ + Unpin + Future<Output = io::Result<u32>> {
+        poll_fn(move |cx| self.poll_wait(cx))
+    }
+}

--- a/support/pal/pal_async/src/windows/tp.rs
+++ b/support/pal/pal_async/src/windows/tp.rs
@@ -580,4 +580,9 @@ mod tests {
             executor_tests::windows::overlapped_file_tests(TpPool::system()),
         ))
     }
+
+    #[test]
+    fn process_works() {
+        block_on(TpPool::system().spawn("test", executor_tests::process_tests(TpPool::system())))
+    }
 }

--- a/vm/vmcore/src/vm_task.rs
+++ b/vm/vmcore/src/vm_task.rs
@@ -318,7 +318,8 @@ impl Driver for VmTaskDriver {
     fn new_dyn_process_wait(
         &self,
         pid: i32,
-    ) -> std::io::Result<pal_async::driver::PollImpl<dyn pal_async::process::macos::PollProcessWait>> {
+    ) -> std::io::Result<pal_async::driver::PollImpl<dyn pal_async::process::macos::PollProcessWait>>
+    {
         self.inner.driver().new_dyn_process_wait(pid)
     }
 }
@@ -586,8 +587,9 @@ pub mod thread {
         fn new_dyn_process_wait(
             &self,
             pid: i32,
-        ) -> std::io::Result<pal_async::driver::PollImpl<dyn pal_async::process::macos::PollProcessWait>>
-        {
+        ) -> std::io::Result<
+            pal_async::driver::PollImpl<dyn pal_async::process::macos::PollProcessWait>,
+        > {
             self.with_driver(|d| d.new_dyn_process_wait(pid))
         }
     }

--- a/vm/vmcore/src/vm_task.rs
+++ b/vm/vmcore/src/vm_task.rs
@@ -313,6 +313,14 @@ impl Driver for VmTaskDriver {
         // SAFETY: passthru from caller
         unsafe { self.inner.driver().io_uring_submit(sqe) }
     }
+
+    #[cfg(target_os = "macos")]
+    fn new_dyn_process_wait(
+        &self,
+        pid: i32,
+    ) -> std::io::Result<pal_async::driver::PollImpl<dyn pal_async::process::macos::PollProcessWait>> {
+        self.inner.driver().new_dyn_process_wait(pid)
+    }
 }
 
 impl Spawn for VmTaskDriver {
@@ -572,6 +580,15 @@ pub mod thread {
                         .await
                 }
             })
+        }
+
+        #[cfg(target_os = "macos")]
+        fn new_dyn_process_wait(
+            &self,
+            pid: i32,
+        ) -> std::io::Result<pal_async::driver::PollImpl<dyn pal_async::process::macos::PollProcessWait>>
+        {
+            self.with_driver(|d| d.new_dyn_process_wait(pid))
         }
     }
 


### PR DESCRIPTION
Add `PolledChild` and `PolledProcess` types to `pal_async` for waiting on child process exit asynchronously, without blocking a thread or consuming the child handle. This replaces the pattern of spawning a dedicated thread per child process just to call `child.wait()`.

`PolledChild<C>` wraps a child process (`std::process::Child` or `pal::unix::process::Child`) and provides `poll_wait`/`wait` methods that use the executor's event loop to detect process exit. `PolledProcess` (Windows-only) does the same for `pal::windows::Process` handles.

Each platform uses its native mechanism for process exit notification:

- **Linux**: Opens a `pidfd` via `pidfd_open(2)` and polls it for readiness through the existing `FdReadyDriver` (epoll/uring).
- **macOS**: Registers a kqueue `EVFILT_PROC` / `NOTE_EXIT` event via a new `ProcessWaitDriver` trait implemented by the kqueue backend.
- **Windows**: Waits on the process handle via the existing `WaitDriver`.

The first consumer is `mesh_process`, which previously spawned a blocking thread per child to wait for exit and relay the result back via a channel. It now uses `PolledChild`/`PolledProcess` to await exit directly on the executor, eliminating the per-child wait thread and the `oneshot` channel plumbing.